### PR TITLE
feat: show table entries in sorted order

### DIFF
--- a/internal/api/v1/models/sort.go
+++ b/internal/api/v1/models/sort.go
@@ -1,0 +1,15 @@
+package models
+
+// Implement the Sort interface for service response slices
+
+func (srl ServiceResponseList) Len() int {
+	return len(srl)
+}
+
+func (srl ServiceResponseList) Swap(i, j int) {
+	srl[i], srl[j] = srl[j], srl[i]
+}
+
+func (srl ServiceResponseList) Less(i, j int) bool {
+	return srl[i].Name < srl[j].Name
+}

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -274,3 +274,17 @@ func (app *Application) Complete() (*Application, error) {
 
 	return app, nil
 }
+
+// Implement the Sort interface for application slices
+
+func (al ApplicationList) Len() int {
+	return len(al)
+}
+
+func (al ApplicationList) Swap(i, j int) {
+	al[i], al[j] = al[j], al[i]
+}
+
+func (al ApplicationList) Less(i, j int) bool {
+	return al[i].Name < al[j].Name
+}

--- a/internal/services/catalog_service.go
+++ b/internal/services/catalog_service.go
@@ -51,6 +51,34 @@ type ServicePlan struct {
 
 type ServicePlanList []ServicePlan
 
+// Implement the Sort interface for service class slices
+
+func (scl ServiceClassList) Len() int {
+	return len(scl)
+}
+
+func (scl ServiceClassList) Swap(i, j int) {
+	scl[i], scl[j] = scl[j], scl[i]
+}
+
+func (scl ServiceClassList) Less(i, j int) bool {
+	return scl[i].Name < scl[j].Name
+}
+
+// Implement the Sort interface for service plan slices
+
+func (spl ServicePlanList) Len() int {
+	return len(spl)
+}
+
+func (spl ServicePlanList) Swap(i, j int) {
+	spl[i], spl[j] = spl[j], spl[i]
+}
+
+func (spl ServicePlanList) Less(i, j int) bool {
+	return spl[i].Name < spl[j].Name
+}
+
 // LookupPlan returns the named ServicePlan, for the specified class
 func (sc *ServiceClass) LookupPlan(plan string) (*ServicePlan, error) {
 	servicePlanGVR := schema.GroupVersionResource{


### PR DESCRIPTION
UI polish.

Sort the contents of various tables (orgs, apps, services, service classes, service plans), by name.
Further sort some dependent information (bound apps, services) in table entries, by name.
