### PR TITLE
Use app reference instead of app model

### DIFF
--- a/internal/api/v1/applications.go
+++ b/internal/api/v1/applications.go
@@ -198,7 +198,7 @@ func (hc ApplicationsController) Update(w http.ResponseWriter, r *http.Request) 
 		return NewBadRequest("instances param should be integer equal or greater than zero")
 	}
 
-	workload := application.NewWorkload(cluster, app)
+	workload := application.NewWorkload(cluster, app.AppRef())
 	err = workload.Scale(r.Context(), updateRequest.Instances)
 	if err != nil {
 		return InternalError(err)

--- a/internal/api/v1/models/app.go
+++ b/internal/api/v1/models/app.go
@@ -15,6 +15,16 @@ type App struct {
 	BoundServices []string `json:"bound_services,omitempty"`
 }
 
+// NewApp returns a new app for name and org
+func NewApp(name string, org string) *App {
+	return &App{Name: name, Organization: org}
+}
+
+// AppRef returns a reference to the app (name, org)
+func (a *App) AppRef() AppRef {
+	return NewAppRef(a.Name, a.Organization)
+}
+
 type AppList []App
 
 // Implement the Sort interface for application slices
@@ -31,11 +41,6 @@ func (al AppList) Less(i, j int) bool {
 	return al[i].Name < al[j].Name
 }
 
-// NewApp returns a new app for name and org
-func NewApp(name string, org string) *App {
-	return &App{Name: name, Organization: org}
-}
-
 // AppRef references an App by name and org
 type AppRef struct {
 	Name string `json:"name"`
@@ -45,6 +50,11 @@ type AppRef struct {
 // NewAppRef returns a new reference to an app
 func NewAppRef(name string, org string) AppRef {
 	return AppRef{Name: name, Org: org}
+}
+
+// App returns an fresh app model for the reference
+func (ar *AppRef) App() *App {
+	return NewApp(ar.Name, ar.Org)
 }
 
 // StageRef references a tekton staging run by ID, currently randomly generated

--- a/internal/api/v1/servicebindings.go
+++ b/internal/api/v1/servicebindings.go
@@ -74,7 +74,7 @@ func (hc ServicebindingsController) Create(w http.ResponseWriter, r *http.Reques
 		return AppIsNotKnown(appName)
 	}
 
-	wl := application.NewWorkload(cluster, app)
+	wl := application.NewWorkload(cluster, app.AppRef())
 
 	// From here on out we collect errors and warnings per
 	// service, to report as much as possible while also applying
@@ -153,7 +153,7 @@ func (hc ServicebindingsController) Delete(w http.ResponseWriter, r *http.Reques
 		return AppIsNotKnown(appName)
 	}
 
-	wl := application.NewWorkload(cluster, app)
+	wl := application.NewWorkload(cluster, app.AppRef())
 
 	service, err := services.Lookup(ctx, cluster, org, serviceName)
 	if err != nil && err.Error() == "service not found" {

--- a/internal/api/v1/services.go
+++ b/internal/api/v1/services.go
@@ -361,7 +361,7 @@ func (sc ServicesController) Delete(w http.ResponseWriter, r *http.Request) APIE
 		}
 
 		for _, app := range boundApps {
-			wl := application.NewWorkload(cluster, &app)
+			wl := application.NewWorkload(cluster, app.AppRef())
 			err = wl.Unbind(ctx, service)
 			if err != nil {
 				return InternalError(err)
@@ -403,7 +403,7 @@ func servicesToApps(ctx context.Context, cluster *kubernetes.Cluster, org string
 	}
 
 	for _, app := range apps {
-		w := application.NewWorkload(cluster, &app)
+		w := application.NewWorkload(cluster, app.AppRef())
 		bound, err := w.Services(ctx)
 		if err != nil {
 			return nil, err

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -1294,7 +1294,7 @@ func (c *EpinioClient) ServicesToApps(ctx context.Context, org string) (map[stri
 	}
 
 	for _, app := range apps {
-		w := application.NewWorkload(c.Cluster, &app)
+		w := application.NewWorkload(c.Cluster, app.AppRef())
 		bound, err := w.Services(ctx)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
As it turns out, the functions dealing with k8s workloads, don't need the app model at all.
The struct member doesn't even need to be public.
(yes, we could just pass the appref as an arg to the functions, but we already have the struct)

Also cleaning up the workload struct's file, by moving unrelated functions into the 'application' file. 

Removes the app model from the workload struct.
It was there to maintain compatibility with existing code, but it turns
out the workload manager doesn't need access to the app model.

We pass just the reference to the app (org, name). The code is no longer
able to mutate the passed in app model.
The one function that did need to mutate the model (Complete()) always
returned it.