### PR TITLE
Redirect all http traffic to https using traffic

### DIFF
--- a/deployments/traefik.go
+++ b/deployments/traefik.go
@@ -136,6 +136,7 @@ func (k Traefik) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI
 		traefikChartURL,
 		`--set`, `globalArguments=`,
 		`--set-string`, `deployment.podAnnotations.linkerd\.io/inject=enabled`,
+		`--set-string`, `ports.web.redirectTo=websecure`,
 		`--set-string`, fmt.Sprintf("service.spec.loadBalancerIP=%s", loadBalancerIP),
 	}
 

--- a/docs/user/explanations/advanced.md
+++ b/docs/user/explanations/advanced.md
@@ -60,7 +60,7 @@ When you installed Epinio, it looked at your cluster to see if you had
 [Traefik](https://doc.traefik.io/traefik/providers/kubernetes-ingress/)
 running. If it wasn't there it installed it.
 
-As Epinio only check two namespaces for Traefik's presence, namely
+As Epinio only checks two namespaces for Traefik's presence, namely
 `traefik` and `kube-system`, it is possible that it tries to install
 it, despite the cluster having Traefik running. Just in an unexpected
 place.
@@ -79,6 +79,14 @@ forces Epinio to not install its own Traefik.
 Note that having some other (non-Traefik) Ingress controller running
 is __not__ a reason to prevent Epinio from installing Traefik. All the
 Ingresses used by Epinio expect to be handled by Traefik.
+
+Also, the Traefik instance installed by Epinio, is configured to redirect all
+http requests to https automatically (e.g. the requests to the Epinio API, and
+the application routes). If you decide to use a Traefik instance which you
+deployed, you have to set this up yourself, Epinio won't change your Traefik
+installation in any way. Here are the relevant upstream docs for the redirection:
+
+https://doc.traefik.io/traefik/routing/entrypoints/#redirection
 
 ## Linkerd
 


### PR DESCRIPTION
Fixes #661

This will only work for the Traefik Epinio installs. If the user decides to use their previously deployed traefik (with `epinio install --skip-traefik`), we have no control on how that is run so we can't setup automatic redirection.