### PR TITLE
Allow mounting of the SA for linkerd sidecars in app pods

### DIFF
--- a/assets/embedded-files/tekton/pipeline.yaml
+++ b/assets/embedded-files/tekton/pipeline.yaml
@@ -209,7 +209,7 @@ spec:
                 app.kubernetes.io/name: "$(params.APP_NAME)"
             spec:
               serviceAccountName: "$(params.ORG)"
-              automountServiceAccountToken: false
+              automountServiceAccountToken: true
               containers:
               - name: "$(params.APP_NAME)"
                 image: "$(params.DEPLOYMENT_IMAGE)"

--- a/internal/organizations/organizations.go
+++ b/internal/organizations/organizations.go
@@ -129,7 +129,7 @@ func copySecret(ctx context.Context, secretName, originOrg, targetOrg string, ku
 }
 
 func createServiceAccount(ctx context.Context, kubeClient *kubernetes.Cluster, targetOrg string) error {
-	automountServiceAccountToken := false
+	automountServiceAccountToken := true
 	_, err := kubeClient.Kubectl.CoreV1().ServiceAccounts(targetOrg).Create(
 		ctx,
 		&corev1.ServiceAccount{


### PR DESCRIPTION
Fix #532 

Note that this expects the SA to be suitably limited so that the application cannot talk to kubernetes.
An __unmodified__ default SA for the namespace is good for this.
