### PR TITLE
fix: Login to dockerhub before running tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Install Tools
         run: make tools-install
       - name: Add Tools to PATH

--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -39,6 +39,8 @@ const (
 )
 
 var _ = SynchronizedBeforeSuite(func() []byte {
+	fmt.Printf("I'm running on runner = %s\n", os.Getenv("HOSTNAME"))
+
 	if os.Getenv("REGISTRY_USERNAME") == "" || os.Getenv("REGISTRY_PASSWORD") == "" {
 		fmt.Println("REGISTRY_USERNAME or REGISTRY_PASSWORD environment variables are empty. Pulling from dockerhub will be subject to rate limiting.")
 	}


### PR DESCRIPTION
because if a registry mirror is not running, the acceptance tests will
try to start it. If the image is not yet there (like it happens on new
github runners), docker command will try to pull it. On self-hosted
runners which share an external IP with lots of other machines, this
could immediately hit the rate limiting of dockerhub.