### PR TITLE
Add owner ref to the application resource

### DIFF
--- a/assets/embedded-files/tekton/pipeline.yaml
+++ b/assets/embedded-files/tekton/pipeline.yaml
@@ -32,6 +32,18 @@ spec:
     - name: STAGE_ID
       type: string
       description: "The identifier of the unique staging process"
+    - name: OWNER_APIVERSION
+      type: string
+      description: "The API version of the owner"
+    - name: OWNER_KIND
+      type: string
+      description: "The API kind of the owner"
+    - name: OWNER_NAME
+      type: string
+      description: "The name of the owner"
+    - name: OWNER_UID
+      type: string
+      description: "The uid of the owner"
   tasks:
   - name: clone
     taskRef:
@@ -74,6 +86,14 @@ spec:
         value: "$(params.DEPLOYMENT_IMAGE)"
       - name: STAGE_ID
         value: "$(params.STAGE_ID)"
+      - name: OWNER_APIVERSION
+        value: "$(params.OWNER_APIVERSION)"
+      - name: OWNER_KIND
+        value: "$(params.OWNER_KIND)"
+      - name: OWNER_NAME
+        value: "$(params.OWNER_NAME)"
+      - name: OWNER_UID
+        value: "$(params.OWNER_UID)"
     runAfter:
     - stage
     workspaces:
@@ -141,6 +161,14 @@ spec:
       type: string
     - name: STAGE_ID
       type: string
+    - name: OWNER_APIVERSION
+      type: string
+    - name: OWNER_KIND
+      type: string
+    - name: OWNER_NAME
+      type: string
+    - name: OWNER_UID
+      type: string
   steps:
   - name: run
     image: lachlanevenson/k8s-kubectl
@@ -162,6 +190,11 @@ spec:
             app.kubernetes.io/part-of: "$(params.ORG)"
             app.kubernetes.io/component: application
             app.kubernetes.io/managed-by: epinio
+          ownerReferences:
+          - apiVersion: "$(params.OWNER_APIVERSION)"
+            kind: "$(params.OWNER_KIND)"
+            name: "$(params.OWNER_NAME)"
+            uid: "$(params.OWNER_UID)"
         spec:
           replicas: $(params.INSTANCES)
           selector:
@@ -204,6 +237,11 @@ spec:
             app.kubernetes.io/managed-by: epinio
             app.kubernetes.io/name: $(params.APP_NAME)
             app.kubernetes.io/part-of: $(params.ORG)
+          ownerReferences:
+          - apiVersion: "$(params.OWNER_APIVERSION)"
+            kind: "$(params.OWNER_KIND)"
+            name: "$(params.OWNER_NAME)"
+            uid: "$(params.OWNER_UID)"
           name: $(params.APP_NAME)
           namespace: $(params.ORG)
         spec:
@@ -231,6 +269,11 @@ spec:
             app.kubernetes.io/managed-by: epinio
             app.kubernetes.io/name: $(params.APP_NAME)
             app.kubernetes.io/part-of: $(params.ORG)
+          ownerReferences:
+          - apiVersion: "$(params.OWNER_APIVERSION)"
+            kind: "$(params.OWNER_KIND)"
+            name: "$(params.OWNER_NAME)"
+            uid: "$(params.OWNER_UID)"
           name: $(params.APP_NAME)
           namespace: $(params.ORG)
         spec:

