### PR TITLE
Remove check of (non) dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,14 @@ FLAKE_ATTEMPTS ?= 2
 acceptance-cluster-delete:
 	k3d cluster delete epinio-acceptance
 
+acceptance-cluster-delete-kind:
+	kind delete cluster --name epinio-acceptance
+
 acceptance-cluster-setup:
 	@./scripts/acceptance-cluster-setup.sh
+
+acceptance-cluster-setup-kind:
+	@./scripts/acceptance-cluster-setup-kind.sh
 
 test-acceptance: showfocus embed_files
 	ginkgo -nodes ${GINKGO_NODES} -stream -randomizeAllSpecs --flakeAttempts=${FLAKE_ATTEMPTS} -failOnPending acceptance/. acceptance/api/v1/.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -105,11 +105,8 @@ func checkDependencies() error {
 	dependencies := []struct {
 		CommandName string
 	}{
-		// update the 'prerequisites' of docs/install.md if you make changes here
 		{CommandName: "kubectl"},
 		{CommandName: "helm"},
-		{CommandName: "sh"},
-		{CommandName: "git"},
 	}
 
 	for _, dependency := range dependencies {

--- a/scripts/acceptance-cluster-setup-kind.sh
+++ b/scripts/acceptance-cluster-setup-kind.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+NETWORK_NAME=epinio-acceptance
+MIRROR_NAME=epinio-acceptance-registry-mirror
+CLUSTER_NAME=epinio-acceptance
+export KUBECONFIG=$SCRIPT_DIR/../tmp/acceptance-kubeconfig
+
+check_deps() {
+  if ! command -v kind &> /dev/null
+  then
+      echo "kind could not be found"
+      exit
+  fi
+}
+
+existingCluster() {
+  kind get clusters | grep ${CLUSTER_NAME}
+}
+
+if [[ "$(existingCluster)" != "" ]]; then
+  echo "Cluster already exists, skipping creation."
+  exit 0
+fi
+
+echo "Ensuring a network"
+docker network create $NETWORK_NAME || echo "Network already exists"
+
+if [[ "$SHARED_REGISTRY_MIRROR" == "" ]]; then
+  echo "Ensuring registry mirror (even if it's stopped)"
+  existingMirror=$(docker ps -a --filter name=$MIRROR_NAME -q)
+  if [[ $existingMirror  == "" ]]; then
+    echo "No mirror found, creating one"
+    docker run -d --network $NETWORK_NAME --name $MIRROR_NAME \
+      -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io \
+      -e REGISTRY_PROXY_USERNAME="${REGISTRY_USERNAME}" \
+      -e REGISTRY_PROXY_PASSWORD="${REGISTRY_PASSWORD}" \
+      registry:2
+  else
+    docker start $MIRROR_NAME # In case it was stopped (we used "-a" when listing)
+  fi
+else
+  echo "Using local registry mirror"
+  MIRROR_NAME="$SHARED_REGISTRY_MIRROR"
+fi
+
+echo "Writing epinio config yaml"
+TMP_CONFIG="$(mktemp)"
+trap "rm -f $TMP_CONFIG" EXIT
+
+cat << EOF > $TMP_CONFIG
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+      endpoint = ["http://${MIRROR_NAME}:5000"]
+EOF
+
+if [ -n ${EXPOSE_ACCEPTANCE_CLUSTER_PORTS+x} ]; then
+  cat << EOF >> $TMP_CONFIG
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+  - containerPort: 443
+    hostPort: 443
+EOF
+fi
+
+echo "Creating a new one named $CLUSTER_NAME"
+kind create cluster --name $CLUSTER_NAME  --config=$TMP_CONFIG
+
+echo "Connecting the kind cluster to the mirror network"
+docker network connect $NETWORK_NAME "${CLUSTER_NAME}-control-plane"
+
+kind get kubeconfig --name $CLUSTER_NAME > $KUBECONFIG
+
+echo "Waiting for node to be ready"
+nodeName=$(kubectl get nodes -o name)
+kubectl wait --for=condition=Ready "$nodeName"
+
+# Setup LoadBalancer
+# https://github.com/epinio/epinio/blob/main/docs/user/howtos/provision_external_ip_for_local_kubernetes.md
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/metallb.yaml
+kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+
+SUBNET_IP=`docker network inspect kind | jq -r '.[0].IPAM.Config[0].Gateway'`
+## Use the last few IP addresses
+IP_ARRAY=(${SUBNET_IP//./ })
+SUBNET_IP="${IP_ARRAY[0]}.${IP_ARRAY[1]}.255.255"
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - ${SUBNET_IP}/28
+EOF
+
+date
+echo "Waiting for the deployments of the foundational services to be ready"
+# 1200s = 20 min, to handle even a horrendously slow setup. Regular is 10 to 30 seconds.
+kubectl wait --for=condition=Available --namespace local-path-storage deployment/local-path-provisioner --timeout=1200s
+date
+
+echo "Done! The cluster is ready."

--- a/scripts/tools/kind.sh
+++ b/scripts/tools/kind.sh
@@ -3,12 +3,12 @@
 
 TOOLS+=(kind)
 
-KIND_VERSION="0.6.0"
+KIND_VERSION="0.11.1"
 
 KIND_URL_DARWIN="https://github.com/kubernetes-sigs/kind/releases/download/v{version}/kind-darwin-amd64"
 KIND_URL_LINUX="https://github.com/kubernetes-sigs/kind/releases/download/v{version}/kind-linux-amd64"
 KIND_URL_WINDOWS="https://github.com/kubernetes-sigs/kind/releases/download/v{version}/kind-windows-amd64"
 
-KIND_SHA256_DARWIN="eba1480b335f1fd091bf3635dba3f901f9ebd9dc1fb32199ca8a6aaacf69691e"
-KIND_SHA256_LINUX="b68e758f5532db408d139fed6ceae9c1400b5137182587fc8da73a5dcdb950ae"
-KIND_SHA256_WINDOWS="f022a4800363bd4a0c17ee84b58d3e5f654a945dcaf5f66e2c1c230e417b05fb"
+KIND_SHA256_DARWIN="432bef555a70e9360b44661c759658265b9eaaf7f75f1beec4c4d1e6bbf97ce3"
+KIND_SHA256_LINUX="949f81b3c30ca03a3d4effdecda04f100fa3edc07a28b19400f72ede7c5f0491"
+KIND_SHA256_WINDOWS="d309d8056cec8bcabb24e185200ef8f9702e0c01a9ec8a7f7185fe956783ed97"


### PR DESCRIPTION
`git` and `sh` are only needed when pushing the application code from
the epinio server to gitea. This check was happening on the client where
those tools are not needed.

Fixes #622