### PR TITLE
328 Prepare for Upload API

### DIFF
--- a/helpers/routes/routes.go
+++ b/helpers/routes/routes.go
@@ -1,0 +1,49 @@
+// Package routes implements registered urls and parameter substitution
+package routes
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// Route describes a route for httprouter
+type Route struct {
+	Method  string
+	Path    string
+	Format  string
+	Handler http.HandlerFunc
+}
+
+var formatRegex = regexp.MustCompile(`:\w+`)
+
+// NewRoute returns a new route, which can be added to NamedRoutes and used with
+// httprouter. Trailing and leading slashes are removed.
+func NewRoute(method string, path string, h http.HandlerFunc) Route {
+	format := formatRegex.ReplaceAllString(path, "%s")
+	format = strings.Trim(format, "/")
+	return Route{method, path, format, h}
+}
+
+// NamedRoutes is a map of all named routes, to provide something like
+// https://github.com/gorilla/mux#registered-urls
+type NamedRoutes map[string]Route
+
+// Path returns a route's path with params substituted, panics if
+// used inproperly.
+func (n NamedRoutes) Path(name string, params ...interface{}) string {
+	r, ok := n[name]
+	if !ok {
+		// this means you have a typo or you allowed a user controlled
+		// string to reach this method, don't.
+		panic(fmt.Sprintf("route not found for '%s'", name))
+	}
+
+	// make sure to pass the right amount of params
+	// otherwise this method might fail
+	if r.Format == "" || len(params) == 0 {
+		return strings.Trim(r.Path, "/")
+	}
+	return fmt.Sprintf(r.Format, params...)
+}

