### PR TITLE
Dynamic silence and ingress type

### DIFF
--- a/assets/container-registry/chart/container-registry/templates/container-registry.yaml
+++ b/assets/container-registry/chart/container-registry/templates/container-registry.yaml
@@ -26,7 +26,7 @@ spec:
     port: 443
     targetPort: 443
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -43,15 +43,18 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: registry
-          servicePort: 5000
+          service:
+            name: registry
+            port:
+              number: 5000
         path: /
+        pathType: ImplementationSpecific
   tls:
   - hosts:
     - {{ .Values.domain }}
     secretName: epinio-registry-tls
-## We create a service with type `NodePort` only in 
-## local deployment as Kubelet cannot access the 
+## We create a service with type `NodePort` only in
+## local deployment as Kubelet cannot access the
 ## secured registry because there is no way to add
 ## registry CA to kubelet.
 {{ if contains "omg.howdoi.website" .Values.domain }}

--- a/assets/embedded-files/epinio/server.yaml
+++ b/assets/embedded-files/epinio/server.yaml
@@ -75,6 +75,8 @@ rules:
   - ingresses
   verbs:
   - get
+  - list
+  - get
 - apiGroups:
   - ""
   resources:

--- a/helpers/kubernetes/cluster.go
+++ b/helpers/kubernetes/cluster.go
@@ -21,7 +21,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	apibatchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -610,8 +610,7 @@ func (c *Cluster) GetVersion() (string, error) {
 
 // ListIngressRoutes returns a list of all routes for ingresses in `namespace` with the given selector
 func (c *Cluster) ListIngressRoutes(ctx context.Context, namespace, name string) ([]string, error) {
-	// TODO: Switch to networking v1 when we don't care about <1.18 clusters
-	ingress, err := c.Kubectl.ExtensionsV1beta1().Ingresses(namespace).Get(ctx, name, metav1.GetOptions{})
+	ingress, err := c.Kubectl.NetworkingV1().Ingresses(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list ingresses")
 	}
@@ -626,14 +625,14 @@ func (c *Cluster) ListIngressRoutes(ctx context.Context, namespace, name string)
 }
 
 // ListIngress returns the list of available ingresses in `namespace` with the given selector
-func (c *Cluster) ListIngress(ctx context.Context, namespace, selector string) (*v1beta1.IngressList, error) {
+func (c *Cluster) ListIngress(ctx context.Context, namespace, selector string) (*networkingv1.IngressList, error) {
 	listOptions := metav1.ListOptions{}
 	if len(selector) > 0 {
 		listOptions.LabelSelector = selector
 	}
 
 	// TODO: Switch to networking v1 when we don't care about <1.18 clusters
-	ingressList, err := c.Kubectl.ExtensionsV1beta1().Ingresses(namespace).List(ctx, listOptions)
+	ingressList, err := c.Kubectl.NetworkingV1().Ingresses(namespace).List(ctx, listOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -69,6 +69,8 @@ var CmdAppCreate = &cobra.Command{
 	Short: "Create just the app, without creating a workload",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
 		client, err := clients.NewEpinioClient(cmd.Context(), cmd.Flags())
 
 		if err != nil {
@@ -82,8 +84,6 @@ var CmdAppCreate = &cobra.Command{
 
 		return nil
 	},
-	SilenceErrors: true,
-	SilenceUsage:  true,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
Two small changes.

* Using the new ingress type for the api server. We used the new type already for workloads.
* Backfilling the silence fix for the "app create" PR


Fix for https://github.com/epinio/epinio/pull/553