### PR TITLE
Cluster patching for Windows. Plus documentation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ compress:
 test: embed_files
 	ginkgo -r -p -race -failOnPending helpers internal
 
+tag:
+	@git describe --tags --abbrev=0
+
 # acceptance is not part of the unit tests, and has its own target, see below.
 
 GINKGO_NODES ?= 2

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ export LDFLAGS += -X github.com/epinio/epinio/internal/version.Version=$(VERSION
 
 build: embed_files build-amd64
 
+build-win: embed_files build-windows
+
 build-all: embed_files build-amd64 build-arm64 build-arm32 build-windows build-darwin
 
 build-all-small:

--- a/docs/developer/howtos/development.md
+++ b/docs/developer/howtos/development.md
@@ -72,11 +72,11 @@ failing server component does not matter.
 
 If the cluster is not running on linux-amd64 it will be necessary to set
 `EPINIO_BINARY_PATH` to the correct binary to place into the epinio server
-([See here](https://github.com/epinio/epinio/blob/2c3c93f79b1019fe7895273b94f40b725ede2996/scripts/patch-epinio-deployment.sh#L19)).
+([See here](https://github.com/epinio/epinio/blob/a4b679af88d58177cecf4a5717c8c96f382058ed/scripts/patch-epinio-deployment.sh#L19)).
 
 If the client operation is performed outside of a git checkout it will be
 necessary to set `EPINIO_BINARY_TAG` to the correct tag
-([See here](https://github.com/epinio/epinio/blob/2c3c93f79b1019fe7895273b94f40b725ede2996/scripts/patch-epinio-deployment.sh#L20)).
+([See here](https://github.com/epinio/epinio/blob/a4b679af88d58177cecf4a5717c8c96f382058ed/scripts/patch-epinio-deployment.sh#L20)).
 
 The make target `tag` can be used in the checkout the binary came from to
 determine this value.

--- a/docs/developer/howtos/development.md
+++ b/docs/developer/howtos/development.md
@@ -33,7 +33,7 @@ make build
 ```
 
 This is building Epinio for linux on amd64 architecture. If you are on a
-different OS or architecture you can use one of the available `build-*` targets.
+different OS or architecture you can use one of other the available `build-*` targets.
 Look at the Makefile at the root of the project to see what is available.
 
 ### Installing Epinio
@@ -50,8 +50,6 @@ make install
 In case you're curious why `make install` is used here instead of
 `epinio install`, [look behind the curtains](behind-the-curtains.md)
 explains the details of running an Epinio dev environment.
-
-
 
 After making changes to the binary simply invoking `make
 patch-epinio-deployment` again will upload the changes into the
@@ -72,9 +70,16 @@ API credentials and certs into the client configuration file. As that
 command talks directly to the cluster and not the epinio API the
 failing server component does not matter.
 
-If the cluster is not running on linux-x64 it may be necessary to set
-`EPINIO_BINARY_PATH` to the right binary
+If the cluster is not running on linux-amd64 it will be necessary to set
+`EPINIO_BINARY_PATH` to the correct binary to place into the epinio server
 ([See here](https://github.com/epinio/epinio/blob/2c3c93f79b1019fe7895273b94f40b725ede2996/scripts/patch-epinio-deployment.sh#L19)).
+
+If the client operation is performed outside of a git checkout it will be
+necessary to set `EPINIO_BINARY_TAG` to the correct tag
+([See here](https://github.com/epinio/epinio/blob/2c3c93f79b1019fe7895273b94f40b725ede2996/scripts/patch-epinio-deployment.sh#L20)).
+
+The make target `tag` can be used in the checkout the binary came from to
+determine this value.
 
 Also, the default `make build` target builds a dynamically linked
 binary. This can cause issues if for example the glibc library in the
@@ -85,3 +90,21 @@ command like:
 ```
 GOARCH="amd64" GOOS="linux" CGO_ENABLED=0 go build -o dist/epinio-linux-amd64
 ```
+
+#### Mixed Windows/Linux Scenario
+
+A concrete example of the above would be the installation of Epinio from a
+Windows host without a checkout, to a Linux-based cluster.
+
+In that scenario the Windows host has to have both windows-amd64 and linux-amd64
+binaries. The first to perform the installation, the second for
+`EPINIO_BINARY_PATH` to be put into the server.
+
+Furthermore, as the Windows host is without a checkout, the tag has to be
+determined in the actual checkout and set into `EPINIO_BINARY_PATH`.
+
+Lastly, do not forget to set up a proper domain so that the client can talk to
+the server after installation is done. While during installation only a suitable
+`KUBECONFIG` is required after the client will go and use the information from
+the ingress, and that then has to properly resolve in the DNS.
+

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/briandowns/spinner v1.12.0
 	github.com/codeskyblue/kexec v0.0.0-20180119015717-5a4bed90d99a
-	github.com/coreos/go-oidc/v3 v3.0.0
 	github.com/fatih/color v1.12.0
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/stdr v0.4.0
@@ -32,7 +31,6 @@ require (
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/tektoncd/pipeline v0.23.0
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
-	golang.org/x/oauth2 v0.0.0-20210126194326-f9ce19ea3013
 	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 // indirect
 	golang.org/x/tools v0.1.1 // indirect
 	k8s.io/api v0.20.5

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kyokomi/emoji v2.2.4+incompatible
+	github.com/mattn/go-isatty v0.0.12
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.3.0
 	github.com/mholt/archiver/v3 v3.5.0
 	github.com/olekukonko/tablewriter v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,6 @@ github.com/coreos/etcd v3.3.15+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-oidc v2.1.0+incompatible h1:sdJrfw8akMnCuUlaZU3tE/uYXFgfqom8DBE9so9EBsM=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
-github.com/coreos/go-oidc/v3 v3.0.0 h1:/mAA0XMgYJw2Uqm7WKGCsKnjitE/+A0FFbOmiRJm7LQ=
-github.com/coreos/go-oidc/v3 v3.0.0/go.mod h1:rEJ/idjfUyfkBit1eI1fvyr+64/g9dcKpAm8MJMesvo=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -1004,7 +1002,6 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200505041828-1ed23360d12c/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
@@ -1352,8 +1349,6 @@ gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
-gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
-gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/src-d/go-billy.v4 v4.3.2/go.mod h1:nDjArDMp+XMs1aFAESLRjfGSgfvoYN0hDfzEk0GjC98=
 gopkg.in/src-d/go-git-fixtures.v3 v3.5.0/go.mod h1:dLBcvytrw/TYZsNTWCnkNF2DSIlzWYqTe3rJR56Ac7g=
 gopkg.in/src-d/go-git.v4 v4.13.1/go.mod h1:nx5NYcxdKxq5fpltdHnPa2Exj4Sx0EclMWZQbYDu2z8=

--- a/helpers/termui/ui.go
+++ b/helpers/termui/ui.go
@@ -194,7 +194,7 @@ func (u *Message) Msg(message string) {
 		message = color.RedString(message)
 	}
 
-	fmt.Printf("%s", message)
+	fmt.Fprintf(color.Output, "%s", message)
 
 	for _, interaction := range u.interactions {
 		switch interaction.variant {
@@ -211,17 +211,17 @@ func (u *Message) Msg(message string) {
 		case show:
 			switch interaction.valueType {
 			case tBool:
-				fmt.Printf("%s: %s\n", emoji.Sprint(interaction.name), color.MagentaString("%t", interaction.value))
+				fmt.Fprintf(color.Output, "%s: %s\n", emoji.Sprint(interaction.name), color.MagentaString("%t", interaction.value))
 			case tInt:
-				fmt.Printf("%s: %s\n", emoji.Sprint(interaction.name), color.CyanString("%d", interaction.value))
+				fmt.Fprintf(color.Output, "%s: %s\n", emoji.Sprint(interaction.name), color.CyanString("%d", interaction.value))
 			case tString:
-				fmt.Printf("%s: %s\n", emoji.Sprint(interaction.name), color.GreenString("%s", interaction.value))
+				fmt.Fprintf(color.Output, "%s: %s\n", emoji.Sprint(interaction.name), color.GreenString("%s", interaction.value))
 			}
 		}
 	}
 
 	for idx, headers := range u.tableHeaders {
-		table := tablewriter.NewWriter(os.Stdout)
+		table := tablewriter.NewWriter(color.Output)
 		table.SetHeader(headers)
 		table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 		table.SetCenterSeparator("|")

--- a/internal/cli/clients/install_client.go
+++ b/internal/cli/clients/install_client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/helpers/termui"
 	"github.com/epinio/epinio/helpers/tracelog"
+	"github.com/epinio/epinio/internal/cli/config"
 	"github.com/epinio/epinio/internal/duration"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -33,6 +34,15 @@ type InstallClient struct {
 }
 
 func NewInstallClient(ctx context.Context, options *kubernetes.InstallationOptions) (*InstallClient, func(), error) {
+	// We do this for the side effect: colorized output vs not.
+	// May also extend the internal CA cert pool.
+	// This and everything else done by loading does not matter.
+	// The later phases of the installer will write a new config.
+	_, err := config.Load()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {
 		return nil, nil, err

--- a/internal/cli/debug.go
+++ b/internal/cli/debug.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+)
+
+var ()
+
+func init() {
+	CmdDebug.AddCommand(CmdDebugTTY)
+}
+
+// CmdDebug implements the epinio debug command
+var CmdDebug = &cobra.Command{
+	Hidden:        true,
+	Use:           "debug",
+	Short:         "Dev Tools",
+	Long:          `Developer Tools. Hidden From Regular User.`,
+	Args:          cobra.ExactArgs(0),
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}
+
+// CmdDebug implements the epinio debug command
+var CmdDebugTTY = &cobra.Command{
+	Use:   "tty",
+	Short: "Running In a Terminal?",
+	Long:  `Running In a Terminal?`,
+	Args:  cobra.ExactArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		if isatty.IsTerminal(os.Stdout.Fd()) {
+			fmt.Println("Is Terminal")
+		} else if isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+			fmt.Println("Is Cygwin/MSYS2 Terminal")
+		} else {
+			fmt.Println("Is Not Terminal")
+		}
+		return nil
+	},
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -89,6 +89,8 @@ func init() {
 	rootCmd.AddCommand(CmdService)
 	rootCmd.AddCommand(CmdServer)
 	rootCmd.AddCommand(cmdVersion)
+	// Hidden command providing developer tools
+	rootCmd.AddCommand(CmdDebug)
 }
 
 var cmdVersion = &cobra.Command{


### PR DESCRIPTION
References #503 
Fixes #673 
Fixes #672
Fixes #660

### Notes

- `kubectl cp` syntax specifies a pod file as `pod`:`path`. Note the `:`. That is a special character on Windows and breaks the command. This got replaced by a series of `kubectl exec` commands using a tar command client- and pod-side to copy the file in, move it into the proper place, and ensure correct permissions.
- Note that in the above we cannot use absolute paths, like `/epinio` either, they are breaking the command as well. Because on Windows these are __drive-relative__ paths and get expanded by the kubectl binary before trying to use them. Luckily for us relative paths, i.e `epinio` do work. Because the CWD for `kubectl exec` is the root directory of the pod, making relative and absolute paths equivalent.
- Newly added to the patch script is the `EPINIO_BINARY_TAG` variable. It contains the tag for the image the binary will be placed in. From within a git checkout the default, provided by a `git describe ...` command is good enough. Outside of a checkout use `make tag` in the checkout to determine the tag, and then set the environment variable explicitly.

