### PR TITLE
Wait for specific app to run

### DIFF
--- a/acceptance/api_v1_applications_test.go
+++ b/acceptance/api_v1_applications_test.go
@@ -338,16 +338,14 @@ var _ = Describe("Apps API Application Endpoints", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
 
-				r := &v1.AppResponse{}
+				r := &models.UploadResponse{}
 				err = json.Unmarshal(bodyBytes, &r)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(r.Message).To(ContainSubstring("ok"))
-				Expect(r.App.Route).To(MatchRegexp(`testapp\..*\.omg\.howdoi\.website`))
-				Expect(r.App.Name).To(Equal("testapp"))
-				Expect(r.App.Org).To(Equal(org))
-				Expect(r.App.Repo.URL).ToNot(BeEmpty())
-				Expect(r.App.Repo.Revision).ToNot(BeEmpty())
+				Expect(r.Route).To(MatchRegexp(`testapp\..*\.omg\.howdoi\.website`))
+				Expect(r.Image.ID).ToNot(BeEmpty())
+				Expect(r.Git.URL).ToNot(BeEmpty())
+				Expect(r.Git.Revision).ToNot(BeEmpty())
 			})
 		})
 
@@ -367,16 +365,13 @@ var _ = Describe("Apps API Application Endpoints", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
 
-				r := &v1.AppResponse{}
+				r := &models.UploadResponse{}
 				err = json.Unmarshal(bodyBytes, &r)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(r.Message).To(ContainSubstring("ok"))
-				Expect(r.App.Route).To(MatchRegexp(`testapp\..*\.omg\.howdoi\.website`))
-				Expect(r.App.Name).To(Equal("testapp"))
-				Expect(r.App.Org).To(Equal(org))
-				Expect(r.App.Repo.URL).ToNot(BeEmpty())
-				Expect(r.App.Instances).To(Equal(int32(2)))
+				Expect(r.Route).To(MatchRegexp(`testapp\..*\.omg\.howdoi\.website`))
+				Expect(r.Image.ID).ToNot(BeEmpty())
+				Expect(r.Git.URL).ToNot(BeEmpty())
 			})
 		})
 
