### PR TITLE
feat: apply basic auth to API ingress

### DIFF
--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -43,6 +43,8 @@ const (
 	afterEachSleepPath  = "../tmp/after_each_sleep"
 	k3dInstallArgsEnv   = "EPINIO_K3D_INSTALL_ARGS" // -p '80:80@server[0]' -p '443:443@server[0]'
 	skipEpinioPatch     = "EPINIO_SKIP_PATCH"
+	epinioUser          = "test-user"
+	epinioPassword      = "secure-testing"
 )
 
 var _ = SynchronizedBeforeSuite(func() []byte {
@@ -255,8 +257,11 @@ func ensureEpinio() {
 		}
 	}
 	fmt.Println("Installing Epinio")
-	// Allow the installation to continue
-	out, err = RunProc("../dist/epinio-linux-amd64 install --skip-default-org", "", false)
+	// Allow the installation to continue by not trying to create the default org
+	// before we patch.
+	out, err = RunProc(
+		fmt.Sprintf("../dist/epinio-linux-amd64 install --skip-default-org --user %s --password %s", epinioUser, epinioPassword),
+		"", false)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)
 }
 

--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -46,6 +46,8 @@ const (
 )
 
 var _ = SynchronizedBeforeSuite(func() []byte {
+	// Singleton setup. Run on node 1 before all
+
 	fmt.Printf("I'm running on runner = %s\n", os.Getenv("HOSTNAME"))
 
 	if os.Getenv(registryUsernameEnv) == "" || os.Getenv(registryPasswordEnv) == "" {
@@ -61,6 +63,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	os.Setenv("EPINIO_BINARY_PATH", path.Join("dist", "epinio-linux-amd64"))
 	os.Setenv("EPINIO_DONT_WAIT_FOR_DEPLOYMENT", "1")
+	os.Setenv("EPINIO_CONFIG", "epinio.yaml") // In test directory
 
 	fmt.Println("Ensuring a docker network")
 	out, err := ensureRegistryNetwork()
@@ -152,6 +155,10 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	}, "3m").ShouldNot(HaveOccurred(), out)
 
 	os.Setenv("EPINIO_CONFIG", nodeTmpDir+"/epinio.yaml")
+
+	// Get config from the installation (API credentials)
+	out, err = RunProc(fmt.Sprintf("cp epinio.yaml %s/epinio.yaml", nodeTmpDir), "", false)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)
 
 	out, err = Epinio("target workspace", nodeTmpDir)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)

