### PR TITLE
Fix upload breakage for push with app directory

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -28,8 +28,16 @@ var _ = Describe("Apps", func() {
 		})
 
 		It("pushes and deletes an app", func() {
-			By("pushing the app")
+			By("pushing the app in the current working directory")
 			makeApp(appName)
+
+			By("deleting the app")
+			deleteApp(appName)
+		})
+
+		It("pushes and deletes an app", func() {
+			By("pushing the app in the specified app directory")
+			makeApp2(appName)
 
 			By("deleting the app")
 			deleteApp(appName)

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -82,7 +82,28 @@ func makeApp(appName string) string {
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	appDir := path.Join(currentDir, "../assets/sample-app")
 
+	// Note: appDir is handed to the working dir argument of Epinio().
+	// This means that the command runs with it as the CWD.
 	pushOutput, err := Epinio(fmt.Sprintf("apps push %s --verbosity 1", appName), appDir)
+	ExpectWithOffset(2, err).ToNot(HaveOccurred(), pushOutput)
+
+	// And check presence
+
+	out, err := Epinio("app list", "")
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)
+	ExpectWithOffset(1, out).To(MatchRegexp(appName + `.*\|.*1\/1.*\|.*`))
+
+	return pushOutput
+}
+
+func makeApp2(appName string) string {
+	currentDir, err := os.Getwd()
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	appDir := path.Join(currentDir, "../assets/sample-app")
+
+	// Note: appDir is handed as second argument to the epinio cli.
+	// This means that the command gets the sources from that directory instead of CWD.
+	pushOutput, err := Epinio(fmt.Sprintf("apps push %s %s --verbosity 1", appName, appDir), "")
 	ExpectWithOffset(2, err).ToNot(HaveOccurred(), pushOutput)
 
 	// And check presence

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -871,14 +871,21 @@ func (c *EpinioClient) Push(app string, source string) error {
 		return fmt.Errorf("%s: %s", "app name incorrect", strings.Join(errorMsgs, "\n"))
 	}
 
-	c.ui.Normal().Msg("Compressing application code ...")
+	c.ui.Normal().Msg("Collecting the application sources ...")
 	files, err := ioutil.ReadDir(source)
 	if err != nil {
 		return errors.Wrap(err, "canot read the apps source files")
 	}
 	sources := []string{}
 	for _, f := range files {
-		sources = append(sources, f.Name())
+		// The FileInfo entries returned by ReadDir provide
+		// only the base name of the file or directory they
+		// are for. We have to add back the path of the
+		// application directory to get the proper paths to
+		// the files and directories to assemble in the
+		// tarball.
+
+		sources = append(sources, path.Join(source, f.Name()))
 	}
 	log.V(3).Info("found app data files", "files", sources)
 


### PR DESCRIPTION
Fixes #353 

Added app source dir back to list of dir entries
Because the dir may not be the local cwd.
Added test pushing an app via name and path, instead of name and cwd.