### PR TITLE
Create application resource when pushing an app

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -251,7 +251,7 @@ var _ = Describe("Apps", func() {
 	})
 
 	Describe("update", func() {
-		It("updates an application with the desired number of instances", func() {
+		It("respects the desired number of instances", func() {
 			makeApp(appName, 1, true)
 			defer deleteApp(appName)
 

--- a/internal/api/v1/errors.go
+++ b/internal/api/v1/errors.go
@@ -15,14 +15,13 @@ type ErrorResponse struct {
 	Errors []APIError `json:"errors"`
 }
 
-// APIErrors interface is used by all the handlers to return a single or
-// multiple errors
+// APIErrors interface is used by all handlers to return one or more errors
 type APIErrors interface {
 	Errors() []APIError
 	FirstStatus() int
 }
 
-// APIError fulfills the error and the APIErrors interface and contains a single error
+// APIError fulfills the error and APIErrors interfaces. It contains a single error.
 type APIError struct {
 	Status  int    `json:"status"`
 	Title   string `json:"title"`
@@ -54,7 +53,7 @@ func NewAPIError(title string, details string, status int) APIError {
 	}
 }
 
-// MultiError fulfills the APIErrors interface and contains multiple errors
+// MultiError fulfills the APIErrors interface. It contains multiple errors.
 type MultiError struct {
 	errors []APIError
 }

--- a/internal/api/v1/errors.go
+++ b/internal/api/v1/errors.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// All our actions match this type. They can return a list of errors.
+// APIActionFunc is matched by all actions. Actions can return a list of errors.
 // The "Status" of the first error in the list becomes the response Status Code.
 type APIActionFunc func(http.ResponseWriter, *http.Request) APIErrors
 
@@ -15,11 +15,14 @@ type ErrorResponse struct {
 	Errors []APIError `json:"errors"`
 }
 
+// APIErrors interface is used by all the handlers to return a single or
+// multiple errors
 type APIErrors interface {
 	Errors() []APIError
 	FirstStatus() int
 }
 
+// APIError fulfills the error and the APIErrors interface and contains a single error
 type APIError struct {
 	Status  int    `json:"status"`
 	Title   string `json:"title"`
@@ -27,13 +30,14 @@ type APIError struct {
 }
 
 var _ APIErrors = APIError{}
+var _ error = APIError{}
 
-// Satisfy the error interface
-func (err APIError) Error() string {
-	return err.Title
+// Error satisfies the error interface
+func (a APIError) Error() string {
+	return a.Title
 }
 
-// Satisfy the multi error interface
+// Errors satisfies the APIErrors interface
 func (a APIError) Errors() []APIError {
 	return []APIError{a}
 }
@@ -50,12 +54,20 @@ func NewAPIError(title string, details string, status int) APIError {
 	}
 }
 
-var _ APIErrors = MultiError{}
-
+// MultiError fulfills the APIErrors interface and contains multiple errors
 type MultiError struct {
 	errors []APIError
 }
 
+var _ APIErrors = MultiError{}
+var _ error = MultiError{}
+
+// Error satisfies the error interface
+func (m MultiError) Error() string {
+	return m.errors[0].Title
+}
+
+// Errors satisfies the APIErrors interface
 func (m MultiError) Errors() []APIError {
 	return m.errors
 }

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -17,7 +17,6 @@ import (
 	"github.com/epinio/epinio/internal/services"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -133,10 +132,7 @@ func Delete(ctx context.Context, cluster *kubernetes.Cluster, gitea GiteaInterfa
 
 	err = client.Namespace(org).Delete(ctx, app.Name, metav1.DeleteOptions{})
 	if err != nil {
-		// ignore a missing app resource until we always create it
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
+		return err
 	}
 
 	err = w.Delete(ctx, gitea)


### PR DESCRIPTION
Using `app push` will always call the AppCreate endpoint to create an application resource.

fixes #509



Some notes:

* APIError implemented the error interface, MultiError did not. Since both are interchangeable, adding `Error()`
* Not sure we ever use APIError as an error, though
* Adding the application resource test to an existing test case (golang app), to avoid another install/wait/delete cycle, could be it's own test, or I could merge it with even more tests (ingress/service test case is a good candidate)
