### PR TITLE
Fix logs by monitoring pods based on labels

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -19,6 +19,14 @@ var _ = Describe("Apps", func() {
 			appName = newAppName()
 		})
 
+		It("shows the staging logs", func() {
+			By("pushing the app")
+			out := makeApp(appName)
+
+			Expect(out).To(MatchRegexp(`.*step-create.*Configuring PHP Application.*`))
+			Expect(out).To(MatchRegexp(`.*step-create.*Using feature -- PHP.*`))
+		})
+
 		It("pushes and deletes an app", func() {
 			By("pushing the app")
 			makeApp(appName)

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -77,19 +77,21 @@ func setupInClusterServices() {
 	}, "5m").ShouldNot(HaveOccurred())
 }
 
-func makeApp(appName string) {
+func makeApp(appName string) string {
 	currentDir, err := os.Getwd()
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	appDir := path.Join(currentDir, "../assets/sample-app")
 
-	out, err := Epinio(fmt.Sprintf("apps push %s --verbosity 1", appName), appDir)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)
+	pushOutput, err := Epinio(fmt.Sprintf("apps push %s --verbosity 1", appName), appDir)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), pushOutput)
 
 	// And check presence
 
-	out, err = Epinio("app list", "")
+	out, err := Epinio("app list", "")
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)
 	ExpectWithOffset(1, out).To(MatchRegexp(appName + `.*\|.*1\/1.*\|.*`))
+
+	return pushOutput
 }
 
 func makeCustomService(serviceName string) {

--- a/helpers/kubernetes/tailer/tailer.go
+++ b/helpers/kubernetes/tailer/tailer.go
@@ -155,6 +155,9 @@ func (t *Tail) Start(ctx context.Context, i v1.PodInterface) {
 
 	go func() {
 		<-ctx.Done()
+		defer func() {
+			_ = recover() // Ignore the case when t.closed is already closed (race conditions)
+		}()
 		close(t.closed)
 	}()
 }


### PR DESCRIPTION
This is a follow-up PR of this: https://github.com/epinio/epinio/pull/337#issuecomment-829083348

We broke the staging logs when we removed the application name from the staging pods. The above PR would break it anyway because the staging pods now run on a dedicated namespace (tekton-staging). This PR is fixing it by adding labels to the staging pods and then when collecting logs, we filter pods using those labels.