--- a/deployments/epinio.go
+++ b/deployments/epinio.go
@@ -157,7 +157,7 @@ func (k Epinio) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI,
 	// Workaround for cert-manager webhook service not being immediately ready.
 	// More here: https://cert-manager.io/v1.2-docs/concepts/webhook/#webhook-connection-problems-shortly-after-cert-manager-installation
 	err = retry.Do(func() error {
-		return auth.CreateCertificate(ctx, c.RestConfig, EpinioDeploymentID, EpinioDeploymentID, domain)
+		return auth.CreateCertificate(ctx, c, EpinioDeploymentID, EpinioDeploymentID, domain, nil)
 	},
 		retry.RetryIf(func(err error) bool {
 			return strings.Contains(err.Error(), " x509: ") ||

--- a/deployments/registry.go
+++ b/deployments/registry.go
@@ -196,7 +196,7 @@ func (k Registry) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 	// Workaround for cert-manager webhook service not being immediately ready.
 	// More here: https://cert-manager.io/v1.2-docs/concepts/webhook/#webhook-connection-problems-shortly-after-cert-manager-installation
 	err = retry.Do(func() error {
-		return auth.CreateCertificate(ctx, c.RestConfig, RegistryDeploymentID, RegistryDeploymentID, domain)
+		return auth.CreateCertificate(ctx, c, RegistryDeploymentID, RegistryDeploymentID, domain, nil)
 	},
 		retry.RetryIf(func(err error) bool {
 			return strings.Contains(err.Error(), "failed calling webhook") ||

--- a/helpers/kubernetes/cluster.go
+++ b/helpers/kubernetes/cluster.go
@@ -161,6 +161,22 @@ func (c *Cluster) ClientCertManager() (dynamic.NamespaceableResourceInterface, e
 	return dynamicClient.Resource(gvr), nil
 }
 
+// ClientCertificate returns a dynamic namespaced client for the cert manager
+// certificate resource
+func (c *Cluster) ClientCertificate() (dynamic.NamespaceableResourceInterface, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "cert-manager.io",
+		Version:  "v1alpha2",
+		Resource: "certificates",
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(c.RestConfig)
+	if err != nil {
+		return nil, err
+	}
+	return dynamicClient.Resource(gvr), nil
+}
+
 // ClientServiceCatalog returns a dynamic namespaced client for the specified service catalog resource
 func (c *Cluster) ClientServiceCatalog(res string) (dynamic.NamespaceableResourceInterface, error) {
 	gvr := schema.GroupVersionResource{

--- a/internal/application/workload.go
+++ b/internal/application/workload.go
@@ -35,24 +35,6 @@ func (a *Workload) Delete(ctx context.Context, gitea GiteaInterface) error {
 		return pkgerrors.Wrap(err, "failed to delete repository")
 	}
 
-	err := a.cluster.Kubectl.AppsV1().Deployments(a.app.Org).
-		Delete(ctx, a.app.Name, metav1.DeleteOptions{})
-	if err != nil {
-		return pkgerrors.Wrap(err, "failed to delete application deployment")
-	}
-
-	err = a.cluster.Kubectl.ExtensionsV1beta1().Ingresses(a.app.Org).
-		Delete(ctx, a.app.Name, metav1.DeleteOptions{})
-	if err != nil {
-		return pkgerrors.Wrap(err, "failed to delete application ingress")
-	}
-
-	err = a.cluster.Kubectl.CoreV1().Services(a.app.Org).
-		Delete(ctx, a.app.Name, metav1.DeleteOptions{})
-	if err != nil {
-		return pkgerrors.Wrap(err, "failed to delete application service")
-	}
-
 	return nil
 }
 

--- a/internal/auth/certs.go
+++ b/internal/auth/certs.go
@@ -12,14 +12,13 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
 
+	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/names"
 )
 
@@ -45,7 +44,7 @@ func ExtendLocalTrust(certs string) {
 	http.DefaultTransport.(*http.Transport).ForceAttemptHTTP2 = false
 }
 
-func CreateCertificate(ctx context.Context, cfg *rest.Config, name, namespace, systemDomain string) error {
+func CreateCertificate(ctx context.Context, cluster *kubernetes.Cluster, name, namespace, systemDomain string, owner *metav1.OwnerReference) error {
 	// Create production certificate if systemDomain is provided by user
 	// else create a local cluster self-signed tls secret.
 
@@ -60,14 +59,31 @@ func CreateCertificate(ctx context.Context, cfg *rest.Config, name, namespace, s
 		origin = "local"
 	}
 
-	err := createCertificate(ctx, cfg, name, namespace, systemDomain, issuer)
+	obj, err := createCertificate(name, namespace, systemDomain, issuer)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("creation of %s ssl certificate failed", origin))
 	}
+
+	client, err := cluster.ClientCertificate()
+	if err != nil {
+		return err
+	}
+
+	if owner != nil {
+		obj.SetOwnerReferences([]metav1.OwnerReference{*owner})
+	}
+
+	_, err = client.Namespace(namespace).
+		Create(ctx, obj, metav1.CreateOptions{})
+	// Ignore the error if it's about cert already existing.
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
 	return nil
 }
 
-func createCertificate(ctx context.Context, cfg *rest.Config, name, namespace, systemDomain, issuer string) error {
+func createCertificate(name, namespace, systemDomain, issuer string) (*unstructured.Unstructured, error) {
 	// Notes:
 	// - spec.CommonName is length-limited.
 	//   At most 64 characters are allowed, as per [RFC 3280](https://www.rfc-editor.org/rfc/rfc3280.txt).
@@ -108,26 +124,8 @@ func createCertificate(ctx context.Context, cfg *rest.Config, name, namespace, s
 	obj := &unstructured.Unstructured{}
 	_, _, err := decoderUnstructured.Decode([]byte(data), nil, obj)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	certificateInstanceGVR := schema.GroupVersionResource{
-		Group:    "cert-manager.io",
-		Version:  "v1alpha2",
-		Resource: "certificates",
-	}
-
-	dynamicClient, err := dynamic.NewForConfig(cfg)
-	if err != nil {
-		return err
-	}
-
-	_, err = dynamicClient.Resource(certificateInstanceGVR).Namespace(namespace).
-		Create(ctx, obj, metav1.CreateOptions{})
-	// Ignore the error if it's about cert already existing.
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
-	}
-
-	return nil
+	return obj, err
 }


### PR DESCRIPTION
Fixes #511

Test failures disappeared with a fresh cluster. This PR modifies the tekton pipeline.
Not adding new tests, removal of ingress and service is already tested by existing tests.


## Note about OwnerRefs

* Owner references are namespaced, an owner reference on a resource can only refer to an owner in the same namespace, or a cluster resource.
* Owner references refer to a specific UID, not just app and name of a resource.

The application resource can't easily own the `PipelineRun` resource, as that's in another namespace.

We have two secrets (`registry-creds`, `ca-cert`) in the org namespace, but they are owned by the org (=namespace), not the application.
