### PR TITLE
feat: Delete apps in an org parallelly

### DIFF
--- a/internal/api/v1/organizations.go
+++ b/internal/api/v1/organizations.go
@@ -185,7 +185,6 @@ func deleteApps(cluster *kubernetes.Cluster, gitea *gitea.Client, org string) er
 				if err != nil {
 					errChan <- err
 				}
-				<-buffer
 			}(app)
 
 			select {


### PR DESCRIPTION
Fixes #370

I added a maximum number of concurrent app deletions. I thought it would be a good a idea just in case the system cannot handle too many requests at the same time. I set 100 for the max number of concurrent deletions, but please let me know if you think we should change this number or if this limit is not needed at all.
I didn't include unit tests as I didn't saw any, but please let me know if they need to be included.

Any feedback would be highly appreciated!