### PR TITLE
Always use cert-manager to generate workload certs

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -2,8 +2,11 @@ package acceptance_test
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path"
+	"regexp"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -33,7 +36,14 @@ var _ = Describe("Apps", func() {
 
 		It("pushes and deletes an app", func() {
 			By("pushing the app in the current working directory")
-			makeApp(appName)
+			out := makeApp(appName)
+
+			routeRegexp := regexp.MustCompile(`https:\/\/.*omg.howdoi.website`)
+			route := string(routeRegexp.Find([]byte(out)))
+
+			resp, err := Curl("GET", route, strings.NewReader(""))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			By("deleting the app")
 			deleteApp(appName)

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -1,6 +1,7 @@
 package acceptance_test
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"os"
@@ -37,7 +38,10 @@ func Curl(method, uri string, requestBody *strings.Reader) (*http.Response, erro
 	if err != nil {
 		return nil, err
 	}
-	return (&http.Client{}).Do(request)
+	transCfg := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // self signed certs
+	}
+	return (&http.Client{Transport: transCfg}).Do(request)
 }
 
 func setupAndTargetOrg(org string) {

--- a/assets/embedded-files/epinio/server.yaml
+++ b/assets/embedded-files/epinio/server.yaml
@@ -98,6 +98,12 @@ rules:
   - quarkssecrets
   verbs:
   - create
+- apiGroups:
+  - "cert-manager.io"
+  resources:
+  - certificates
+  verbs:
+  - create
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/internal/api/v1/stage.go
+++ b/internal/api/v1/stage.go
@@ -179,7 +179,7 @@ func createCertificates(ctx context.Context, cfg *rest.Config, app gitea.App) er
 			return errors.Wrap(err, "create production ssl certificate failed")
 		}
 	} else {
-		err = createCertificate(ctx, cfg, app, c.Domain, "selfsigned-issuers")
+		err = createCertificate(ctx, cfg, app, c.Domain, "selfsigned-issuer")
 		if err != nil {
 			return errors.Wrap(err, "create local ssl certificate failed")
 		}

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -770,14 +770,9 @@ func (c *EpinioClient) Delete(appname string) error {
 	}
 
 	if !strings.Contains(c.GiteaClient.Domain, "omg.howdoi.website") {
-		err = c.deleteProductionCertificate(appname)
+		err = c.deleteCertificate(appname)
 		if err != nil {
-			return errors.Wrap(err, "failed to delete production certificate")
-		}
-	} else {
-		err = c.deleteLocalCertificate(appname)
-		if err != nil {
-			return errors.Wrap(err, "failed to delete local certificate")
+			return errors.Wrap(err, "failed to delete certificate")
 		}
 	}
 
@@ -1053,28 +1048,7 @@ func (c *EpinioClient) check() {
 	c.GiteaClient.Client.GetMyUserInfo()
 }
 
-func (c *EpinioClient) deleteLocalCertificate(appName string) error {
-	quarksSecretInstanceGVR := schema.GroupVersionResource{
-		Group:    "quarks.cloudfoundry.org",
-		Version:  "v1alpha1",
-		Resource: "quarkssecrets",
-	}
-
-	dynamicClient, err := dynamic.NewForConfig(c.KubeClient.RestConfig)
-	if err != nil {
-		return err
-	}
-
-	err = dynamicClient.Resource(quarksSecretInstanceGVR).Namespace(c.Config.Org).
-		Delete(context.Background(), appName, metav1.DeleteOptions{})
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (c *EpinioClient) deleteProductionCertificate(appName string) error {
+func (c *EpinioClient) deleteCertificate(appName string) error {
 	certificateInstanceGVR := schema.GroupVersionResource{
 		Group:    "cert-manager.io",
 		Version:  "v1alpha2",


### PR DESCRIPTION
Tests didn't test cert-manager since it was only used in prod.

This adds the missing RBAC for the server to create certificates. 
I don't have a production env to test, but https://github.com/epinio/epinio/pull/360 moved the certificate creation into the server and didn't add permissions. Tests couldn't detect it.

Now dev/CI and prod are closer.