### PR TITLE
Add create app to CLI

### DIFF
--- a/acceptance/api_v1_applications_test.go
+++ b/acceptance/api_v1_applications_test.go
@@ -263,8 +263,8 @@ var _ = Describe("Apps API Application Endpoints", func() {
 				err = json.Unmarshal(bodyBytes, &resp)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp).To(HaveLen(1))
-				Expect(resp).To(HaveKey("UnboundServices"))
-				Expect(resp["UnboundServices"]).To(ContainElement(service))
+				Expect(resp).To(HaveKey("unboundservices"))
+				Expect(resp["unboundservices"]).To(ContainElement(service))
 			})
 
 			It("returns a 404 when the org does not exist", func() {

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Apps", func() {
 		appName = newAppName()
 	})
 
-	When("creating an application", func() {
+	When("creating just an application", func() {
 		AfterEach(func() {
 			deleteApp(appName)
 		})

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -30,6 +30,18 @@ var _ = Describe("Apps", func() {
 		appName = newAppName()
 	})
 
+	When("creating an application", func() {
+		AfterEach(func() {
+			deleteApp(appName)
+		})
+
+		It("creates the app", func() {
+			out, err := Epinio(fmt.Sprintf("app create %s", appName), "")
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(MatchRegexp("Ok"))
+		})
+	})
+
 	When("pushing an app multiple times", func() {
 		var (
 			timeout  = 30 * time.Second

--- a/internal/api/v1/models/models.go
+++ b/internal/api/v1/models/models.go
@@ -64,3 +64,7 @@ type StageRequest struct {
 type StageResponse struct {
 	Stage StageRef `json:"stage,omitempty"`
 }
+
+type ApplicationDeleteResponse struct {
+	UnboundServices []string `json:"unboundservices"`
+}

--- a/internal/api/v1/stage.go
+++ b/internal/api/v1/stage.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/clients/gitea"
 	"github.com/epinio/epinio/internal/domain"
 	"github.com/julienschmidt/httprouter"
@@ -89,12 +90,7 @@ func (hc ApplicationsController) Stage(w http.ResponseWriter, r *http.Request) A
 	}
 
 	// check application resource
-	appClient, err := cluster.ClientApp()
-	if err != nil {
-		return InternalError(err, "failed to get access to a kube application client")
-	}
-
-	app, err := appClient.Namespace(org).Get(ctx, name, metav1.GetOptions{})
+	app, err := application.Get(ctx, cluster, req.App)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return AppIsNotKnown("cannot stage app, application resource is missing")

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -77,7 +77,7 @@ var CmdAppCreate = &cobra.Command{
 
 		err = client.AppCreate(args[0])
 		if err != nil {
-			return errors.Wrap(err, "error listing apps")
+			return errors.Wrap(err, "error creating app")
 		}
 
 		return nil
@@ -116,7 +116,7 @@ var CmdAppShow = &cobra.Command{
 
 		err = client.AppShow(args[0])
 		if err != nil {
-			return errors.Wrap(err, "error listing apps")
+			return errors.Wrap(err, "error showing app")
 		}
 
 		return nil

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -32,6 +32,7 @@ func init() {
 		panic(err)
 	}
 
+	CmdApp.AddCommand(CmdAppCreate)
 	CmdApp.AddCommand(CmdAppShow)
 	CmdApp.AddCommand(CmdAppList)
 	CmdApp.AddCommand(CmdDeleteApp)
@@ -59,6 +60,43 @@ var CmdAppList = &cobra.Command{
 		}
 
 		return nil
+	},
+}
+
+// CmdAppCreate implements the epinio `apps create` command
+var CmdAppCreate = &cobra.Command{
+	Use:   "create NAME",
+	Short: "Create just the app, without creating a workload",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
+
+		if err != nil {
+			return errors.Wrap(err, "error initializing cli")
+		}
+
+		err = client.AppCreate(args[0])
+		if err != nil {
+			return errors.Wrap(err, "error listing apps")
+		}
+
+		return nil
+	},
+	SilenceErrors: true,
+	SilenceUsage:  true,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		app, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		matches := app.AppsMatching(cmd.Context(), toComplete)
+
+		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
 }
 

--- a/internal/cli/clients/apps_create.go
+++ b/internal/cli/clients/apps_create.go
@@ -1,0 +1,37 @@
+package clients
+
+import (
+	"encoding/json"
+
+	api "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/internal/api/v1/models"
+)
+
+// AppCreate updates the credentials stored in the config from the
+// currently targeted kube cluster
+func (c *EpinioClient) AppCreate(appName string) error {
+	log := c.Log.WithName("Apps").WithValues("Organization", c.Config.Org, "Application", appName)
+	log.Info("start")
+	defer log.Info("return")
+	details := log.V(1) // NOTE: Increment of level, not absolute.
+
+	c.ui.Note().
+		WithStringValue("Organization", c.Config.Org).
+		WithStringValue("Application", appName).
+		Msg("Create application")
+
+	details.Info("create application")
+
+	request := models.ApplicationCreateRequest{Name: appName}
+	b, err := json.Marshal(request)
+	if err != nil {
+		return nil
+	}
+	_, err = c.post(api.Routes.Path("AppCreate", c.Config.Org), string(b))
+	if err != nil {
+		return err
+	}
+
+	c.ui.Success().Msg("Ok")
+	return nil
+}

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -998,7 +998,7 @@ func (c *EpinioClient) Delete(ctx context.Context, appname string) error {
 	if err != nil {
 		return err
 	}
-	var response map[string][]string
+	var response *models.ApplicationDeleteResponse
 	if err := json.Unmarshal(jsonResponse, &response); err != nil {
 		return err
 	}
@@ -1015,10 +1015,7 @@ func (c *EpinioClient) Delete(ctx context.Context, appname string) error {
 		}
 	}
 
-	unboundServices, ok := response["UnboundServices"]
-	if !ok {
-		return errors.Errorf("bad response, expected key missing: %v", response)
-	}
+	unboundServices := response.UnboundServices
 	if len(unboundServices) > 0 {
 		s.Stop()
 


### PR DESCRIPTION
With the new `apps create` command, it was also necessary to fix `apps delete`, so it can delete apps that don't have a  workload.

Commented in code, that our "delete organization" doesn't work 100% for "apps without workloads". It relies on deployments, which could be missing if the staging failed, so it will leave the Gitea repo or the pipelineruns behind.

We could switch https://github.com/epinio/epinio/blob/5ea479d9eaebaafc6ebf349eb785668bcb5723f5/internal/api/v1/organizations.go#L161-L255 to iterate over the application resources to delete left-over Gitea repos and pipelineruns. Namespace deletion will take care of the workloads.


fixes https://github.com/epinio/epinio/issues/515