### PR TITLE
Cleanup some small things

### DIFF
--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -47,10 +47,10 @@ func Client() *http.Client {
 // func Curl is used to make requests against a server
 func Curl(method, uri string, requestBody *strings.Reader) (*http.Response, error) {
 	request, err := http.NewRequest(method, uri, requestBody)
-	request.SetBasicAuth(epinioUser, epinioPassword)
 	if err != nil {
 		return nil, err
 	}
+	request.SetBasicAuth(epinioUser, epinioPassword)
 	return Client().Do(request)
 }
 

--- a/deployments/quarks.go
+++ b/deployments/quarks.go
@@ -129,6 +129,7 @@ func (k Quarks) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI,
 
 	// Setup Quarks helm values
 	var helmArgs = []string{
+		"--set logLevel=info",
 		"--set image.tag=" + quarksLiteImageTag,
 	}
 

--- a/deployments/tekton.go
+++ b/deployments/tekton.go
@@ -206,7 +206,6 @@ func (k Tekton) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI,
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("%s failed:\n%s", message, out))
 			}
-			ui.Success().Msgf("applied %s", tektonPipelineYamlPath)
 			return nil
 		},
 		retry.RetryIf(func(err error) bool {

--- a/internal/api/v1/applications.go
+++ b/internal/api/v1/applications.go
@@ -222,7 +222,7 @@ func (hc ApplicationsController) Logs(w http.ResponseWriter, r *http.Request) {
 // closed.
 // Internally this uses two concurrent "threads" talking with each other
 // over the logChan. This is a channel of ContainerLogLine.
-// The first thread runs `models.Logs` in a go routine. It spins up a number of supporting go routines
+// The first thread runs `application.Logs` in a go routine. It spins up a number of supporting go routines
 // that are stopped when the passed context is "Done()". The parent go routine
 // waits until all the subordinate routines are stopped. It does this by waiting on a WaitGroup.
 // When that happens the parent go routine closes the logChan. This signals
@@ -241,7 +241,7 @@ func (hc ApplicationsController) streamPodLogs(ctx context.Context, orgName, app
 	wg.Add(1)
 	go func(outerWg *sync.WaitGroup) {
 		var tailWg sync.WaitGroup
-		err := models.Logs(logCtx, logChan, &tailWg, cluster, follow, appName, stageID, orgName)
+		err := application.Logs(logCtx, logChan, &tailWg, cluster, follow, appName, stageID, orgName)
 		if err != nil {
 			logger.Error(err, "setting up log routines failed")
 		}

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -1,3 +1,5 @@
+// Package application has actor functions that deal with application workloads
+// on k8s
 package application
 
 import (

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -38,7 +38,7 @@ type Application struct {
 	StageID       string
 	Routes        []string
 	BoundServices []string
-	kubeClient    *kubernetes.Cluster
+	cluster       *kubernetes.Cluster
 }
 
 type ApplicationList []Application
@@ -53,21 +53,21 @@ func (a *Application) Delete(ctx context.Context, gitea GiteaInterface) error {
 		return pkgerrors.Wrap(err, "failed to delete repository")
 	}
 
-	err := a.kubeClient.Kubectl.AppsV1().Deployments(a.Organization).
+	err := a.cluster.Kubectl.AppsV1().Deployments(a.Organization).
 		Delete(ctx, a.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return pkgerrors.Wrap(err, "failed to delete application deployment")
 	}
 
-	err = a.kubeClient.Kubectl.ExtensionsV1beta1().Ingresses(a.Organization).
+	err = a.cluster.Kubectl.ExtensionsV1beta1().Ingresses(a.Organization).
 		Delete(ctx, a.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return pkgerrors.Wrap(err, "failed to delete application ingress")
 	}
 
-	err = a.kubeClient.Kubectl.CoreV1().Services(a.Organization).
+	err = a.cluster.Kubectl.CoreV1().Services(a.Organization).
 		Delete(ctx, a.Name, metav1.DeleteOptions{})
 
 	if err != nil {
@@ -87,7 +87,7 @@ func (a *Application) Services(ctx context.Context) (interfaces.ServiceList, err
 	var bound = interfaces.ServiceList{}
 
 	for _, volume := range deployment.Spec.Template.Spec.Volumes {
-		service, err := services.Lookup(ctx, a.kubeClient, a.Organization, volume.Name)
+		service, err := services.Lookup(ctx, a.cluster, a.Organization, volume.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -110,7 +110,7 @@ func (a *Application) Scale(ctx context.Context, instances int32) error {
 
 		deployment.Spec.Replicas = &instances
 
-		_, err = a.kubeClient.Kubectl.AppsV1().Deployments(a.Organization).Update(
+		_, err = a.cluster.Kubectl.AppsV1().Deployments(a.Organization).Update(
 			ctx, deployment, metav1.UpdateOptions{})
 
 		return err
@@ -157,7 +157,7 @@ func (a *Application) Unbind(ctx context.Context, service interfaces.Service) er
 		deployment.Spec.Template.Spec.Volumes = newVolumes
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = newVolumeMounts
 
-		_, err = a.kubeClient.Kubectl.AppsV1().Deployments(a.Organization).Update(
+		_, err = a.cluster.Kubectl.AppsV1().Deployments(a.Organization).Update(
 			ctx,
 			deployment,
 			metav1.UpdateOptions{},
@@ -177,7 +177,7 @@ func (a *Application) Unbind(ctx context.Context, service interfaces.Service) er
 }
 
 func (a *Application) deployment(ctx context.Context) (*appsv1.Deployment, error) {
-	return a.kubeClient.Kubectl.AppsV1().Deployments(a.Organization).Get(
+	return a.cluster.Kubectl.AppsV1().Deployments(a.Organization).Get(
 		ctx, a.Name, metav1.GetOptions{},
 	)
 }
@@ -222,7 +222,7 @@ func (a *Application) Bind(ctx context.Context, service interfaces.Service) erro
 		deployment.Spec.Template.Spec.Volumes = volumes
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
 
-		_, err = a.kubeClient.Kubectl.AppsV1().Deployments(a.Organization).Update(
+		_, err = a.cluster.Kubectl.AppsV1().Deployments(a.Organization).Update(
 			ctx,
 			deployment,
 			metav1.UpdateOptions{},
@@ -242,8 +242,8 @@ func (a *Application) Bind(ctx context.Context, service interfaces.Service) erro
 }
 
 // Lookup locates an Application by org and name
-func Lookup(ctx context.Context, kubeClient *kubernetes.Cluster, org, lookupApp string) (*Application, error) {
-	apps, err := List(ctx, kubeClient, org)
+func Lookup(ctx context.Context, cluster *kubernetes.Cluster, org, lookupApp string) (*Application, error) {
+	apps, err := List(ctx, cluster, org)
 	if err != nil {
 		return nil, err
 	}
@@ -258,10 +258,10 @@ func Lookup(ctx context.Context, kubeClient *kubernetes.Cluster, org, lookupApp 
 }
 
 // Delete deletes an application by org and name
-func Delete(ctx context.Context, kubeClient *kubernetes.Cluster, gitea GiteaInterface, org string, app Application) error {
+func Delete(ctx context.Context, cluster *kubernetes.Cluster, gitea GiteaInterface, org string, app Application) error {
 	if len(app.BoundServices) > 0 {
 		for _, bonded := range app.BoundServices {
-			bound, err := services.Lookup(ctx, kubeClient, org, bonded)
+			bound, err := services.Lookup(ctx, cluster, org, bonded)
 			if err != nil {
 				return err
 			}
@@ -283,7 +283,7 @@ func Delete(ctx context.Context, kubeClient *kubernetes.Cluster, gitea GiteaInte
 		return err
 	}
 
-	err = kubeClient.WaitForPodBySelectorMissing(ctx, nil,
+	err = cluster.WaitForPodBySelectorMissing(ctx, nil,
 		app.Organization,
 		fmt.Sprintf("app.kubernetes.io/name=%s", app.Name),
 		duration.ToDeployment())
@@ -295,14 +295,14 @@ func Delete(ctx context.Context, kubeClient *kubernetes.Cluster, gitea GiteaInte
 }
 
 // List returns an ApplicationList of all available applications (in the org)
-func List(ctx context.Context, kubeClient *kubernetes.Cluster, org string) (ApplicationList, error) {
+func List(ctx context.Context, cluster *kubernetes.Cluster, org string) (ApplicationList, error) {
 	listOptions := metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/component=application,app.kubernetes.io/managed-by=epinio",
 	}
 
 	result := ApplicationList{}
 
-	exists, err := organizations.Exists(ctx, kubeClient, org)
+	exists, err := organizations.Exists(ctx, cluster, org)
 	if err != nil {
 		return result, err
 	}
@@ -310,7 +310,7 @@ func List(ctx context.Context, kubeClient *kubernetes.Cluster, org string) (Appl
 		return result, fmt.Errorf("organization %s does not exist", org)
 	}
 
-	deployments, err := kubeClient.Kubectl.AppsV1().Deployments(org).List(ctx, listOptions)
+	deployments, err := cluster.Kubectl.AppsV1().Deployments(org).List(ctx, listOptions)
 	if err != nil {
 		return result, err
 	}
@@ -319,7 +319,7 @@ func List(ctx context.Context, kubeClient *kubernetes.Cluster, org string) (Appl
 		appEpinio, err := (&Application{
 			Organization: org,
 			Name:         deployment.ObjectMeta.Name,
-			kubeClient:   kubeClient,
+			cluster:      cluster,
 		}).Complete(ctx)
 		if err != nil {
 			return result, err
@@ -341,14 +341,14 @@ func (app *Application) Complete(ctx context.Context) (*Application, error) {
 		LabelSelector: selector,
 	}
 
-	pods, err := app.kubeClient.Kubectl.CoreV1().Pods(app.Organization).List(ctx, listOptions)
+	pods, err := app.cluster.Kubectl.CoreV1().Pods(app.Organization).List(ctx, listOptions)
 	if err != nil {
 		return nil, err
 	}
 
 	app.StageID = pods.Items[0].ObjectMeta.Labels["epinio.suse.org/stage-id"]
 
-	app.Status, err = app.kubeClient.DeploymentStatus(ctx,
+	app.Status, err = app.cluster.DeploymentStatus(ctx,
 		app.Organization,
 		fmt.Sprintf("app.kubernetes.io/part-of=%s,app.kubernetes.io/name=%s",
 			app.Organization, app.Name))
@@ -356,7 +356,7 @@ func (app *Application) Complete(ctx context.Context) (*Application, error) {
 		app.Status = err.Error()
 	}
 
-	app.Routes, err = app.kubeClient.ListIngressRoutes(ctx,
+	app.Routes, err = app.cluster.ListIngressRoutes(ctx,
 		app.Organization, app.Name)
 	if err != nil {
 		app.Routes = []string{err.Error()}
@@ -430,7 +430,7 @@ func Unstage(ctx context.Context, app, org, stageIdCurrent string) error {
 // to close the logChan when done.
 // When stageID is an empty string, no staging logs are returned. If it is set,
 // then only logs from that staging process are returned.
-func Logs(ctx context.Context, logChan chan tailer.ContainerLogLine, wg *sync.WaitGroup, client *kubernetes.Cluster, follow bool, app, stageID, org string) error {
+func Logs(ctx context.Context, logChan chan tailer.ContainerLogLine, wg *sync.WaitGroup, cluster *kubernetes.Cluster, follow bool, app, stageID, org string) error {
 	selector := labels.NewSelector()
 
 	var selectors [][]string
@@ -474,8 +474,8 @@ func Logs(ctx context.Context, logChan chan tailer.ContainerLogLine, wg *sync.Wa
 	}
 
 	if follow {
-		return tailer.StreamLogs(ctx, logChan, wg, config, client)
+		return tailer.StreamLogs(ctx, logChan, wg, config, cluster)
 	}
 
-	return tailer.FetchLogs(ctx, logChan, wg, config, client)
+	return tailer.FetchLogs(ctx, logChan, wg, config, cluster)
 }


### PR DESCRIPTION
Refers to #347 

* applied tekton.yaml message, was introduced for testing
* nil error in utilities, should be called after error checking
* quarks-secret debug message spam in logs every seconds
* models.Logs is an actor that uses a context, should go into application package
* kubeClient is a `Cluster`, not a client