### PR TITLE
Consistently use extensions/v1beta1 for ingress and hide warnings

### DIFF
--- a/assets/embedded-files/epinio/server.yaml
+++ b/assets/embedded-files/epinio/server.yaml
@@ -23,6 +23,7 @@ rules:
   - ingresses
   verbs:
   - list
+  - get
 - apiGroups:
   - networking.k8s.io
   resources:


### PR DESCRIPTION
networking v1 doesn't work for clusters <1.18 and extensions v1beta1 is
removed in 1.22. No need to show warning to the Epinio users. We will
handle this when 1.22 it out.

Fixes #188, #200 (and others ?)

When 1.22 is out we can say we no longer care about <1.18 and switch everything to networking/v1