### PR TITLE
Fix make build-images when there is a `tmp` dir in the root dir or epinio

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE=splatform/epinio-base
 
 FROM ruby:3.0.1 AS tools
+WORKDIR /workdir
 COPY . .
 RUN apt-get update && apt-get install -y python3-venv
 RUN ./scripts/tools-install.sh helm


### PR DESCRIPTION

The COPY line happens on `/` inside the container. If there is a
directory `tmp` at the root directory of epinio (from where the `docker
build` command is called), it will overwrite the `/tmp` inside the
container messing up permissions and resulting in errors like:

```
Err:3 http://deb.debian.org/debian buster-updates InRelease
  Couldn't create temporary file /tmp/apt.conf.lVTMwm for passing config to apt-key
Reading package lists...
W: GPG error: http://security.debian.org/debian-security buster/updates InRelease: Couldn't create temporary file /tmp/apt.conf.xehqje for passing config to apt-key
E: The repository 'http://security.debian.org/debian-security buster/updates InRelease' is not signed.
W: GPG error: http://deb.debian.org/debian buster InRelease: Couldn't create temporary file /tmp/apt.conf.mfqdEg for passing config to apt-key
E: The repository 'http://deb.debian.org/debian buster InRelease' is not signed.
W: GPG error: http://deb.debian.org/debian buster-updates InRelease: Couldn't create temporary file /tmp/apt.conf.lVTMwm for passing config to apt-key
E: The repository 'http://deb.debian.org/debian buster-updates InRelease' is not signed.
```

Simply changing to some other directory fixes it.