### PR TITLE
fix: Wait for the namespace to be gone

### DIFF
--- a/deployments/service_catalog.go
+++ b/deployments/service_catalog.go
@@ -85,6 +85,11 @@ func (k ServiceCatalog) Delete(c *kubernetes.Cluster, ui *termui.UI) error {
 		return errors.Wrapf(err, "Failed deleting namespace %s", ServiceCatalogDeploymentID)
 	}
 
+	err = c.WaitForNamespaceMissing(ui, ServiceCatalogDeploymentID, k.Timeout)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete namespace")
+	}
+
 	ui.Success().Msg("ServiceCatalog removed")
 
 	return nil


### PR DESCRIPTION
Fixes #412 

The kube command can and will return before the namespace is gone.

See also the other deployments, waiting for the command to be done, and then the namespace to be actually gone.
