### PR TITLE
Make service params be a json string and validate it

### DIFF
--- a/acceptance/catalog_services_test.go
+++ b/acceptance/catalog_services_test.go
@@ -1,6 +1,9 @@
 package acceptance_test
 
 import (
+	"fmt"
+
+	"github.com/epinio/epinio/helpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -17,6 +20,17 @@ var _ = Describe("Catalog Services", func() {
 	Describe("service create", func() {
 		It("creates a catalog based service, with waiting", func() {
 			makeCatalogService(serviceName)
+		})
+
+		It("creates a catalog based service, with additional data", func() {
+			makeCatalogService(serviceName, `{ "db": { "name": "wordpress" }}`)
+			serviceInstanceName := fmt.Sprintf("service.org-%s.svc-%s", org, serviceName)
+
+			out, err := helpers.Kubectl(
+				fmt.Sprintf("get serviceinstance -n %s %s -o=jsonpath='{.status.externalProperties.parameters.db.name}'",
+					org, serviceInstanceName))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(Equal("wordpress"))
 		})
 
 		It("creates a catalog based service, without waiting", func() {

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -143,8 +143,12 @@ func makeCustomService(serviceName string) {
 	ExpectWithOffset(1, out).To(MatchRegexp(serviceName))
 }
 
-func makeCatalogService(serviceName string) {
-	out, err := Epinio(fmt.Sprintf("service create %s mariadb 10-3-22", serviceName), "")
+func makeCatalogService(serviceName string, dataJSON ...string) {
+	dataStr := ""
+	if len(dataJSON) > 0 {
+		dataStr = fmt.Sprintf("--data '%s'", dataJSON[0])
+	}
+	out, err := Epinio(fmt.Sprintf("service create %s mariadb 10-3-22 %s", serviceName, dataStr), "")
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)
 
 	// Look for the messaging indicating that the command waited
@@ -158,8 +162,12 @@ func makeCatalogService(serviceName string) {
 	ExpectWithOffset(1, out).To(MatchRegexp(serviceName))
 }
 
-func makeCatalogServiceDontWait(serviceName string) {
-	out, err := Epinio(fmt.Sprintf("service create --dont-wait %s mariadb 10-3-22", serviceName), "")
+func makeCatalogServiceDontWait(serviceName string, dataJSON ...string) {
+	dataStr := ""
+	if len(dataJSON) > 0 {
+		dataStr = fmt.Sprintf("--data '%s'", dataJSON[0])
+	}
+	out, err := Epinio(fmt.Sprintf("service create --dont-wait %s mariadb 10-3-22 %s", serviceName, dataStr), "")
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)
 
 	// Look for indicator that command did not wait

--- a/internal/api/v1/models/models.go
+++ b/internal/api/v1/models/models.go
@@ -10,11 +10,11 @@ type ServiceResponse struct {
 type ServiceResponseList []ServiceResponse
 
 type CatalogCreateRequest struct {
-	Name             string            `json:"name"`
-	Class            string            `json:"class"`
-	Plan             string            `json:"plan"`
-	Data             map[string]string `json:"data"`
-	WaitForProvision bool              `json:"waitforprovision"`
+	Name             string `json:"name"`
+	Class            string `json:"class"`
+	Plan             string `json:"plan"`
+	Data             string `json:"data"`
+	WaitForProvision bool   `json:"waitforprovision"`
 }
 
 type CustomCreateRequest struct {

--- a/internal/api/v1/services.go
+++ b/internal/api/v1/services.go
@@ -269,9 +269,19 @@ func (sc ServicesController) Create(w http.ResponseWriter, r *http.Request) APIE
 		return ServicePlanIsNotKnown(createRequest.Plan, createRequest.Class)
 	}
 
+	data := createRequest.Data
+	if createRequest.Data == "" {
+		data = "{}"
+	}
+	var dataObj map[string]interface{}
+	err = json.Unmarshal([]byte(data), &dataObj)
+	if err != nil {
+		return BadRequest(err, data)
+	}
+
 	// Create the new service. At last.
 	service, err := services.CreateCatalogService(ctx, cluster, createRequest.Name, org,
-		createRequest.Class, createRequest.Plan, createRequest.Data)
+		createRequest.Class, createRequest.Plan, data)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -429,25 +429,18 @@ func (c *EpinioClient) DeleteService(name string, unbind bool) error {
 
 // CreateService creates a service specified by name, class, plan, and optional key/value dictionary
 // TODO: Allow underscores in service names (right now they fail because of kubernetes naming rules for secrets)
-func (c *EpinioClient) CreateService(name, class, plan string, dict []string, waitForProvision bool) error {
+func (c *EpinioClient) CreateService(name, class, plan string, data string, waitForProvision bool) error {
 	log := c.Log.WithName("Create Service").
 		WithValues("Name", name, "Class", class, "Plan", plan, "Organization", c.Config.Org)
 	log.Info("start")
 	defer log.Info("return")
 
-	data := make(map[string]string)
 	msg := c.ui.Note().
 		WithStringValue("Name", name).
 		WithStringValue("Organization", c.Config.Org).
 		WithStringValue("Class", class).
 		WithStringValue("Plan", plan).
 		WithTable("Parameter", "Value")
-	for i := 0; i < len(dict); i += 2 {
-		key := dict[i]
-		value := dict[i+1]
-		msg = msg.WithTableRow(key, value)
-		data[key] = value
-	}
 	msg.Msg("Create Service")
 
 	request := models.CatalogCreateRequest{

--- a/internal/services/catalog_service.go
+++ b/internal/services/catalog_service.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -374,13 +373,8 @@ func CatalogServiceLookup(ctx context.Context, kubeClient *kubernetes.Cluster, o
 	}, nil
 }
 
-func CreateCatalogService(ctx context.Context, kubeClient *kubernetes.Cluster, name, org, class, plan string, parameters map[string]string) (interfaces.Service, error) {
+func CreateCatalogService(ctx context.Context, kubeClient *kubernetes.Cluster, name, org, class, plan string, parameters string) (interfaces.Service, error) {
 	resourceName := serviceResourceName(org, name)
-
-	param, err := json.Marshal(parameters)
-	if err != nil {
-		return nil, err
-	}
 
 	data := fmt.Sprintf(`{
 		"apiVersion": "servicecatalog.k8s.io/v1beta1",
@@ -397,13 +391,14 @@ func CreateCatalogService(ctx context.Context, kubeClient *kubernetes.Cluster, n
 		},
 		"spec": {
 			"clusterServiceClassExternalName": "%s",
-			"clusterServicePlanExternalName": "%s" },
-		"parameters": %s
-	}`, resourceName, org, name, org, class, plan, param)
+			"clusterServicePlanExternalName": "%s",
+			"parameters": %s
+	  }
+	}`, resourceName, org, name, org, class, plan, parameters)
 
 	decoderUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 	obj := &unstructured.Unstructured{}
-	_, _, err = decoderUnstructured.Decode([]byte(data), nil, obj)
+	_, _, err := decoderUnstructured.Decode([]byte(data), nil, obj)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
because the user may need to specify deeply nested params

Fixes #481 