### PR TITLE
Ignore verbosity when printing staging logs

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Apps", func() {
 
 		act := func(arg string) (string, error) {
 			appDir := "../assets/sample-app"
-			return Epinio(fmt.Sprintf("apps push %[1]s --verbosity 1 %[2]s", appName, arg), appDir)
+			return Epinio(fmt.Sprintf("apps push %[1]s %[2]s", appName, arg), appDir)
 		}
 
 		replicas := func(ns, name string) string {
@@ -181,7 +181,7 @@ var _ = Describe("Apps", func() {
 				currentDir, err := os.Getwd()
 				Expect(err).ToNot(HaveOccurred())
 
-				pushOutput, err := Epinio(fmt.Sprintf("apps push %s -b %s --verbosity 1",
+				pushOutput, err := Epinio(fmt.Sprintf("apps push %s -b %s",
 					appName, serviceName),
 					path.Join(currentDir, "../assets/sample-app"))
 				Expect(err).ToNot(HaveOccurred(), pushOutput)

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -106,11 +106,11 @@ func makeAppWithDir(appName string, instances int, deployFromCurrentDir bool, ap
 	if deployFromCurrentDir {
 		// Note: appDir is handed to the working dir argument of Epinio().
 		// This means that the command runs with it as the CWD.
-		pushOutput, err = Epinio(fmt.Sprintf("apps push %s --verbosity 1 --instances %d", appName, instances), appDir)
+		pushOutput, err = Epinio(fmt.Sprintf("apps push %s --instances %d", appName, instances), appDir)
 	} else {
 		// Note: appDir is handed as second argument to the epinio cli.
 		// This means that the command gets the sources from that directory instead of CWD.
-		pushOutput, err = Epinio(fmt.Sprintf("apps push %s %s --verbosity 1 --instances %d", appName, appDir, instances), "")
+		pushOutput, err = Epinio(fmt.Sprintf("apps push %s %s --instances %d", appName, appDir, instances), "")
 	}
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), pushOutput)
 

--- a/acceptance/wordpress_test.go
+++ b/acceptance/wordpress_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Wordpress", func() {
 	})
 
 	It("can deploy Wordpress", func() {
-		out, err := Epinio(fmt.Sprintf("apps push %s --verbosity 1", wordpress.Name), wordpress.Dir)
+		out, err := Epinio(fmt.Sprintf("apps push %s", wordpress.Name), wordpress.Dir)
 		Expect(err).ToNot(HaveOccurred(), out)
 
 		out, err = Epinio("app list", "")

--- a/internal/cli/clients/push.go
+++ b/internal/cli/clients/push.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/mholt/archiver/v3"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 	tekton "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -96,11 +95,6 @@ func (c *EpinioClient) waitForPipelineRun(app models.AppRef, id string) error {
 		return err
 	}
 	client := cs.TektonV1beta1().PipelineRuns(deployments.TektonStagingNamespace)
-
-	if viper.GetInt("verbosity") == 0 {
-		s := c.ui.Progressf("Waiting for pipelinerun %s", id)
-		defer s.Stop()
-	}
 
 	return wait.PollImmediate(time.Second, duration.ToAppBuilt(),
 		func() (bool, error) {


### PR DESCRIPTION
It was only used to decide whether to print a message and then dots.
Since we always print the staging logs now, we shouldn't be printing any
dots. Also the message reveals Epinio internals (pipelinerun) and is not
useful to the user.