### PR TITLE
fix: Drop general silencing of the usage display on cli command line errors

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -46,6 +46,8 @@ var CmdAppList = &cobra.Command{
 	Short: "Lists all applications",
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
 		client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
@@ -58,8 +60,6 @@ var CmdAppList = &cobra.Command{
 
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 }
 
 // CmdAppShow implements the epinio `apps show` command
@@ -68,6 +68,8 @@ var CmdAppShow = &cobra.Command{
 	Short: "Describe the named application",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
 		client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 
 		if err != nil {
@@ -81,8 +83,6 @@ var CmdAppShow = &cobra.Command{
 
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
@@ -105,6 +105,8 @@ var CmdAppLogs = &cobra.Command{
 	Short: "Streams the logs of the application",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
 		client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
@@ -112,12 +114,12 @@ var CmdAppLogs = &cobra.Command{
 
 		follow, err := cmd.Flags().GetBool("follow")
 		if err != nil {
-			return errors.Wrap(err, "error reading the follow option")
+			return errors.Wrap(err, "error reading option --follow")
 		}
 
 		staging, err := cmd.Flags().GetBool("staging")
 		if err != nil {
-			return errors.Wrap(err, "error reading the staging option")
+			return errors.Wrap(err, "error reading option --staging")
 		}
 
 		stageId := ""
@@ -136,8 +138,6 @@ var CmdAppLogs = &cobra.Command{
 
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 }
 
 // CmdAppUpdate is used by the epinio `apps update` command to scale
@@ -148,6 +148,8 @@ var CmdAppUpdate = &cobra.Command{
 	Long:  "Update the running application's attributes (e.g. instances)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
 		client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 
 		if err != nil {
@@ -156,7 +158,7 @@ var CmdAppUpdate = &cobra.Command{
 
 		i, err := instances(cmd)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "trouble with instances")
 		}
 		if i == nil {
 			d := v1.DefaultInstances
@@ -169,8 +171,6 @@ var CmdAppUpdate = &cobra.Command{
 
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -32,7 +32,7 @@ func init() {
 
 // CmdConfigColors implements the `epinio config colors` command
 var CmdConfigColors = &cobra.Command{
-	Use:   "colors",
+	Use:   "colors BOOL",
 	Short: "Manage colored output",
 	Long:  "Enable/Disable colored output",
 	Args: func(cmd *cobra.Command, args []string) error {
@@ -49,17 +49,19 @@ var CmdConfigColors = &cobra.Command{
 		fmt.Println("Hello, World!")
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
 		ui := termui.NewUI()
 
 		theConfig, err := config.Load()
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to load configuration")
 		}
 
 		colors, err := strconv.ParseBool(args[0])
 		// assert: err == nil -- see args validation
 		if err != nil {
-			return err
+			return errors.Wrap(err, "unexpected bool parsing error")
 		}
 
 		theConfig.Colors = colors
@@ -68,8 +70,6 @@ var CmdConfigColors = &cobra.Command{
 		ui.Success().WithBoolValue("Colors", theConfig.Colors).Msg("Ok")
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 }
 
 // CmdConfigShow implements the `epinio config show` command
@@ -78,11 +78,13 @@ var CmdConfigShow = &cobra.Command{
 	Short: "Show the current configuration",
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
 		ui := termui.NewUI()
 
 		theConfig, err := config.Load()
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to load configuration")
 		}
 
 		certInfo := color.CyanString("None defined")
@@ -101,8 +103,6 @@ var CmdConfigShow = &cobra.Command{
 
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 }
 
 // CmdConfigUpdateCreds implements the `epinio config update-credentials` command
@@ -112,6 +112,8 @@ var CmdConfigUpdateCreds = &cobra.Command{
 	Long:  "Update the stored credentials from the current cluster",
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
 		client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 
 		if err != nil {
@@ -120,11 +122,9 @@ var CmdConfigUpdateCreds = &cobra.Command{
 
 		err = client.ConfigUpdate(cmd.Context())
 		if err != nil {
-			return errors.Wrap(err, "error updating the config")
+			return errors.Wrap(err, "failed to update the configuration")
 		}
 
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 }

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -14,6 +14,8 @@ var CmdDeleteApp = &cobra.Command{
 	Short: "Deletes an application",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
 		client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
@@ -26,8 +28,6 @@ var CmdDeleteApp = &cobra.Command{
 
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp

--- a/internal/cli/disable.go
+++ b/internal/cli/disable.go
@@ -21,23 +21,19 @@ var CmdDisable = &cobra.Command{
 
 // TODO: Implement a flag to also delete provisioned services [TBD]
 var CmdDisableInCluster = &cobra.Command{
-	Use:           "services-incluster",
-	Short:         "disable in-cluster services in Epinio",
-	Long:          `disable in-cluster services in Epinio which will disable provisioning services on the same cluster as Epinio. Doesn't delete already provisioned services by default.`,
-	Args:          cobra.ExactArgs(0),
-	RunE:          DisableInCluster,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:   "services-incluster",
+	Short: "disable in-cluster services in Epinio",
+	Long:  `disable in-cluster services in Epinio which will disable provisioning services on the same cluster as Epinio. Doesn't delete already provisioned services by default.`,
+	Args:  cobra.ExactArgs(0),
+	RunE:  DisableInCluster,
 }
 
 var CmdDisableGoogle = &cobra.Command{
-	Use:           "services-google",
-	Short:         "disable Google Cloud service in Epinio",
-	Long:          `disable Google Cloud services in Epinio which will disable the provisioning of those services. Doesn't delete already provisioned services by default.`,
-	Args:          cobra.ExactArgs(0),
-	RunE:          DisableGoogle,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:   "services-google",
+	Short: "disable Google Cloud service in Epinio",
+	Long:  `disable Google Cloud services in Epinio which will disable the provisioning of those services. Doesn't delete already provisioned services by default.`,
+	Args:  cobra.ExactArgs(0),
+	RunE:  DisableGoogle,
 }
 
 func init() {
@@ -58,6 +54,8 @@ func DisableGoogle(cmd *cobra.Command, args []string) error {
 }
 
 func UninstallDeployment(cmd *cobra.Command, deployment kubernetes.Deployment, successMessage string) error {
+	cmd.SilenceUsage = true
+
 	uiUI := termui.NewUI()
 	installClient, installCleanup, err := clients.NewInstallClient(cmd.Context(), cmd.Flags(), &kubernetes.InstallationOptions{})
 	defer func() {
@@ -69,10 +67,13 @@ func UninstallDeployment(cmd *cobra.Command, deployment kubernetes.Deployment, s
 	if err != nil {
 		return errors.Wrap(err, "error initializing cli")
 	}
+
 	uiUI.Note().Msg(deployment.ID() + " uninstalling...")
+
 	if err := installClient.UninstallDeployment(cmd.Context(), deployment, installClient.Log); err != nil {
-		return err
+		return errors.Wrap(err, "failed to remove")
 	}
+
 	uiUI.Note().Msg(successMessage)
 
 	return nil

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -14,6 +14,8 @@ var CmdInfo = &cobra.Command{
 	Short: "Shows information about the Epinio environment",
 	Long:  `Shows status and version for Kubernetes, Gitea, Tekton, Quarks and Eirini.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
 		client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
@@ -26,6 +28,4 @@ var CmdInfo = &cobra.Command{
 
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -84,13 +84,11 @@ const (
 )
 
 var CmdInstall = &cobra.Command{
-	Use:           "install",
-	Short:         "install Epinio in your configured kubernetes cluster",
-	Long:          `install Epinio PaaS in your configured kubernetes cluster`,
-	Args:          cobra.ExactArgs(0),
-	RunE:          Install,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:   "install",
+	Short: "install Epinio in your configured kubernetes cluster",
+	Long:  `install Epinio PaaS in your configured kubernetes cluster`,
+	Args:  cobra.ExactArgs(0),
+	RunE:  Install,
 }
 
 // Note: The command is called `install-ingress` instead of `install
@@ -102,13 +100,11 @@ var CmdInstall = &cobra.Command{
 // is exposed through a new toplevel command.
 
 var CmdInstallIngress = &cobra.Command{
-	Use:           "install-ingress",
-	Short:         "install Epinio's Ingress in your configured kubernetes cluster",
-	Long:          `install Epinio Ingress Controller in your configured kubernetes cluster`,
-	Args:          cobra.ExactArgs(0),
-	RunE:          InstallIngress,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:   "install-ingress",
+	Short: "install Epinio's Ingress in your configured kubernetes cluster",
+	Long:  `install Epinio Ingress Controller in your configured kubernetes cluster`,
+	Args:  cobra.ExactArgs(0),
+	RunE:  InstallIngress,
 }
 
 func init() {
@@ -123,6 +119,8 @@ func init() {
 
 // Install command installs epinio on a configured cluster
 func Install(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
 	installClient, installCleanup, err := clients.NewInstallClient(cmd.Context(), cmd.Flags(), &NeededOptions)
 	defer func() {
 		if installCleanup != nil {
@@ -165,7 +163,7 @@ func Install(cmd *cobra.Command, args []string) error {
 
 	skipDefaultOrg, err := cmd.Flags().GetBool("skip-default-org")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error reading option --skip-default-org")
 	}
 
 	if !skipDefaultOrg {
@@ -185,6 +183,8 @@ func Install(cmd *cobra.Command, args []string) error {
 
 // InstallIngress command installs epinio's ingress controller on a configured cluster
 func InstallIngress(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
 	installClient, installCleanup, err := clients.NewInstallClient(cmd.Context(), cmd.Flags(), &TraefikOptions)
 	defer func() {
 		if installCleanup != nil {

--- a/internal/cli/orgs.go
+++ b/internal/cli/orgs.go
@@ -40,6 +40,8 @@ var CmdOrgList = &cobra.Command{
 	Use:   "list",
 	Short: "Lists all organizations",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
 		client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
@@ -52,8 +54,6 @@ var CmdOrgList = &cobra.Command{
 
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 }
 
 // CmdOrgCreate implements the epinio `orgs create` command
@@ -62,6 +62,8 @@ var CmdOrgCreate = &cobra.Command{
 	Short: "Creates an organization",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
 		client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
@@ -74,8 +76,6 @@ var CmdOrgCreate = &cobra.Command{
 
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 }
 
 // CmdOrgDelete implements the epinio `orgs delete` command
@@ -98,6 +98,8 @@ var CmdOrgDelete = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
 		client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
@@ -110,8 +112,6 @@ var CmdOrgDelete = &cobra.Command{
 
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 }
 
 func askConfirmation(cmd *cobra.Command) bool {

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -75,6 +75,8 @@ var CmdPush = &cobra.Command{
 	Short: "Push an application from the specified directory, or the current working directory",
 	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
 		client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
@@ -84,19 +86,21 @@ var CmdPush = &cobra.Command{
 		if len(args) == 1 {
 			path, err = os.Getwd()
 			if err != nil {
-				return errors.Wrap(err, "error pushing app")
+				return errors.Wrap(err, "working directory not accessible")
 			}
 		} else {
 			path = args[1]
 		}
 
 		if _, err := os.Stat(path); err != nil {
+			// Path issue is user error. Show usage
+			cmd.SilenceUsage = false
 			return errors.Wrap(err, "path not accessible")
 		}
 
 		i, err := instances(cmd)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "trouble with instances")
 		}
 		params := clients.PushParams{
 			Instances: i,
@@ -104,7 +108,7 @@ var CmdPush = &cobra.Command{
 
 		services, err := cmd.Flags().GetStringSlice("bind")
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to read option --bind")
 		}
 		params.Services = services
 
@@ -115,8 +119,6 @@ var CmdPush = &cobra.Command{
 
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 }
 
 func init() {

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -58,6 +58,7 @@ func instances(cmd *cobra.Command) (*int32, error) {
 	var i *int32
 	instances, err := cmd.Flags().GetInt32("instances")
 	if err != nil {
+		cmd.SilenceUsage = false
 		return i, errors.Wrap(err, "could not read instances parameter")
 	}
 	cmd.Flags().Visit(func(f *pflag.Flag) {

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/epinio/epinio/internal/filesystem"
 	"github.com/epinio/epinio/internal/web"
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -37,6 +38,7 @@ var CmdServer = &cobra.Command{
 	Use:   "server",
 	Short: "starts the Epinio server. You can connect to it using either your browser or the Epinio client.",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		httpServerWg := &sync.WaitGroup{}
 		httpServerWg.Add(1)
 		port := viper.GetInt("port")
@@ -44,15 +46,13 @@ var CmdServer = &cobra.Command{
 		logger := tracelog.NewServerLogger()
 		_, listeningPort, err := startEpinioServer(httpServerWg, port, ui, logger)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to start server")
 		}
 		ui.Normal().Msg("listening on localhost on port " + listeningPort)
 		httpServerWg.Wait()
 
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 }
 
 func startEpinioServer(wg *sync.WaitGroup, port int, ui *termui.UI, logger logr.Logger) (*http.Server, string, error) {

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -36,13 +36,11 @@ var CmdService = &cobra.Command{
 
 // CmdServiceShow implements the epinio service show command
 var CmdServiceShow = &cobra.Command{
-	Use:           "show NAME",
-	Short:         "Service information",
-	Long:          `Show detailed information of the named service.`,
-	Args:          cobra.ExactArgs(1),
-	RunE:          ServiceShow,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:   "show NAME",
+	Short: "Service information",
+	Long:  `Show detailed information of the named service.`,
+	Args:  cobra.ExactArgs(1),
+	RunE:  ServiceShow,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
@@ -70,9 +68,7 @@ var CmdServiceCreate = &cobra.Command{
 		}
 		return nil
 	},
-	RunE:          ServiceCreate,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	RunE: ServiceCreate,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) > 2 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
@@ -114,20 +110,16 @@ var CmdServiceCreateCustom = &cobra.Command{
 		}
 		return nil
 	},
-	RunE:          ServiceCreateCustom,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	RunE: ServiceCreateCustom,
 }
 
 // CmdServiceDelete implements the epinio service delete command
 var CmdServiceDelete = &cobra.Command{
-	Use:           "delete NAME",
-	Short:         "Delete a service",
-	Long:          `Delete service by name.`,
-	Args:          cobra.ExactArgs(1),
-	RunE:          ServiceDelete,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:   "delete NAME",
+	Short: "Delete a service",
+	Long:  `Delete service by name.`,
+	Args:  cobra.ExactArgs(1),
+	RunE:  ServiceDelete,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
@@ -146,13 +138,11 @@ var CmdServiceDelete = &cobra.Command{
 
 // CmdServiceBind implements the epinio service bind command
 var CmdServiceBind = &cobra.Command{
-	Use:           "bind NAME APP",
-	Short:         "Bind a service to an application",
-	Long:          `Bind service by name, to named application.`,
-	Args:          cobra.ExactArgs(2),
-	RunE:          ServiceBind,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:   "bind NAME APP",
+	Short: "Bind a service to an application",
+	Long:  `Bind service by name, to named application.`,
+	Args:  cobra.ExactArgs(2),
+	RunE:  ServiceBind,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) > 1 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
@@ -179,13 +169,11 @@ var CmdServiceBind = &cobra.Command{
 
 // CmdServiceUnbind implements the epinio service unbind command
 var CmdServiceUnbind = &cobra.Command{
-	Use:           "unbind NAME APP",
-	Short:         "Unbind service from an application",
-	Long:          `Unbind service by name, from named application.`,
-	Args:          cobra.ExactArgs(2),
-	RunE:          ServiceUnbind,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:   "unbind NAME APP",
+	Short: "Unbind service from an application",
+	Long:  `Unbind service by name, from named application.`,
+	Args:  cobra.ExactArgs(2),
+	RunE:  ServiceUnbind,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) > 1 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
@@ -211,21 +199,17 @@ var CmdServiceUnbind = &cobra.Command{
 
 // CmdServiceListClasses implements the epinio service classes command
 var CmdServiceListClasses = &cobra.Command{
-	Use:           "list-classes",
-	Short:         "Lists the available service classes",
-	RunE:          ServiceListClasses,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:   "list-classes",
+	Short: "Lists the available service classes",
+	RunE:  ServiceListClasses,
 }
 
 // CmdServiceListPlans implements the epinio service plans command
 var CmdServiceListPlans = &cobra.Command{
-	Use:           "list-plans CLASS",
-	Short:         "Lists all plans provided by the named service class",
-	Args:          cobra.ExactArgs(1),
-	RunE:          ServiceListPlans,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:   "list-plans CLASS",
+	Short: "Lists all plans provided by the named service class",
+	Args:  cobra.ExactArgs(1),
+	RunE:  ServiceListPlans,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
@@ -244,15 +228,15 @@ var CmdServiceListPlans = &cobra.Command{
 
 // CmdServiceList implements the epinio service list command
 var CmdServiceList = &cobra.Command{
-	Use:           "list",
-	Short:         "Lists all services",
-	RunE:          ServiceList,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:   "list",
+	Short: "Lists all services",
+	RunE:  ServiceList,
 }
 
 // ServiceShow implements the epinio service show command
 func ServiceShow(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
 	client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 	if err != nil {
 		return errors.Wrap(err, "error initializing cli")
@@ -268,6 +252,8 @@ func ServiceShow(cmd *cobra.Command, args []string) error {
 
 // ServiceList implements the epinio service list command
 func ServiceList(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
 	client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 	if err != nil {
 		return errors.Wrap(err, "error initializing cli")
@@ -283,6 +269,8 @@ func ServiceList(cmd *cobra.Command, args []string) error {
 
 // ServiceCreate implements the epinio service create command
 func ServiceCreate(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
 	client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 	if err != nil {
 		return errors.Wrap(err, "error initializing cli")
@@ -290,13 +278,13 @@ func ServiceCreate(cmd *cobra.Command, args []string) error {
 
 	dw, err := cmd.Flags().GetBool("dont-wait")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error reading option --dont-wait")
 	}
 	waitforProvision := !dw
 
 	data, err := cmd.Flags().GetString("data")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error reading option --data")
 	}
 
 	if data == "" {
@@ -306,6 +294,8 @@ func ServiceCreate(cmd *cobra.Command, args []string) error {
 	var dataObj map[string]interface{}
 	err = json.Unmarshal([]byte(data), &dataObj)
 	if err != nil {
+		// User error. Show usage for this one.
+		cmd.SilenceUsage = false
 		return errors.Wrap(err, "Invalid json format for data")
 	}
 
@@ -319,6 +309,8 @@ func ServiceCreate(cmd *cobra.Command, args []string) error {
 
 // ServiceCreateCustom implements the epinio service create-custom command
 func ServiceCreateCustom(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
 	client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 	if err != nil {
 		return errors.Wrap(err, "error initializing cli")
@@ -334,9 +326,11 @@ func ServiceCreateCustom(cmd *cobra.Command, args []string) error {
 
 // ServiceDelete implements the epinio service delete command
 func ServiceDelete(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
 	unbind, err := cmd.Flags().GetBool("unbind")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error reading option --unbind")
 	}
 
 	client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
@@ -354,6 +348,8 @@ func ServiceDelete(cmd *cobra.Command, args []string) error {
 
 // ServiceBind implements the epinio service bind command
 func ServiceBind(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
 	client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 	if err != nil {
 		return errors.Wrap(err, "error initializing cli")
@@ -369,6 +365,8 @@ func ServiceBind(cmd *cobra.Command, args []string) error {
 
 // ServiceUnbind implements the epinio service unbind command
 func ServiceUnbind(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
 	client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 	if err != nil {
 		return errors.Wrap(err, "error initializing cli")
@@ -384,6 +382,8 @@ func ServiceUnbind(cmd *cobra.Command, args []string) error {
 
 // ServiceListClasses implements the epinio service list-classes command
 func ServiceListClasses(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
 	client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 	if err != nil {
 		return errors.Wrap(err, "error initializing cli")
@@ -399,6 +399,8 @@ func ServiceListClasses(cmd *cobra.Command, args []string) error {
 
 // ServiceListPlans implements the epinio service list-plans command
 func ServiceListPlans(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
 	client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 	if err != nil {
 		return errors.Wrap(err, "error initializing cli")

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -14,6 +14,8 @@ var CmdTarget = &cobra.Command{
 	Short: "Targets an organization in Epinio.",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
 		client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
@@ -31,8 +33,6 @@ var CmdTarget = &cobra.Command{
 
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -7,17 +7,17 @@ import (
 )
 
 var CmdUninstall = &cobra.Command{
-	Use:           "uninstall",
-	Short:         "uninstall Epinio from your configured kubernetes cluster",
-	Long:          `uninstall Epinio PaaS from your configured kubernetes cluster`,
-	Args:          cobra.ExactArgs(0),
-	RunE:          Uninstall,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:   "uninstall",
+	Short: "uninstall Epinio from your configured kubernetes cluster",
+	Long:  `uninstall Epinio PaaS from your configured kubernetes cluster`,
+	Args:  cobra.ExactArgs(0),
+	RunE:  Uninstall,
 }
 
 // Uninstall command removes epinio from a configured cluster
 func Uninstall(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
 	installClient, _, err := clients.NewInstallClient(cmd.Context(), cmd.Flags(), nil)
 	if err != nil {
 		return errors.Wrap(err, "error initializing cli")
@@ -25,7 +25,7 @@ func Uninstall(cmd *cobra.Command, args []string) error {
 
 	err = installClient.Uninstall(cmd)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to remove")
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #537

:notes: Dynamically silence usage display for errors unrelated to the commandline, i.e. from the backend and such. In most places this simply means silencing the moment we are in the command function. In very few places this silence has to be lifted again for specific issues.

The ensemble command specs are unchanged.