@@ -469,8 +464,7 @@ var _ = Describe("Apps API Application Endpoints", func() {
 
 		BeforeEach(func() {
 			url = serverURL + "/" + v1.Routes.Path("AppStage", org, "testapp")
-			body = fmt.Sprintf(`{"Name":"testapp","Org":"%s","Repo":{"Revision":"7730c8f3e6490c334397b3125da5173061d656ff","URL":"http://gitea.172.27.0.2.omg.howdoi.website"},"Route":"apps-786195048.172.27.0.2.omg.howdoi.website","ImageID":"9827b03f"}`, org)
-
+			body = fmt.Sprintf(`{"app":{"name":"testapp","org":"%s"},"image":{"id":"d516ad09"},"git":{"revision":"ceed03cd261d6c1f27d7bf997b78e","url":"http://gitea.172.27.0.2.omg.howdoi.website"}}`, org)
 		})
 
 		When("staging a new app", func() {

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"regexp"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -41,9 +42,11 @@ var _ = Describe("Apps", func() {
 			routeRegexp := regexp.MustCompile(`https:\/\/.*omg.howdoi.website`)
 			route := string(routeRegexp.Find([]byte(out)))
 
-			resp, err := Curl("GET", route, strings.NewReader(""))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Eventually(func() int {
+				resp, err := Curl("GET", route, strings.NewReader(""))
+				Expect(err).ToNot(HaveOccurred())
+				return resp.StatusCode
+			}, 30*time.Second, 1*time.Second).Should(Equal(http.StatusOK))
 
 			By("deleting the app")
 			deleteApp(appName)

--- a/assets/embedded-files/epinio/server.yaml
+++ b/assets/embedded-files/epinio/server.yaml
@@ -160,7 +160,7 @@ spec:
       serviceAccountName: epinio-server
       containers:
         - command: ["/epinio", "server"]
-          args: ["--port", "80"]
+          args: ["--port", "80", "--trace-level", "0"]
           image: splatform/epinio-server:##current_epinio_version##
           livenessProbe:
             httpGet:

--- a/assets/embedded-files/epinio/staging.yaml
+++ b/assets/embedded-files/epinio/staging.yaml
@@ -11,6 +11,7 @@ rules:
   - pipelineruns
   verbs:
   - create
+  - list
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helpers/tracelog/logger.go
+++ b/helpers/tracelog/logger.go
@@ -33,7 +33,8 @@ func TraceLevel() int {
 
 // LoggerFlags adds to viper flags
 func LoggerFlags(pf *flag.FlagSet, argToEnv map[string]string) {
-	pf.IntP("trace-level", "", 0, "Only print trace messages at or above this level (0 to 2, default 0)")
+	// trace-level 0 prints nothing, well technically it would print NewLogger().V(-1)
+	pf.IntP("trace-level", "", 0, "Only print trace messages at or above this level (0 to 5, default 0, print nothing)")
 	viper.BindPFlag("trace-level", pf.Lookup("trace-level"))
 	argToEnv["trace-level"] = "TRACE_LEVEL"
 }
@@ -53,7 +54,11 @@ func NewInstallClientLogger() logr.Logger {
 	return NewLogger().WithName("InstallClient")
 }
 
-// NewLogger creates a new logger with our setup
+// NewLogger creates a new logger with our setup. It only prints messages below
+// TraceLevel().  The starting point for derived loggers is 1. So in the
+// default configuration, TRACE_LEVEL=0, V(1), nothing is printed.
+// TRACE_LEVEL=1 shows simple log statements, everything above like `details`,
+// or V(3) needs a higher TRACE_LEVEL.
 func NewLogger() logr.Logger {
 	stdr.SetVerbosity(TraceLevel())
 	return stdr.New(log.New(os.Stderr, "", log.LstdFlags)).V(1) // NOTE: Increment of level, not absolute.

--- a/internal/api/v1/models/app.go
+++ b/internal/api/v1/models/app.go
@@ -1,0 +1,68 @@
+package models
+
+import "fmt"
+
+const (
+	EpinioImageIDLabel = "epinio.suse.org/image-id"
+	EpinioStageIDLabel = "epinio.suse.org/stage-id"
+)
+
+// App has all the app properties, like the image, repo, route and staging information
+type App struct {
+	AppRef
+	Image     ImageRef
+	Git       *GitRef
+	Route     string
+	Stage     StageRef
+	Instances int32
+}
+
+// NewApp returns a new app for name and org
+func NewApp(name string, org string) *App {
+	return &App{AppRef: AppRef{Name: name, Org: org}}
+}
+
+// GitURL returns the git URL by combining the server with the org and name
+func (a *App) GitURL(server string) string {
+	return fmt.Sprintf("%s/%s/%s", server, a.Org, a.Name)
+}
+
+// ImageURL returns the URL of the image, using the ImageID. The ImageURL is
+// later used in app.yml.  Since the final commit is not know when the app.yml
+// is written, we cannot use Repo.Revision
+func (a *App) ImageURL(server string) string {
+	return fmt.Sprintf("%s/%s-%s", server, a.Name, a.Image.ID)
+}
+
+// AppRef references an App by name and org
+type AppRef struct {
+	Name string `json:"name"`
+	Org  string `json:"org"`
+}
+
+// StageRef references a tekton staging run by ID, currently randomly generated
+// for each POST to the staging endpoint
+type StageRef struct {
+	ID string `json:"id,omitempty"`
+}
+
+// NewStage returns a new reference to a staging run
+func NewStage(id string) StageRef {
+	return StageRef{id}
+}
+
+// ImageRef references an upload
+type ImageRef struct {
+	ID string `json:"id,omitempty"`
+}
+
+// NewImage returns a new image ref for the given ID
+func NewImage(id string) ImageRef {
+	return ImageRef{id}
+}
+
+// GitRef describes a git commit in a repo
+type GitRef struct {
+	Revision string `json:"revision"`
+	URL      string `json:"url"`
+}

--- a/internal/api/v1/models/app.go
+++ b/internal/api/v1/models/app.go
@@ -28,7 +28,7 @@ func (a *App) GitURL(server string) string {
 }
 
 // ImageURL returns the URL of the image, using the ImageID. The ImageURL is
-// later used in app.yml.  Since the final commit is not know when the app.yml
+// later used in app.yml.  Since the final commit is not known when the app.yml
 // is written, we cannot use Repo.Revision
 func (a *App) ImageURL(server string) string {
 	return fmt.Sprintf("%s/%s-%s", server, a.Name, a.Image.ID)

--- a/internal/api/v1/models/models.go
+++ b/internal/api/v1/models/models.go
@@ -1,7 +1,6 @@
-package models
-
-// The structures in this package encapsulate the requested and
+// Package models contains structures to encapsulate the requested and
 // response data used by the communication between cli and api server.
+package models
 
 type ServiceResponse struct {
 	Name      string   `json:"name"`
@@ -40,3 +39,21 @@ type UpdateAppRequest struct {
 }
 
 // TODO: CreateOrgRequest
+
+// UploadRequest is a multipart form
+
+type UploadResponse struct {
+	Image ImageRef `json:"image,omitempty"`
+	Git   *GitRef  `json:"git,omitempty"`
+	Route string   `json:"route,omitempty"`
+}
+
+type StageRequest struct {
+	App   AppRef   `json:"app,omitempty"`
+	Image ImageRef `json:"image,omitempty"`
+	Git   *GitRef  `json:"git,omitempty"`
+}
+
+type StageResponse struct {
+	Stage StageRef `json:"stage,omitempty"`
+}

--- a/internal/api/v1/models/models.go
+++ b/internal/api/v1/models/models.go
@@ -1,4 +1,4 @@
-// Package models contains structures to encapsulate the requested and
+// Package models contains structures encapsulating the requested and
 // response data used by the communication between cli and api server.
 package models
 

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -12,6 +12,17 @@ import (
 
 const v = "/api/v1"
 
+// jsonResponse writes the response struct as JSON to the writer
+func jsonResponse(w http.ResponseWriter, response interface{}) error {
+	w.Header().Set("Content-Type", "application/json")
+	js, err := json.Marshal(response)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(js)
+	return err
+}
+
 func errorHandler(action APIActionFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		responseErrors := action(w, r)

--- a/internal/api/v1/stage.go
+++ b/internal/api/v1/stage.go
@@ -80,7 +80,7 @@ func (hc ApplicationsController) Stage(w http.ResponseWriter, r *http.Request) A
 		return singleInternalError(err, "failed to get access to a tekton client")
 	}
 
-	// return if another run for this is imageID is running; one imageID == one stagingID at the same time
+	// return if another run for this imageID is running; one imageID == one stagingID at the same time
 	l, err := client.List(ctx, metav1.ListOptions{LabelSelector: models.EpinioImageIDLabel + "=" + req.Image.ID})
 	if err != nil {
 		return singleError(err, http.StatusInternalServerError)

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -897,6 +897,12 @@ func (c *EpinioClient) Orgs() error {
 }
 
 // Push pushes an app
+// * validate
+// * upload
+// * stage
+// * wait for pipelinerun
+// * tail logs
+// * wait for app
 func (c *EpinioClient) Push(app string, source string, params PushParams) error {
 	log := c.Log.
 		WithName("Push").
@@ -905,7 +911,7 @@ func (c *EpinioClient) Push(app string, source string, params PushParams) error 
 			"Sources", source)
 	log.Info("start")
 	defer log.Info("return")
-	details := log.V(1) // NOTE: Increment of level, not absolute.
+	details := log.V(1) // NOTE: Increment of level, not absolute. Visible via TRACE_LEVEL=2
 
 	msg := c.ui.Note().
 		WithStringValue("Name", app).
@@ -966,39 +972,54 @@ func (c *EpinioClient) Push(app string, source string, params PushParams) error 
 
 	// upload blob to the server's uplad API endpoint
 	details.Info("upload code")
-	uploadResponse, err := c.upload(api.Routes.Path("AppUpload", c.Config.Org, app), tarball, params)
+	b, err := c.upload(api.Routes.Path("AppUpload", c.Config.Org, app), tarball, params)
 	if err != nil {
 		return errors.Wrap(err, "can't upload archive")
 	}
 
 	// returns git commit and app route
-	resp := &api.AppResponse{}
-	if err := json.Unmarshal(uploadResponse, resp); err != nil {
+	upload := &models.UploadResponse{}
+	if err := json.Unmarshal(b, upload); err != nil {
 		return err
 	}
+	log.V(3).Info("upload response", "response", upload)
 
 	c.ui.Normal().Msg("Stage application ...")
 
+	appRef := models.AppRef{Name: app, Org: c.Config.Org}
+	req := &models.StageRequest{
+		App:   appRef,
+		Image: upload.Image,
+		Git:   upload.Git,
+	}
 	details.Info("staging code")
-	out, err := json.Marshal(resp.App)
+	out, err := json.Marshal(req)
 	if err != nil {
 		return errors.Wrap(err, "can't marshall upload response")
 	}
 
-	_, err = c.post(api.Routes.Path("AppStage", c.Config.Org, app), string(out))
+	b, err = c.post(api.Routes.Path("AppStage", c.Config.Org, app), string(out))
 	if err != nil {
 		return errors.Wrap(err, "can't stage app")
 	}
 
+	// returns staging ID
+	stage := &models.StageResponse{}
+	if err := json.Unmarshal(b, stage); err != nil {
+		return err
+	}
+	log.V(3).Info("stage response", "response", stage)
+
 	details.Info("start tailing logs")
-	stopFunc, err := c.logs(app, c.Config.Org)
+	stopFunc, err := c.logs(app, c.Config.Org, stage.Stage.ID)
 	if err != nil {
 		return errors.Wrap(err, "failed to tail logs")
 	}
 	defer stopFunc()
 
 	details.Info("wait for app")
-	err = c.waitForApp(c.Config.Org, app)
+	// TODO cannot use stage.Stage.ID
+	err = c.waitForApp(c.Config.Org, app, upload.Image.ID)
 	if err != nil {
 		return errors.Wrap(err, "waiting for app failed")
 	}
@@ -1030,7 +1051,7 @@ func (c *EpinioClient) Push(app string, source string, params PushParams) error 
 	c.ui.Success().
 		WithStringValue("Name", app).
 		WithStringValue("Organization", c.Config.Org).
-		WithStringValue("Route", fmt.Sprintf("https://%s", resp.App.Route)).
+		WithStringValue("Route", fmt.Sprintf("https://%s", upload.Route)).
 		Msg("App is online.")
 
 	return nil
@@ -1103,7 +1124,7 @@ func (c *EpinioClient) deleteCertificate(appName string) error {
 	return nil
 }
 
-func (c *EpinioClient) logs(appName, org string) (context.CancelFunc, error) {
+func (c *EpinioClient) logs(appName, org, stageID string) (context.CancelFunc, error) {
 	c.ui.ProgressNote().V(1).Msg("Tailing application logs ...")
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -1112,6 +1133,7 @@ func (c *EpinioClient) logs(appName, org string) (context.CancelFunc, error) {
 
 	for _, req := range [][]string{
 		{"app.kubernetes.io/managed-by", "epinio"},
+		{models.EpinioStageIDLabel, stageID},
 		{"app.kubernetes.io/part-of", org},
 		{"app.kubernetes.io/name", appName},
 	} {
@@ -1144,10 +1166,10 @@ func (c *EpinioClient) logs(appName, org string) (context.CancelFunc, error) {
 	return cancelFunc, nil
 }
 
-func (c *EpinioClient) waitForApp(org, name string) error {
+func (c *EpinioClient) waitForApp(org, name, id string) error {
 	c.ui.ProgressNote().KeeplineUnder(1).Msg("Creating application resources")
 	err := c.KubeClient.WaitUntilPodBySelectorExist(
-		c.ui, org, fmt.Sprintf("app.kubernetes.io/name=%s", name),
+		c.ui, org, fmt.Sprintf("app.kubernetes.io/name=%s,%s=%s", name, models.EpinioImageIDLabel, id),
 		duration.ToAppBuilt())
 	if err != nil {
 		return errors.Wrap(err, "waiting for app to be created failed")


### PR DESCRIPTION
This PR stops a new staging run from happening, if one is already running for that image.

The CLI client now waits for the exact pipelinerun, that was triggered by the staging endpoint, to finish (fixes #246).

The CLI push commands waits for the app to start. Now it looks for an app, with the exact image ID from the upload endpoint (fixes #357).

- This should be improved so we wait for the right staging ID (from the staging endpoint), instead of the image ID. 
Even though the code now returns a random staging ID, we can't wait for it, because it's unknown by the time of the upload. This will change, once the `.kube` files are not created in upload anymore.

Also, minor changes:
* document logger
* add request/response structs for upload/staging endpoint
* remove app part from pipelinerun name
