### PR TITLE
feat: Show warning as part of `enable services-incluster`, about the delays to expect.

### DIFF
--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -78,6 +78,7 @@ func setupAndTargetOrg(org string) {
 func setupInClusterServices() {
 	out, err := RunProc("../dist/epinio-linux-amd64 enable services-incluster", "", false)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)
+	ExpectWithOffset(1, out).To(ContainSubstring("Beware, "))
 
 	// Wait until classes appear
 	EventuallyWithOffset(1, func() error {

--- a/internal/cli/enable.go
+++ b/internal/cli/enable.go
@@ -43,10 +43,21 @@ func init() {
 }
 
 func EnableInCluster(cmd *cobra.Command, args []string) error {
-	return InstallDeployment(
+	err := InstallDeployment(
 		cmd, &deployments.Minibroker{Timeout: duration.ToDeployment()},
 		kubernetes.InstallationOptions{},
 		"You can now use in-cluster services")
+	if err != nil {
+		return err
+	}
+
+	ui := termui.NewUI()
+	ui.Exclamation().Msg("Beware, minibroker requires some time to catalog and declare the available services.")
+	ui.Exclamation().Msg("And ServiceCatalog some more to pick up these declarations.")
+	ui.Exclamation().Msg("Please do not expect `list-classes` to show them instantly.")
+	ui.Exclamation().Msg("If they are not present when you try to list them, try again a bit later.")
+
+	return nil
 }
 
 func EnableGoogle(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Fixes #540 
