### PR TITLE
Makefile and Releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: main
 
 on:
   push:
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go for Building
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.13.7'
+          go-version: '^1.16.3'
       - name: Setup Ginkgo Test Framework
         run: go install github.com/onsi/ginkgo/ginkgo@v1.16.2
       - name: Cache Tools

--- a/.github/workflows/outside-pr.yml
+++ b/.github/workflows/outside-pr.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go for Building
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.13.7'
+          go-version: '^1.16.3'
       - name: Setup Ginkgo Test Framework
         run: go get -u github.com/onsi/ginkgo/ginkgo
       - name: Lint Epinio

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release-pipeline
+name: release
 
 on:
   push:
@@ -22,11 +22,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.13.7'
+          go-version: '^1.16.3'
       - name: Build Epinio
         if: steps.branch.outputs.BRANCH_NAME == 'main'
         run: |
-          make build-all-small
+          make build-releases
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ build-all: embed_files lint build-amd64 build-arm64 build-arm32 build-windows bu
 build-all-small:
 	@$(MAKE) LDFLAGS+="-s -w" build-all
 
+build-releases:
+	@$(MAKE) LDFLAGS+="-s -w" -o lint embed_files build-all
+
 build-arm32: lint
 	GOARCH="arm" GOOS="linux" CGO_ENABLED=$(CGO_ENABLED) go build $(BUILD_ARGS) -ldflags '$(LDFLAGS)' -o dist/epinio-linux-arm32
 

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /go/src/github.com/epinio
 COPY . .
 COPY --from=tools /helm /usr/bin/helm
 
-RUN make build-all-small
+RUN make -o lint embed_files build-amd64 LDFLAGS="-s -w"
 
 FROM $BASE_IMAGE
 COPY --from=build /go/src/github.com/epinio/dist/epinio-linux-amd64 /epinio


### PR DESCRIPTION
This adds a new task for the release pipeline 'build-releases'.
The target just generates all embedded files and builds all the binaries.
It does not call 'lint' to validate and/or modify the source.

Also changes the names of the workflows to match their filename.
And bumps the Go version used for building.