### PR TITLE
Create helper method to properly wait for quarks deployment to be ready

### DIFF
--- a/deployments/registry.go
+++ b/deployments/registry.go
@@ -131,13 +131,7 @@ func (k Registry) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 		return err
 	}
 
-	// Wait until quarks is ready because we need it to create the secret
-	if err := c.WaitUntilPodBySelectorExist(ctx, ui, QuarksDeploymentID, "name=quarks-secret", k.Timeout); err != nil {
-		return errors.Wrap(err, "Epinio-workloads failed waiting Quarks quarks-secret deployment to exist")
-	}
-	if err := c.WaitForPodBySelectorRunning(ctx, ui, QuarksDeploymentID, "name=quarks-secret", k.Timeout); err != nil {
-		return errors.Wrap(err, "Epinio-workloads failed waiting Quarks quarks-secret deployment to come up")
-	}
+	waitForQuarks(c, ctx, ui, duration.ToQuarksDeploymentReady())
 
 	tarPath, err := helpers.ExtractFile(registryChartFile)
 	if err != nil {

--- a/deployments/tekton.go
+++ b/deployments/tekton.go
@@ -231,13 +231,7 @@ func (k Tekton) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI,
 		return err
 	}
 
-	// Wait until quarks is ready because we need it to create the secret
-	if err := c.WaitUntilPodBySelectorExist(ctx, ui, QuarksDeploymentID, "name=quarks-secret", k.Timeout); err != nil {
-		return errors.Wrap(err, "failed waiting Quarks quarks-secret deployment to exist")
-	}
-	if err := c.WaitForPodBySelectorRunning(ctx, ui, QuarksDeploymentID, "name=quarks-secret", k.Timeout); err != nil {
-		return errors.Wrap(err, "failed waiting Quarks quarks-secret deployment to come up")
-	}
+	waitForQuarks(c, ctx, ui, duration.ToQuarksDeploymentReady())
 
 	domain, err := options.GetString("system_domain", TektonDeploymentID)
 	if err != nil {

--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -10,16 +10,17 @@ import (
 )
 
 const (
-	systemDomain     = 2 * time.Minute
-	appReady         = 2 * time.Minute
-	deployment       = 5 * time.Minute
-	orgDeletion      = 5 * time.Minute
-	serviceSecret    = 5 * time.Minute
-	serviceProvision = 5 * time.Minute
-	podReady         = 5 * time.Minute
-	appBuilt         = 10 * time.Minute
-	warmupJobReady   = 30 * time.Minute
-	certManagerReady = 5 * time.Minute
+	systemDomain          = 2 * time.Minute
+	appReady              = 2 * time.Minute
+	deployment            = 5 * time.Minute
+	orgDeletion           = 5 * time.Minute
+	serviceSecret         = 5 * time.Minute
+	serviceProvision      = 5 * time.Minute
+	podReady              = 5 * time.Minute
+	appBuilt              = 10 * time.Minute
+	warmupJobReady        = 30 * time.Minute
+	certManagerReady      = 5 * time.Minute
+	quarksDeploymentReady = 5 * time.Minute
 
 	// Fixed. __Not__ affected by the multiplier.
 	pollInterval = 3 * time.Second
@@ -37,6 +38,10 @@ func Flags(pf *flag.FlagSet, argToEnv map[string]string) {
 // Multiplier returns the timeout-multiplier argument
 func Multiplier() time.Duration {
 	return time.Duration(viper.GetInt("timeout-multiplier"))
+}
+
+func ToQuarksDeploymentReady() time.Duration {
+	return Multiplier() * quarksDeploymentReady
 }
 
 func ToCertManagerReady() time.Duration {


### PR DESCRIPTION
Fixes #502

There seems to be a time window between quarks pods being ready and
QuarksSecret CRD being established. Deployments that need to create
QuarksSecrets should wait until they are all ready.