--- a/helpers/tracelog/logger.go
+++ b/helpers/tracelog/logger.go
@@ -1,4 +1,6 @@
-package config
+// Package tracelog provides a logger for debugging and tracing
+// This logger will not print anything, unless TRACE_LEVEL is at least 1
+package tracelog
 
 import (
 	"log"
@@ -22,17 +24,22 @@ func LoggerFlags(pf *flag.FlagSet, argToEnv map[string]string) {
 	argToEnv["trace-level"] = "TRACE_LEVEL"
 }
 
-// New creates a new logger with our setup
+// NewServerLogger creates a new logger for server subcommand
+func NewServerLogger() logr.Logger {
+	return NewLogger().WithName("epinio")
+}
+
+// NewClientLogger creates a new logger with our setup
 func NewClientLogger() logr.Logger {
 	return NewLogger().WithName("EpinioClient")
 }
 
-// New creates a new logger with our setup
+// NewInstallClientLogger creates a new logger for the install subcommand
 func NewInstallClientLogger() logr.Logger {
 	return NewLogger().WithName("InstallClient")
 }
 
-// New creates a new logger with our setup
+// NewLogger creates a new logger with our setup
 func NewLogger() logr.Logger {
 	stdr.SetVerbosity(TraceLevel())
 	return stdr.New(log.New(os.Stderr, "", log.LstdFlags)).V(1) // NOTE: Increment of level, not absolute.

--- a/internal/api/v1/applications.go
+++ b/internal/api/v1/applications.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/application"
-	"github.com/epinio/epinio/internal/cli/clients"
+	"github.com/epinio/epinio/internal/cli/clients/gitea"
 	"github.com/epinio/epinio/internal/duration"
 	"github.com/epinio/epinio/internal/organizations"
 	"github.com/epinio/epinio/internal/services"
@@ -98,7 +98,7 @@ func (hc ApplicationsController) Delete(w http.ResponseWriter, r *http.Request) 
 	org := params.ByName("org")
 	appName := params.ByName("app")
 
-	gitea, err := clients.GetGiteaClient()
+	gitea, err := gitea.New()
 	if handleError(w, err, http.StatusInternalServerError) {
 		return
 	}

--- a/internal/api/v1/organizations.go
+++ b/internal/api/v1/organizations.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
-	"github.com/epinio/epinio/internal/cli/clients"
+	"github.com/epinio/epinio/internal/cli/clients/gitea"
 	"github.com/epinio/epinio/internal/organizations"
 )
 
@@ -44,7 +44,7 @@ func (oc OrganizationsController) Index(w http.ResponseWriter, r *http.Request) 
 }
 
 func (oc OrganizationsController) Create(w http.ResponseWriter, r *http.Request) {
-	gitea, err := clients.GetGiteaClient()
+	gitea, err := gitea.New()
 	if handleError(w, err, http.StatusInternalServerError) {
 		return
 	}

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -4,36 +4,56 @@ package v1
 import (
 	"net/http"
 
+	"github.com/epinio/epinio/helpers/routes"
 	"github.com/julienschmidt/httprouter"
 )
 
-func Router() *httprouter.Router {
-	router := httprouter.New()
-	router.HandlerFunc("GET", "/api/v1/info", InfoController{}.Info)
+const v = "/api/v1"
 
-	// List, show, and delete applications
-	router.HandlerFunc("GET", "/api/v1/orgs/:org/applications", ApplicationsController{}.Index)
-	router.HandlerFunc("GET", "/api/v1/orgs/:org/applications/:app", ApplicationsController{}.Show)
-	router.HandlerFunc("DELETE", "/api/v1/orgs/:org/applications/:app", ApplicationsController{}.Delete)
+func get(path string, h http.HandlerFunc) routes.Route {
+	return routes.NewRoute("GET", v+path, h)
+}
+
+func post(path string, h http.HandlerFunc) routes.Route {
+	return routes.NewRoute("POST", v+path, h)
+}
+
+func delete(path string, h http.HandlerFunc) routes.Route {
+	return routes.NewRoute("DELETE", v+path, h)
+}
+
+var Routes = routes.NamedRoutes{
+	"Info":      get("/info", InfoController{}.Info),
+	"Apps":      get("/orgs/:org/applications", ApplicationsController{}.Index),
+	"AppShow":   get("/orgs/:org/applications/:app", ApplicationsController{}.Show),
+	"AppDelete": delete("/orgs/:org/applications/:app", ApplicationsController{}.Delete),
 
 	// Bind and unbind services to/from applications, by means of servicebindings in applications
-	router.HandlerFunc("POST", "/api/v1/orgs/:org/applications/:app/servicebindings", ServicebindingsController{}.Create)
-	router.HandlerFunc("DELETE", "/api/v1/orgs/:org/applications/:app/servicebindings/:service", ServicebindingsController{}.Delete)
+	"ServiceBindingCreate": post("/orgs/:org/applications/:app/servicebindings", ServicebindingsController{}.Create),
+	"ServiceBindingDelete": delete("/orgs/:org/applications/:app/servicebindings/:service", ServicebindingsController{}.Delete),
 
 	// List and create organizations
-	router.HandlerFunc("GET", "/api/v1/orgs", OrganizationsController{}.Index)
-	router.HandlerFunc("POST", "/api/v1/orgs", OrganizationsController{}.Create)
+	"Orgs":      get("/orgs", OrganizationsController{}.Index),
+	"OrgCreate": post("/orgs", OrganizationsController{}.Create),
 
 	// List, show, create and delete services, catalog and custom
-	router.HandlerFunc("GET", "/api/v1/orgs/:org/services", ServicesController{}.Index)
-	router.HandlerFunc("GET", "/api/v1/orgs/:org/services/:service", ServicesController{}.Show)
-	router.HandlerFunc("POST", "/api/v1/orgs/:org/services", ServicesController{}.Create)
-	router.HandlerFunc("POST", "/api/v1/orgs/:org/custom-services", ServicesController{}.CreateCustom)
-	router.HandlerFunc("DELETE", "/api/v1/orgs/:org/services/:service", ServicesController{}.Delete)
+	"Services":            get("/orgs/:org/services", ServicesController{}.Index),
+	"ServiceShow":         get("/orgs/:org/services/:service", ServicesController{}.Show),
+	"ServiceCreate":       post("/orgs/:org/services", ServicesController{}.Create),
+	"ServiceCreateCustom": post("/orgs/:org/custom-services", ServicesController{}.CreateCustom),
+	"ServiceDelete":       delete("/orgs/:org/services/:service", ServicesController{}.Delete),
 
 	// list service classes and plans (of catalog services)
-	router.HandlerFunc("GET", "/api/v1/serviceclasses", ServiceClassesController{}.Index)
-	router.HandlerFunc("GET", "/api/v1/serviceclasses/:serviceclass/serviceplans", ServicePlansController{}.Index)
+	"ServiceClasses": get("/serviceclasses", ServiceClassesController{}.Index),
+	"ServicePlans":   get("/serviceclasses/:serviceclass/serviceplans", ServicePlansController{}.Index),
+}
+
+func Router() *httprouter.Router {
+	router := httprouter.New()
+
+	for _, r := range Routes {
+		router.HandlerFunc(r.Method, r.Path, r.Handler)
+	}
 
 	router.NotFound = http.NotFoundHandler()
 

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -8,6 +8,8 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+type CtxLoggerKey struct{}
+
 const v = "/api/v1"
 
 func get(path string, h http.HandlerFunc) routes.Route {

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"code.gitea.io/sdk/gitea"
+	giteaSDK "code.gitea.io/sdk/gitea"
 	"github.com/epinio/epinio/deployments"
 	"github.com/epinio/epinio/helpers/kubernetes"
 	kubeconfig "github.com/epinio/epinio/helpers/kubernetes/config"
@@ -25,6 +25,7 @@ import (
 	"github.com/epinio/epinio/helpers/termui"
 	"github.com/epinio/epinio/internal/api/v1/models"
 	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/internal/cli/clients/gitea"
 	"github.com/epinio/epinio/internal/cli/config"
 	"github.com/epinio/epinio/internal/duration"
 	"github.com/epinio/epinio/internal/services"
@@ -55,7 +56,7 @@ var (
 // EpinioClient provides functionality for talking to a
 // Epinio installation on Kubernetes
 type EpinioClient struct {
-	GiteaClient *GiteaClient
+	GiteaClient *gitea.Client
 	KubeClient  *kubernetes.Cluster
 	Config      *config.Config
 	Log         logr.Logger
@@ -74,8 +75,7 @@ func NewEpinioClient(flags *pflag.FlagSet) (*EpinioClient, error) {
 		return nil, err
 	}
 
-	client, err := GetGiteaClient()
-
+	client, err := gitea.New()
 	if err != nil {
 		return nil, err
 	}
@@ -1157,7 +1157,7 @@ func (c *EpinioClient) createRepo(name string) error {
 		return nil
 	}
 
-	_, _, err = c.GiteaClient.Client.CreateOrgRepo(c.Config.Org, gitea.CreateRepoOption{
+	_, _, err = c.GiteaClient.Client.CreateOrgRepo(c.Config.Org, giteaSDK.CreateRepoOption{
 		Name:          name,
 		AutoInit:      true,
 		Private:       true,
@@ -1174,7 +1174,7 @@ func (c *EpinioClient) createRepo(name string) error {
 }
 
 func (c *EpinioClient) createRepoWebhook(name string) error {
-	hooks, _, err := c.GiteaClient.Client.ListRepoHooks(c.Config.Org, name, gitea.ListHooksOptions{})
+	hooks, _, err := c.GiteaClient.Client.ListRepoHooks(c.Config.Org, name, giteaSDK.ListHooksOptions{})
 	if err != nil {
 		return errors.Wrap(err, "failed to list webhooks")
 	}
@@ -1189,7 +1189,7 @@ func (c *EpinioClient) createRepoWebhook(name string) error {
 
 	c.ui.Normal().Msg("Creating webhook in the repo...")
 
-	c.GiteaClient.Client.CreateRepoHook(c.Config.Org, name, gitea.CreateHookOption{
+	c.GiteaClient.Client.CreateRepoHook(c.Config.Org, name, giteaSDK.CreateHookOption{
 		Active:       true,
 		BranchFilter: "*",
 		Config: map[string]string{

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -595,10 +595,19 @@ func (c *EpinioClient) Info() error {
 		giteaVersion = version
 	}
 
+	epinioVersion := "unavailable"
+	if jsonResponse, err := c.get(api.Routes.Path("Info")); err == nil {
+		v := struct{ Version string }{}
+		if err := json.Unmarshal(jsonResponse, &v); err == nil {
+			epinioVersion = v.Version
+		}
+	}
+
 	c.ui.Success().
 		WithStringValue("Platform", platform.String()).
 		WithStringValue("Kubernetes Version", kubeVersion).
 		WithStringValue("Gitea Version", giteaVersion).
+		WithStringValue("Epinio Version", epinioVersion).
 		Msg("Epinio Environment")
 
 	return nil

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -20,9 +20,9 @@ import (
 	giteaSDK "code.gitea.io/sdk/gitea"
 	"github.com/epinio/epinio/deployments"
 	"github.com/epinio/epinio/helpers/kubernetes"
-	kubeconfig "github.com/epinio/epinio/helpers/kubernetes/config"
 	"github.com/epinio/epinio/helpers/kubernetes/tailer"
 	"github.com/epinio/epinio/helpers/termui"
+	"github.com/epinio/epinio/helpers/tracelog"
 	api "github.com/epinio/epinio/internal/api/v1"
 	"github.com/epinio/epinio/internal/api/v1/models"
 	"github.com/epinio/epinio/internal/application"
@@ -88,7 +88,7 @@ func NewEpinioClient(flags *pflag.FlagSet) (*EpinioClient, error) {
 	}
 	serverURL := epClient.URL
 
-	logger := kubeconfig.NewClientLogger()
+	logger := tracelog.NewClientLogger()
 	epinioClient := &EpinioClient{
 		GiteaClient: client,
 		KubeClient:  cluster,
@@ -1580,6 +1580,8 @@ func (c *EpinioClient) delete(endpoint string) ([]byte, error) {
 
 func (c *EpinioClient) curl(endpoint, method, requestBody string) ([]byte, error) {
 	uri := fmt.Sprintf("%s/%s", c.serverURL, endpoint)
+	c.Log.Info(fmt.Sprintf("%s %s", method, uri))
+	c.Log.V(1).Info(requestBody)
 	request, err := http.NewRequest(method, uri, strings.NewReader(requestBody))
 	if err != nil {
 		return []byte{}, err

--- a/internal/cli/clients/install_client.go
+++ b/internal/cli/clients/install_client.go
@@ -10,8 +10,8 @@ import (
 	"github.com/epinio/epinio/deployments"
 	"github.com/epinio/epinio/helpers"
 	"github.com/epinio/epinio/helpers/kubernetes"
-	kubeconfig "github.com/epinio/epinio/helpers/kubernetes/config"
 	"github.com/epinio/epinio/helpers/termui"
+	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/cli/config"
 	"github.com/epinio/epinio/internal/duration"
 	"github.com/go-logr/logr"
@@ -42,7 +42,7 @@ func NewInstallClient(flags *pflag.FlagSet, options *kubernetes.InstallationOpti
 	if err != nil {
 		return nil, nil, err
 	}
-	logger := kubeconfig.NewInstallClientLogger()
+	logger := tracelog.NewInstallClientLogger()
 	installClient := &InstallClient{
 		kubeClient: cluster,
 		ui:         uiUI,

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -31,6 +31,10 @@ var CmdPush = &cobra.Command{
 			path = args[1]
 		}
 
+		if _, err := os.Stat(path); err != nil {
+			return errors.Wrap(err, "path not accessible")
+		}
+
 		err = client.Push(args[0], path)
 		if err != nil {
 			return errors.Wrap(err, "error pushing app")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 
 	"github.com/epinio/epinio/helpers/kubernetes/config"
 	pconfig "github.com/epinio/epinio/internal/cli/config"
@@ -63,11 +64,21 @@ func Execute() {
 	rootCmd.AddCommand(CmdDisable)
 	rootCmd.AddCommand(CmdService)
 	rootCmd.AddCommand(CmdServer)
+	rootCmd.AddCommand(cmdVersion)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}
+}
+
+var cmdVersion = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Epinio Version: %s\n", version.Version)
+		fmt.Printf("Go Version: %s\n", runtime.Version())
+	},
 }
 
 func checkDependencies() error {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/epinio/epinio/helpers/kubernetes/config"
+	"github.com/epinio/epinio/helpers/tracelog"
 	pconfig "github.com/epinio/epinio/internal/cli/config"
 	"github.com/epinio/epinio/internal/duration"
 	"github.com/epinio/epinio/internal/version"
@@ -43,7 +44,7 @@ func Execute() {
 	argToEnv["config-file"] = "EPINIO_CONFIG"
 
 	config.KubeConfigFlags(pf, argToEnv)
-	config.LoggerFlags(pf, argToEnv)
+	tracelog.LoggerFlags(pf, argToEnv)
 	duration.Flags(pf, argToEnv)
 
 	pf.IntP("verbosity", "", 0, "Only print progress messages at or above this level (0 or 1, default 0)")


### PR DESCRIPTION
Several changes to the API (refers to #328), prepares PR #338



* Gitea related code was moved into a separate gitea package, so it can be reused without introducing cyclic imports
* Added a helper struct to register named routes and retrieve them later (better than constants, not as complicated as verbose as registered URLs in mux)
