### PR TITLE
Retry org creation when running into gateway and cert issues

### DIFF
--- a/deployments/epinio.go
+++ b/deployments/epinio.go
@@ -165,7 +165,7 @@ func (k Epinio) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI,
 				strings.Contains(err.Error(), "EOF")
 		}),
 		retry.OnRetry(func(n uint, err error) {
-			ui.Note().Msgf("retrying to create the epinio cert using cert-manager")
+			ui.Note().Msgf("Retrying creation of API cert via cert-manager (%d/10)", n)
 		}),
 		retry.Delay(5*time.Second),
 		retry.Attempts(10),

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/avast/retry-go"
 	"github.com/epinio/epinio/deployments"
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/helpers/kubernetes/tailer"
@@ -916,7 +917,22 @@ func (c *EpinioClient) CreateOrg(org string) error {
 		return fmt.Errorf("%s: %s", "org name incorrect", strings.Join(errorMsgs, "\n"))
 	}
 
-	_, err := c.post(api.Routes.Path("Orgs"), fmt.Sprintf(`{ "name": "%s" }`, org))
+	err := retry.Do(
+		func() error {
+			_, err := c.post(api.Routes.Path("Orgs"), fmt.Sprintf(`{ "name": "%s" }`, org))
+			return err
+		},
+		retry.RetryIf(func(err error) bool {
+			return strings.Contains(err.Error(), " x509: ") ||
+				strings.Contains(err.Error(), "Gateway")
+		}),
+		retry.OnRetry(func(n uint, err error) {
+			c.ui.Note().Msgf("Retrying (%d/10) after %s", n, err.Error())
+		}),
+		retry.Delay(time.Second),
+		retry.Attempts(10),
+	)
+
 	if err != nil {
 		return err
 	}

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -927,10 +927,10 @@ func (c *EpinioClient) CreateOrg(org string) error {
 				strings.Contains(err.Error(), "Gateway")
 		}),
 		retry.OnRetry(func(n uint, err error) {
-			c.ui.Note().Msgf("Retrying (%d/10) after %s", n, err.Error())
+			c.ui.Note().Msgf("Retrying (%d/%d) after %s", n, duration.RetryMax, err.Error())
 		}),
 		retry.Delay(time.Second),
-		retry.Attempts(10),
+		retry.Attempts(duration.RetryMax),
 	)
 
 	if err != nil {

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -123,6 +123,13 @@ func (c *Config) Save() error {
 		return errors.Wrapf(err, "failed to write config file '%s'", c.v.ConfigFileUsed())
 	}
 
+	// Note: Install saves the config via ConfigUpdate. The newly
+	// retrieved cert(s) have to be made available now, so that
+	// creation of the default org can do proper verification.
+	if c.Certs != "" {
+		auth.ExtendLocalTrust(c.Certs)
+	}
+
 	return nil
 }
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -169,7 +169,8 @@ func Install(cmd *cobra.Command, args []string) error {
 	}
 
 	if !skipDefaultOrg {
-		err = epinio_client.CreateOrg(DefaultOrganization)
+		err := epinio_client.CreateOrg(DefaultOrganization)
+
 		if err != nil {
 			return errors.Wrap(err, "error creating org")
 		}

--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -26,6 +26,9 @@ const (
 	pollInterval = 3 * time.Second
 	userAbort    = 5 * time.Second
 	logHistory   = 48 * time.Hour
+
+	// Fixed. Standard number of attempts to retry various operations.
+	RetryMax = 10
 )
 
 // Flags adds to viper flags


### PR DESCRIPTION
Fixes #530 .

I do not see how we can test this in the EATs.

Even manual testing is a bit fraught, for a dev deployment.
I suspect it needs testing with a public cloud and the regular deployment flow (no `make patch-...`) to be sure.
