### PR TITLE
393-Ignore errors about existing certificates

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -57,6 +57,16 @@ var _ = Describe("Apps", func() {
 			deleteApp(appName)
 		})
 
+		It("pushes the same app again successfully", func() {
+			makeApp(appName, 1, false)
+
+			By("pushing the app again")
+			makeApp(appName, 1, false)
+
+			By("deleting the app")
+			deleteApp(appName)
+		})
+
 		It("pushes an application with the desired number of instances", func() {
 			app := newAppName()
 			makeApp(app, 3, true)

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -97,7 +97,7 @@ func makeApp(appName string, instances int, deployFromCurrentDir bool) string {
 		// This means that the command gets the sources from that directory instead of CWD.
 		pushOutput, err = Epinio(fmt.Sprintf("apps push %s %s --verbosity 1", appName, appDir), "")
 	}
-	ExpectWithOffset(2, err).ToNot(HaveOccurred(), pushOutput)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), pushOutput)
 
 	// And check presence
 

--- a/internal/api/v1/stage.go
+++ b/internal/api/v1/stage.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -228,7 +229,8 @@ func createCertificate(ctx context.Context, cfg *rest.Config, app gitea.App, sys
 
 	_, err = dynamicClient.Resource(certificateInstanceGVR).Namespace(app.Org).
 		Create(ctx, obj, metav1.CreateOptions{})
-	if err != nil {
+	// Ignore the error if it's about cert already existing.
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 


### PR DESCRIPTION
This was a regression. When a certificate already exists we don't need
to do anything. Just ignore the error.

Fixes #393