### PR TITLE
Add initial swagger spec generation for API docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,16 @@ embed_files:
 help:
 	( echo _ _ ___ _____ ________ Overview ; epinio help ; for cmd in apps completion create-org delete help info install orgs push target uninstall ; do echo ; echo _ _ ___ _____ ________ Command $$cmd ; epinio $$cmd --help ; done ; echo ) | tee HELP
 
+
+########################################################################
+# Docs
+
+swagger:
+	swagger generate spec > swagger.json
+
+swagger-serve:
+	swagger serve swagger.json
+
 ########################################################################
 # Support
 

--- a/internal/api/v1/docs/docs.go
+++ b/internal/api/v1/docs/docs.go
@@ -1,0 +1,44 @@
+package docs
+
+//go:generate swagger generate spec
+
+import (
+	"github.com/suse/carrier/internal/application"
+)
+
+// swagger:route GET /api/v1/orgs/{org}/applications application listApplications
+// List deployed applications
+// responses:
+//   200: listApplicationsResponse
+
+// List of applications
+// swagger:response listApplicationsResponse
+type listApplicationsResponseWrapper struct {
+	// in:body
+	Body application.Application
+}
+
+// swagger:parameters listApplications
+type listApplicationsParamWrapper struct {
+	// Parameters for list applications
+	Org string
+}
+
+// swagger:route GET /api/v1/orgs/{org}/applications/:app application showApplication
+// Show info about an application
+// responses:
+//   200: showApplicationResponse
+
+// This text will appear as description of your response body.
+// swagger:response showApplicationResponse
+type showApplicationResponseWrapper struct {
+	// in:body
+	Body application.Application
+}
+
+// swagger:parameters showApplication
+type showApplicationParamWrapper struct {
+	// Parameters for show application
+	Org string
+	App string
+}


### PR DESCRIPTION

![Screenshot 2021-04-12 at 16-50-40 API documentation](https://user-images.githubusercontent.com/393653/114414611-42f70880-9baf-11eb-8eaa-c89924b05fc4.png)

This adds swagger comments into a separate doc package, so they don't
interfere with existing comments.  Models are scanned automatically, but
routes are not and need to be added manually.

https://goswagger.io/use/spec.html