### PR TITLE
fix: drop deprecated apiextensions.k8s.io/v1beta1 CustomResourceDefinition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,9 +81,9 @@ update_google_service_broker:
 
 update_tekton:
 	mkdir -p assets/embedded-files/tekton
-	wget https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.19.0/release.yaml -O assets/embedded-files/tekton/pipeline-v0.19.0.yaml
-	wget https://storage.googleapis.com/tekton-releases/triggers/previous/v0.11.1/release.yaml -O assets/embedded-files/tekton/triggers-v0.11.1.yaml
-	wget https://github.com/tektoncd/dashboard/releases/download/v0.11.1/tekton-dashboard-release.yaml -O assets/embedded-files/tekton/dashboard-v0.11.1.yaml
+	wget https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.23.0/release.yaml -O assets/embedded-files/tekton/pipeline-v0.23.0.yaml
+	wget https://storage.googleapis.com/tekton-releases/triggers/previous/v0.12.1/release.yaml -O assets/embedded-files/tekton/triggers-v0.12.1.yaml
+	wget https://github.com/tektoncd/dashboard/releases/download/v0.15.0/tekton-dashboard-release.yaml -O assets/embedded-files/tekton/dashboard-v0.15.0.yaml
 
 embed_files: getstatik
 	statik -m -f -src=./assets/embedded-files -dest assets

--- a/deployments/tekton.go
+++ b/deployments/tekton.go
@@ -30,10 +30,10 @@ type Tekton struct {
 const (
 	TektonDeploymentID            = "tekton"
 	tektonNamespace               = "tekton-pipelines"
-	tektonPipelineReleaseYamlPath = "tekton/pipeline-v0.19.0.yaml"
-	tektonDashboardYamlPath       = "tekton/dashboard-v0.11.1.yaml"
+	tektonPipelineReleaseYamlPath = "tekton/pipeline-v0.23.0.yaml"
+	tektonDashboardYamlPath       = "tekton/dashboard-v0.15.0.yaml"
 	tektonAdminRoleYamlPath       = "tekton/admin-role.yaml"
-	tektonTriggersReleaseYamlPath = "tekton/triggers-v0.11.1.yaml"
+	tektonTriggersReleaseYamlPath = "tekton/triggers-v0.12.1.yaml"
 	tektonTriggersYamlPath        = "tekton/triggers.yaml"
 	tektonStagingYamlPath         = "tekton/staging.yaml"
 )

--- a/helpers/kubernetes/cluster.go
+++ b/helpers/kubernetes/cluster.go
@@ -204,7 +204,7 @@ func (c *Cluster) WaitForCRD(ui *termui.UI, CRDName string, timeout time.Duratio
 			return false, err
 		}
 
-		_, err = clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.Background(), CRDName, metav1.GetOptions{})
+		_, err = clientset.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), CRDName, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return false, nil


### PR DESCRIPTION

It was used in Tekton and kubernetes/cluster.go

fixes #204