### PR TITLE
feat: Enable the binding of services to an app as part of `push`

### DIFF
--- a/acceptance/api_v1_services_mutation_test.go
+++ b/acceptance/api_v1_services_mutation_test.go
@@ -524,7 +524,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 			var responseBody map[string][]apiv1.APIError
 			json.Unmarshal(bodyBytes, &responseBody)
 			Expect(responseBody["errors"][0].Title).To(
-				Equal("service 'bogus' not found"))
+				Equal("Service 'bogus' does not exist"))
 
 		})
 
@@ -660,13 +660,13 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 			var responseBody map[string][]apiv1.APIError
 			json.Unmarshal(bodyBytes, &responseBody)
 			Expect(responseBody["errors"][0].Title).To(
-				Equal("Cannot bind service without a name"))
+				Equal("Cannot bind service without names"))
 		})
 
 		It("returns a 'not found' when the org does not exist", func() {
 			response, err := Curl("POST",
 				fmt.Sprintf("%s/api/v1/orgs/bogus/applications/_dummy_/servicebindings", serverURL),
-				strings.NewReader(`{ "name": "meh" }`))
+				strings.NewReader(`{ "names": ["meh"] }`))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 
@@ -683,7 +683,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 		It("returns a 'not found' when the application does not exist", func() {
 			response, err := Curl("POST",
 				fmt.Sprintf("%s/api/v1/orgs/%s/applications/bogus/servicebindings", serverURL, org),
-				strings.NewReader(`{ "name": "meh" }`))
+				strings.NewReader(`{ "names": ["meh"] }`))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 
@@ -694,7 +694,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 			var responseBody map[string][]apiv1.APIError
 			json.Unmarshal(bodyBytes, &responseBody)
 			Expect(responseBody["errors"][0].Title).To(
-				Equal("application 'bogus' not found"))
+				Equal("Application 'bogus' does not exist"))
 		})
 
 		Context("with application", func() {
@@ -717,7 +717,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 				response, err := Curl("POST",
 					fmt.Sprintf("%s/api/v1/orgs/%s/applications/%s/servicebindings",
 						serverURL, org, app),
-					strings.NewReader(`{ "name": "bogus" }`))
+					strings.NewReader(`{ "names": ["bogus"] }`))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response).ToNot(BeNil())
 
@@ -728,7 +728,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 				var responseBody map[string][]apiv1.APIError
 				json.Unmarshal(bodyBytes, &responseBody)
 				Expect(responseBody["errors"][0].Title).To(
-					Equal("service 'bogus' not found"))
+					Equal("Service 'bogus' does not exist"))
 			})
 
 			Context("and already bound", func() {
@@ -740,7 +740,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 					response, err := Curl("POST",
 						fmt.Sprintf("%s/api/v1/orgs/%s/applications/%s/servicebindings",
 							serverURL, org, app),
-						strings.NewReader(fmt.Sprintf(`{ "name": "%s" }`, service)))
+						strings.NewReader(fmt.Sprintf(`{ "names": ["%s"] }`, service)))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(response).ToNot(BeNil())
 
@@ -751,7 +751,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 					var responseBody map[string][]apiv1.APIError
 					json.Unmarshal(bodyBytes, &responseBody)
 					Expect(responseBody["errors"][0].Title).To(
-						Equal("service '" + service + "' already bound"))
+						Equal("Service '" + service + "' already bound"))
 				})
 			})
 
@@ -759,7 +759,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 				response, err := Curl("POST",
 					fmt.Sprintf("%s/api/v1/orgs/%s/applications/%s/servicebindings",
 						serverURL, org, app),
-					strings.NewReader(fmt.Sprintf(`{ "name": "%s" }`, service)))
+					strings.NewReader(fmt.Sprintf(`{ "names": ["%s"] }`, service)))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response).ToNot(BeNil())
 
@@ -815,7 +815,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 			var responseBody map[string][]apiv1.APIError
 			json.Unmarshal(bodyBytes, &responseBody)
 			Expect(responseBody["errors"][0].Title).To(
-				Equal("application 'bogus' not found"))
+				Equal("Application 'bogus' does not exist"))
 		})
 
 		Context("with application", func() {
@@ -845,7 +845,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 				var responseBody map[string][]apiv1.APIError
 				json.Unmarshal(bodyBytes, &responseBody)
 				Expect(responseBody["errors"][0].Title).To(
-					Equal("service 'bogus' not found"))
+					Equal("Service 'bogus' does not exist"))
 			})
 
 			Context("with service", func() {
@@ -896,7 +896,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 					var responseBody map[string][]apiv1.APIError
 					json.Unmarshal(bodyBytes, &responseBody)
 					Expect(responseBody["errors"][0].Title).To(
-						Equal("service '" + service + "' is not bound"))
+						Equal("Service '" + service + "' is not bound"))
 				})
 			})
 		})

