### PR TITLE
Wait for deployments and retry until cert-manager is ready

### DIFF
--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -19,6 +19,7 @@ const (
 	podReady         = 5 * time.Minute
 	appBuilt         = 10 * time.Minute
 	warmupJobReady   = 30 * time.Minute
+	certManagerReady = 5 * time.Minute
 
 	// Fixed. __Not__ affected by the multiplier.
 	pollInterval = 3 * time.Second
@@ -36,6 +37,10 @@ func Flags(pf *flag.FlagSet, argToEnv map[string]string) {
 // Multiplier returns the timeout-multiplier argument
 func Multiplier() time.Duration {
 	return time.Duration(viper.GetInt("timeout-multiplier"))
+}
+
+func ToCertManagerReady() time.Duration {
+	return Multiplier() * certManagerReady
 }
 
 // ToAppBuilt returns the duration to wait until giving up on the


### PR DESCRIPTION
because waiting for pods to come up doesn't mean the deployment is ready
to serve requests.

In the case of cert-manager, a ready Deployment also doesn't mean the
webhook server is working:

https://cert-manager.io/v1.2-docs/concepts/webhook/#webhook-connection-problems-shortly-after-cert-manager-installation

As suggested in the link above, we simply retry until it works.

Co-authored-by: Dimitris Karakasilis <DKarakasilis@suse.com>