### PR TITLE
Fix command completion crashes

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"context"
+
 	v1 "github.com/epinio/epinio/internal/api/v1"
 	"github.com/epinio/epinio/internal/cli/clients"
 	"github.com/pkg/errors"
@@ -90,12 +92,12 @@ var CmdAppCreate = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		app, err := clients.NewEpinioClient(cmd.Context())
+		app, err := clients.NewEpinioClient(context.Background())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		matches := app.AppsMatching(cmd.Context(), toComplete)
+		matches := app.AppsMatching(context.Background(), toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
@@ -127,12 +129,12 @@ var CmdAppShow = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		app, err := clients.NewEpinioClient(cmd.Context())
+		app, err := clients.NewEpinioClient(context.Background())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		matches := app.AppsMatching(cmd.Context(), toComplete)
+		matches := app.AppsMatching(context.Background(), toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
@@ -216,12 +218,12 @@ var CmdAppUpdate = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		app, err := clients.NewEpinioClient(cmd.Context())
+		app, err := clients.NewEpinioClient(context.Background())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		matches := app.AppsMatching(cmd.Context(), toComplete)
+		matches := app.AppsMatching(context.Background(), toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/epinio/epinio/internal/cli/clients"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -32,12 +34,12 @@ var CmdDeleteApp = &cobra.Command{
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		app, err := clients.NewEpinioClient(cmd.Context())
+		app, err := clients.NewEpinioClient(context.Background())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		matches := app.AppsMatching(cmd.Context(), toComplete)
+		matches := app.AppsMatching(context.Background(), toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/epinio/epinio/internal/cli/clients"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -51,12 +53,12 @@ var CmdEnvList = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		app, err := clients.NewEpinioClient(cmd.Context())
+		app, err := clients.NewEpinioClient(context.Background())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		matches := app.AppsMatching(cmd.Context(), toComplete)
+		matches := app.AppsMatching(context.Background(), toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
@@ -91,13 +93,13 @@ var CmdEnvSet = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		app, err := clients.NewEpinioClient(cmd.Context())
+		app, err := clients.NewEpinioClient(context.Background())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
 		// #args == 0: application name.
-		matches := app.AppsMatching(cmd.Context(), toComplete)
+		matches := app.AppsMatching(context.Background(), toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
@@ -129,19 +131,19 @@ var CmdEnvShow = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		app, err := clients.NewEpinioClient(cmd.Context())
+		app, err := clients.NewEpinioClient(context.Background())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
 		if len(args) == 1 {
 			// #args == 1: environment variable name (in application)
-			matches := app.EnvMatching(cmd.Context(), args[0], toComplete)
+			matches := app.EnvMatching(context.Background(), args[0], toComplete)
 			return matches, cobra.ShellCompDirectiveNoFileComp
 		}
 
 		// #args == 0: application name.
-		matches := app.AppsMatching(cmd.Context(), toComplete)
+		matches := app.AppsMatching(context.Background(), toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
@@ -174,14 +176,14 @@ var CmdEnvUnset = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		// TODO: arg 1: EV match
+		// TODO: match EV names for arg 1 completion
 
-		app, err := clients.NewEpinioClient(cmd.Context())
+		app, err := clients.NewEpinioClient(context.Background())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		matches := app.AppsMatching(cmd.Context(), toComplete)
+		matches := app.AppsMatching(context.Background(), toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/epinio/epinio/internal/cli/clients"
@@ -46,12 +47,12 @@ var CmdServiceShow = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		app, err := clients.NewEpinioClient(cmd.Context())
+		app, err := clients.NewEpinioClient(context.Background())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		matches := app.ServiceMatching(cmd.Context(), toComplete)
+		matches := app.ServiceMatching(context.Background(), toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
@@ -79,19 +80,19 @@ var CmdServiceCreate = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		app, err := clients.NewEpinioClient(cmd.Context())
+		app, err := clients.NewEpinioClient(context.Background())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
 		if len(args) == 2 {
 			// #args == 2: service plan name.
-			matches := app.ServicePlanMatching(cmd.Context(), args[1], toComplete)
+			matches := app.ServicePlanMatching(context.Background(), args[1], toComplete)
 			return matches, cobra.ShellCompDirectiveNoFileComp
 		}
 
 		// #args == 1: service class name.
-		matches := app.ServiceClassMatching(cmd.Context(), toComplete)
+		matches := app.ServiceClassMatching(context.Background(), toComplete)
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
 }
@@ -125,12 +126,12 @@ var CmdServiceDelete = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		app, err := clients.NewEpinioClient(cmd.Context())
+		app, err := clients.NewEpinioClient(context.Background())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		matches := app.ServiceMatching(cmd.Context(), toComplete)
+		matches := app.ServiceMatching(context.Background(), toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
@@ -148,20 +149,20 @@ var CmdServiceBind = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		app, err := clients.NewEpinioClient(cmd.Context())
+		app, err := clients.NewEpinioClient(context.Background())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
 		if len(args) == 1 {
 			// #args == 1: app name.
-			matches := app.AppsMatching(cmd.Context(), toComplete)
+			matches := app.AppsMatching(context.Background(), toComplete)
 			return matches, cobra.ShellCompDirectiveNoFileComp
 		}
 
 		// #args == 0: service name.
 
-		matches := app.ServiceMatching(cmd.Context(), toComplete)
+		matches := app.ServiceMatching(context.Background(), toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
@@ -179,19 +180,19 @@ var CmdServiceUnbind = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		app, err := clients.NewEpinioClient(cmd.Context())
+		app, err := clients.NewEpinioClient(context.Background())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
 		if len(args) == 1 {
 			// #args == 1: app name.
-			matches := app.AppsMatching(cmd.Context(), toComplete)
+			matches := app.AppsMatching(context.Background(), toComplete)
 			return matches, cobra.ShellCompDirectiveNoFileComp
 		}
 
 		// #args == 0: service name.
-		matches := app.ServiceMatching(cmd.Context(), toComplete)
+		matches := app.ServiceMatching(context.Background(), toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
@@ -215,12 +216,12 @@ var CmdServiceListPlans = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		app, err := clients.NewEpinioClient(cmd.Context())
+		app, err := clients.NewEpinioClient(context.Background())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		matches := app.ServiceClassMatching(cmd.Context(), toComplete)
+		matches := app.ServiceClassMatching(context.Background(), toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/epinio/epinio/internal/cli/clients"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -38,7 +40,7 @@ var CmdTarget = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		app, err := clients.NewEpinioClient(cmd.Context())
+		app, err := clients.NewEpinioClient(context.Background())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}


### PR DESCRIPTION
Fix #557 

A `nil`-valued `cmd.Context()` result in cobra `ValidArgsFunction` broke command completion across the board.
Use `context.Background()` instead.
