### PR TITLE
Extended `app logs` to support `--staging`

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -311,6 +311,14 @@ var _ = Describe("Apps", func() {
 			deleteApp(appName)
 		})
 
+		It("shows the staging logs", func() {
+			out, err := Epinio("app logs --staging "+appName, "")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			Expect(out).To(MatchRegexp(`.*step-create.*Configuring PHP Application.*`))
+			Expect(out).To(MatchRegexp(`.*step-create.*Using feature -- PHP.*`))
+		})
+
 		It("follows logs", func() {
 			p, err := GetProc(nodeTmpDir+"/epinio app logs --follow "+appName, "")
 			Expect(err).NotTo(HaveOccurred())

--- a/assets/embedded-files/epinio/server.yaml
+++ b/assets/embedded-files/epinio/server.yaml
@@ -20,6 +20,12 @@ metadata:
   name: epinio-server
 rules:
 - apiGroups:
+  - "tekton.dev"
+  resources:
+  - pipelineruns
+  verbs:
+  - delete
+- apiGroups:
   - ""
   resources:
   - nodes

--- a/internal/api/v1/stage.go
+++ b/internal/api/v1/stage.go
@@ -30,6 +30,7 @@ import (
 	"github.com/epinio/epinio/helpers/randstr"
 	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/api/v1/models"
+	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/clients/gitea"
 	"github.com/epinio/epinio/internal/domain"
 	"github.com/epinio/epinio/internal/names"
@@ -118,6 +119,11 @@ func (hc ApplicationsController) Stage(w http.ResponseWriter, r *http.Request) A
 		Git:       req.Git,
 		Route:     req.Route,
 		Instances: instances,
+	}
+
+	err = application.Unstage(name, org, uid)
+	if err != nil {
+		return singleInternalError(err, "failed delete previous pipeline runs")
 	}
 
 	pr := newPipelineRun(uid, app)

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -255,7 +255,7 @@ func Delete(kubeClient *kubernetes.Cluster, gitea GiteaInterface, org string, ap
 		return err
 	}
 
-	err = unstage(app, "")
+	err = Unstage(app.Name, app.Organization, "")
 	if err != nil {
 		return err
 	}
@@ -366,8 +366,8 @@ func (al ApplicationList) Less(i, j int) bool {
 	return al[i].Name < al[j].Name
 }
 
-// Unstage deletes either all PipelineRuns of an application, or all but the current.
-func unstage(app Application, stageIdCurrent string) error {
+// Unstage deletes either all PipelineRuns of the named application, or all but the current.
+func Unstage(app, org, stageIdCurrent string) error {
 	ctx := context.Background()
 
 	cluster, err := kubernetes.GetCluster()
@@ -384,7 +384,7 @@ func unstage(app Application, stageIdCurrent string) error {
 
 	l, err := client.List(ctx, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s,app.kubernetes.io/part-of=%s",
-			app.Name, app.Organization),
+			app, org),
 	})
 	if err != nil {
 		return err

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -392,7 +392,6 @@ func Unstage(app, org, stageIdCurrent string) error {
 
 	for _, pr := range l.Items {
 		if stageIdCurrent != "" && stageIdCurrent == pr.ObjectMeta.Name {
-			fmt.Printf("skip\n")
 			continue
 		}
 

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/epinio/epinio/deployments"
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/duration"
 	"github.com/epinio/epinio/internal/interfaces"
 	"github.com/epinio/epinio/internal/organizations"
 	"github.com/epinio/epinio/internal/services"
 	pkgerrors "github.com/pkg/errors"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -253,6 +255,11 @@ func Delete(kubeClient *kubernetes.Cluster, gitea GiteaInterface, org string, ap
 		return err
 	}
 
+	err = unstage(app, "")
+	if err != nil {
+		return err
+	}
+
 	err = kubeClient.WaitForPodBySelectorMissing(nil,
 		app.Organization,
 		fmt.Sprintf("app.kubernetes.io/name=%s", app.Name),
@@ -357,4 +364,43 @@ func (al ApplicationList) Swap(i, j int) {
 
 func (al ApplicationList) Less(i, j int) bool {
 	return al[i].Name < al[j].Name
+}
+
+// Unstage deletes either all PipelineRuns of an application, or all but the current.
+func unstage(app Application, stageIdCurrent string) error {
+	ctx := context.Background()
+
+	cluster, err := kubernetes.GetCluster()
+	if err != nil {
+		return err
+	}
+
+	cs, err := versioned.NewForConfig(cluster.RestConfig)
+	if err != nil {
+		return err
+	}
+
+	client := cs.TektonV1beta1().PipelineRuns(deployments.TektonStagingNamespace)
+
+	l, err := client.List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s,app.kubernetes.io/part-of=%s",
+			app.Name, app.Organization),
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, pr := range l.Items {
+		if stageIdCurrent != "" && stageIdCurrent == pr.ObjectMeta.Name {
+			fmt.Printf("skip\n")
+			continue
+		}
+
+		err := client.Delete(ctx, pr.ObjectMeta.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -23,6 +23,7 @@ var CmdApp = &cobra.Command{
 func init() {
 	flags := CmdAppLogs.Flags()
 	flags.Bool("follow", false, "follow the logs of the application")
+	flags.Bool("staging", false, "show the staging logs of the application")
 
 	updateFlags := CmdAppUpdate.Flags()
 	updateFlags.Int32P("instances", "i", 1, "The number of instances the application should have")
@@ -111,10 +112,24 @@ var CmdAppLogs = &cobra.Command{
 
 		follow, err := cmd.Flags().GetBool("follow")
 		if err != nil {
-			return errors.Wrap(err, "error reading the staging param")
+			return errors.Wrap(err, "error reading the follow option")
 		}
 
-		err = client.AppLogs(args[0], "", follow, nil)
+		staging, err := cmd.Flags().GetBool("staging")
+		if err != nil {
+			return errors.Wrap(err, "error reading the staging option")
+		}
+
+		stageId := ""
+		if staging {
+			follow = false
+			stageId, err = client.AppStageId(args[0])
+			if err != nil {
+				return errors.Wrap(err, "error retrieving the stage Id")
+			}
+		}
+
+		err = client.AppLogs(args[0], stageId, follow, nil)
 		if err != nil {
 			return errors.Wrap(err, "error streaming application logs")
 		}

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -123,7 +123,7 @@ var CmdAppLogs = &cobra.Command{
 		stageId := ""
 		if staging {
 			follow = false
-			stageId, err = client.AppStageId(args[0])
+			stageId, err = client.AppStageID(args[0])
 			if err != nil {
 				return errors.Wrap(err, "error retrieving the stage Id")
 			}

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -681,7 +681,7 @@ func (c *EpinioClient) AppShow(appName string) error {
 		WithStringValue("Application", appName).
 		Msg("Show application details")
 
-	details.Info("list applications")
+	details.Info("show application")
 
 	jsonResponse, err := c.get(api.Routes.Path("AppShow", c.Config.Org, appName))
 	if err != nil {
@@ -695,11 +695,30 @@ func (c *EpinioClient) AppShow(appName string) error {
 	c.ui.Success().
 		WithTable("Key", "Value").
 		WithTableRow("Status", app.Status).
+		WithTableRow("StageId", app.StageID).
 		WithTableRow("Routes", strings.Join(app.Routes, ", ")).
 		WithTableRow("Services", strings.Join(app.BoundServices, ", ")).
 		Msg("Details:")
 
 	return nil
+}
+
+// AppStageID returns the stage id of the named app, in the targeted org
+func (c *EpinioClient) AppStageId(appName string) (string, error) {
+	log := c.Log.WithName("Apps").WithValues("Organization", c.Config.Org, "Application", appName)
+	log.Info("start")
+	defer log.Info("return")
+
+	jsonResponse, err := c.get(api.Routes.Path("AppShow", c.Config.Org, appName))
+	if err != nil {
+		return "", err
+	}
+	var app application.Application
+	if err := json.Unmarshal(jsonResponse, &app); err != nil {
+		return "", err
+	}
+
+	return app.StageID, nil
 }
 
 // AppUpdate updates the specified running application's attributes (e.g. instances)

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -704,7 +704,7 @@ func (c *EpinioClient) AppShow(appName string) error {
 }
 
 // AppStageID returns the stage id of the named app, in the targeted org
-func (c *EpinioClient) AppStageId(appName string) (string, error) {
+func (c *EpinioClient) AppStageID(appName string) (string, error) {
 	log := c.Log.WithName("Apps").WithValues("Organization", c.Config.Org, "Application", appName)
 	log.Info("start")
 	defer log.Info("return")


### PR DESCRIPTION
Fixes #431.

Beyond support for `epinio app logs --staging` this also implements:

  - Delete pipelinerun(s) for app when deleting app
  - Delete old pipelinerun(s) for app when pushing new revision for app

TODO: Documentation for --staging, and tests.
