### PR TITLE
fix: Use a registry proxy when running acceptance tests

### DIFF
--- a/scripts/patch-epinio-deployment.sh
+++ b/scripts/patch-epinio-deployment.sh
@@ -49,7 +49,7 @@ spec:
         claimName: epinio-binary
   containers:
     - name: copier
-      image: busybox
+      image: busybox:stable
       command: ["/bin/sh", "-ec", "while :; do printf '.'; sleep 5 ; done"]
       volumeMounts:
         - mountPath: "/epinio"


### PR DESCRIPTION
and use `stable` tag for busybox. These 2 changes should limit the
number of requests we make to dockerhub and avoid CI being rate limited.

Co-authored-by: Mario Manno <mario.manno@suse.com>