--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -284,7 +284,8 @@ func ensureCluster(k3dClusterName string) {
 		if notExists {
 			fmt.Printf("k3d cluster %s doesn't exist. I will try to create it.\n", k3dClusterName)
 			out, err := RunProc(
-				fmt.Sprintf("k3d cluster create %s --registry-config %s --network %s %s",
+				fmt.Sprintf("k3d cluster create %s --registry-config %s --network %s %s"+
+					" --k3s-server-arg --disable --k3s-server-arg traefik",
 					k3dClusterName, tmpk3dConfig, networkName, os.Getenv(k3dInstallArgsEnv)),
 				"", false)
 			if err != nil {

--- a/acceptance/api_v1_applications_test.go
+++ b/acceptance/api_v1_applications_test.go
@@ -218,6 +218,7 @@ var _ = Describe("Apps API Application Endpoints", func() {
 
 			// make the request
 			request, err := http.NewRequest("POST", url, body)
+			request.SetBasicAuth("me", "change")
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to build request")
 			}

--- a/acceptance/api_v1_applications_test.go
+++ b/acceptance/api_v1_applications_test.go
@@ -218,7 +218,7 @@ var _ = Describe("Apps API Application Endpoints", func() {
 
 			// make the request
 			request, err := http.NewRequest("POST", url, body)
-			request.SetBasicAuth("me", "change")
+			request.SetBasicAuth(epinioUser, epinioPassword)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to build request")
 			}

--- a/acceptance/api_v1_orgs_test.go
+++ b/acceptance/api_v1_orgs_test.go
@@ -45,6 +45,15 @@ var _ = Describe("Orgs API Application Endpoints", func() {
 				// See global BeforeEach for where this org is set up.
 				Expect(orgs).Should(ContainElements(org))
 			})
+			When("basic auth credentials are not provided", func() {
+				It("returns a 401 response", func() {
+					request, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/orgs", serverURL), strings.NewReader(""))
+					Expect(err).ToNot(HaveOccurred())
+					response, err := (&http.Client{}).Do(request)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+				})
+			})
 		})
 
 		Describe("POST api/v1/orgs", func() {

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -35,6 +35,7 @@ func newServiceName() string {
 // func Curl is used to make requests against a server
 func Curl(method, uri string, requestBody *strings.Reader) (*http.Response, error) {
 	request, err := http.NewRequest(method, uri, requestBody)
+	request.SetBasicAuth("me", "change")
 	if err != nil {
 		return nil, err
 	}

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -35,7 +35,7 @@ func newServiceName() string {
 // func Curl is used to make requests against a server
 func Curl(method, uri string, requestBody *strings.Reader) (*http.Response, error) {
 	request, err := http.NewRequest(method, uri, requestBody)
-	request.SetBasicAuth("me", "change")
+	request.SetBasicAuth(epinioUser, epinioPassword)
 	if err != nil {
 		return nil, err
 	}

--- a/assets/embedded-files/epinio/basicauth.yaml
+++ b/assets/embedded-files/epinio/basicauth.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: epinio-api-auth
+  namespace: epinio
+spec:
+  basicAuth:
+    secret: epinio-api-auth-secret

--- a/assets/embedded-files/epinio/server.yaml
+++ b/assets/embedded-files/epinio/server.yaml
@@ -1,5 +1,13 @@
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: epinio-api-auth-secret
+  namespace: epinio
+data:
+  users: "##api_credentials##"
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: epinio-server

--- a/docs/install.md
+++ b/docs/install.md
@@ -84,11 +84,8 @@ microk8s enable metallb:${IP}/16
 
 ## Prerequisites
 
-- bash
-- git 2.22 or later
 - helm (3.0 or later)
 - kubectl (1.18 or later)
-- openssl
 
 Where no explicit version number is given, a release not older than
 ~2 years is assumed.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	code.gitea.io/sdk/gitea v0.13.2
 	github.com/Azure/go-autorest/autorest v0.11.17 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.10 // indirect
+	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
 	github.com/briandowns/spinner v1.12.0
 	github.com/codeskyblue/kexec v0.0.0-20180119015717-5a4bed90d99a
 	github.com/fatih/color v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317/go.mod h1:DF8FZRxMHMGv/vP2lQP6h+dYzzjpuRn24VeRiYn3qjQ=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
+github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962 h1:KeNholpO2xKjgaaSyd+DyQRrsQjhbSeS7qe4nEw8aQw=
+github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962/go.mod h1:kC29dT1vFpj7py2OvG1khBdQpo3kInWP+6QipLbdngo=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -1205,6 +1205,8 @@ func (c *EpinioClient) upload(endpoint string, path string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build request")
 	}
+
+	request.SetBasicAuth(c.Config.User, c.Config.Password)
 	request.Header.Add("Content-Type", writer.FormDataContentType())
 
 	response, err := (&http.Client{}).Do(request)
@@ -1234,6 +1236,9 @@ func (c *EpinioClient) curl(endpoint, method, requestBody string) ([]byte, error
 	if err != nil {
 		return []byte{}, err
 	}
+
+	request.SetBasicAuth(c.Config.User, c.Config.Password)
+
 	response, err := (&http.Client{}).Do(request)
 	if err != nil {
 		return []byte{}, err
@@ -1264,6 +1269,9 @@ func (c *EpinioClient) curlWithCustomErrorHandling(endpoint, method, requestBody
 	if err != nil {
 		return []byte{}, err
 	}
+
+	request.SetBasicAuth(c.Config.User, c.Config.Password)
+
 	response, err := (&http.Client{}).Do(request)
 	if err != nil {
 		return []byte{}, err

--- a/internal/cli/clients/install_client.go
+++ b/internal/cli/clients/install_client.go
@@ -92,6 +92,25 @@ func (c *InstallClient) Install(cmd *cobra.Command) error {
 	details.Info("show option configuration")
 	c.showInstallConfiguration(c.options)
 
+	// Take the API credentials from the options and save them to
+	// the epinio configuration.
+	apiUser, err := c.options.GetOpt("user", "")
+	if err != nil {
+		return err
+	}
+
+	apiPassword, err := c.options.GetOpt("password", "")
+	if err != nil {
+		return err
+	}
+
+	c.config.User = apiUser.Value.(string)
+	c.config.Password = apiPassword.Value.(string)
+	err = c.config.Save()
+	if err != nil {
+		return errors.Wrap(err, "failed to save configuration")
+	}
+
 	// TODO (post MVP): Run a validation phase which perform
 	// additional checks on the values. For example range limits,
 	// proper syntax of the string, etc. do it as pghase, and late
@@ -140,7 +159,11 @@ func (c *InstallClient) Install(cmd *cobra.Command) error {
 
 	installationWg.Wait()
 
-	c.ui.Success().WithStringValue("System domain", domain.Value.(string)).Msg("Epinio installed.")
+	c.ui.Success().
+		WithStringValue("System domain", domain.Value.(string)).
+		WithStringValue("API User", c.config.User).
+		WithStringValue("API Password", c.config.Password).
+		Msg("Epinio installed.")
 
 	return nil
 }

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	GiteaProtocol  string `mapstructure:"gitea_protocol"`
 	EpinioProtocol string `mapstructure:"epinio_protocol"`
 	Org            string `mapstructure:"org"`
+	User           string `mapstructure:"user"`
+	Password       string `mapstructure:"pass"`
 
 	v *viper.Viper
 }
@@ -41,6 +43,10 @@ func Load() (*Config, error) {
 	v.SetDefault("gitea_protocol", "http")
 	v.SetDefault("epinio_protocol", "http")
 	v.SetDefault("org", "workspace")
+
+	// Use empty defaults in viper to allow NeededOptions defaults to apply
+	v.SetDefault("user", "")
+	v.SetDefault("pass", "")
 
 	configExists, err := fileExists(file)
 	if err != nil {
@@ -68,6 +74,8 @@ func Load() (*Config, error) {
 // Save saves the Epinio config
 func (c *Config) Save() error {
 	c.v.Set("org", c.Org)
+	c.v.Set("user", c.User)
+	c.v.Set("pass", c.Password)
 
 	err := os.MkdirAll(filepath.Dir(c.v.ConfigFileUsed()), 0700)
 	if err != nil {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -22,6 +22,20 @@ var NeededOptions = kubernetes.InstallationOptions{
 		Default:     "epinio@suse.com",
 		Value:       "",
 	},
+	{
+		Name:        "user",
+		Description: "The user name for authenticating all API requests",
+		Type:        kubernetes.StringType,
+		Default:     "me",
+		Value:       "",
+	},
+	{
+		Name:        "password",
+		Description: "The password for authenticating all API requests",
+		Type:        kubernetes.StringType,
+		Default:     "change",
+		Value:       "",
+	},
 }
 
 const (


### PR DESCRIPTION
Fixes #350 

Note: Uses fixed credentials at the moment.
Todo:
  - setup user-chosen credentials during install,
  -  save to config,
  -  get from config.

The auth is working, i.e. traefik v1 (1) processed the annotations and activates auth handling.
API requests with the auth credentials work. Without they get `401 unauthorized`.

----
  1. That is k3d/k3s builtin traefik. The epinio traefik is v2 and has to checked to be working. If not, setup for it will be required also.

