### PR TITLE
Separate Traefik Installation

### DIFF
--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -283,6 +283,15 @@ func ensureEpinio() {
 		}
 	}
 	fmt.Println("Installing Epinio")
+
+	// Installing linkerd and ingress separate from the main
+	// pieces.  Ensures that the main install command invokes and
+	// passes the presence checks for linkerd and traefik.
+	out, err = RunProc(
+		"../dist/epinio-linux-amd64 install-ingress",
+		"", false)
+	Expect(err).ToNot(HaveOccurred(), out)
+
 	// Allow the installation to continue by not trying to create the default org
 	// before we patch.
 	out, err = RunProc(

--- a/deployments/linkerd.go
+++ b/deployments/linkerd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kyokomi/emoji"
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -143,6 +144,8 @@ func (k Linkerd) Deploy(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 
 		ui.Exclamation().Msg("Linkerd already installed, skipping")
 		return nil
+	} else if !apierrors.IsNotFound(err) {
+		return err
 	}
 
 	log.Info("check presence, linkerd namespace")
@@ -154,6 +157,8 @@ func (k Linkerd) Deploy(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 	)
 	if err == nil {
 		return errors.New("Namespace " + LinkerdDeploymentID + " present already")
+	} else if !apierrors.IsNotFound(err) {
+		return err
 	}
 
 	ui.Note().KeeplineUnder(1).Msg("Deploying Linkerd...")

--- a/deployments/traefik.go
+++ b/deployments/traefik.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kyokomi/emoji"
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -186,6 +187,8 @@ func (k Traefik) Deploy(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 
 		ui.Exclamation().Msg("Traefik Ingress already installed, skipping")
 		return nil
+	} else if !apierrors.IsNotFound(err) {
+		return err
 	}
 
 	log.Info("check presence, system service")
@@ -200,6 +203,8 @@ func (k Traefik) Deploy(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 
 		ui.Exclamation().Msg("System Ingress present, skipping")
 		return nil
+	} else if !apierrors.IsNotFound(err) {
+		return err
 	}
 
 	log.Info("check presence, traefik namespace")
@@ -213,6 +218,8 @@ func (k Traefik) Deploy(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 		log.Info("namespace present")
 
 		return errors.New("Namespace " + TraefikDeploymentID + " present already")
+	} else if !apierrors.IsNotFound(err) {
+		return err
 	}
 
 	ui.Note().KeeplineUnder(1).Msg("Deploying Traefik Ingress...")

--- a/deployments/traefik.go
+++ b/deployments/traefik.go
@@ -157,6 +157,18 @@ func (k Traefik) Deploy(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 		return nil
 	}
 
+	// Cases to consider, plus actions
+	//
+	//     | Service | Namespace | Meaning                             | Actions
+	// --- | ---     | ---       | ---                                 | ---
+	//  a  | yes     | yes       | Traefik present, likely from Epinio | Nothing
+	//  b  | yes     | no        | Traefik present, likely external    | Nothing
+	//  c  | no      | yes       | Something has claimed the namespace | Error
+	//  d  | no      | no        | Namespace is free for use           | Deploy
+
+	// Bug: The current order of checking (namespace first, then
+	// service), and associated actions, mishandles case A (Error
+	// instead of nothing).
 
 	log.Info("check presence, namespace")
 

--- a/deployments/traefik.go
+++ b/deployments/traefik.go
@@ -145,9 +145,17 @@ func (k Traefik) Deploy(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 	log.Info("start")
 	defer log.Info("return")
 
+	// When called from `install` option `skip-traefik` is present.
+	// When called from `install-ingress` the option is NOT present.
+	// It does not make sense to skip installing the very thing the command is about.
+
 	skipTraefik, err := options.GetBool("skip-traefik", TraefikDeploymentID)
 	if err != nil {
-		return errors.Wrap(err, "Couldn't get skip-traefik option")
+		if err.Error() != "skip-traefik not set" {
+			return errors.Wrap(err, "Couldn't get skip-traefik option")
+		}
+
+		skipTraefik = false
 	}
 
 	log.Info("config", "skipTraefik", skipTraefik)

--- a/internal/cli/clients/install_client.go
+++ b/internal/cli/clients/install_client.go
@@ -123,7 +123,10 @@ func (c *InstallClient) Install(cmd *cobra.Command) error {
 		return err
 	}
 
-	if err := c.InstallDeployment(ctx, &deployments.Traefik{Timeout: duration.ToDeployment()}, details); err != nil {
+	if err := c.InstallDeployment(ctx, &deployments.Traefik{
+		Timeout: duration.ToDeployment(),
+		Log:     details.V(1),
+	}, details); err != nil {
 		return err
 	}
 
@@ -286,6 +289,8 @@ func (c *InstallClient) DeleteWorkloads(ctx context.Context, ui *termui.UI) erro
 // InstallDeployment installs one single Deployment on the cluster
 func (c *InstallClient) InstallDeployment(ctx context.Context, deployment kubernetes.Deployment, logger logr.Logger) error {
 	logger.Info("deploy", "Deployment", deployment.ID())
+	defer logger.Info("return")
+
 	return deployment.Deploy(ctx, c.kubeClient, c.ui, c.options.ForDeployment(deployment.ID()))
 }
 

--- a/internal/cli/clients/install_client.go
+++ b/internal/cli/clients/install_client.go
@@ -119,7 +119,10 @@ func (c *InstallClient) Install(cmd *cobra.Command) error {
 	// to report all problems at once, instead of early and
 	// piecemal.
 
-	if err := c.InstallDeployment(ctx, &deployments.Linkerd{Timeout: duration.ToDeployment()}, details); err != nil {
+	if err := c.InstallDeployment(ctx, &deployments.Linkerd{
+		Timeout: duration.ToDeployment(),
+		Log:     details.V(1),
+	}, details); err != nil {
 		return err
 	}
 
@@ -256,7 +259,10 @@ func (c *InstallClient) Uninstall(cmd *cobra.Command) error {
 		return err
 	}
 
-	if err := c.UninstallDeployment(ctx, &deployments.Linkerd{Timeout: duration.ToDeployment()}, details); err != nil {
+	if err := c.UninstallDeployment(ctx, &deployments.Linkerd{
+		Timeout: duration.ToDeployment(),
+		Log:     details.V(1),
+	}, details); err != nil {
 		panic(err)
 	}
 
@@ -311,7 +317,10 @@ func (c *InstallClient) InstallIngress(cmd *cobra.Command) error {
 	// to report all problems at once, instead of early and
 	// piecemal.
 
-	if err := c.InstallDeployment(ctx, &deployments.Linkerd{Timeout: duration.ToDeployment()}, details); err != nil {
+	if err := c.InstallDeployment(ctx, &deployments.Linkerd{
+		Timeout: duration.ToDeployment(),
+		Log:     details.V(1),
+	}, details); err != nil {
 		return err
 	}
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -59,6 +59,7 @@ func Execute() {
 
 	rootCmd.AddCommand(CmdCompletion)
 	rootCmd.AddCommand(CmdInstall)
+	rootCmd.AddCommand(CmdInstallIngress)
 	rootCmd.AddCommand(CmdUninstall)
 	rootCmd.AddCommand(CmdInfo)
 	rootCmd.AddCommand(CmdOrg)


### PR DESCRIPTION
Fixes #477 

User can install `linkerd` and `traefik` separately, via `epinio install-ingress`.
This separation then allows setup of DNS for custom domains.
I.e. point domain to the IP of the main traefik ingress.

See #488 for the main epic explaining the underlying issue.
See #476 for an competing/supporting change.
See #489 for needed documentation in this area (Traefik/Linkerd meshing)
