### PR TITLE
559 extract acceptance cluster setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,4 +53,8 @@ jobs:
           REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
-          GINKGO_NODES=8 make test-acceptance
+          export GINKGO_NODES=8
+          make acceptance-cluster-delete
+          make acceptance-cluster-setup
+          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+          make test-acceptance

--- a/.github/workflows/outside-pr.yml
+++ b/.github/workflows/outside-pr.yml
@@ -42,4 +42,8 @@ jobs:
           REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
-          GINKGO_NODES=8 make test-acceptance
+          export GINKGO_NODES=8
+          make acceptance-cluster-delete
+          make acceptance-cluster-setup
+          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+          make test-acceptance

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,13 @@ test: embed_files
 
 GINKGO_NODES ?= 2
 FLAKE_ATTEMPTS ?= 2
+
+acceptance-cluster-delete:
+	k3d cluster delete epinio-acceptance
+
+acceptance-cluster-setup:
+	@./scripts/acceptance-cluster-setup.sh
+
 test-acceptance: showfocus embed_files
 	ginkgo -nodes ${GINKGO_NODES} -stream -randomizeAllSpecs --flakeAttempts=${FLAKE_ATTEMPTS} -failOnPending acceptance/.
 

--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -224,10 +224,15 @@ func ensureEpinio() {
 		"", false)
 	Expect(err).ToNot(HaveOccurred(), out)
 
+	domainSetting := ""
+	if domain := os.Getenv("EPINIO_SYSTEM_DOMAIN"); domain != "" {
+		domainSetting = fmt.Sprintf(" --system-domain %s", domain)
+	}
+
 	// Allow the installation to continue by not trying to create the default org
 	// before we patch.
 	out, err = RunProc(
-		fmt.Sprintf("../dist/epinio-linux-amd64 install --skip-default-org --user %s --password %s", epinioUser, epinioPassword),
+		fmt.Sprintf("../dist/epinio-linux-amd64 install --skip-default-org --user %s --password %s %s", epinioUser, epinioPassword, domainSetting),
 		"", false)
 	Expect(err).ToNot(HaveOccurred(), out)
 }

--- a/scripts/acceptance-cluster-setup.sh
+++ b/scripts/acceptance-cluster-setup.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+NETWORK_NAME=epinio-acceptance
+MIRROR_NAME=epinio-acceptance-registry-mirror
+CLUSTER_NAME=epinio-acceptance
+export KUBECONFIG=$SCRIPT_DIR/../tmp/acceptance-kubeconfig
+
+check_deps() {
+  if ! command -v k3d &> /dev/null
+  then
+      echo "k3d could not be found"
+      exit
+  fi
+}
+
+existingCluster() {
+  k3d cluster list | grep ${CLUSTER_NAME}
+}
+
+if [[ "$(existingCluster)" != "" ]]; then
+  echo "Cluster already exists, skipping creation."
+  exit 0
+fi
+
+echo "Ensuring a network"
+docker network create $NETWORK_NAME || echo "Network already exists"
+
+echo "Ensuring registry mirror (even if it's stopped)"
+existingMirror=$(docker ps -a --filter name=$MIRROR_NAME -q)
+if [[ $existingMirror  == "" ]]; then
+  echo "No mirror found, creating one"
+  docker run -d --network $NETWORK_NAME --name $MIRROR_NAME \
+    -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io \
+    -e REGISTRY_PROXY_USERNAME="${REGISTRY_USERNAME}" \
+    -e REGISTRY_PROXY_PASSWORD="${REGISTRY_PASSWORD}" \
+    registry:2
+else
+  docker start $MIRROR_NAME # In case it was stopped (we used "-a" when listing)
+fi
+
+echo "Writing epinio config yaml"
+TMP_CONFIG="$(mktemp)"
+trap "rm -f $TMP_CONFIG" EXIT
+
+cat << EOF > $TMP_CONFIG
+mirrors:
+  "docker.io":
+    endpoint:
+      - http://$MIRROR_NAME:5000
+EOF
+
+echo "Creating a new one named $CLUSTER_NAME"
+if [ -z ${EXPOSE_ACCEPTANCE_CLUSTER_PORTS+x} ]; then
+  # Without exposing ports on the host:
+  k3d cluster create $CLUSTER_NAME --network $NETWORK_NAME --registry-config $TMP_CONFIG --k3s-server-arg --disable --k3s-server-arg traefik
+else
+  # Exposing ports on the host:
+  k3d cluster create $CLUSTER_NAME --network $NETWORK_NAME --registry-config $TMP_CONFIG -p 80:80@server[0] -p 443:443@server[0] --k3s-server-arg --disable --k3s-server-arg traefik
+fi
+k3d kubeconfig get $CLUSTER_NAME > $KUBECONFIG
+
+echo "Waiting for node to be ready"
+nodeName=$(kubectl get nodes -o name)
+kubectl wait --for=condition=Ready ${nodeName}
+
+echo "Done! The cluster is ready."


### PR DESCRIPTION
Fixes #559 

This should allow us to use other types of clusters (other than k3d) by simply setting the KUBECONFIG environment variable.

Some of the changes also allow us to use real DNS (not the magic one) like this in the future:

```bash
make acceptance-cluster-delete # Delete the old cluster
EXPOSE_ACCEPTANCE_CLUSTER_PORTS=1 make acceptance-cluster-setup # Create a new one and bind ports 80 and 443 on the host
export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig # Point to the new cluster
EPINIO_SYSTEM_DOMAIN=some.real.domain.org make test-acceptance # Use a domain that points to the runner VM's IP address
```

We can't predict the IP address of the k3d container but the IP address of the VM doesn't change so we can use a real domain pointing to that IP address (even if it's not publicly accessible). This way we avoid problems related to `omg.howdoi.website` DNS server. Each worker would have to infer the `EPINIO_SYSTEM_DOMAIN` to be used base on it's hostname or something like that (each runner would have a different system domain).

The only reason this can't work yet is that whenever we see a system-domain that is not `omg.howdoi.website`, we assume it's a production deployment and we try to create let's encrypt certificates with HTTP challenges. Since our runners are not publicly accessible, http challenges are not possible. There are stories in the backlog that could solve this (e.g. #63) but another way would be to implement a flag that explicitly enables the let's encrypt signer during installation (or after?) and avoid deducting it from the system-domain. See also comments here: https://github.com/epinio/epinio/pull/560#issuecomment-871121956


For now, with this PR we can at least try tests on different types of clusters.