--- a/internal/api/v1/errors.go
+++ b/internal/api/v1/errors.go
@@ -1,0 +1,96 @@
+package v1
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type APIError struct {
+	Status  int
+	Title   string
+	Details string
+}
+
+// Satisfy the error interface
+func (err APIError) Error() string {
+	return err.Title
+}
+
+func NewAPIError(message, details string, status int) APIError {
+	return APIError{
+		Title:   message,
+		Details: details,
+		Status:  status,
+	}
+}
+
+type APIErrors []APIError
+
+// All our actions match this type. They can return a list of errors.
+// The "Status" of the first error in the list becomes the response Status Code.
+type APIActionFunc func(http.ResponseWriter, *http.Request) APIErrors
+
+func InternalError(err error) APIError {
+	return NewAPIError(err.Error(), "", http.StatusInternalServerError)
+}
+
+func BadRequest(err error, details ...string) APIError {
+	return NewAPIError(err.Error(), strings.Join(details, ", "), http.StatusBadRequest)
+}
+
+func OrgIsNotKnown(org string) APIError {
+	return NewAPIError(
+		fmt.Sprintf("Organization '%s' does not exist", org),
+		"",
+		http.StatusNotFound)
+}
+
+func AppIsNotKnown(app string) APIError {
+	return NewAPIError(
+		fmt.Sprintf("Application '%s' does not exist", app),
+		"",
+		http.StatusNotFound)
+}
+
+func ServiceIsNotKnown(service string) APIError {
+	return NewAPIError(
+		fmt.Sprintf("Service '%s' does not exist", service),
+		"",
+		http.StatusNotFound)
+}
+
+func ServiceClassIsNotKnown(serviceclass string) APIError {
+	return NewAPIError(
+		fmt.Sprintf("ServiceClass '%s' does not exist", serviceclass),
+		"",
+		http.StatusNotFound)
+}
+
+func OrgAlreadyKnown(org string) APIError {
+	return NewAPIError(
+		fmt.Sprintf("Organization '%s' already exists", org),
+		"",
+		http.StatusConflict)
+}
+
+func ServiceAlreadyKnown(service string) APIError {
+	return NewAPIError(
+		fmt.Sprintf("Service '%s' already exists", service),
+		"",
+		http.StatusConflict)
+}
+
+func ServiceAlreadyBound(service string) APIError {
+	return NewAPIError(
+		fmt.Sprintf("Service '%s' already bound", service),
+		"",
+		http.StatusConflict)
+}
+
+func ServiceIsNotBound(service string) APIError {
+	return NewAPIError(
+		fmt.Sprintf("Service '%s' is not bound", service),
+		"",
+		http.StatusBadRequest)
+}

--- a/internal/api/v1/info.go
+++ b/internal/api/v1/info.go
@@ -18,12 +18,12 @@ func (hc InfoController) Info(w http.ResponseWriter, r *http.Request) APIErrors 
 	}
 	js, err := json.Marshal(info)
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(js)
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	return nil

