### PR TITLE
Fix error message when Traefik fails to get an IP

### DIFF
--- a/deployments/traefik.go
+++ b/deployments/traefik.go
@@ -135,7 +135,10 @@ func (k Traefik) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI
 	}
 
 	if err := c.WaitUntilServiceHasLoadBalancer(ctx, ui, TraefikDeploymentID, "traefik", duration.ToServiceLoadBalancer()); err != nil {
-		return errors.Wrap(err, "failed waiting for Traefik Ingress to contact the Load Balancer")
+		return errors.Wrap(err, "failed waiting for Traefik Ingress to contact the Load Balancer.\n" +
+			"Ensure your kubernetes platform has the ability to provision LoadBalancer IP address.\n\n" +
+			"Follow these steps to enable this ability\n" +
+			"https://github.com/epinio/epinio/blob/main/docs/install.md")
 	}
 
 	ui.Success().Msg("Traefik Ingress deployed")

--- a/deployments/traefik.go
+++ b/deployments/traefik.go
@@ -138,7 +138,7 @@ func (k Traefik) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI
 		return errors.Wrap(err, "timed out waiting for LoadBalancer IP on traefik service\n" +
 			"Ensure your kubernetes platform has the ability to provision LoadBalancer IP address.\n\n" +
 			"Follow these steps to enable this ability\n" +
-			"https://github.com/epinio/epinio/blob/main/docs/install.md\n")
+			"https://github.com/epinio/epinio/blob/main/docs/user/howtos/proivision_externalIP_kube_distros.md\n")
 	}
 
 	ui.Success().Msg("Traefik Ingress deployed")

--- a/deployments/traefik.go
+++ b/deployments/traefik.go
@@ -128,14 +128,14 @@ func (k Traefik) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI
 	}
 
 	if err := c.WaitUntilPodBySelectorExist(ctx, ui, TraefikDeploymentID, "app.kubernetes.io/name=traefik", k.Timeout); err != nil {
-		return errors.Wrap(err, "failed waiting Traefik Ingress deployment to exist")
+		return errors.Wrap(err, "failed waiting for Traefik Ingress deployment to exist")
 	}
 	if err := c.WaitForPodBySelectorRunning(ctx, ui, TraefikDeploymentID, "app.kubernetes.io/name=traefik", k.Timeout); err != nil {
-		return errors.Wrap(err, "failed waiting Traefik Ingress deployment to come up")
+		return errors.Wrap(err, "failed waiting for Traefik Ingress deployment to come up")
 	}
 
 	if err := c.WaitUntilServiceHasLoadBalancer(ctx, ui, TraefikDeploymentID, "traefik", duration.ToServiceLoadBalancer()); err != nil {
-		return errors.Wrap(err, "failed waiting for Traefik Ingress to have get a Load Balancer")
+		return errors.Wrap(err, "failed waiting for Traefik Ingress to contact the Load Balancer")
 	}
 
 	ui.Success().Msg("Traefik Ingress deployed")

--- a/deployments/traefik.go
+++ b/deployments/traefik.go
@@ -138,7 +138,7 @@ func (k Traefik) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI
 		return errors.Wrap(err, "failed waiting for Traefik Ingress to contact the Load Balancer.\n" +
 			"Ensure your kubernetes platform has the ability to provision LoadBalancer IP address.\n\n" +
 			"Follow these steps to enable this ability\n" +
-			"https://github.com/epinio/epinio/blob/main/docs/install.md")
+			"https://github.com/epinio/epinio/blob/main/docs/install.md\n")
 	}
 
 	ui.Success().Msg("Traefik Ingress deployed")

--- a/deployments/traefik.go
+++ b/deployments/traefik.go
@@ -135,7 +135,7 @@ func (k Traefik) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI
 	}
 
 	if err := c.WaitUntilServiceHasLoadBalancer(ctx, ui, TraefikDeploymentID, "traefik", duration.ToServiceLoadBalancer()); err != nil {
-		return errors.Wrap(err, "failed waiting for Traefik Ingress to contact the Load Balancer.\n" +
+		return errors.Wrap(err, "timed out waiting for LoadBalancer IP on traefik service\n" +
 			"Ensure your kubernetes platform has the ability to provision LoadBalancer IP address.\n\n" +
 			"Follow these steps to enable this ability\n" +
 			"https://github.com/epinio/epinio/blob/main/docs/install.md\n")

--- a/deployments/traefik.go
+++ b/deployments/traefik.go
@@ -138,7 +138,7 @@ func (k Traefik) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI
 		return errors.Wrap(err, "timed out waiting for LoadBalancer IP on traefik service\n" +
 			"Ensure your kubernetes platform has the ability to provision LoadBalancer IP address.\n\n" +
 			"Follow these steps to enable this ability\n" +
-			"https://github.com/epinio/epinio/blob/main/docs/user/howtos/proivision_externalIP_kube_distros.md\n")
+			"https://github.com/epinio/epinio/blob/main/docs/user/howtos/provision_external_ip_for_local_kubernetes.md\n")
 	}
 
 	ui.Success().Msg("Traefik Ingress deployed")


### PR DESCRIPTION
The existing (helpful) message [is never reached](https://github.com/epinio/epinio/issues/187#issuecomment-877022028)

This PR makes the Traefik related error messages more readable and helpful.

See #187 

/cc @jimmykarily since he worked in this area recently.