### PR TITLE
fix: missing container include/exclude checks in FetchLogs

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -345,6 +345,8 @@ var _ = Describe("Apps", func() {
 
 			Expect(out).To(MatchRegexp(`.*step-create.*Configuring PHP Application.*`))
 			Expect(out).To(MatchRegexp(`.*step-create.*Using feature -- PHP.*`))
+			// Doesn't include linkerd sidecar logs
+			Expect(out).ToNot(MatchRegexp(`linkerd-.*`))
 		})
 
 		It("follows logs", func() {


### PR DESCRIPTION
Fixes #534 

FetchLogs simply streamed all containers, in contrast to StreamLogs which streamed only selected and not excluded containers.
(Example of excluded: linkerd sidecars). See the details in #534.