### PR TITLE
Delete old pipelineruns only when new staging succeeds

### DIFF
--- a/internal/api/v1/models/models.go
+++ b/internal/api/v1/models/models.go
@@ -56,3 +56,7 @@ type StageRequest struct {
 type StageResponse struct {
 	Stage StageRef `json:"stage,omitempty"`
 }
+
+type StageStatusResponse struct {
+	ErrorMessage string `json:"errorMessage,omitempty"`
+}

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -64,15 +64,16 @@ func patch(path string, h http.HandlerFunc) routes.Route {
 }
 
 var Routes = routes.NamedRoutes{
-	"Info":        get("/info", errorHandler(InfoController{}.Info)),
-	"Apps":        get("/orgs/:org/applications", errorHandler(ApplicationsController{}.Index)),
-	"AppShow":     get("/orgs/:org/applications/:app", errorHandler(ApplicationsController{}.Show)),
-	"AppLogs":     get("/orgs/:org/applications/:app/logs", ApplicationsController{}.Logs),
-	"StagingLogs": get("/orgs/:org/staging/:stage_id/logs", ApplicationsController{}.Logs),
-	"AppDelete":   delete("/orgs/:org/applications/:app", errorHandler(ApplicationsController{}.Delete)),
-	"AppUpload":   post("/orgs/:org/applications/:app/store", errorHandler(ApplicationsController{}.Upload)),
-	"AppStage":    post("/orgs/:org/applications/:app/stage", errorHandler(ApplicationsController{}.Stage)),
-	"AppUpdate":   patch("/orgs/:org/applications/:app", errorHandler(ApplicationsController{}.Update)),
+	"Info":           get("/info", errorHandler(InfoController{}.Info)),
+	"Apps":           get("/orgs/:org/applications", errorHandler(ApplicationsController{}.Index)),
+	"AppShow":        get("/orgs/:org/applications/:app", errorHandler(ApplicationsController{}.Show)),
+	"AppLogs":        get("/orgs/:org/applications/:app/logs", ApplicationsController{}.Logs),
+	"StagingLogs":    get("/orgs/:org/staging/:stage_id/logs", ApplicationsController{}.Logs),
+	"AppDelete":      delete("/orgs/:org/applications/:app", errorHandler(ApplicationsController{}.Delete)),
+	"AppUpload":      post("/orgs/:org/applications/:app/store", errorHandler(ApplicationsController{}.Upload)),
+	"AppStage":       post("/orgs/:org/applications/:app/stage", errorHandler(ApplicationsController{}.Stage)),
+	"AppUntilStaged": post("/orgs/:org/applications/:app/staged/:id", errorHandler(ApplicationsController{}.WaitUntilStaged)),
+	"AppUpdate":      patch("/orgs/:org/applications/:app", errorHandler(ApplicationsController{}.Update)),
 
 	// Bind and unbind services to/from applications, by means of servicebindings in applications
 	"ServiceBindingCreate": post("/orgs/:org/applications/:app/servicebindings",

--- a/internal/api/v1/stage.go
+++ b/internal/api/v1/stage.go
@@ -68,7 +68,7 @@ func (hc ApplicationsController) WaitUntilStaged(w http.ResponseWriter, r *http.
 
 	err = wait.PollImmediate(time.Second, duration.ToAppBuilt(),
 		func() (bool, error) {
-			l, err := client.List(context.TODO(),
+			l, err := client.List(ctx,
 				metav1.ListOptions{LabelSelector: models.EpinioStageIDLabel + "=" + stageId})
 			if err != nil {
 				return false, err

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -1132,7 +1132,7 @@ func (c *EpinioClient) Push(app string, source string, params PushParams) error 
 		}
 	}()
 
-	details.Info("wait for pipelinerun", "StageID", stage.Stage.ID)
+	details.Info("wait for pipelinerun", "org", appRef.Org, "app", appRef.Name, "StageID", stage.Stage.ID)
 	err = c.waitForPipelineRun(appRef, stage.Stage.ID)
 	if err != nil {
 		stopChan <- true // Stop the printing go routine
@@ -1140,8 +1140,8 @@ func (c *EpinioClient) Push(app string, source string, params PushParams) error 
 	}
 	stopChan <- true // Stop the printing go routine
 
-	details.Info("wait for app", "StageID", stage.Stage.ID)
-	err = c.waitForApp(appRef, stage.Stage.ID)
+	details.Info("wait for app", "org", appRef.Org, "app", appRef.Name)
+	err = c.waitForApp(appRef)
 	if err != nil {
 		return errors.Wrap(err, "waiting for app failed")
 	}


### PR DESCRIPTION
Was made to fix the issue #452 
The alternate pull request #483 looks to be better. It does the cleanup in the pipeline itself, as just another stage.