--- a/internal/api/v1/models/models.go
+++ b/internal/api/v1/models/models.go
@@ -32,7 +32,7 @@ type DeleteResponse struct {
 }
 
 type BindRequest struct {
-	Name string `json:"name"`
+	Names []string `json:"names"`
 }
 
 // TODO: CreateOrgRequest

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -12,31 +12,6 @@ import (
 
 const v = "/api/v1"
 
-type APIError struct {
-	Status  int
-	Title   string
-	Details string
-}
-
-// Satisfy the error interface
-func (err APIError) Error() string {
-	return err.Title
-}
-
-func NewAPIError(message, details string, status int) APIError {
-	return APIError{
-		Title:   message,
-		Details: details,
-		Status:  status,
-	}
-}
-
-type APIErrors []APIError
-
-// All our actions match this type. They can return a list of errors.
-// The "Status" of the first error in the list becomes the response Status Code.
-type APIActionFunc func(http.ResponseWriter, *http.Request) APIErrors
-
 func errorHandler(action APIActionFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		responseErrors := action(w, r)

--- a/internal/api/v1/servicebindings.go
+++ b/internal/api/v1/servicebindings.go
@@ -2,13 +2,13 @@ package v1
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/models"
 	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/internal/interfaces"
 	"github.com/epinio/epinio/internal/organizations"
 	"github.com/epinio/epinio/internal/services"
 	"github.com/julienschmidt/httprouter"
@@ -18,6 +18,11 @@ import (
 type ServicebindingsController struct {
 }
 
+// General behaviour: Internal errors (5xx) abort an action.
+// Non-internal errors and warnings may be reported with it,
+// however always after it. IOW an internal error is always
+// the first element when reporting more than one error.
+
 func (hc ServicebindingsController) Create(w http.ResponseWriter, r *http.Request) APIErrors {
 	params := httprouter.ParamsFromContext(r.Context())
 	org := params.ByName("org")
@@ -26,71 +31,90 @@ func (hc ServicebindingsController) Create(w http.ResponseWriter, r *http.Reques
 	defer r.Body.Close()
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	var bindRequest models.BindRequest
 	err = json.Unmarshal(bodyBytes, &bindRequest)
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusBadRequest)}
+		return APIErrors{BadRequest(err)}
 	}
 
-	if bindRequest.Name == "" {
-		err := errors.New("Cannot bind service without a name")
-		if err != nil {
-			return APIErrors{NewAPIError(err.Error(), "", http.StatusBadRequest)}
+	if len(bindRequest.Names) == 0 {
+		err := errors.New("Cannot bind service without names")
+		return APIErrors{BadRequest(err)}
+	}
+
+	for _, serviceName := range bindRequest.Names {
+		if serviceName == "" {
+			err := errors.New("Cannot bind service with empty name")
+			return APIErrors{BadRequest(err)}
 		}
 	}
 
 	cluster, err := kubernetes.GetCluster()
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	exists, err := organizations.Exists(cluster, org)
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 	if !exists {
-		return APIErrors{
-			NewAPIError(fmt.Sprintf("Organization '%s' does not exist", org), "", http.StatusNotFound),
-		}
+		return APIErrors{OrgIsNotKnown(org)}
 	}
 
 	app, err := application.Lookup(cluster, org, appName)
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 	if app == nil {
-		return APIErrors{
-			NewAPIError(fmt.Sprintf("application '%s' not found", appName), "", http.StatusNotFound),
+		return APIErrors{AppIsNotKnown(appName)}
+	}
+
+	// From here on out we collect errors and warnings per
+	// service, to report as much as possible while also applying
+	// as much as possible. IOW even when errors are reported it
+	// is possible for some of the services to be properly bound.
+
+	var theServices interfaces.ServiceList
+	var theIssues APIErrors
+
+	for _, serviceName := range bindRequest.Names {
+		service, err := services.Lookup(cluster, org, serviceName)
+		if err != nil {
+			if err.Error() == "service not found" {
+				theIssues = append(theIssues, ServiceIsNotKnown(serviceName))
+				continue
+			}
+
+			return append(APIErrors{InternalError(err)}, theIssues...)
+		}
+
+		theServices = append(theServices, service)
+	}
+
+	for _, service := range theServices {
+		err = app.Bind(service)
+		if err != nil {
+			if err.Error() == "service already bound" {
+				theIssues = append(theIssues, ServiceAlreadyBound(service.Name()))
+				continue
+			}
+
+			return append(APIErrors{InternalError(err)}, theIssues...)
 		}
 	}
 
-	service, err := services.Lookup(cluster, org, bindRequest.Name)
-	if err != nil && err.Error() == "service not found" {
-		return APIErrors{
-			NewAPIError(fmt.Sprintf("service '%s' not found", bindRequest.Name), "", http.StatusNotFound),
-		}
-	}
-	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
-	}
-
-	err = app.Bind(service)
-	if err != nil && err.Error() == "service already bound" {
-		return APIErrors{
-			NewAPIError(fmt.Sprintf("service '%s' already bound", bindRequest.Name), "", http.StatusConflict),
-		}
-	}
-	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+	if len(theIssues) > 0 {
+		return theIssues
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write([]byte{})
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return append(APIErrors{InternalError(err)}, theIssues...)
 	}
 
 	return nil
@@ -104,53 +128,45 @@ func (hc ServicebindingsController) Delete(w http.ResponseWriter, r *http.Reques
 
 	cluster, err := kubernetes.GetCluster()
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	exists, err := organizations.Exists(cluster, org)
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 	if !exists {
-		return APIErrors{
-			NewAPIError(fmt.Sprintf("Organization '%s' does not exist", org), "", http.StatusNotFound),
-		}
+		return APIErrors{OrgIsNotKnown(org)}
 	}
 
 	app, err := application.Lookup(cluster, org, appName)
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 	if app == nil {
-		return APIErrors{
-			NewAPIError(fmt.Sprintf("application '%s' not found", appName), "", http.StatusNotFound),
-		}
+		return APIErrors{AppIsNotKnown(appName)}
 	}
 
 	service, err := services.Lookup(cluster, org, serviceName)
 	if err != nil && err.Error() == "service not found" {
-		return APIErrors{
-			NewAPIError(fmt.Sprintf("service '%s' not found", serviceName), "", http.StatusNotFound),
-		}
+		return APIErrors{ServiceIsNotKnown(serviceName)}
 	}
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	err = app.Unbind(service)
 	if err != nil && err.Error() == "service is not bound to the application" {
-		return APIErrors{
-			NewAPIError(fmt.Sprintf("service '%s' is not bound", serviceName), "", http.StatusBadRequest),
-		}
+		return APIErrors{ServiceIsNotBound(serviceName)}
 	}
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write([]byte{})
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	return nil

--- a/internal/api/v1/servicebindings.go
+++ b/internal/api/v1/servicebindings.go
@@ -114,7 +114,7 @@ func (hc ServicebindingsController) Create(w http.ResponseWriter, r *http.Reques
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write([]byte{})
 	if err != nil {
-		return append(APIErrors{InternalError(err)}, theIssues...)
+		return APIErrors{InternalError(err)}
 	}
 
 	return nil

--- a/internal/api/v1/serviceclasses.go
+++ b/internal/api/v1/serviceclasses.go
@@ -14,17 +14,17 @@ type ServiceClassesController struct {
 func (scc ServiceClassesController) Index(w http.ResponseWriter, r *http.Request) APIErrors {
 	cluster, err := kubernetes.GetCluster()
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	serviceClasses, err := services.ListClasses(cluster)
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	js, err := json.Marshal(serviceClasses)
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(js)

--- a/internal/api/v1/serviceplans.go
+++ b/internal/api/v1/serviceplans.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
@@ -19,33 +18,30 @@ func (spc ServicePlansController) Index(w http.ResponseWriter, r *http.Request) 
 
 	cluster, err := kubernetes.GetCluster()
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	serviceClass, err := services.ClassLookup(cluster, serviceClassName)
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	if serviceClass == nil {
-		return APIErrors{
-			NewAPIError(fmt.Sprintf("ServiceClass '%s' does not exist", serviceClassName),
-				"", http.StatusNotFound),
-		}
+		return APIErrors{ServiceClassIsNotKnown(serviceClassName)}
 	}
 	servicePlans, err := serviceClass.ListPlans()
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	js, err := json.Marshal(servicePlans)
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(js)
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	return nil

--- a/internal/api/v1/upload.go
+++ b/internal/api/v1/upload.go
@@ -27,7 +27,7 @@ func (hc ApplicationsController) Upload(w http.ResponseWriter, r *http.Request) 
 
 	gitea, err := gitea.New()
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	log.V(2).Info("parsing multipart form")
@@ -79,14 +79,14 @@ func (hc ApplicationsController) Upload(w http.ResponseWriter, r *http.Request) 
 	log.V(2).Info("create gitea app")
 	err = gitea.CreateApp(org, app, appDir)
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	js, _ := json.Marshal(struct{ Message string }{"ok"})
 	_, err = w.Write(js)
 	if err != nil {
-		return APIErrors{NewAPIError(err.Error(), "", http.StatusInternalServerError)}
+		return APIErrors{InternalError(err)}
 	}
 
 	return nil

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -857,10 +857,8 @@ func (c *EpinioClient) Push(app, source string, services []string) error {
 	services = uniqueStrings(services)
 
 	if len(services) > 0 {
-		msg = msg.WithTable("Service")
-		for _, serviceName := range services {
-			msg = msg.WithTableRow(serviceName)
-		}
+		sort.Strings(services)
+		msg = msg.WithStringValue("Services:", strings.Join(services, ", "))
 	}
 
 	msg.Msg("About to push an application with given name and sources into the specified organization")


### PR DESCRIPTION
Fixes #303

INCOMPATIBILITY: API CHANGE
	Modified service bind requests to carry an array of service
	names, instead of a single name.

Enables the binding of multiple services to one app in a single API
call.

Modified the receiver to match.
Note that the receiver still performs the binds sequentially.

TODO: Collect as many errors as possible to return in a single
response.

Updated the `service bind` command to match.

Extended the `push` command to accept services to be bound, via a new
option `--bind`/`-b` for `push`. Note that the option allows the
specification of multiple services (1). The code removes duplicates in
the specified set of services.

Added command completion for `--bind`.

__Simple implementation__: Internally does what the user would otherwise
do manually, i.e.

  - push the app
  - bind the specified services to the app, one after the other

The only optimization right now is that the entire set of services is
transfered to the server in a single bind call.

__Optimizations__ like adding the services to the app kube deployment as
part of starting the app, instead of via separate updates, are __defered__
until we have separated uploading the app sources from starting the
app (2).

----

  1. Example: `... --bind service1,service2 --bind service3`

  2. Currently app start is automatically triggered by the source
upload (into gitea). See issues #347 and #358 for the requisite work
needed.