### PR TITLE
Add app logs cmd

### DIFF
--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -433,7 +433,7 @@ func Epinio(command string, dir string) (string, error) {
 	return RunProc(cmd, commandDir, false)
 }
 
-// GetKCommand retuns the KCommand without running it
+// GetKCommand returns the KCommand without running it
 func GetKCommand(command string, dir string) (*kexec.KCommand, error) {
 	var err error
 

--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -443,7 +443,7 @@ func GetKCommand(command string, dir string) (*kexec.KCommand, error) {
 			return nil, err
 		}
 	}
-	cmd := fmt.Sprintf(nodeTmpDir+"/epinio-darwin-amd64 %s", command)
+	cmd := fmt.Sprintf(nodeTmpDir+"/epinio %s", command)
 
 	p := kexec.CommandString(cmd)
 	p.Dir = dir

--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -32,7 +32,7 @@ func TestAcceptance(t *testing.T) {
 var nodeSuffix, nodeTmpDir string
 
 // serverURL is the URL of the epinio API server
-var serverURL string
+var serverURL, websocketURL string
 var registryMirrorName = "epinio-acceptance-registry-mirror"
 
 const (
@@ -193,6 +193,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)
 
 	serverURL = "http://" + out
+	websocketURL = "ws://" + out
 })
 
 var _ = SynchronizedAfterSuite(func() {
@@ -430,6 +431,24 @@ func Epinio(command string, dir string) (string, error) {
 	cmd := fmt.Sprintf(nodeTmpDir+"/epinio %s", command)
 
 	return RunProc(cmd, commandDir, false)
+}
+
+// GetKCommand retuns the KCommand without running it
+func GetKCommand(command string, dir string) (*kexec.KCommand, error) {
+	var err error
+
+	if dir == "" {
+		dir, err = os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+	}
+	cmd := fmt.Sprintf(nodeTmpDir+"/epinio-darwin-amd64 %s", command)
+
+	p := kexec.CommandString(cmd)
+	p.Dir = dir
+
+	return p, nil
 }
 
 func checkDependencies() error {

--- a/acceptance/api_v1_applications_test.go
+++ b/acceptance/api_v1_applications_test.go
@@ -565,7 +565,7 @@ var _ = Describe("Apps API Application Endpoints", func() {
 				}, 30*time.Second, 1*time.Second).Should(BeTrue())
 
 				By("checking if the logs are right")
-				podNames := getPodNames(app, org, 1)
+				podNames := getPodNames(app, org)
 				for _, podName := range podNames {
 					Expect(logs).To(ContainSubstring(podName))
 				}

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -299,7 +299,7 @@ var _ = Describe("Apps", func() {
 			out, err := Epinio("app logs "+appName, "")
 			Expect(err).ToNot(HaveOccurred(), out)
 
-			podNames := getPodNames(appName, org, 1)
+			podNames := getPodNames(appName, org)
 			for _, podName := range podNames {
 				Expect(out).To(ContainSubstring(podName))
 			}

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -272,13 +272,9 @@ func makeWebSocketConnection(url string) *websocket.Conn {
 }
 
 func getPodNames(appName, orgName string) []string {
-	var podNames []string
-	for i := 0; i < 1; i++ { // TODO: fix this
-		out, err := helpers.Kubectl(fmt.Sprintf("get pods -n %s --selector 'app.kubernetes.io/component=application,app.kubernetes.io/name=%s, app.kubernetes.io/part-of=%s'", orgName, appName, orgName))
+	jsonPath := `'{range .items[*]}{.metadata.name}{"\n"}{end}'`
+	out, err := helpers.Kubectl(fmt.Sprintf("get pods -n %s --selector 'app.kubernetes.io/component=application,app.kubernetes.io/name=%s, app.kubernetes.io/part-of=%s' -o=jsonpath=%s", orgName, appName, orgName, jsonPath))
+	Expect(err).NotTo(HaveOccurred())
 
-		Expect(err).NotTo(HaveOccurred())
-		podNames = append(podNames, out)
-	}
-
-	return podNames
+	return strings.Split(out, "\n")
 }

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -271,10 +271,11 @@ func makeWebSocketConnection(url string) *websocket.Conn {
 	return ws
 }
 
-func getPodNames(appName, orgName string, replicas int) []string {
+func getPodNames(appName, orgName string) []string {
 	var podNames []string
-	for i := 0; i < replicas; i++ {
-		out, err := helpers.Kubectl(fmt.Sprintf("get pods -n %s -o=jsonpath='{.items[%d].metadata.name}'", orgName, i))
+	for i := 0; i < 1; i++ { // TODO: fix this
+		out, err := helpers.Kubectl(fmt.Sprintf("get pods -n %s --selector 'app.kubernetes.io/component=application,app.kubernetes.io/name=%s, app.kubernetes.io/part-of=%s'", orgName, appName, orgName))
+
 		Expect(err).NotTo(HaveOccurred())
 		podNames = append(podNames, out)
 	}

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -110,7 +110,7 @@ func makeAppWithDir(appName string, instances int, deployFromCurrentDir bool, ap
 	} else {
 		// Note: appDir is handed as second argument to the epinio cli.
 		// This means that the command gets the sources from that directory instead of CWD.
-		pushOutput, err = Epinio(fmt.Sprintf("apps push %s %s --verbosity 1", appName, appDir), "")
+		pushOutput, err = Epinio(fmt.Sprintf("apps push %s %s --verbosity 1 --instances %d", appName, appDir, instances), "")
 	}
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), pushOutput)
 

--- a/assets/embedded-files/epinio/server.yaml
+++ b/assets/embedded-files/epinio/server.yaml
@@ -39,6 +39,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - extensions
   resources:

--- a/assets/embedded-files/epinio/server.yaml
+++ b/assets/embedded-files/epinio/server.yaml
@@ -26,6 +26,20 @@ rules:
   verbs:
   - list
 - apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
   - extensions
   resources:
   - ingresses

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/stdr v0.4.0
-	github.com/google/go-cmp v0.5.4 // indirect
-	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/gorilla/websocket v1.4.2
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kyokomi/emoji v2.2.4+incompatible

--- a/go.mod
+++ b/go.mod
@@ -29,8 +29,8 @@ require (
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/tektoncd/pipeline v0.23.0
-	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
-	golang.org/x/sys v0.0.0-20210511113859-b0526f3d8744 // indirect
+	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
+	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 // indirect
 	golang.org/x/tools v0.1.1 // indirect
 	k8s.io/api v0.20.5
 	k8s.io/apiextensions-apiserver v0.20.4

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/tektoncd/pipeline v0.23.0
-	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
+	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 // indirect
 	golang.org/x/tools v0.1.1 // indirect
 	k8s.io/api v0.20.5

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/stdr v0.4.0
+	github.com/google/go-cmp v0.5.4 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kyokomi/emoji v2.2.4+incompatible

--- a/go.sum
+++ b/go.sum
@@ -335,6 +335,7 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -433,6 +434,7 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/go.sum
+++ b/go.sum
@@ -335,7 +335,6 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/go.sum
+++ b/go.sum
@@ -1058,8 +1058,8 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210511113859-b0526f3d8744 h1:yhBbb4IRs2HS9PPlAg6DMC6mUOKexJBNsLf4Z+6En1Q=
-golang.org/x/sys v0.0.0-20210511113859-b0526f3d8744/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 h1:hZR0X1kPW+nwyJ9xRxqZk1vx5RUObAPBdKVvXPDUH/E=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=

--- a/helpers/kubernetes/tailer/setup.go
+++ b/helpers/kubernetes/tailer/setup.go
@@ -3,12 +3,15 @@ package tailer
 import (
 	"context"
 	"regexp"
+	"sync"
 	"text/template"
 	"time"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -45,11 +48,83 @@ type ContainerLogLine struct {
 //
 //   - For log entries `Exclude` is applied before `Include`.
 
-// Run starts the log watching
-func Run(ctx context.Context, config *Config, cluster *kubernetes.Cluster) (chan ContainerLogLine, error) {
-	var namespace string
+// Run returns a channel of ContainerLogLine.
+// Depending on the value of the "follow" argument, the channel may stay open until the consumer
+// closes the context or until there are no containers left to stream logs.
+func Run(ctx context.Context, follow bool, config *Config, cluster *kubernetes.Cluster) (chan ContainerLogLine, error) {
+	var result chan ContainerLogLine
+	var err error
+	if !follow {
+		result, err = RunUntilStopped(ctx, config, cluster)
+	} else {
+		result, err = RunUntilNoMoreLogs(ctx, config, cluster)
+	}
+
+	return result, err
+}
+
+// RunUntilStopped will keep watching for matching containers and stream their
+// logs to the ContainerLogLine channel until ctx is Done(). The channel will
+// be closed then that happens.
+func RunUntilStopped(ctx context.Context, config *Config, cluster *kubernetes.Cluster) (chan ContainerLogLine, error) {
+	var wg sync.WaitGroup
+
 	containerLogsChan := make(chan ContainerLogLine, 10)
 
+	var namespace string
+	if config.AllNamespaces {
+		namespace = ""
+	} else if config.Namespace == "" {
+		return nil, errors.New("no namespace set for tailing logs")
+	}
+
+	podList, err := cluster.Kubectl.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: config.LabelSelector.String()})
+	if err != nil {
+		return nil, err
+	}
+	addTail := func(pod corev1.Pod, c corev1.Container) {
+		tail := NewTail(containerLogsChan, pod.Namespace, pod.Name, c.Name, config.Template,
+			tracelog.NewLogger().WithName("log-tracing"),
+			&TailOptions{
+				Timestamps:   config.Timestamps,
+				SinceSeconds: int64(config.Since.Seconds()),
+				Exclude:      config.Exclude,
+				Include:      config.Include,
+				Namespace:    config.AllNamespaces,
+				TailLines:    config.TailLines,
+			})
+
+		wg.Add(1)
+		go func() {
+			tail.Start(ctx, cluster.Kubectl.CoreV1().Pods(pod.Namespace))
+			wg.Done()
+		}()
+	}
+	for _, pod := range podList.Items {
+		for _, c := range pod.Spec.Containers {
+			addTail(pod, c)
+		}
+		for _, c := range pod.Spec.InitContainers {
+			addTail(pod, c)
+		}
+	}
+
+	go func() {
+		// If ctx is Done() then the go routines will stop themselves and this will
+		// close the channel too. The channel is also closed when all go routines
+		// return.
+		wg.Wait()
+		close(containerLogsChan)
+	}()
+
+	return containerLogsChan, nil
+}
+
+// RunUntilNoMoreLogs stream the logs of all the matching containers (without
+// follow) and close the channel when it's done.
+func RunUntilNoMoreLogs(ctx context.Context, config *Config, cluster *kubernetes.Cluster) (chan ContainerLogLine, error) {
+	containerLogsChan := make(chan ContainerLogLine, 10)
+	var namespace string
 	if config.AllNamespaces {
 		namespace = ""
 	} else if config.Namespace == "" {

--- a/helpers/kubernetes/tailer/tailer.go
+++ b/helpers/kubernetes/tailer/tailer.go
@@ -45,7 +45,7 @@ func NewTail(namespace, podName, containerName string, logger logr.Logger, clien
 }
 
 // Start writes log lines to the logChan. It can be stopped using the ctx.
-// It's the calles responsibility to close the logChan (because there may be more
+// It's the caller's responsibility to close the logChan (because there may be more
 // instances of this method (go routines) writing to the same channel.
 func (t *Tail) Start(ctx context.Context, logChan chan ContainerLogLine, follow bool) error {
 	// TODO: Remove this prints or move the to higher trace level

--- a/helpers/kubernetes/tailer/tailer.go
+++ b/helpers/kubernetes/tailer/tailer.go
@@ -48,6 +48,7 @@ func NewTail(namespace, podName, containerName string, logger logr.Logger, clien
 // It's the calles responsibility to close the logChan (because there may be more
 // instances of this method (go routines) writing to the same channel.
 func (t *Tail) Start(ctx context.Context, logChan chan ContainerLogLine, follow bool) error {
+	// TODO: Remove this prints or move the to higher trace level
 	fmt.Println("starting the tail for pod " + t.PodName)
 	var m string
 	if t.Options.Namespace {

--- a/helpers/kubernetes/tailer/watcher.go
+++ b/helpers/kubernetes/tailer/watcher.go
@@ -32,6 +32,7 @@ func (t *Target) GetID() string {
 func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp, containerFilter *regexp.Regexp, containerExcludeFilter *regexp.Regexp, containerState ContainerState, labelSelector labels.Selector) (chan *Target, chan *Target, error) {
 	watcher, err := i.Watch(ctx, metav1.ListOptions{Watch: true, LabelSelector: labelSelector.String()})
 	if err != nil {
+		fmt.Printf("err.Error() = %+v\n", err.Error())
 		return nil, nil, errors.Wrap(err, "failed to set up watch")
 	}
 

--- a/internal/api/v1/applications.go
+++ b/internal/api/v1/applications.go
@@ -25,8 +25,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var upgrader = websocket.Upgrader{}
-
 type ApplicationsController struct {
 	conn *websocket.Conn
 }

--- a/internal/api/v1/applications.go
+++ b/internal/api/v1/applications.go
@@ -1,19 +1,34 @@
 package v1
 
 import (
+	"bufio"
+	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/models"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/clients/gitea"
 	"github.com/epinio/epinio/internal/organizations"
+	"github.com/gorilla/websocket"
 	"github.com/julienschmidt/httprouter"
+	"github.com/pkg/errors"
 )
 
+var upgrader = websocket.Upgrader{}
+
 type ApplicationsController struct {
+	conn *websocket.Conn
 }
 
 func (hc ApplicationsController) Index(w http.ResponseWriter, r *http.Request) APIErrors {
@@ -146,6 +161,165 @@ func (hc ApplicationsController) Update(w http.ResponseWriter, r *http.Request) 
 	}
 
 	return nil
+}
+func (hc ApplicationsController) Logs(w http.ResponseWriter, r *http.Request) APIErrors {
+	params := httprouter.ParamsFromContext(r.Context())
+	org := params.ByName("org")
+	appName := params.ByName("app")
+
+	queryValues := r.URL.Query()
+	follow := queryValues.Get("follow")
+
+	cluster, err := kubernetes.GetCluster()
+	if err != nil {
+		return APIErrors{InternalError(err)}
+	}
+
+	var upgrader = websocket.Upgrader{}
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return APIErrors{InternalError(err)}
+	}
+
+	hc.conn = conn
+	err = hc.streamPodLogs(org, appName, cluster, follow)
+	if err != nil {
+		return APIErrors{InternalError(err)}
+	}
+
+	return nil
+}
+
+func (hc ApplicationsController) streamPodLogs(orgName string, appName string, cluster *kubernetes.Cluster, follow string) error {
+	selector := labels.NewSelector()
+	for _, req := range [][]string{
+		{"app.kubernetes.io/component", "application"},
+		{"app.kubernetes.io/managed-by", "epinio"},
+		{"app.kubernetes.io/part-of", orgName},
+		{"app.kubernetes.io/name", appName},
+	} {
+		req, err := labels.NewRequirement(req[0], selection.Equals, []string{req[1]})
+		if err != nil {
+			return err
+		}
+		selector = selector.Add(*req)
+	}
+
+	podList, err := cluster.Kubectl.CoreV1().Pods(orgName).List(context.Background(), metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return err
+	}
+
+	podLogOpts := corev1.PodLogOptions{
+		Container: appName,
+	}
+	if follow == "true" {
+		podLogOpts.Follow = true
+	}
+
+	errorChan := make(chan error, 1)
+	doneChan := make(chan bool)
+	quitChan := make(chan bool)
+
+	podLen := len(podList.Items)
+	var mu sync.Mutex
+	for _, pod := range podList.Items {
+
+		// Call goroutines for each pod replica
+		go func(pod corev1.Pod) {
+			req := cluster.Kubectl.CoreV1().Pods(orgName).GetLogs(pod.Name, &podLogOpts)
+			stream, err := req.Stream(context.Background())
+			if err != nil {
+				errorChan <- err
+				return
+			}
+			defer stream.Close()
+
+			scanner := bufio.NewScanner(stream)
+			for scanner.Scan() {
+				message := fmt.Sprintf("[%s] %s", pod.Name, scanner.Text())
+
+				// websocket connection doesn't support multiple writes
+				mu.Lock()
+				err = hc.conn.WriteMessage(websocket.TextMessage, []byte(message))
+				mu.Unlock()
+				if err != nil {
+					errorChan <- err
+					return
+				}
+			}
+
+			// Exit goroutine by sending true to done channel
+			// Exit goroutine by waiting quit channel
+			select {
+			case doneChan <- true:
+				return
+			case <-quitChan:
+				return
+			}
+		}(pod)
+	}
+
+	go func() {
+
+		// Websocket closure from peer can be only captured
+		// from reading the connection until err occurs
+		for {
+			if _, _, err := hc.conn.NextReader(); err != nil {
+				errorChan <- err
+				break
+			}
+		}
+
+		// Exit goroutine by waiting on quit channel
+		select {
+		case <-quitChan:
+			return
+		}
+	}()
+
+	// Capture errors and done signals from goroutines spawned above
+	countPod := 0
+	for {
+		select {
+		case err := <-errorChan:
+			close(quitChan)
+
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+				hc.conn.Close()
+				return nil
+			}
+			if websocket.IsUnexpectedCloseError(err) {
+				hc.conn.Close()
+				fmt.Println(errors.Wrap(err, "error from client"))
+				return nil
+			}
+
+			err = hc.conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), time.Time{})
+			if err != nil {
+				err = hc.conn.Close()
+				if err != nil {
+					return err
+				}
+			}
+			return err
+		case <-doneChan:
+			countPod++
+
+			if countPod == podLen {
+				close(quitChan)
+				err = hc.conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), time.Time{})
+				if err != nil {
+					err = hc.conn.Close()
+					if err != nil {
+						return err
+					}
+				}
+
+				return nil
+			}
+		}
+	}
 }
 
 func (hc ApplicationsController) Delete(w http.ResponseWriter, r *http.Request) APIErrors {

--- a/internal/api/v1/models/app.go
+++ b/internal/api/v1/models/app.go
@@ -51,6 +51,7 @@ func (app *App) Logs(ctx context.Context, logChan chan tailer.ContainerLogLine, 
 		}
 	} else {
 		selectors = [][]string{
+			{"app.kubernetes.io/component", "staging"},
 			{"app.kubernetes.io/managed-by", "epinio"},
 			{EpinioStageIDLabel, stageID},
 			{"app.kubernetes.io/part-of", app.Org},

--- a/internal/api/v1/models/app.go
+++ b/internal/api/v1/models/app.go
@@ -72,7 +72,7 @@ func (app *App) Logs(ctx context.Context, client *kubernetes.Cluster, follow boo
 		selector = selector.Add(*req)
 	}
 
-	logChan, err := tailer.Run(ctx, &tailer.Config{
+	logChan, err := tailer.Run(ctx, follow, &tailer.Config{
 		ContainerQuery:        regexp.MustCompile(".*"),
 		ExcludeContainerQuery: nil,
 		ContainerState:        "running",

--- a/internal/api/v1/models/app.go
+++ b/internal/api/v1/models/app.go
@@ -37,8 +37,7 @@ func NewApp(name string, org string) *App {
 // to close the logChan when done.
 // When stageID is an empty string, no staging logs are returned. If it is set,
 // then only logs from that staging process are returned.
-// TODO: Fix this, when stageID is set, it also returns application logs. Needs extra label?
-func (app *App) Logs(ctx context.Context, logChan chan tailer.ContainerLogLine, wg *sync.WaitGroup, client *kubernetes.Cluster, follow bool, stageID string) error {
+func Logs(ctx context.Context, logChan chan tailer.ContainerLogLine, wg *sync.WaitGroup, client *kubernetes.Cluster, follow bool, app, stageID, org string) error {
 	selector := labels.NewSelector()
 
 	var selectors [][]string
@@ -46,16 +45,15 @@ func (app *App) Logs(ctx context.Context, logChan chan tailer.ContainerLogLine, 
 		selectors = [][]string{
 			{"app.kubernetes.io/component", "application"},
 			{"app.kubernetes.io/managed-by", "epinio"},
-			{"app.kubernetes.io/part-of", app.Org},
-			{"app.kubernetes.io/name", app.Name},
+			{"app.kubernetes.io/part-of", org},
+			{"app.kubernetes.io/name", app},
 		}
 	} else {
 		selectors = [][]string{
 			{"app.kubernetes.io/component", "staging"},
 			{"app.kubernetes.io/managed-by", "epinio"},
 			{EpinioStageIDLabel, stageID},
-			{"app.kubernetes.io/part-of", app.Org},
-			{"app.kubernetes.io/name", app.Name},
+			{"app.kubernetes.io/part-of", org},
 		}
 	}
 

--- a/internal/api/v1/models/app.go
+++ b/internal/api/v1/models/app.go
@@ -37,6 +37,7 @@ func NewApp(name string, org string) *App {
 // to close the logChan when done.
 // When stageID is an empty string, no staging logs are returned. If it is set,
 // then only logs from that staging process are returned.
+// TODO: Fix this, when stageID is set, it also returns application logs. Needs extra label?
 func (app *App) Logs(ctx context.Context, logChan chan tailer.ContainerLogLine, wg *sync.WaitGroup, client *kubernetes.Cluster, follow bool, stageID string) error {
 	selector := labels.NewSelector()
 

--- a/internal/api/v1/models/app.go
+++ b/internal/api/v1/models/app.go
@@ -1,6 +1,17 @@
 package models
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/helpers/kubernetes/tailer"
+	"github.com/epinio/epinio/internal/duration"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+)
 
 const (
 	EpinioStageIDLabel = "epinio.suse.org/stage-id"
@@ -21,16 +32,77 @@ func NewApp(name string, org string) *App {
 	return &App{AppRef: AppRef{Name: name, Org: org}}
 }
 
+func (app *App) StagingLogs(ctx context.Context, client *kubernetes.Cluster, follow bool, stageID string) (chan tailer.ContainerLogLine, error) {
+	return app.Logs(ctx, client, follow, stageID)
+}
+
+func (app *App) RuntimeLogs(ctx context.Context, client *kubernetes.Cluster, follow bool) (chan tailer.ContainerLogLine, error) {
+	return app.Logs(ctx, client, follow, "")
+}
+
+// Logs returns a channel of tailer.ContainerLogLine . Consumers can decide what
+// to do with it (print it, send it as json etc).
+// When stageID is an empty string, no staging logs are returned. If it is seti,
+// then only logs from that staging process are returned.
+func (app *App) Logs(ctx context.Context, client *kubernetes.Cluster, follow bool, stageID string) (chan tailer.ContainerLogLine, error) {
+	selector := labels.NewSelector()
+
+	var selectors [][]string
+	if stageID == "" {
+		selectors = [][]string{
+			{"app.kubernetes.io/component", "application"},
+			{"app.kubernetes.io/managed-by", "epinio"},
+			{"app.kubernetes.io/part-of", app.Org},
+			{"app.kubernetes.io/name", app.Name},
+		}
+	} else {
+		selectors = [][]string{
+			{"app.kubernetes.io/managed-by", "epinio"},
+			{EpinioStageIDLabel, stageID},
+			{"app.kubernetes.io/part-of", app.Org},
+			{"app.kubernetes.io/name", app.Name},
+		}
+	}
+
+	for _, req := range selectors {
+		req, err := labels.NewRequirement(req[0], selection.Equals, []string{req[1]})
+		if err != nil {
+			return nil, err
+		}
+		selector = selector.Add(*req)
+	}
+
+	logChan, err := tailer.Run(ctx, &tailer.Config{
+		ContainerQuery:        regexp.MustCompile(".*"),
+		ExcludeContainerQuery: nil,
+		ContainerState:        "running",
+		Exclude:               nil,
+		Include:               nil,
+		Timestamps:            false,
+		Since:                 duration.LogHistory(),
+		AllNamespaces:         true,
+		LabelSelector:         selector,
+		TailLines:             nil,
+		Namespace:             "",
+		PodQuery:              regexp.MustCompile(".*"),
+	}, client)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to start log tail")
+	}
+
+	return logChan, nil
+}
+
 // GitURL returns the git URL by combining the server with the org and name
-func (a *App) GitURL(server string) string {
-	return fmt.Sprintf("%s/%s/%s", server, a.Org, a.Name)
+func (app *App) GitURL(server string) string {
+	return fmt.Sprintf("%s/%s/%s", server, app.Org, app.Name)
 }
 
 // ImageURL returns the URL of the image, using the ImageID. The ImageURL is
 // later used in app.yml.  Since the final commit is not known when the app.yml
 // is written, we cannot use Repo.Revision
-func (a *App) ImageURL(server string) string {
-	return fmt.Sprintf("%s/%s-%s", server, a.Name, a.Git.Revision)
+func (app *App) ImageURL(server string) string {
+	return fmt.Sprintf("%s/%s-%s", server, app.Name, app.Git.Revision)
 }
 
 // AppRef references an App by name and org

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -64,14 +64,15 @@ func patch(path string, h http.HandlerFunc) routes.Route {
 }
 
 var Routes = routes.NamedRoutes{
-	"Info":      get("/info", errorHandler(InfoController{}.Info)),
-	"Apps":      get("/orgs/:org/applications", errorHandler(ApplicationsController{}.Index)),
-	"AppShow":   get("/orgs/:org/applications/:app", errorHandler(ApplicationsController{}.Show)),
-	"AppLogs":   get("/orgs/:org/applications/:app/logs", ApplicationsController{}.Logs),
-	"AppDelete": delete("/orgs/:org/applications/:app", errorHandler(ApplicationsController{}.Delete)),
-	"AppUpload": post("/orgs/:org/applications/:app/store", errorHandler(ApplicationsController{}.Upload)),
-	"AppStage":  post("/orgs/:org/applications/:app/stage", errorHandler(ApplicationsController{}.Stage)),
-	"AppUpdate": patch("/orgs/:org/applications/:app", errorHandler(ApplicationsController{}.Update)),
+	"Info":        get("/info", errorHandler(InfoController{}.Info)),
+	"Apps":        get("/orgs/:org/applications", errorHandler(ApplicationsController{}.Index)),
+	"AppShow":     get("/orgs/:org/applications/:app", errorHandler(ApplicationsController{}.Show)),
+	"AppLogs":     get("/orgs/:org/applications/:app/logs", ApplicationsController{}.Logs),
+	"StagingLogs": get("/orgs/:org/staging/:stage_id/logs", ApplicationsController{}.Logs),
+	"AppDelete":   delete("/orgs/:org/applications/:app", errorHandler(ApplicationsController{}.Delete)),
+	"AppUpload":   post("/orgs/:org/applications/:app/store", errorHandler(ApplicationsController{}.Upload)),
+	"AppStage":    post("/orgs/:org/applications/:app/stage", errorHandler(ApplicationsController{}.Stage)),
+	"AppUpdate":   patch("/orgs/:org/applications/:app", errorHandler(ApplicationsController{}.Update)),
 
 	// Bind and unbind services to/from applications, by means of servicebindings in applications
 	"ServiceBindingCreate": post("/orgs/:org/applications/:app/servicebindings",

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -66,6 +66,7 @@ var Routes = routes.NamedRoutes{
 	"Info":      get("/info", errorHandler(InfoController{}.Info)),
 	"Apps":      get("/orgs/:org/applications", errorHandler(ApplicationsController{}.Index)),
 	"AppShow":   get("/orgs/:org/applications/:app", errorHandler(ApplicationsController{}.Show)),
+	"AppLogs":   get("/orgs/:org/applications/:app/logs", errorHandler(ApplicationsController{}.Logs)),
 	"AppDelete": delete("/orgs/:org/applications/:app", errorHandler(ApplicationsController{}.Delete)),
 	"AppUpload": post("/orgs/:org/applications/:app/store", errorHandler(ApplicationsController{}.Upload)),
 	"AppStage":  post("/orgs/:org/applications/:app/stage", errorHandler(ApplicationsController{}.Stage)),

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -114,7 +114,7 @@ var CmdAppLogs = &cobra.Command{
 			return errors.Wrap(err, "error reading the staging param")
 		}
 
-		err = client.AppLogs(args[0], follow)
+		err = client.AppLogs(args[0], "", follow, nil)
 		if err != nil {
 			return errors.Wrap(err, "error streaming application logs")
 		}

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -26,7 +26,10 @@ func init() {
 
 	updateFlags := CmdAppUpdate.Flags()
 	updateFlags.Int32P("instances", "i", 1, "The number of instances the application should have")
-	cobra.MarkFlagRequired(updateFlags, "instances")
+	err := cobra.MarkFlagRequired(updateFlags, "instances")
+	if err != nil {
+		panic(err)
+	}
 
 	CmdApp.AddCommand(CmdAppShow)
 	CmdApp.AddCommand(CmdAppList)

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -1079,7 +1079,6 @@ func (c *EpinioClient) Push(app string, source string, params PushParams) error 
 		err := c.AppLogs(appRef.Name, stage.Stage.ID, true, stopChan)
 		if err != nil {
 			c.ui.Problem().Msg(fmt.Sprintf("failed to tail logs: %s", err.Error()))
-			return
 		}
 	}()
 

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -789,7 +789,6 @@ func (c *EpinioClient) AppLogs(appName, stageID string, follow bool, interrupt c
 		_, message, err := webSocketConn.ReadMessage()
 		if err != nil {
 			if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
-				c.ui.Normal().Msg("-- Logs End --")
 				webSocketConn.Close()
 				done <- true // Stop the go routine
 				return nil

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -755,9 +755,9 @@ func (c *EpinioClient) AppLogs(appName, stageID string, follow bool, interrupt c
 		"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", c.Config.User, c.Config.Password)))},
 	}
 
-	webSocketConn, _, err := websocket.DefaultDialer.Dial(fmt.Sprintf("%s/%s?%s", c.wsServerURL, api.Routes.Path("AppLogs", c.Config.Org, appName), strings.Join(urlArgs, "&")), headers)
+	webSocketConn, resp, err := websocket.DefaultDialer.Dial(fmt.Sprintf("%s/%s?%s", c.wsServerURL, api.Routes.Path("AppLogs", c.Config.Org, appName), strings.Join(urlArgs, "&")), headers)
 	if err != nil {
-		return err
+		return errors.Wrap(err, fmt.Sprintf("Failed to connect to websockets endpoint. Response was = %+v\nThe error is", resp))
 	}
 
 	done := make(chan bool)

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -1061,8 +1061,6 @@ func (c *EpinioClient) Push(app string, source string, params PushParams) error 
 	defer cancelFunc()
 
 	details.Info("wait for pipelinerun", "StageID", stage.Stage.ID)
-	// TODO: Don't print dots when in verbose mode (because they appear between the log lines)
-	// TODO: Maybe fixed in the main branch? rebase.
 	err = c.waitForPipelineRun(appRef, stage.Stage.ID)
 	if err != nil {
 		return errors.Wrap(err, "waiting for staging failed")

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -792,7 +792,7 @@ func (c *EpinioClient) AppLogs(appName string, follow bool) error {
 				Namespace:     logLine.Namespace,
 				PodName:       logLine.PodName,
 				ContainerName: logLine.ContainerName,
-			}, c.ui)
+			}, c.ui.ProgressNote().Compact())
 		}
 	}()
 

--- a/internal/cli/clients/epinio_api.go
+++ b/internal/cli/clients/epinio_api.go
@@ -12,8 +12,8 @@ import (
 // EpinioAPIClient provides functionality for talking to an Epinio API
 // server on Kubernetes
 type EpinioAPIClient struct {
-	URL    string
-	WS_URL string
+	URL   string
+	WsURL string
 }
 
 var epinioClientMemo *EpinioAPIClient
@@ -33,14 +33,14 @@ func GetEpinioAPIClient() (*EpinioAPIClient, error) {
 		return nil, err
 	}
 
-	epinioURL, epinioWSURL, err := getEpinioURL(configConfig, cluster)
+	epinioURL, epinioWsURL, err := getEpinioURL(configConfig, cluster)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to resolve epinio api host")
 	}
 
 	epinioClient := &EpinioAPIClient{
-		URL:    epinioURL,
-		WS_URL: epinioWSURL,
+		URL:   epinioURL,
+		WsURL: epinioWsURL,
 	}
 
 	epinioClientMemo = epinioClient

--- a/internal/cli/clients/push.go
+++ b/internal/cli/clients/push.go
@@ -120,7 +120,7 @@ func (c *EpinioClient) waitForPipelineRun(app models.AppRef, id string) error {
 	}
 	client := cs.TektonV1beta1().PipelineRuns(deployments.TektonStagingNamespace)
 
-	if viper.GetInt("verbosity") > 0 {
+	if viper.GetInt("verbosity") == 0 {
 		s := c.ui.Progressf("Waiting for pipelinerun %s", id)
 		defer s.Stop()
 	}

--- a/internal/cli/clients/push.go
+++ b/internal/cli/clients/push.go
@@ -114,7 +114,7 @@ func (c *EpinioClient) logs(ctx context.Context, appRef models.AppRef, stageID s
 			Namespace:     logLine.Namespace,
 			PodName:       logLine.PodName,
 			ContainerName: logLine.ContainerName,
-		}, c.ui)
+		}, c.ui.ProgressNote().Compact().V(1))
 	}
 
 	return nil

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -15,10 +15,11 @@ var (
 
 // Config represents a epinio config
 type Config struct {
-	EpinioProtocol string `mapstructure:"epinio_protocol"`
-	Org            string `mapstructure:"org"`
-	User           string `mapstructure:"user"`
-	Password       string `mapstructure:"pass"`
+	EpinioProtocol   string `mapstructure:"epinio_protocol"`
+	EpinioWSProtocol string `mapstructure:"epinio_ws_protocol"`
+	Org              string `mapstructure:"org"`
+	User             string `mapstructure:"user"`
+	Password         string `mapstructure:"pass"`
 
 	v *viper.Viper
 }
@@ -39,6 +40,7 @@ func Load() (*Config, error) {
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
 	v.SetDefault("epinio_protocol", "http")
+	v.SetDefault("epinio_ws_protocol", "ws")
 	v.SetDefault("org", "workspace")
 
 	// Use empty defaults in viper to allow NeededOptions defaults to apply

--- a/internal/cli/logprinter/logprinter.go
+++ b/internal/cli/logprinter/logprinter.go
@@ -59,7 +59,7 @@ func (printer LogPrinter) Print(log Log, ui *termui.UI) {
 		return
 	}
 
-	ui.ProgressNote().V(1).Compact().Msg(result.String() + " ")
+	ui.ProgressNote().Compact().Msg(result.String() + " ")
 }
 
 func originOf(podName string) string {

--- a/internal/cli/logprinter/logprinter.go
+++ b/internal/cli/logprinter/logprinter.go
@@ -1,0 +1,79 @@
+// Package logprinter is used to print container log lines in color
+package logprinter
+
+import (
+	"bytes"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/epinio/epinio/helpers/termui"
+	"github.com/fatih/color"
+)
+
+var colorList = [][2]*color.Color{
+	{color.New(color.FgHiCyan), color.New(color.FgCyan)},
+	{color.New(color.FgHiGreen), color.New(color.FgGreen)},
+	{color.New(color.FgHiMagenta), color.New(color.FgMagenta)},
+	{color.New(color.FgHiYellow), color.New(color.FgYellow)},
+	{color.New(color.FgHiBlue), color.New(color.FgBlue)},
+	{color.New(color.FgHiRed), color.New(color.FgRed)},
+}
+
+type LogPrinter struct {
+	Tmpl *template.Template
+}
+
+// Log is the object which will be used together with the template to generate
+// the output.
+type Log struct {
+	// Message is the log message itself
+	Message string `json:"message"`
+
+	// Namespace of the pod
+	Namespace string `json:"namespace"`
+
+	// PodName of the pod
+	PodName string `json:"podName"`
+
+	// Origin
+	Origin string `json:"origin"`
+
+	// ContainerName of the container
+	ContainerName string `json:"containerName"`
+
+	PodColor       *color.Color `json:"-"`
+	ContainerColor *color.Color `json:"-"`
+}
+
+func (printer LogPrinter) Print(log Log, ui *termui.UI) {
+	log.PodColor, log.ContainerColor = determineColor(log.PodName)
+	log.Origin = originOf(log.PodName)
+
+	var result bytes.Buffer
+	err := printer.Tmpl.Execute(&result, log)
+	if err != nil {
+		os.Stderr.WriteString(fmt.Sprintf("expanding template failed: %s", err))
+		return
+	}
+
+	ui.ProgressNote().V(1).Compact().Msg(result.String() + " ")
+}
+
+func originOf(podName string) string {
+	if strings.HasPrefix(podName, "staging-pipeline-run-") {
+		return "[STAGE]"
+	}
+	return "[APP]"
+}
+
+func determineColor(podName string) (podColor, containerColor *color.Color) {
+	hash := fnv.New32()
+	hash.Write([]byte(podName))
+	idx := hash.Sum32() % uint32(len(colorList))
+
+	colors := colorList[idx]
+	return colors[0], colors[1]
+}

--- a/internal/cli/logprinter/logprinter.go
+++ b/internal/cli/logprinter/logprinter.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"os"
-	"strings"
 	"text/template"
 
 	"github.com/epinio/epinio/helpers/termui"
@@ -38,9 +37,6 @@ type Log struct {
 	// PodName of the pod
 	PodName string `json:"podName"`
 
-	// Origin
-	Origin string `json:"origin"`
-
 	// ContainerName of the container
 	ContainerName string `json:"containerName"`
 
@@ -48,9 +44,8 @@ type Log struct {
 	ContainerColor *color.Color `json:"-"`
 }
 
-func (printer LogPrinter) Print(log Log, ui *termui.UI) {
+func (printer LogPrinter) Print(log Log, uiMsg *termui.Message) {
 	log.PodColor, log.ContainerColor = determineColor(log.PodName)
-	log.Origin = originOf(log.PodName)
 
 	var result bytes.Buffer
 	err := printer.Tmpl.Execute(&result, log)
@@ -59,14 +54,7 @@ func (printer LogPrinter) Print(log Log, ui *termui.UI) {
 		return
 	}
 
-	ui.ProgressNote().Compact().Msg(result.String() + " ")
-}
-
-func originOf(podName string) string {
-	if strings.HasPrefix(podName, "staging-pipeline-run-") {
-		return "[STAGE]"
-	}
-	return "[APP]"
+	uiMsg.Msg(result.String() + " ")
 }
 
 func determineColor(podName string) (podColor, containerColor *color.Color) {

--- a/internal/cli/logprinter/templates.go
+++ b/internal/cli/logprinter/templates.go
@@ -1,4 +1,4 @@
-package tailer
+package logprinter
 
 import (
 	"encoding/json"

--- a/internal/cli/logprinter/templates.go
+++ b/internal/cli/logprinter/templates.go
@@ -11,7 +11,7 @@ import (
 // DefaultSingleNamespaceTemplate returns a printing template used when
 // printing with colors and watching resources in a single namespace
 func DefaultSingleNamespaceTemplate() *template.Template {
-	t := "{{color .PodColor .Origin}} {{color .ContainerColor .ContainerName}} {{.Message}}"
+	t := "[{{ color .PodColor .PodName}}] {{color .ContainerColor .ContainerName}} {{.Message}}"
 
 	funs := map[string]interface{}{
 		"json": func(in interface{}) (string, error) {


### PR DESCRIPTION
fixes #367 

This PR only implements the basic functionality of the `app logs {appName}` command. It also implements the `--follow` option for the command. 

The next PR's will include
- Watch for addition and removal of Pods while log streaming is done
- color the output of the `app logs` command for different instances
- Implement the `--staging` option for the command