### PR TITLE
Support for disabling of color output

### DIFF
--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -8,10 +8,33 @@ import (
 )
 
 var _ = Describe("Config", func() {
+	Describe("Colors", func() {
+		It("changes the configuration when disabling colors", func() {
+			config, err := Epinio("config colors 0", "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config).To(MatchRegexp(`Colors: false`))
+
+			config, err = Epinio("config show", "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config).To(MatchRegexp(`Colorized Output.*\|.*false`))
+		})
+
+		It("changes the configuration when enabling colors", func() {
+			config, err := Epinio("config colors 1", "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config).To(MatchRegexp(`Colors: true`))
+
+			config, err = Epinio("config show", "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config).To(MatchRegexp(`Colorized Output.*\|.*true`))
+		})
+	})
+
 	Describe("Show", func() {
 		It("shows the configuration", func() {
 			config, err := Epinio("config show", "")
 			Expect(err).ToNot(HaveOccurred())
+			Expect(config).To(MatchRegexp(`Colorized Output.*\|`))     // Exact state not relevant
 			Expect(config).To(MatchRegexp(`Current Organization.*\|`)) // Exact name of org is not relevant, and varies
 			Expect(config).To(MatchRegexp(`Certificates.*\|.*Present`))
 			Expect(config).To(MatchRegexp(fmt.Sprintf(`API User Name.*\|.*%s`, epinioUser)))

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -24,6 +25,7 @@ type Config struct {
 	User     string `mapstructure:"user"`
 	Password string `mapstructure:"pass"`
 	Certs    string `mapstructure:"certs"`
+	Colors   bool   `mapstructure:"colors"`
 
 	v *viper.Viper
 }
@@ -49,6 +51,7 @@ func Load() (*Config, error) {
 	v.SetDefault("user", "")
 	v.SetDefault("pass", "")
 	v.SetDefault("certs", "")
+	v.SetDefault("colors", true)
 
 	configExists, err := fileExists(file)
 	if err != nil {
@@ -95,6 +98,10 @@ func Load() (*Config, error) {
 		}
 	}
 
+	if !cfg.Colors || viper.GetBool("no-colors") {
+		color.NoColor = true
+	}
+
 	return cfg, nil
 }
 
@@ -104,6 +111,7 @@ func (c *Config) Save() error {
 	c.v.Set("user", c.User)
 	c.v.Set("pass", c.Password)
 	c.v.Set("certs", c.Certs)
+	c.v.Set("colors", c.Colors)
 
 	err := os.MkdirAll(filepath.Dir(c.v.ConfigFileUsed()), 0700)
 	if err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -55,6 +55,10 @@ func Execute() {
 	viper.BindPFlag("skip-ssl-verification", pf.Lookup("skip-ssl-verification"))
 	argToEnv["skip-ssl-verification"] = "SKIP_SSL_VERIFICATION"
 
+	pf.BoolP("no-colors", "", false, "Suppress colorized output")
+	viper.BindPFlag("no-colors", pf.Lookup("no-colors"))
+	argToEnv["colors"] = "EPINIO_COLORS"
+
 	config.AddEnvToUsage(rootCmd, argToEnv)
 
 	rootCmd.AddCommand(CmdCompletion)


### PR DESCRIPTION
Fix #494

Ability to disable color for specific commands by means of global option `--no-colors`.
Ability to enable/disable colors globally by means of command `epinio config colors`.
