### PR TITLE
chore fix: Reworked infrastructure for shelling out, prevent quoting issues

### DIFF
--- a/acceptance/api/v1/applications_test.go
+++ b/acceptance/api/v1/applications_test.go
@@ -122,7 +122,10 @@ var _ = Describe("Apps API Application Endpoints", func() {
 
 	waitForPipeline := func(stageID string) {
 		Eventually(func() string {
-			out, err := helpers.Kubectl(fmt.Sprintf("-n %s get pipelinerun %s  -o jsonpath='{.status.conditions[0].status}'", deployments.TektonStagingNamespace, stageID))
+			out, err := helpers.Kubectl("get", "pipelinerun",
+				"--namespace", deployments.TektonStagingNamespace,
+				stageID,
+				"-o", "jsonpath={.status.conditions[0].status}")
 			Expect(err).NotTo(HaveOccurred())
 			return out
 		}, "5m").Should(Equal("True"))
@@ -527,7 +530,10 @@ var _ = Describe("Apps API Application Endpoints", func() {
 
 					// Check if autoserviceaccounttoken is true
 					labels := fmt.Sprintf("app.kubernetes.io/name=%s", appName)
-					out, err := helpers.Kubectl(fmt.Sprintf("-n %s get pod -l %s  -o jsonpath='{.items[*].spec.automountServiceAccountToken}'", org, labels))
+					out, err := helpers.Kubectl("get", "pod",
+						"--namespace", org,
+						"-l", labels,
+						"-o", "jsonpath={.items[*].spec.automountServiceAccountToken}")
 					Expect(err).NotTo(HaveOccurred())
 					Expect(out).To(ContainSubstring("true"))
 				})
@@ -736,7 +742,7 @@ var _ = Describe("Apps API Application Endpoints", func() {
 
 		AfterEach(func() {
 			Eventually(func() string {
-				out, err := env.Epinio("app delete "+appName, "")
+				out, err := env.Epinio("", "app", "delete", appName)
 				if err != nil {
 					return out
 				}

--- a/acceptance/api/v1/orgs_test.go
+++ b/acceptance/api/v1/orgs_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Orgs API Application Endpoints", func() {
 				Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
 				Expect(string(bodyBytes)).To(Equal(""))
 
-				_, err = helpers.Kubectl(fmt.Sprintf("get namespace %s", org))
+				_, err = helpers.Kubectl("get", "namespace", org)
 				Expect(err).To(HaveOccurred())
 			})
 

--- a/acceptance/api/v1/services_mutation_test.go
+++ b/acceptance/api/v1/services_mutation_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 				Expect(response.StatusCode).To(Equal(http.StatusCreated), string(bodyBytes))
 				Expect(string(bodyBytes)).To(Equal(""))
 
-				out, err := env.Epinio("service list", "")
+				out, err := env.Epinio("", "service", "list")
 				Expect(err).ToNot(HaveOccurred(), out)
 				Expect(out).To(MatchRegexp(service))
 			})
@@ -282,7 +282,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 				// This takes the place of the `service list` command in the previous test,
 				// which simply checks for presence.
 				Eventually(func() string {
-					out, err := env.Epinio("service show "+service, "")
+					out, err := env.Epinio("", "service", "show", service)
 					ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)
 					return out
 				}, "5m").Should(MatchRegexp(`Status .*\|.* Provisioned`))

--- a/acceptance/api/v1/suite_test.go
+++ b/acceptance/api/v1/suite_test.go
@@ -70,7 +70,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	fmt.Println("Setup cluster services")
 	testenv.SetupInClusterServices(epinioBinary)
 
-	out, err = helpers.Kubectl(`get pods -n minibroker --selector=app=minibroker-minibroker`)
+	out, err = helpers.Kubectl("get", "pods", "--namespace", "minibroker", "--selector=app=minibroker-minibroker")
 	Expect(err).ToNot(HaveOccurred(), out)
 	Expect(out).To(MatchRegexp(`minibroker.*2/2.*Running`))
 
@@ -103,13 +103,15 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	os.Setenv("EPINIO_CONFIG", nodeTmpDir+"/epinio.yaml")
 
 	// Get config from the installation (API credentials)
-	out, err = proc.Run(fmt.Sprintf("cp %s %s/epinio.yaml", testenv.EpinioYAML(), nodeTmpDir), "", false)
+	out, err = proc.Run("", false, "cp", testenv.EpinioYAML(), nodeTmpDir+"/epinio.yaml")
 	Expect(err).ToNot(HaveOccurred(), out)
 
-	out, err = env.Epinio("target workspace", nodeTmpDir)
+	out, err = env.Epinio(nodeTmpDir, "target", "workspace")
 	Expect(err).ToNot(HaveOccurred(), out)
 
-	out, err = proc.Run("kubectl get ingress -n epinio epinio -o=jsonpath='{.spec.rules[0].host}'", testenv.Root(), false)
+	out, err = proc.Run(testenv.Root(), false, "kubectl", "get", "ingress",
+		"--namespace", "epinio", "epinio",
+		"-o", "jsonpath={.spec.rules[0].host}")
 	Expect(err).ToNot(HaveOccurred(), out)
 
 	serverURL = "https://" + out

--- a/acceptance/bindings_test.go
+++ b/acceptance/bindings_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Bounds between Apps & Services", func() {
 			env.BindAppService(appName, serviceName, org)
 		})
 		It("shows the bound app for services list, and vice versa", func() {
-			out, err := env.Epinio("service list", "")
+			out, err := env.Epinio("", "service", "list")
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(MatchRegexp(serviceName + `.*` + appName))
 
@@ -40,7 +40,7 @@ var _ = Describe("Bounds between Apps & Services", func() {
 			// system to settle back into a normal state.
 
 			Eventually(func() string {
-				out, err = env.Epinio("app list", "")
+				out, err := env.Epinio("", "app", "list")
 				Expect(err).ToNot(HaveOccurred(), out)
 				return out
 			}, "5m").Should(MatchRegexp(appName + `.*\|.*1\/1.*\|.*` + serviceName))

--- a/acceptance/catalog_services_test.go
+++ b/acceptance/catalog_services_test.go
@@ -30,9 +30,9 @@ var _ = Describe("Catalog Services", func() {
 			env.MakeCatalogService(serviceName, `{ "db": { "name": "wordpress" }}`)
 			serviceInstanceName := fmt.Sprintf("service.org-%s.svc-%s", org, serviceName)
 
-			out, err := helpers.Kubectl(
-				fmt.Sprintf("get serviceinstance -n %s %s -o=jsonpath='{.status.externalProperties.parameters.db.name}'",
-					org, serviceInstanceName))
+			out, err := helpers.Kubectl("get", "serviceinstance",
+				"--namespace", org, serviceInstanceName,
+				"-o", "jsonpath={.status.externalProperties.parameters.db.name}")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).To(Equal("wordpress"))
 		})
@@ -60,7 +60,7 @@ var _ = Describe("Catalog Services", func() {
 			env.MakeDockerImageApp(appName, 1, dockerImageURL)
 			env.BindAppService(appName, serviceName, org)
 
-			out, err := env.Epinio("service delete "+serviceName, "")
+			out, err := env.Epinio("", "service", "delete", serviceName)
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			Expect(out).To(MatchRegexp("Unable to delete service. It is still used by"))
@@ -71,7 +71,7 @@ var _ = Describe("Catalog Services", func() {
 
 			// Delete again, and force unbind
 
-			out, err = env.Epinio("service delete --unbind "+serviceName, "")
+			out, err = env.Epinio("", "service", "delete", "--unbind", serviceName)
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			Expect(out).To(MatchRegexp("PREVIOUSLY BOUND TO"))
@@ -83,7 +83,7 @@ var _ = Describe("Catalog Services", func() {
 
 			// And check non-presence
 			Eventually(func() string {
-				out, err = env.Epinio("service list", "")
+				out, err = env.Epinio("", "service", "list")
 				Expect(err).ToNot(HaveOccurred(), out)
 				return out
 			}, "10m").ShouldNot(MatchRegexp(serviceName))
@@ -135,7 +135,7 @@ var _ = Describe("Catalog Services", func() {
 		})
 
 		It("it shows service details", func() {
-			out, err := env.Epinio("service show "+serviceName, "")
+			out, err := env.Epinio("", "service", "show", serviceName)
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(MatchRegexp("Service Details"))
 			Expect(out).To(MatchRegexp(`Status .*\|.* Provisioned`))

--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -12,21 +12,21 @@ import (
 var _ = Describe("Config", func() {
 	Describe("Colors", func() {
 		It("changes the configuration when disabling colors", func() {
-			config, err := env.Epinio("config colors 0", "")
+			config, err := env.Epinio("", "config", "colors", "0")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(config).To(MatchRegexp(`Colors: false`))
 
-			config, err = env.Epinio("config show", "")
+			config, err = env.Epinio("", "config", "show")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(config).To(MatchRegexp(`Colorized Output.*\|.*false`))
 		})
 
 		It("changes the configuration when enabling colors", func() {
-			config, err := env.Epinio("config colors 1", "")
+			config, err := env.Epinio("", "config", "colors", "1")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(config).To(MatchRegexp(`Colors: true`))
 
-			config, err = env.Epinio("config show", "")
+			config, err = env.Epinio("", "config", "show")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(config).To(MatchRegexp(`Colorized Output.*\|.*true`))
 		})
@@ -34,7 +34,7 @@ var _ = Describe("Config", func() {
 
 	Describe("Show", func() {
 		It("shows the configuration", func() {
-			config, err := env.Epinio("config show", "")
+			config, err := env.Epinio("", "config", "show")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(config).To(MatchRegexp(`Colorized Output.*\|`))     // Exact state not relevant
 			Expect(config).To(MatchRegexp(`Current Organization.*\|`)) // Exact name of org is not relevant, and varies
@@ -47,20 +47,20 @@ var _ = Describe("Config", func() {
 	Describe("Update-Credentials", func() {
 		BeforeEach(func() {
 			// Set current configuration aside
-			out, err := proc.Run(fmt.Sprintf("mv %s/epinio.yaml %s/epinio.yaml.bak", nodeTmpDir, nodeTmpDir), "", false)
+			out, err := proc.Run("", false, "mv", nodeTmpDir+"/epinio.yaml", nodeTmpDir+"/epinio.yaml.bak")
 			Expect(err).ToNot(HaveOccurred(), out)
 		})
 
 		AfterEach(func() {
 			// Restore full configuration
-			out, err := proc.Run(fmt.Sprintf("mv %s/epinio.yaml.bak %s/epinio.yaml", nodeTmpDir, nodeTmpDir), "", false)
+			out, err := proc.Run("", false, "mv", nodeTmpDir+"/epinio.yaml.bak", nodeTmpDir+"/epinio.yaml")
 			Expect(err).ToNot(HaveOccurred(), out)
 		})
 
 		It("regenerates certs and credentials", func() {
 			// Get back the certs and credentials
 			// Note that org, as a purely local setting, is not restored
-			_, err := env.Epinio("config update-credentials", "")
+			_, err := env.Epinio("", "config", "update-credentials")
 			Expect(err).ToNot(HaveOccurred())
 
 			newConfig, err := env.GetConfig()

--- a/acceptance/custom_services_test.go
+++ b/acceptance/custom_services_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Custom Services", func() {
 			env.MakeDockerImageApp(appName, 1, dockerImageURL)
 			env.BindAppService(appName, serviceName, org)
 
-			out, err := env.Epinio("service delete "+serviceName, "")
+			out, err := env.Epinio("", "service", "delete", serviceName)
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			Expect(out).To(MatchRegexp("Unable to delete service. It is still used by"))
@@ -56,7 +56,7 @@ var _ = Describe("Custom Services", func() {
 
 			// Delete again, and force unbind
 
-			out, err = env.Epinio("service delete --unbind "+serviceName, "")
+			out, err = env.Epinio("", "service", "delete", "--unbind", serviceName)
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			Expect(out).To(MatchRegexp("PREVIOUSLY BOUND TO"))
@@ -68,7 +68,7 @@ var _ = Describe("Custom Services", func() {
 
 			// And check non-presence
 			Eventually(func() string {
-				out, err = env.Epinio("service list", "")
+				out, err = env.Epinio("", "service", "list")
 				Expect(err).ToNot(HaveOccurred(), out)
 				return out
 			}, "2m").ShouldNot(MatchRegexp(serviceName))
@@ -120,7 +120,7 @@ var _ = Describe("Custom Services", func() {
 		})
 
 		It("it shows service details", func() {
-			out, err := env.Epinio("service show "+serviceName, "")
+			out, err := env.Epinio("", "service", "show", serviceName)
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(MatchRegexp("Service Details"))
 			Expect(out).To(MatchRegexp(`Status .*\|.* Provisioned`))

--- a/acceptance/epinio_installation_test.go
+++ b/acceptance/epinio_installation_test.go
@@ -11,15 +11,16 @@ import (
 
 var _ = Describe("Epinio Installation", func() {
 	It("has linkerd sidecars", func() {
-		kubectlCommand := "get pods -n epinio -l app.kubernetes.io/component=epinio-server -o=jsonpath='{.items[0].spec.containers[*].name}'"
-		out, err := helpers.Kubectl(kubectlCommand)
+		out, err := helpers.Kubectl("get", "pods",
+			"--namespace", "epinio",
+			"-l", "app.kubernetes.io/component=epinio-server",
+			"-o", "jsonpath={.items[0].spec.containers[*].name}")
 		Expect(err).ToNot(HaveOccurred())
 		containers := strings.Split(out, " ")
 		Expect(containers).To(ContainElement("linkerd-proxy"))
 	})
 	It("has linkerd control plane components running", func() {
-		kubectlCommand := "get pods -n linkerd -o name"
-		out, err := helpers.Kubectl(kubectlCommand)
+		out, err := helpers.Kubectl("get", "pods", "--namespace", "linkerd", "-o", "name")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(out).To(MatchRegexp("linkerd-identity"))
 		Expect(out).To(MatchRegexp("linkerd-proxy-injector"))

--- a/acceptance/helpers/epinio/epinio.go
+++ b/acceptance/helpers/epinio/epinio.go
@@ -1,13 +1,11 @@
 package epinio
 
 import (
-	"fmt"
-
 	"github.com/epinio/epinio/acceptance/helpers/proc"
 )
 
 type Epinio struct {
-	Flags            string
+	Flags            []string
 	EpinioBinaryPath string
 }
 
@@ -18,8 +16,7 @@ func NewEpinioHelper(epinioBinaryPath string) Epinio {
 }
 
 func (e *Epinio) Install() (string, error) {
-	out, err := proc.Run(fmt.Sprintf("%s install %s", e.EpinioBinaryPath, e.Flags),
-		"", false)
+	out, err := proc.Run("", false, e.EpinioBinaryPath, append([]string{"install"}, e.Flags...)...)
 	if err != nil {
 		return out, err
 	}
@@ -27,8 +24,7 @@ func (e *Epinio) Install() (string, error) {
 }
 
 func (e *Epinio) Uninstall() (string, error) {
-	out, err := proc.Run(fmt.Sprintf("%s uninstall", e.EpinioBinaryPath),
-		"", false)
+	out, err := proc.Run("", false, e.EpinioBinaryPath, "uninstall")
 	if err != nil {
 		return out, err
 	}

--- a/acceptance/helpers/proc/proc.go
+++ b/acceptance/helpers/proc/proc.go
@@ -8,7 +8,7 @@ import (
 	"github.com/codeskyblue/kexec"
 )
 
-func Get(command string, dir string) (*kexec.KCommand, error) {
+func Get(dir, command string, arg ...string) (*kexec.KCommand, error) {
 	var commandDir string
 	var err error
 
@@ -21,14 +21,14 @@ func Get(command string, dir string) (*kexec.KCommand, error) {
 		commandDir = dir
 	}
 
-	p := kexec.CommandString(command)
+	p := kexec.Command(command, arg...)
 	p.Dir = commandDir
 
 	return p, nil
 }
 
-func Run(cmd, dir string, toStdout bool) (string, error) {
-	p, err := Get(cmd, dir)
+func Run(dir string, toStdout bool, cmd string, arg ...string) (string, error) {
+	p, err := Get(dir, cmd, arg...)
 	if err != nil {
 		return "", err
 	}

--- a/acceptance/install/config_test.go
+++ b/acceptance/install/config_test.go
@@ -13,7 +13,6 @@ import (
 
 var _ = Describe("Epinio Installation", func() {
 	var (
-		flags      string
 		configFile string
 	)
 
@@ -34,10 +33,12 @@ var _ = Describe("Epinio Installation", func() {
 		err = f.Close()
 		Expect(err).NotTo(HaveOccurred())
 
-		flags = fmt.Sprintf("--config-file %s", configFile)
-		flags = fmt.Sprintf("%s --skip-default-org", flags)
-		flags = fmt.Sprintf("%s --user %s --password %s", flags, epinioUser, epinioPassword)
-		epinioHelper.Flags = flags
+		epinioHelper.Flags = []string{
+			"--config-file", configFile,
+			"--skip-default-org",
+			"--user", epinioUser,
+			"--password", epinioPassword,
+		}
 	})
 
 	AfterEach(func() {
@@ -47,7 +48,7 @@ var _ = Describe("Epinio Installation", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	When("a epinio config file already exits", func() {
+	When("a epinio config file already exists", func() {
 		It("should install epinio with new values and update the file", func() {
 			By("Installing epinio")
 			out, err := epinioHelper.Install()

--- a/acceptance/orgs_test.go
+++ b/acceptance/orgs_test.go
@@ -11,7 +11,7 @@ import (
 
 var _ = Describe("Orgs", func() {
 	It("has a default org", func() {
-		orgs, err := env.Epinio("org list", "")
+		orgs, err := env.Epinio("", "org", "list")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(orgs).To(MatchRegexp("workspace"))
 	})
@@ -22,7 +22,7 @@ var _ = Describe("Orgs", func() {
 			env.SetupAndTargetOrg(org)
 
 			By("switching org back to default")
-			out, err := env.Epinio("target workspace", "")
+			out, err := env.Epinio("", "target", "workspace")
 			Expect(err).ToNot(HaveOccurred(), out)
 		})
 
@@ -30,7 +30,7 @@ var _ = Describe("Orgs", func() {
 			org := catalog.NewOrgName()
 			env.SetupAndTargetOrg(org)
 
-			out, err := env.Epinio("org create "+org, "")
+			out, err := env.Epinio("", "org", "create", org)
 			Expect(err).To(HaveOccurred(), out)
 
 			Expect(out).To(MatchRegexp(fmt.Sprintf("Organization '%s' already exists", org)))
@@ -43,7 +43,7 @@ var _ = Describe("Orgs", func() {
 			env.SetupAndTargetOrg(org)
 
 			By("deleting organization")
-			out, err := env.Epinio("org delete -f "+org, "")
+			out, err := env.Epinio("", "org", "delete", "-f", org)
 
 			Expect(err).ToNot(HaveOccurred(), out)
 		})

--- a/acceptance/rails_test.go
+++ b/acceptance/rails_test.go
@@ -34,22 +34,23 @@ func (r *RailsApp) CreateDir() error {
 		return err
 	}
 
-	if out, err := helpers.RunProc(
-		fmt.Sprintf("wget %s -O rails.tar", r.SourceURL), tmpDir, false); err != nil {
+	if out, err := helpers.RunProc(tmpDir, false,
+		"wget", r.SourceURL, "-O", "rails.tar"); err != nil {
 		return errors.Wrap(err, out)
 	}
 
-	if out, err := helpers.RunProc("mkdir rails", tmpDir, false); err != nil {
+	if out, err := helpers.RunProc(tmpDir, false, "mkdir", "rails"); err != nil {
 		return errors.Wrap(err, out)
 	}
 
-	if out, err := helpers.RunProc("tar xvf rails.tar -C rails --strip-components 1", tmpDir, false); err != nil {
+	if out, err := helpers.RunProc(tmpDir, false,
+		"tar", "xvf", "rails.tar", "-C", "rails", "--strip-components", "1"); err != nil {
 		return errors.Wrap(err, out)
 	}
 
 	r.Dir = path.Join(tmpDir, "rails")
 
-	if out, err := helpers.RunProc("rm rails.tar", tmpDir, false); err != nil {
+	if out, err := helpers.RunProc(tmpDir, false, "rm", "rails.tar"); err != nil {
 		return errors.Wrap(err, out)
 	}
 
@@ -81,20 +82,20 @@ var _ = Describe("RubyOnRails", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create the app
-		out, err := env.Epinio(fmt.Sprintf("apps create %s", rails.Name), "")
+		out, err := env.Epinio("", "apps", "create", rails.Name)
 		Expect(err).ToNot(HaveOccurred(), out)
 
 		// Set the RAILS_MASTER_KEY env variable
-		out, err = env.Epinio(fmt.Sprintf("apps env set %s RAILS_MASTER_KEY %s", rails.Name, rails.MasterKey), "")
+		out, err = env.Epinio("", "apps", "env", "set", rails.Name, "RAILS_MASTER_KEY", rails.MasterKey)
 		Expect(err).ToNot(HaveOccurred(), out)
 
 		// Create a database for Rails
 		serviceName = catalog.NewServiceName()
-		out, err = env.Epinio(fmt.Sprintf("service create %s mariadb 10-3-22", serviceName), "")
+		out, err = env.Epinio("", "service", "create", serviceName, "mariadb", "10-3-22")
 		Expect(err).ToNot(HaveOccurred(), out)
 
 		// Change Rails database configuration to match the service name
-		out, err = proc.Run(fmt.Sprintf("sed -i 's/mydb/%s/' config/database.yml", serviceName), rails.Dir, false)
+		out, err = proc.Run(rails.Dir, false, "sed", "-i", fmt.Sprintf("s/mydb/%s/", serviceName), "config/database.yml")
 		Expect(err).ToNot(HaveOccurred(), out)
 	})
 
@@ -104,7 +105,7 @@ var _ = Describe("RubyOnRails", func() {
 	})
 
 	It("can deploy Rails", func() {
-		out, err := env.Epinio(fmt.Sprintf("apps push %s -b %s", rails.Name, serviceName), rails.Dir)
+		out, err := env.Epinio(rails.Dir, "apps", "push", rails.Name, "-b", serviceName)
 		Expect(err).ToNot(HaveOccurred(), out)
 
 		routeRegexp := regexp.MustCompile(`https:\/\/.*omg.howdoi.website`)

--- a/acceptance/service_classes_test.go
+++ b/acceptance/service_classes_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Service Classes, and Plans", func() {
 
 	Describe("service list-classes", func() {
 		It("shows all available service classes", func() {
-			out, err := env.Epinio("service list-classes", "")
+			out, err := env.Epinio("", "service", "list-classes")
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(MatchRegexp("mariadb"))
 			Expect(out).To(MatchRegexp("Helm Chart for mariadb"))
@@ -26,7 +26,7 @@ var _ = Describe("Service Classes, and Plans", func() {
 
 	Describe("service list-plans", func() {
 		It("shows all available service plans for a class", func() {
-			out, err := env.Epinio("service list-plans mariadb", "")
+			out, err := env.Epinio("", "service", "list-plans", "mariadb")
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(MatchRegexp("10-3-22"))
 			Expect(out).To(MatchRegexp("MariaDB Server is intended"))

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Services", func() {
 		})
 
 		It("shows all created services", func() {
-			out, err := env.Epinio("service list", "")
+			out, err := env.Epinio("", "service", "list")
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(MatchRegexp(serviceCustomName))
 			Expect(out).To(MatchRegexp(serviceCatalogName))

--- a/acceptance/suite_test.go
+++ b/acceptance/suite_test.go
@@ -70,7 +70,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	fmt.Println("Setup cluster services")
 	testenv.SetupInClusterServices(epinioBinary)
 
-	out, err = helpers.Kubectl(`get pods -n minibroker --selector=app=minibroker-minibroker`)
+	out, err = helpers.Kubectl("get", "pods", "--namespace", "minibroker", "--selector", "app=minibroker-minibroker")
 	Expect(err).ToNot(HaveOccurred(), out)
 	Expect(out).To(MatchRegexp(`minibroker.*2/2.*Running`))
 
@@ -103,13 +103,15 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	os.Setenv("EPINIO_CONFIG", nodeTmpDir+"/epinio.yaml")
 
 	// Get config from the installation (API credentials)
-	out, err = proc.Run(fmt.Sprintf("cp %s %s/epinio.yaml", testenv.EpinioYAML(), nodeTmpDir), "", false)
+	out, err = proc.Run("", false, "cp", testenv.EpinioYAML(), nodeTmpDir+"/epinio.yaml")
 	Expect(err).ToNot(HaveOccurred(), out)
 
-	out, err = env.Epinio("target workspace", nodeTmpDir)
+	out, err = env.Epinio(nodeTmpDir, "target", "workspace")
 	Expect(err).ToNot(HaveOccurred(), out)
 
-	out, err = proc.Run("kubectl get ingress -n epinio epinio -o=jsonpath='{.spec.rules[0].host}'", testenv.Root(), false)
+	out, err = proc.Run(testenv.Root(), false, "kubectl", "get", "ingress",
+		"--namespace", "epinio", "epinio",
+		"-o", "jsonpath={.spec.rules[0].host}")
 	Expect(err).ToNot(HaveOccurred(), out)
 
 	serverURL = "https://" + out

--- a/acceptance/testenv/epinio.go
+++ b/acceptance/testenv/epinio.go
@@ -60,7 +60,7 @@ func New(nodeDir string, rootDir string) EpinioEnv {
 
 func (e *EpinioEnv) CopyEpinio() (string, error) {
 	binaryPath := path.Join("dist", "epinio-"+runtime.GOOS+"-"+runtime.GOARCH)
-	return proc.Run("cp "+binaryPath+" "+e.nodeTmpDir+"/epinio", Root(), false)
+	return proc.Run(Root(), false, "cp", binaryPath, e.nodeTmpDir+"/epinio")
 }
 
 func EpinioYAML() string {
@@ -68,7 +68,9 @@ func EpinioYAML() string {
 }
 
 func EnsureEpinio(epinioBinary string) error {
-	out, err := helpers.Kubectl(`get pods -n epinio --selector=app.kubernetes.io/name=epinio-server`)
+	out, err := helpers.Kubectl("get", "pods",
+		"--namespace", "epinio",
+		"--selector", "app.kubernetes.io/name=epinio-server")
 	if err == nil {
 		running, err := regexp.Match(`epinio-server.*Running`, []byte(out))
 		if err != nil {
@@ -83,22 +85,25 @@ func EnsureEpinio(epinioBinary string) error {
 	// Installing linkerd and ingress separate from the main
 	// pieces.  Ensures that the main install command invokes and
 	// passes the presence checks for linkerd and traefik.
-	out, err = proc.Run(fmt.Sprintf("%s%s install-ingress", Root(), epinioBinary),
-		"", false)
+	out, err = proc.Run("", false, Root()+epinioBinary, "install-ingress")
 	if err != nil {
 		return errors.Wrap(err, out)
 	}
 
-	domainSetting := ""
-	if domain := os.Getenv("EPINIO_SYSTEM_DOMAIN"); domain != "" {
-		domainSetting = fmt.Sprintf(" --system-domain %s", domain)
+	// Allow the installation to continue by not trying to create
+	// the default org before we patch.
+	installArgs := []string{
+		"install",
+		"--skip-default-org",
+		"--user", epinioUser,
+		"--password", epinioPassword,
 	}
 
-	// Allow the installation to continue by not trying to create the default org
-	// before we patch.
-	out, err = proc.Run(
-		fmt.Sprintf("%s%s install --skip-default-org --user %s --password %s %s", Root(), epinioBinary, epinioUser, epinioPassword, domainSetting),
-		"", false)
+	if domain := os.Getenv("EPINIO_SYSTEM_DOMAIN"); domain != "" {
+		installArgs = append(installArgs, "--system-domain", domain)
+	}
+
+	out, err = proc.Run("", false, Root()+epinioBinary, installArgs...)
 	if err != nil {
 		return errors.Wrap(err, out)
 	}
@@ -106,14 +111,14 @@ func EnsureEpinio(epinioBinary string) error {
 }
 
 func BuildEpinio() {
-	output, err := proc.Run("make", Root(), false)
+	output, err := proc.Run(Root(), false, "make")
 	if err != nil {
 		panic(fmt.Sprintf("Couldn't build Epinio: %s\n %s\n"+err.Error(), output))
 	}
 }
 
 func ExpectGoodInstallation(epinioBinary string) {
-	info, err := proc.Run(fmt.Sprintf("%s%s info", Root(), epinioBinary), "", false)
+	info, err := proc.Run("", false, Root()+epinioBinary, "info")
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	gomega.Expect(info).To(gomega.Or(
 		gomega.MatchRegexp("Kubernetes Version: v1.21"),
@@ -149,7 +154,7 @@ func CheckDependencies() error {
 
 func EnsureDefaultWorkspace(epinioBinary string) {
 	gomega.Eventually(func() string {
-		out, err := proc.Run(fmt.Sprintf("%s%s org create workspace", Root(), epinioBinary), "", false)
+		out, err := proc.Run("", false, Root()+epinioBinary, "org", "create", "workspace")
 		if err != nil {
 			if exists, err := regexp.Match(`Organization 'workspace' already exists`, []byte(out)); err == nil && exists {
 				return ""

--- a/acceptance/testenv/epinio.go
+++ b/acceptance/testenv/epinio.go
@@ -115,7 +115,10 @@ func BuildEpinio() {
 func ExpectGoodInstallation(epinioBinary string) {
 	info, err := proc.Run(fmt.Sprintf("%s%s info", Root(), epinioBinary), "", false)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	gomega.Expect(info).To(gomega.Or(gomega.MatchRegexp("Kubernetes Version: v1.20"), gomega.MatchRegexp("Kubernetes Version: v1.19")))
+	gomega.Expect(info).To(gomega.Or(
+		gomega.MatchRegexp("Kubernetes Version: v1.21"),
+		gomega.MatchRegexp("Kubernetes Version: v1.20"),
+		gomega.MatchRegexp("Kubernetes Version: v1.19")))
 	gomega.Expect(info).To(gomega.MatchRegexp("Gitea Version: unavailable"))
 }
 

--- a/acceptance/testenv/google.go
+++ b/acceptance/testenv/google.go
@@ -1,7 +1,6 @@
 package testenv
 
 import (
-	"fmt"
 	"os"
 	"regexp"
 
@@ -31,12 +30,15 @@ func SetupGoogleServices(epinioBinary string) error {
 
 	defer os.Remove(serviceAccountJSON)
 
-	out, err := proc.Run(fmt.Sprintf("%s%s enable services-google --service-account-json %s", Root(), epinioBinary, serviceAccountJSON), "", false)
+	out, err := proc.Run("", false, Root()+epinioBinary, "enable", "services-google",
+		"--service-account-json", serviceAccountJSON)
 	if err != nil {
 		return errors.Wrap(err, out)
 	}
 
-	out, err = helpers.Kubectl(`get pods -n google-service-broker --selector=app.kubernetes.io/name=gcp-service-broker`)
+	out, err = helpers.Kubectl("get", "pods",
+		"--namespace", "google-service-broker",
+		"--selector", "app.kubernetes.io/name=gcp-service-broker")
 	if err != nil {
 		return errors.Wrap(err, out)
 	}

--- a/acceptance/testenv/patch.go
+++ b/acceptance/testenv/patch.go
@@ -13,5 +13,5 @@ func PatchEpinio() (string, error) {
 	}
 	// Patch Epinio deployment to inject the current binary
 	fmt.Println("Patching Epinio deployment with test binary")
-	return proc.Run("make patch-epinio-deployment", Root(), false)
+	return proc.Run(Root(), false, "make", "patch-epinio-deployment")
 }

--- a/acceptance/testenv/registry.go
+++ b/acceptance/testenv/registry.go
@@ -22,10 +22,10 @@ func RegistryPassword() string {
 func CreateRegistrySecret() {
 	if RegistryUsername() != "" && RegistryPassword() != "" {
 		fmt.Printf("Creating image pull secret for Dockerhub on node %d\n", config.GinkgoConfig.ParallelNode)
-		_, _ = helpers.Kubectl(fmt.Sprintf("create secret docker-registry regcred --docker-server=%s --docker-username=%s --docker-password=%s",
-			"https://index.docker.io/v1/",
-			RegistryUsername(),
-			RegistryPassword(),
-		))
+		_, _ = helpers.Kubectl("create", "secret", "docker-registry", "regcred",
+			"--docker-server", "https://index.docker.io/v1/",
+			"--docker-username", RegistryUsername(),
+			"--docker-password", RegistryPassword(),
+		)
 	}
 }

--- a/acceptance/testenv/services.go
+++ b/acceptance/testenv/services.go
@@ -1,8 +1,6 @@
 package testenv
 
 import (
-	"fmt"
-
 	"github.com/epinio/epinio/acceptance/helpers/proc"
 	"github.com/epinio/epinio/helpers"
 
@@ -10,19 +8,19 @@ import (
 )
 
 func SetupInClusterServices(epinioBinary string) {
-	out, err := proc.Run(fmt.Sprintf("%s%s enable services-incluster", Root(), epinioBinary), "", false)
+	out, err := proc.Run("", false, Root()+epinioBinary, "enable", "services-incluster")
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)
 	ExpectWithOffset(1, out).To(ContainSubstring("Beware, "))
 
 	// Wait until classes appear
 	EventuallyWithOffset(1, func() error {
-		_, err = helpers.Kubectl("get clusterserviceclass mariadb")
+		_, err = helpers.Kubectl("get", "clusterserviceclass", "mariadb")
 		return err
 	}, "5m").ShouldNot(HaveOccurred())
 
 	// Wait until plans appear
 	EventuallyWithOffset(1, func() error {
-		_, err = helpers.Kubectl("get clusterserviceplan mariadb-10-3-22")
+		_, err = helpers.Kubectl("get", "clusterserviceplan", "mariadb-10-3-22")
 		return err
 	}, "5m").ShouldNot(HaveOccurred())
 }

--- a/acceptance/testenv/tmpdir.go
+++ b/acceptance/testenv/tmpdir.go
@@ -3,6 +3,7 @@ package testenv
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/epinio/epinio/acceptance/helpers/proc"
 )
@@ -40,5 +41,9 @@ func DeleteTmpDir(nodeTmpDir string) {
 // is run in parallel (e.g. two PRs on one worker). However we keep it as an
 // extra measure.
 func CleanupTmp() (string, error) {
-	return proc.Run("rm -rf /tmp/epinio-*", "", true)
+	temps, err := filepath.Glob("/tmp/epinio-*")
+	if err != nil {
+		return "", err
+	}
+	return proc.Run("", true, "rm", append([]string{"-rf"}, temps...)...)
 }

--- a/deployments/cert_manager.go
+++ b/deployments/cert_manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/helpers/termui"
 	"github.com/epinio/epinio/internal/duration"
+	"github.com/go-logr/logr"
 	"github.com/kyokomi/emoji"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,6 +23,7 @@ import (
 type CertManager struct {
 	Debug   bool
 	Timeout time.Duration
+	Log     logr.Logger
 }
 
 var _ kubernetes.Deployment = &CertManager{}
@@ -91,8 +93,8 @@ func (cm CertManager) Delete(ctx context.Context, c *kubernetes.Cluster, ui *ter
 	message := "Removing helm release " + CertManagerDeploymentID
 	out, err := helpers.WaitForCommandCompletion(ui, message,
 		func() (string, error) {
-			helmCmd := fmt.Sprintf("helm uninstall cert-manager --namespace %s", CertManagerDeploymentID)
-			return helpers.RunProc(helmCmd, currentdir, cm.Debug)
+			return helpers.RunProc(currentdir, cm.Debug,
+				"helm", "uninstall", "cert-manager", "--namespace", CertManagerDeploymentID)
 		},
 	)
 	if err != nil {
@@ -110,7 +112,9 @@ func (cm CertManager) Delete(ctx context.Context, c *kubernetes.Cluster, ui *ter
 		"clusterissuers.cert-manager.io",
 		"orders.acme.cert-manager.io",
 	} {
-		out, err := helpers.Kubectl("delete crds --ignore-not-found=true " + crd)
+		out, err := helpers.Kubectl("delete", "crds",
+			"--ignore-not-found", "true",
+			crd)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Deleting cert-manager CRD failed:\n%s", out))
 		}
@@ -119,7 +123,9 @@ func (cm CertManager) Delete(ctx context.Context, c *kubernetes.Cluster, ui *ter
 	for _, webhook := range []string{
 		"cert-manager-webhook",
 	} {
-		out, err := helpers.Kubectl("delete validatingwebhookconfigurations --ignore-not-found=true " + webhook)
+		out, err := helpers.Kubectl("delete", "validatingwebhookconfigurations",
+			"--ignore-not-found", "true",
+			webhook)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Deleting cert-manager validatingwebhook failed:\n%s", out))
 		}
@@ -128,7 +134,9 @@ func (cm CertManager) Delete(ctx context.Context, c *kubernetes.Cluster, ui *ter
 	for _, webhook := range []string{
 		"cert-manager-webhook",
 	} {
-		out, err := helpers.Kubectl("delete mutatingwebhookconfigurations --ignore-not-found=true " + webhook)
+		out, err := helpers.Kubectl("delete", "mutatingwebhookconfigurations",
+			"--ignore-not-found", "true",
+			webhook)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Deleting cert-manager mutatingwebhook failed:\n%s", out))
 		}
@@ -154,7 +162,7 @@ func (cm CertManager) Delete(ctx context.Context, c *kubernetes.Cluster, ui *ter
 	return nil
 }
 
-func (cm CertManager) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, options kubernetes.InstallationOptions, upgrade bool) error {
+func (cm CertManager) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, options kubernetes.InstallationOptions, upgrade bool, log logr.Logger) error {
 	action := "install"
 	if upgrade {
 		action = "upgrade"
@@ -165,14 +173,14 @@ func (cm CertManager) apply(ctx context.Context, c *kubernetes.Cluster, ui *term
 		return err
 	}
 
+	log.Info("creating namespace", "namespace", CertManagerDeploymentID)
 	if err := c.CreateNamespace(ctx, CertManagerDeploymentID, map[string]string{
 		kubernetes.EpinioDeploymentLabelKey: kubernetes.EpinioDeploymentLabelValue,
 	}, map[string]string{}); err != nil {
 		return err
 	}
 
-	// Setup CertManager helm values
-	var helmArgs []string
+	log.Info("extracting chart file", "name", certManagerChartFile)
 
 	tarPath, err := helpers.ExtractFile(certManagerChartFile)
 	if err != nil {
@@ -180,13 +188,28 @@ func (cm CertManager) apply(ctx context.Context, c *kubernetes.Cluster, ui *term
 	}
 	defer os.Remove(tarPath)
 
-	helmArgs = append(helmArgs, `--set installCRDs=true`)
-	helmArgs = append(helmArgs, `--set extraArgs[0]=' --enable-certificate-owner-ref=true'`)
-	helmCmd := fmt.Sprintf("helm %s cert-manager --namespace %s %s %s", action, CertManagerDeploymentID, tarPath, strings.Join(helmArgs, " "))
+	log.Info("local transient tar archive", "name", tarPath)
 
-	if out, err := helpers.RunProc(helmCmd, currentdir, cm.Debug); err != nil {
+	// Setup CertManager helm values
+	var helmArgs []string
+
+	log.Info("assembling helm command")
+
+	helmArgs = append(helmArgs, action, `cert-manager`)
+	helmArgs = append(helmArgs, `--namespace`, CertManagerDeploymentID)
+	helmArgs = append(helmArgs, tarPath)
+	helmArgs = append(helmArgs, `--set`, `installCRDs=true`)
+	helmArgs = append(helmArgs, `--set`, `extraArgs[0]=--enable-certificate-owner-ref=true`)
+
+	log.Info("assembled helm command", "command", strings.Join(append([]string{`helm`}, helmArgs...), " "))
+	log.Info("run helm command")
+
+	if out, err := helpers.RunProc(currentdir, cm.Debug, "helm", helmArgs...); err != nil {
 		return errors.New("Failed installing CertManager: " + out)
 	}
+
+	log.Info("completed helm command")
+	log.Info("waiting for pods to exist, and run")
 
 	for _, podname := range []string{
 		"webhook",
@@ -206,9 +229,12 @@ func (cm CertManager) apply(ctx context.Context, c *kubernetes.Cluster, ui *term
 		return err
 	}
 
+	leIssuer := fmt.Sprintf(clusterIssuerLetsencrypt, emailAddress.Value)
+	log.Info("create cluster issuer", "issuer", leIssuer)
+
 	err = helpers.RunToSuccessWithTimeout(
 		func() error {
-			return cm.CreateClusterIssuer(ctx, c, fmt.Sprintf(clusterIssuerLetsencrypt, emailAddress.Value))
+			return cm.CreateClusterIssuer(ctx, c, leIssuer)
 		}, duration.ToDeployment(), duration.PollInterval())
 	if err != nil {
 		if strings.Contains(err.Error(), "Timed out after") {
@@ -216,6 +242,8 @@ func (cm CertManager) apply(ctx context.Context, c *kubernetes.Cluster, ui *term
 		}
 		return err
 	}
+
+	log.Info("create cluster issuer", "issuer", clusterIssuerLocal)
 
 	err = helpers.RunToSuccessWithTimeout(
 		func() error {
@@ -265,6 +293,8 @@ func (cm CertManager) apply(ctx context.Context, c *kubernetes.Cluster, ui *term
 		return err
 	}
 
+	log.Info("create private CA cert", "spec", caCert)
+
 	err = helpers.RunToSuccessWithTimeout(
 		func() error {
 			_, err = cc.Namespace(CertManagerDeploymentID).
@@ -285,6 +315,8 @@ func (cm CertManager) apply(ctx context.Context, c *kubernetes.Cluster, ui *term
 
 	// Epinio CA bootstrap phase 2: Create issuer based on the above-made CA cert.
 
+	log.Info("create cluster issuer", "issuer", clusterIssuerEpinio)
+
 	err = helpers.RunToSuccessWithTimeout(
 		func() error {
 			return cm.CreateClusterIssuer(ctx, c, clusterIssuerEpinio)
@@ -297,6 +329,8 @@ func (cm CertManager) apply(ctx context.Context, c *kubernetes.Cluster, ui *term
 	}
 
 	ui.Success().Msg("CertManager deployed")
+
+	log.Info("apply done")
 
 	return nil
 }
@@ -396,6 +430,10 @@ func (cm CertManager) DeleteClusterIssuer(ctx context.Context, c *kubernetes.Clu
 }
 
 func (cm CertManager) Deploy(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, options kubernetes.InstallationOptions) error {
+	log := cm.Log.WithName("Deploy")
+	log.Info("start")
+	defer log.Info("return")
+
 	if skip := options.GetBoolNG("skip-cert-manager"); skip {
 		ui.Exclamation().Msg("Skipping cert-manager deployment by user request")
 		return nil
@@ -412,7 +450,7 @@ func (cm CertManager) Deploy(ctx context.Context, c *kubernetes.Cluster, ui *ter
 
 	ui.Note().KeeplineUnder(1).Msg("Deploying CertManager...")
 
-	err = cm.apply(ctx, c, ui, options, false)
+	err = cm.apply(ctx, c, ui, options, false, log)
 	if err != nil {
 		return err
 	}
@@ -421,6 +459,10 @@ func (cm CertManager) Deploy(ctx context.Context, c *kubernetes.Cluster, ui *ter
 }
 
 func (cm CertManager) Upgrade(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, options kubernetes.InstallationOptions) error {
+	log := cm.Log.WithName("Upgrade")
+	log.Info("start")
+	defer log.Info("return")
+
 	_, err := c.Kubectl.CoreV1().Namespaces().Get(
 		ctx,
 		CertManagerDeploymentID,
@@ -432,7 +474,7 @@ func (cm CertManager) Upgrade(ctx context.Context, c *kubernetes.Cluster, ui *te
 
 	ui.Note().Msg("Upgrading CertManager...")
 
-	return cm.apply(ctx, c, ui, options, true)
+	return cm.apply(ctx, c, ui, options, true, log)
 }
 
 func waitForCertManagerReady(ctx context.Context, ui *termui.UI, c *kubernetes.Cluster, issuer string) error {

--- a/deployments/cert_manager.go
+++ b/deployments/cert_manager.go
@@ -191,15 +191,15 @@ func (cm CertManager) apply(ctx context.Context, c *kubernetes.Cluster, ui *term
 	log.Info("local transient tar archive", "name", tarPath)
 
 	// Setup CertManager helm values
-	var helmArgs []string
 
 	log.Info("assembling helm command")
-
-	helmArgs = append(helmArgs, action, `cert-manager`)
-	helmArgs = append(helmArgs, `--namespace`, CertManagerDeploymentID)
-	helmArgs = append(helmArgs, tarPath)
-	helmArgs = append(helmArgs, `--set`, `installCRDs=true`)
-	helmArgs = append(helmArgs, `--set`, `extraArgs[0]=--enable-certificate-owner-ref=true`)
+	helmArgs := []string{
+		action, CertManagerDeploymentID,
+		`--namespace`, CertManagerDeploymentID,
+		tarPath,
+		`--set`, `installCRDs=true`,
+		`--set`, `extraArgs[0]=--enable-certificate-owner-ref=true`,
+	}
 
 	log.Info("assembled helm command", "command", strings.Join(append([]string{`helm`}, helmArgs...), " "))
 	log.Info("run helm command")

--- a/deployments/epinio.go
+++ b/deployments/epinio.go
@@ -249,7 +249,9 @@ func (k Epinio) applyEpinioConfigYaml(ctx context.Context, c *kubernetes.Cluster
 	}
 	defer os.Remove(yamlPathOnDisk)
 
-	out, err := helpers.Kubectl(fmt.Sprintf("apply -n %s --filename %s", EpinioDeploymentID, yamlPathOnDisk))
+	out, err := helpers.Kubectl("apply",
+		"--namespace", EpinioDeploymentID,
+		"--filename", yamlPathOnDisk)
 	if err != nil && !strings.Contains(out, `no matches for kind "Middleware"`) {
 		return "", err
 	}
@@ -301,7 +303,9 @@ func (k Epinio) applyEpinioConfigYaml(ctx context.Context, c *kubernetes.Cluster
 	}
 	defer os.Remove(tmpFilePath)
 
-	if out, err := helpers.Kubectl(fmt.Sprintf("apply -n %s --filename %s", EpinioDeploymentID, tmpFilePath)); err != nil {
+	if out, err := helpers.Kubectl("apply",
+		"--namespace", EpinioDeploymentID,
+		"--filename", tmpFilePath); err != nil {
 		return out, err
 	}
 
@@ -316,7 +320,9 @@ func (k Epinio) applyEpinioConfigYaml(ctx context.Context, c *kubernetes.Cluster
 	}
 	defer os.Remove(yamlPathOnDisk)
 
-	return helpers.Kubectl(fmt.Sprintf("apply -n %s --filename %s", TektonStagingNamespace, yamlPathOnDisk))
+	return helpers.Kubectl("apply",
+		"--namespace", TektonStagingNamespace,
+		"--filename", yamlPathOnDisk)
 }
 
 func (k *Epinio) createIngress(ctx context.Context, c *kubernetes.Cluster, subdomain string) error {

--- a/deployments/gitea.go
+++ b/deployments/gitea.go
@@ -79,8 +79,8 @@ func (k Gitea) Delete(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI)
 	message := "Removing helm release " + GiteaDeploymentID
 	out, err := helpers.WaitForCommandCompletion(ui, message,
 		func() (string, error) {
-			helmCmd := fmt.Sprintf("helm uninstall gitea --namespace %s", GiteaDeploymentID)
-			return helpers.RunProc(helmCmd, currentdir, k.Debug)
+			return helpers.RunProc(currentdir, k.Debug,
+				"helm", "uninstall", "gitea", "--namespace", GiteaDeploymentID)
 		},
 	)
 	if err != nil {
@@ -122,9 +122,6 @@ func (k Gitea) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, 
 	if err != nil {
 		return err
 	}
-
-	// Setup Gitea helm values
-	var helmArgs []string
 
 	domain, err := options.GetString("system_domain", GiteaDeploymentID)
 	if err != nil {
@@ -204,9 +201,8 @@ postgresql:
 	}
 	defer os.Remove(configPath)
 
-	helmCmd := fmt.Sprintf("helm %s gitea --values %s --namespace %s %s %s", action, configPath, GiteaDeploymentID, giteaChartURL, strings.Join(helmArgs, " "))
-
-	if out, err := helpers.RunProc(helmCmd, currentdir, k.Debug); err != nil {
+	if out, err := helpers.RunProc(currentdir, k.Debug,
+		"helm", action, "gitea", "--values", configPath, "--namespace", GiteaDeploymentID, giteaChartURL); err != nil {
 		return errors.New("Failed installing Gitea: " + out)
 	}
 

--- a/deployments/google_services.go
+++ b/deployments/google_services.go
@@ -63,8 +63,8 @@ func (k GoogleServices) Delete(ctx context.Context, c *kubernetes.Cluster, ui *t
 	message := "Removing helm release " + GoogleServicesDeploymentID
 	out, err := helpers.WaitForCommandCompletion(ui, message,
 		func() (string, error) {
-			helmCmd := fmt.Sprintf("helm uninstall '%s' --namespace %s", GoogleServicesDeploymentID, GoogleServicesDeploymentID)
-			return helpers.RunProc(helmCmd, currentdir, k.Debug)
+			return helpers.RunProc(currentdir, k.Debug,
+				"helm", "uninstall", GoogleServicesDeploymentID, "--namespace", GoogleServicesDeploymentID)
 		},
 	)
 	if err != nil {
@@ -144,8 +144,8 @@ broker:
 		return err
 	}
 
-	helmCmd := fmt.Sprintf("helm %s %s --namespace %s --values %s %s", action, GoogleServicesDeploymentID, GoogleServicesDeploymentID, valuesYamlPath, tarPath)
-	if out, err := helpers.RunProc(helmCmd, currentdir, k.Debug); err != nil {
+	if out, err := helpers.RunProc(currentdir, k.Debug,
+		"helm", action, GoogleServicesDeploymentID, "--namespace", GoogleServicesDeploymentID, "--values", valuesYamlPath, tarPath); err != nil {
 		return errors.New("Failed installing GoogleServices: " + out)
 	}
 

--- a/deployments/kubed.go
+++ b/deployments/kubed.go
@@ -64,8 +64,8 @@ func (k Kubed) Delete(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI)
 	message := "Removing helm release " + KubedDeploymentID
 	out, err := helpers.WaitForCommandCompletion(ui, message,
 		func() (string, error) {
-			helmCmd := fmt.Sprintf("helm uninstall kubed --namespace %s", KubedDeploymentID)
-			return helpers.RunProc(helmCmd, currentdir, k.Debug)
+			return helpers.RunProc(currentdir, k.Debug,
+				"helm", "uninstall", "kubed", "--namespace", KubedDeploymentID)
 		},
 	)
 	if err != nil {
@@ -111,10 +111,9 @@ func (k Kubed) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, 
 	defer os.Remove(tarPath)
 
 	// Setup Kubed helm values
-	var helmArgs = []string{}
-	helmCmd := fmt.Sprintf("helm %s kubed --namespace %s %s %s", action, KubedDeploymentID, tarPath, strings.Join(helmArgs, " "))
-	if out, err := helpers.RunProc(helmCmd, currentdir, k.Debug); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Failed installing Kubed:\n%s\nReturning\n%s", helmCmd, out))
+	if out, err := helpers.RunProc(currentdir, k.Debug,
+		"helm", action, "kubed", "--namespace", KubedDeploymentID, tarPath); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("Failed installing Kubed, Returning\n%s", out))
 	}
 
 	if err := c.WaitForDeploymentCompleted(ctx, ui, KubedDeploymentID, "kubed", duration.ToKubedReady()); err != nil {

--- a/deployments/minibroker.go
+++ b/deployments/minibroker.go
@@ -2,7 +2,6 @@ package deployments
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -61,8 +60,8 @@ func (k Minibroker) Delete(ctx context.Context, c *kubernetes.Cluster, ui *termu
 	message := "Removing helm release " + MinibrokerDeploymentID
 	out, err := helpers.WaitForCommandCompletion(ui, message,
 		func() (string, error) {
-			helmCmd := fmt.Sprintf("helm uninstall '%s' --namespace %s", MinibrokerDeploymentID, MinibrokerDeploymentID)
-			return helpers.RunProc(helmCmd, currentdir, k.Debug)
+			return helpers.RunProc(currentdir, k.Debug,
+				"helm", "uninstall", MinibrokerDeploymentID, "--namespace", MinibrokerDeploymentID)
 		},
 	)
 	if err != nil {
@@ -116,8 +115,8 @@ func (k Minibroker) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui
 	}
 	defer os.Remove(tarPath)
 
-	helmCmd := fmt.Sprintf("helm %s %s --namespace %s %s", action, MinibrokerDeploymentID, MinibrokerDeploymentID, tarPath)
-	if out, err := helpers.RunProc(helmCmd, currentdir, k.Debug); err != nil {
+	if out, err := helpers.RunProc(currentdir, k.Debug,
+		"helm", action, MinibrokerDeploymentID, "--namespace", MinibrokerDeploymentID, tarPath); err != nil {
 		return errors.New("Failed installing Minibroker: " + out)
 	}
 

--- a/deployments/registry.go
+++ b/deployments/registry.go
@@ -155,17 +155,16 @@ func (k Registry) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 
 	log.Info("system domain", "domain", domain)
 
-	var helmArgs []string
-
 	log.Info("assembling helm command")
 	// (**) See also `deployments/tekton.go`, func `createClusterRegistryCredsSecret`.
-
-	helmArgs = append(helmArgs, action, RegistryDeploymentID)
-	helmArgs = append(helmArgs, `--namespace`, RegistryDeploymentID)
-	helmArgs = append(helmArgs, tarPath)
-	helmArgs = append(helmArgs, `--set`, `auth.htpasswd=`+htpasswd)
-	helmArgs = append(helmArgs, `--set`, fmt.Sprintf("domain=%s.%s", RegistryDeploymentID, domain))
-	helmArgs = append(helmArgs, `--set`, fmt.Sprintf(`createNodePort=%v`, options.GetBoolNG("use-internal-registry-node-port")))
+	helmArgs := []string{
+		action, RegistryDeploymentID,
+		`--namespace`, RegistryDeploymentID,
+		tarPath,
+		`--set`, `auth.htpasswd=` + htpasswd,
+		`--set`, fmt.Sprintf("domain=%s.%s", RegistryDeploymentID, domain),
+		`--set`, fmt.Sprintf(`createNodePort=%v`, options.GetBoolNG("use-internal-registry-node-port")),
+	}
 
 	log.Info("assembled helm command", "command", strings.Join(append([]string{`helm`}, helmArgs...), " "))
 	log.Info("run helm command")

--- a/deployments/service_catalog.go
+++ b/deployments/service_catalog.go
@@ -2,7 +2,6 @@ package deployments
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -61,8 +60,8 @@ func (k ServiceCatalog) Delete(ctx context.Context, c *kubernetes.Cluster, ui *t
 	message := "Removing helm release " + ServiceCatalogDeploymentID
 	out, err := helpers.WaitForCommandCompletion(ui, message,
 		func() (string, error) {
-			helmCmd := fmt.Sprintf("helm uninstall '%s' --namespace %s", ServiceCatalogDeploymentID, ServiceCatalogDeploymentID)
-			return helpers.RunProc(helmCmd, currentdir, k.Debug)
+			return helpers.RunProc(currentdir, k.Debug,
+				"helm", "uninstall", ServiceCatalogDeploymentID, "--namespace", ServiceCatalogDeploymentID)
 		},
 	)
 	if err != nil {
@@ -116,8 +115,8 @@ func (k ServiceCatalog) apply(ctx context.Context, c *kubernetes.Cluster, ui *te
 	}
 	defer os.Remove(tarPath)
 
-	helmCmd := fmt.Sprintf("helm %s %s --namespace %s %s", action, ServiceCatalogDeploymentID, ServiceCatalogDeploymentID, tarPath)
-	if out, err := helpers.RunProc(helmCmd, currentdir, k.Debug); err != nil {
+	if out, err := helpers.RunProc(currentdir, k.Debug,
+		"helm", action, ServiceCatalogDeploymentID, "--namespace", ServiceCatalogDeploymentID, tarPath); err != nil {
 		return errors.New("Failed installing ServiceCatalog: " + out)
 	}
 

--- a/deployments/tekton.go
+++ b/deployments/tekton.go
@@ -173,7 +173,10 @@ func (k Tekton) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI,
 		message := fmt.Sprintf("Establish CRD %s", crd)
 		out, err := helpers.WaitForCommandCompletion(ui, message,
 			func() (string, error) {
-				return helpers.Kubectl("wait --for=condition=established --timeout=" + kTimeout + "s crd/" + crd)
+				return helpers.Kubectl("wait",
+					"--for", "condition=established",
+					"--timeout", kTimeout+"s",
+					"crd/"+crd)
 			},
 		)
 		if err != nil {
@@ -225,7 +228,9 @@ func (k Tekton) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI,
 		func() (string, error) {
 			out, err := helpers.ExecToSuccessWithTimeout(
 				func() (string, error) {
-					out, err := helpers.Kubectl(fmt.Sprintf(`get secret -n %s %s -o 'jsonpath={.data.tls\.crt}'`, RegistryDeploymentID, RegistryCertSecret))
+					out, err := helpers.Kubectl("get", "secret",
+						"--namespace", RegistryDeploymentID, RegistryCertSecret,
+						"-o", "jsonpath={.data.tls\\.crt}")
 					if err != nil {
 						return "", err
 					}

--- a/deployments/traefik.go
+++ b/deployments/traefik.go
@@ -117,19 +117,18 @@ func (k Traefik) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI
 	loadBalancerIP := options.GetStringNG("ingress-service-ip")
 
 	// Setup Traefik helm values
-	var helmArgs []string
-
 	log.Info("assembling helm command")
 	// Disable sending anonymous usage statistics
 	// https://github.com/traefik/traefik-helm-chart/blob/v9.11.0/traefik/values.yaml#L170
 	// Overwrite globalArguments until https://github.com/traefik/traefik-helm-chart/issues/357 is fixed
-
-	helmArgs = append(helmArgs, action, `traefik`)
-	helmArgs = append(helmArgs, `--namespace`, TraefikDeploymentID)
-	helmArgs = append(helmArgs, traefikChartURL)
-	helmArgs = append(helmArgs, `--set`, `globalArguments=`)
-	helmArgs = append(helmArgs, `--set-string`, `deployment.podAnnotations.linkerd\.io/inject=enabled`)
-	helmArgs = append(helmArgs, `--set-string`, fmt.Sprintf("service.spec.loadBalancerIP=%s", loadBalancerIP))
+	helmArgs := []string{
+		action, TraefikDeploymentID,
+		`--namespace`, TraefikDeploymentID,
+		traefikChartURL,
+		`--set`, `globalArguments=`,
+		`--set-string`, `deployment.podAnnotations.linkerd\.io/inject=enabled`,
+		`--set-string`, fmt.Sprintf("service.spec.loadBalancerIP=%s", loadBalancerIP),
+	}
 
 	log.Info("assembled helm command", "command", strings.Join(append([]string{`helm`}, helmArgs...), " "))
 	log.Info("run helm command")

--- a/deployments/traefik.go
+++ b/deployments/traefik.go
@@ -69,8 +69,8 @@ func (k Traefik) Delete(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 	message := "Removing helm release " + TraefikDeploymentID
 	out, err := helpers.WaitForCommandCompletion(ui, message,
 		func() (string, error) {
-			helmCmd := fmt.Sprintf("helm uninstall traefik --namespace '%s'", TraefikDeploymentID)
-			return helpers.RunProc(helmCmd, currentdir, k.Debug)
+			return helpers.RunProc(currentdir, k.Debug,
+				"helm", "uninstall", "traefik", "--namespace", TraefikDeploymentID)
 		},
 	)
 	if err != nil {
@@ -96,12 +96,14 @@ func (k Traefik) Delete(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 	return nil
 }
 
-func (k Traefik) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, options kubernetes.InstallationOptions, upgrade bool) error {
+func (k Traefik) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI,
+	options kubernetes.InstallationOptions, upgrade bool, log logr.Logger) error {
 	action := "install"
 	if upgrade {
 		action = "upgrade"
 	}
 
+	log.Info("creating namespace", "namespace", TraefikDeploymentID)
 	if err := c.CreateNamespace(ctx, TraefikDeploymentID, map[string]string{
 		kubernetes.EpinioDeploymentLabelKey: kubernetes.EpinioDeploymentLabelValue,
 	}, nil); err != nil {
@@ -117,28 +119,45 @@ func (k Traefik) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI
 	// Setup Traefik helm values
 	var helmArgs []string
 
+	log.Info("assembling helm command")
 	// Disable sending anonymous usage statistics
 	// https://github.com/traefik/traefik-helm-chart/blob/v9.11.0/traefik/values.yaml#L170
 	// Overwrite globalArguments until https://github.com/traefik/traefik-helm-chart/issues/357 is fixed
-	helmArgs = append(helmArgs, `--set "globalArguments="`)
-	helmArgs = append(helmArgs, `--set-string deployment.podAnnotations."linkerd\.io/inject"=enabled`)
-	helmArgs = append(helmArgs, fmt.Sprintf("--set-string service.spec.loadBalancerIP=%s", loadBalancerIP))
 
-	helmCmd := fmt.Sprintf("helm %s traefik --namespace %s %s %s", action, TraefikDeploymentID, traefikChartURL, strings.Join(helmArgs, " "))
-	if out, err := helpers.RunProc(helmCmd, currentdir, k.Debug); err != nil {
+	helmArgs = append(helmArgs, action, `traefik`)
+	helmArgs = append(helmArgs, `--namespace`, TraefikDeploymentID)
+	helmArgs = append(helmArgs, traefikChartURL)
+	helmArgs = append(helmArgs, `--set`, `globalArguments=`)
+	helmArgs = append(helmArgs, `--set-string`, `deployment.podAnnotations.linkerd\.io/inject=enabled`)
+	helmArgs = append(helmArgs, `--set-string`, fmt.Sprintf("service.spec.loadBalancerIP=%s", loadBalancerIP))
+
+	log.Info("assembled helm command", "command", strings.Join(append([]string{`helm`}, helmArgs...), " "))
+	log.Info("run helm command")
+
+	if out, err := helpers.RunProc(currentdir, k.Debug, "helm", helmArgs...); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Failed installing Traefik: %s\n", out))
 	}
+
+	log.Info("completed helm command")
+	log.Info("waiting for pods to exist")
 
 	if err := c.WaitUntilPodBySelectorExist(ctx, ui, TraefikDeploymentID, "app.kubernetes.io/name=traefik", k.Timeout); err != nil {
 		return errors.Wrap(err, "failed waiting for Traefik Ingress deployment to exist")
 	}
+
+	log.Info("waiting for pods to run")
+
 	if err := c.WaitForPodBySelectorRunning(ctx, ui, TraefikDeploymentID, "app.kubernetes.io/name=traefik", k.Timeout); err != nil {
 		return errors.Wrap(err, "failed waiting for Traefik Ingress deployment to come up")
 	}
 
+	log.Info("waiting for loadbalancer on service")
+
 	if err := c.WaitUntilServiceHasLoadBalancer(ctx, ui, TraefikDeploymentID, "traefik", duration.ToServiceLoadBalancer()); err != nil {
 		return errors.Wrap(err, MessageLoadbalancerIP)
 	}
+
+	log.Info("apply done")
 
 	ui.Success().Msg("Traefik Ingress deployed")
 
@@ -234,10 +253,14 @@ func (k Traefik) Deploy(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 
 	log.Info("deploying traefik")
 
-	return k.apply(ctx, c, ui, options, false)
+	return k.apply(ctx, c, ui, options, false, log)
 }
 
 func (k Traefik) Upgrade(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, options kubernetes.InstallationOptions) error {
+	log := k.Log.WithName("Upgrade")
+	log.Info("start")
+	defer log.Info("return")
+
 	_, err := c.Kubectl.CoreV1().Namespaces().Get(
 		ctx,
 		TraefikDeploymentID,
@@ -249,5 +272,5 @@ func (k Traefik) Upgrade(ctx context.Context, c *kubernetes.Cluster, ui *termui.
 
 	ui.Note().Msg("Upgrading Traefik Ingress...")
 
-	return k.apply(ctx, c, ui, options, true)
+	return k.apply(ctx, c, ui, options, true, log)
 }

--- a/helpers/embedded_files.go
+++ b/helpers/embedded_files.go
@@ -2,7 +2,6 @@ package helpers
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -48,7 +47,7 @@ func KubectlApplyEmbeddedYaml(yamlPath string) (string, error) {
 	}
 	defer os.Remove(yamlPathOnDisk)
 
-	return Kubectl(fmt.Sprintf("apply --filename %s", yamlPathOnDisk))
+	return Kubectl("apply", "--filename", yamlPathOnDisk)
 }
 
 // KubectlDeleteEmbeddedYaml un-embeds the given yaml file and calls `kubectl delete`
@@ -61,8 +60,11 @@ func KubectlDeleteEmbeddedYaml(yamlPath string, ignoreMissing bool) (string, err
 	defer os.Remove(yamlPathOnDisk)
 
 	if ignoreMissing {
-		return Kubectl(fmt.Sprintf("delete --ignore-not-found=true --wait=false --filename %s", yamlPathOnDisk))
+		return Kubectl("delete",
+			"--ignore-not-found", "true",
+			"--wait", "false",
+			"--filename", yamlPathOnDisk)
 	} else {
-		return Kubectl(fmt.Sprintf("delete --filename %s", yamlPathOnDisk))
+		return Kubectl("delete", "--filename", yamlPathOnDisk)
 	}
 }

--- a/helpers/exec.go
+++ b/helpers/exec.go
@@ -19,11 +19,11 @@ type ExternalFuncWithString func() (output string, err error)
 
 type ExternalFunc func() (err error)
 
-func RunProc(cmd, dir string, toStdout bool) (string, error) {
+func RunProc(dir string, toStdout bool, cmd string, args ...string) (string, error) {
 	if os.Getenv("DEBUG") == "true" {
-		fmt.Println("Executing ", cmd)
+		fmt.Printf("Executing: %s %v (in: %s)\n", cmd, args, dir)
 	}
-	p := kexec.CommandString(cmd)
+	p := kexec.Command(cmd, args...)
 
 	var b bytes.Buffer
 	if toStdout {
@@ -44,11 +44,11 @@ func RunProc(cmd, dir string, toStdout bool) (string, error) {
 	return b.String(), err
 }
 
-func RunProcNoErr(cmd, dir string, toStdout bool) (string, error) {
+func RunProcNoErr(dir string, toStdout bool, cmd string, args ...string) (string, error) {
 	if os.Getenv("DEBUG") == "true" {
-		fmt.Println("Executing ", cmd)
+		fmt.Printf("Executing %s %v\n", cmd, args)
 	}
-	p := kexec.CommandString(cmd)
+	p := kexec.Command(cmd, args...)
 
 	var b bytes.Buffer
 	if toStdout {
@@ -88,7 +88,7 @@ func CreateTmpFile(contents string) (string, error) {
 
 // Kubectl invokes the `kubectl` command in PATH, running the specified command.
 // It returns the command output and/or error.
-func Kubectl(command string) (string, error) {
+func Kubectl(command ...string) (string, error) {
 	_, err := exec.LookPath("kubectl")
 	if err != nil {
 		return "", errors.Wrap(err, "kubectl not in path")
@@ -99,9 +99,7 @@ func Kubectl(command string) (string, error) {
 		return "", err
 	}
 
-	cmd := fmt.Sprintf("kubectl " + command)
-
-	return RunProc(cmd, currentdir, false)
+	return RunProc(currentdir, false, "kubectl", command...)
 }
 
 // WaitForCommandCompletion prints progress dots until the func completes

--- a/internal/cli/clients/install_client.go
+++ b/internal/cli/clients/install_client.go
@@ -143,10 +143,10 @@ func (c *InstallClient) Install(ctx context.Context, flags *pflag.FlagSet) error
 
 	steps := []kubernetes.Deployment{
 		&deployments.Kubed{Timeout: duration.ToDeployment()},
-		&deployments.CertManager{Timeout: duration.ToDeployment()},
+		&deployments.CertManager{Timeout: duration.ToDeployment(), Log: details.V(1)},
 		&deployments.Epinio{Timeout: duration.ToDeployment()},
 		&deployments.Gitea{Timeout: duration.ToDeployment()},
-		&deployments.Registry{Timeout: duration.ToDeployment()},
+		&deployments.Registry{Timeout: duration.ToDeployment(), Log: details.V(1)},
 		&deployments.Tekton{Timeout: duration.ToDeployment()},
 		&deployments.ServiceCatalog{Timeout: duration.ToDeployment()},
 	}
@@ -229,11 +229,11 @@ func (c *InstallClient) Uninstall(ctx context.Context) error {
 		&deployments.GoogleServices{Timeout: duration.ToDeployment()},
 		&deployments.ServiceCatalog{Timeout: duration.ToDeployment()},
 		&deployments.Tekton{Timeout: duration.ToDeployment()},
-		&deployments.Registry{Timeout: duration.ToDeployment()},
+		&deployments.Registry{Timeout: duration.ToDeployment(), Log: details.V(1)},
 		&deployments.Gitea{Timeout: duration.ToDeployment()},
 		&deployments.Kubed{Timeout: duration.ToDeployment()},
 		&deployments.Traefik{Timeout: duration.ToDeployment()},
-		&deployments.CertManager{Timeout: duration.ToDeployment()},
+		&deployments.CertManager{Timeout: duration.ToDeployment(), Log: details.V(1)},
 		&deployments.Epinio{Timeout: duration.ToDeployment()},
 	} {
 		wg.Add(1)


### PR DESCRIPTION
Fixes #503

### Description

Portability work induced by trialing installing Epinio on Windows.

The main issue found so far is our use of the `kexec.CommandString()` for shelling out to external commands.
Per the documentation that indirects through `bash -c` and `cmd /c` on Linux and Windows, respectively.
Some of the invoked commands come with their own quotes, both `'` and `"` however, and at least on Windows this causes garbage in the final command to be run. :boom: 

This PR rewrites the foundational code to use the `Command()` function instead, which takes a `...string` argument.
The affected functions (see below for the list) now also take such an argument.
To make that work the arguments got reordered also.
This in turn required rewriting all their callers.

While the conversion was quite mechanical (but not enough to allow search and replace) the tediousness of it may have created typos and such which slipped through the basic check (IOW the code here does compile at least).

Oh, yes, as this was part of the investigation of the issues with installation on Windows the cert manager and registry deployments got extended tracing of their operation also.

### Functions, and notes

  - `helpers.RunProc`,
  - `helpers.KubeCtl`,
  - `proc.Run`, and
  - `machine.Epinio`

The last two are in the test suite helpers.

Note on calling the modified function `helpers.RunProc` (shorthand: `RP`). Similarly for the others

You can call it in one of three ways:

  - `RP(dir, toStdout, "app", "push", more, fixed, strings, ...)`

  - `RP(dir, toStdout, "app", words...)` where `words` is a `[]string{}` slice.

  - `RP(dir, toStdout, "app", append([]string{fixed, strings, ...}, words...)...)`

    This is the form needed when trying to mix fixed strings with variadics from a slice, for the args argument.
    You __cannot__ write

    `RP(dir, toStdout, "app", fixed, strings, words...)`.



