### PR TITLE
fix: When the application name is long staging fails

### DIFF
--- a/assets/embedded-files/tekton/triggers.yaml
+++ b/assets/embedded-files/tekton/triggers.yaml
@@ -18,7 +18,7 @@ spec:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
-        name: staging-pipeline-run-$(tt.params.appname)-$(uid)
+        name: staging-$(uid)
         namespace: epinio-workloads
       spec:
         serviceAccountName: staging-triggers-admin


### PR DESCRIPTION
If it's too long, app creation would fail anyway because of the
Deployment name having the same issue but we add a uid on top so it
happened in tests that the app was created but the el-staging-listener
showed this error:

ce=pipelineruns\\\": admission webhook \\\"validation.webhook.pipeline.tekton.
dev\\\" denied the request: validation failed: Invalid resource name: length
must be no more than 63 characters: metadata.name\"}","knative.dev/controller"