### PR TITLE
Add make install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,3 +134,7 @@ minikube-start:
 
 minikube-delete:
 	@./scripts/minikube-delete.sh
+
+local-install:
+	EPINIO_DONT_WAIT_FOR_DEPLOYMENT=1 epinio install --skip-default-org
+	@./scripts/patch-epinio-deployment.sh

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,6 @@ minikube-start:
 minikube-delete:
 	@./scripts/minikube-delete.sh
 
-local-install:
-	EPINIO_DONT_WAIT_FOR_DEPLOYMENT=1 epinio install --skip-default-org
+install: build
+	EPINIO_DONT_WAIT_FOR_DEPLOYMENT=1 ./dist/epinio-linux-amd64 install --skip-default-org
 	@./scripts/patch-epinio-deployment.sh

--- a/docs/developer/howtos/behind-the-curtains.md
+++ b/docs/developer/howtos/behind-the-curtains.md
@@ -1,0 +1,51 @@
+#### Behind the curtains
+
+`make install` does quite a bit more than the plain
+
+```
+epinio install
+```
+
+found in the quick install intructions.
+
+Let's look at what `make install` actually does:
+
+When building Epinio, the generated binary assumes that there is a
+container image for the Epinio server components, with a tag that
+matches the commit you built from.  For example, when calling `make
+build` on commit `7bfb700`, the version reported by Epinio is
+something like `v0.0.5-75-g7bfb700` and an image `epinio/server:v0.0.5-75-g7bfb700`
+is expected to be found.
+
+This works fine for released versions, because the release pipeline ensures
+that such an image is built and published.
+
+However when building locally building and publishing an image for
+every little change is ... inconvenient.
+
+`make install` is setting
+```
+export EPINIO_DONT_WAIT_FOR_DEPLOYMENT=1
+```
+
+before calling the `epinio` binary that was created during `make build`.
+
+This tells the `epinio install` command to not wait for the Epinio server
+deployment. Since that will be failing without the image. Inspecting
+the cluster with
+
+```
+kubectl get pod -n epinio --selector=app.kubernetes.io/name=epinio-server
+```
+
+will confirm this.
+
+Then `make install` runs `scripts/patch-epinio-deployment.sh` which compensates for this
+issue. This make target patches the failing Epinio server deployment
+to use an existing image from some release and then copies the locally
+built `dist/epinio-linux-amd64` binary into it, ensuring that it runs
+the same binary as the client.
+
+__Note__ When building for another OS or architecture the
+`dist/epinio-linux-amd64` binary will not exist, and the script has to
+be adjusted accordingly.

--- a/docs/developer/howtos/development.md
+++ b/docs/developer/howtos/development.md
@@ -42,60 +42,16 @@ You can have a look at [the dedicated document](/docs/user/howtos/install.md) fo
 specific instructions, but generally this should be sufficient to get you running:
 
 ```
-export EPINIO_DONT_WAIT_FOR_DEPLOYMENT=1
-./dist/epinio-linux-amd64 install --skip-default-org
-make patch-epinio-deployment
+make install
 ./dist/epinio-linux-amd64 org create workspace
 ./dist/epinio-linux-amd64 target workspace
 ```
 
-This is quite a bit more than the plain
+In case you're curious why `make install` is used here instead of
+`epinio install`, [look behind the curtains](behind-the-curtains.md)
+explains the details of running an Epinio dev environment.
 
-```
-epinio install
-```
 
-found in the quick install intructions.
-
-Let us unpack the above:
-
-When building Epinio, the generated binary assumes that there is a
-container image for the Epinio server components, with a tag that
-matches the commit you built from.  For example, when calling `make
-build` on commit `7bfb700`, the version reported by Epinio is
-`v0.0.5-75-g7bfb700` and an image `epinio/server:v0.0.5-75-g7bfb700`
-is expected to be found.
-
-This works fine for released versions, because the pipeline ensures
-that such an image is built and published.
-
-However when building locally building and publishing an image for
-every little change is ... inconvenient.
-
-Setting
-```
-export EPINIO_DONT_WAIT_FOR_DEPLOYMENT=1
-```
-
-tells the `epinio install` command to not wait for the epinio server
-deployment. Since that will be failing without the image. Inspecting
-the cluster with
-
-```
-kubectl get pod -n epinio --selector=app.kubernetes.io/name=epinio-server
-```
-
-will confirm this.
-
-The invocation of `make patch-epinio-deployment` compensates for this
-issue. This make target patches the failing epinio server deployment
-to use an existing image from some release and then copies the locally
-built `dist/epinio-linux-amd64` binary into it, ensuring that it runs
-the same binary as the client.
-
-__Note__ When building for another OS or architecture the
-`dist/epinio-linux-amd64` binary will not exist, and the script has to
-be adjusted accordingly.
 
 After making changes to the binary simply invoking `make
 patch-epinio-deployment` again will upload the changes into the


### PR DESCRIPTION
Simplify the developer workflow by introducing a `make install` target and adapt the documentation accordingly