### PR TITLE
Split Application Acceptance Tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,6 +129,49 @@ jobs:
           export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
           make test-acceptance-api
 
+  acceptance-apps:
+    needs:
+      - linter
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get All Git Tags
+        run: git fetch --force --prune --unshallow --tags
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+      - name: Setup Ginkgo Test Framework
+        run: go install github.com/onsi/ginkgo/ginkgo@v1.16.2
+      - name: Cache Tools
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/tools
+          key: ${{ runner.os }}-tools
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Install Tools
+        run: make tools-install
+      - name: Add Tools to PATH
+        run: |
+          echo "`pwd`/output/bin" >> $GITHUB_PATH
+      - name: Unit Tests
+        run: make test
+      - name: API Acceptance Tests
+        env:
+          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          make acceptance-cluster-delete
+          make acceptance-cluster-setup
+          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+          make test-acceptance-apps
+
   acceptance-install:
     needs:
       - linter

--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,14 @@ acceptance-cluster-setup-kind:
 	@./scripts/acceptance-cluster-setup-kind.sh
 
 test-acceptance: showfocus embed_files
-	ginkgo -nodes ${GINKGO_NODES} -stream -slowSpecThreshold ${GINKGO_SLOW_TRESHOLD} -randomizeAllSpecs --flakeAttempts=${FLAKE_ATTEMPTS} -failOnPending acceptance/. acceptance/api/v1/.
+	ginkgo -nodes ${GINKGO_NODES} -stream -slowSpecThreshold ${GINKGO_SLOW_TRESHOLD} -randomizeAllSpecs --flakeAttempts=${FLAKE_ATTEMPTS} -failOnPending acceptance/. acceptance/api/v1/. acceptance/apps/.
 
 
 test-acceptance-api: showfocus embed_files
 	ginkgo -nodes ${GINKGO_NODES} -stream -slowSpecThreshold ${GINKGO_SLOW_TRESHOLD} -randomizeAllSpecs --flakeAttempts=${FLAKE_ATTEMPTS} -failOnPending acceptance/api/v1/.
+
+test-acceptance-apps: showfocus embed_files
+	ginkgo -nodes ${GINKGO_NODES} -stream -slowSpecThreshold ${GINKGO_SLOW_TRESHOLD} -randomizeAllSpecs --flakeAttempts=${FLAKE_ATTEMPTS} -failOnPending acceptance/apps/.
 
 test-acceptance-cli: showfocus embed_files
 	ginkgo -nodes ${GINKGO_NODES} -stream -slowSpecThreshold ${GINKGO_SLOW_TRESHOLD} -randomizeAllSpecs --flakeAttempts=${FLAKE_ATTEMPTS} -failOnPending acceptance/.
@@ -86,7 +89,6 @@ test-acceptance-cli: showfocus embed_files
 test-acceptance-install: showfocus embed_files
 	# TODO support for labels is coming in ginkgo v2
 	ginkgo -nodes ${GINKGO_NODES} -focus "${REGEX}" -stream -randomizeAllSpecs --flakeAttempts=${FLAKE_ATTEMPTS} acceptance/install/.
-
 
 showfocus:
 	@if test `cat acceptance/*.go acceptance/api/v1/*.go | grep -c 'FIt\|FWhen\|FDescribe\|FContext'` -gt 0 ; then echo ; echo 'Focus:' ; grep 'FIt\|FWhen\|FDescribe\|FContext' acceptance/*.go acceptance/api/v1/*.go ; echo ; fi

--- a/acceptance/apps/rails_test.go
+++ b/acceptance/apps/rails_test.go
@@ -1,4 +1,4 @@
-package acceptance_test
+package apps_test
 
 import (
 	"fmt"

--- a/acceptance/apps/suite_test.go
+++ b/acceptance/apps/suite_test.go
@@ -1,0 +1,147 @@
+package apps_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/epinio/epinio/acceptance/helpers/proc"
+	"github.com/epinio/epinio/acceptance/testenv"
+	"github.com/epinio/epinio/helpers"
+	"github.com/onsi/ginkgo/config"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAcceptance(t *testing.T) {
+	RegisterFailHandler(FailWithReport)
+	RunSpecs(t, "Acceptance Suite for Application Tests")
+}
+
+var (
+	nodeSuffix, nodeTmpDir string
+
+	// serverURL is the URL of the epinio API server
+	serverURL, websocketURL string
+
+	env testenv.EpinioEnv
+)
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	// Singleton setup. Run on node 1 before all
+
+	fmt.Printf("I'm running on runner = %s\n", os.Getenv("HOSTNAME"))
+
+	testenv.SetRoot("../..")
+
+	testenv.SetupEnv()
+
+	if err := testenv.CheckDependencies(); err != nil {
+		panic("Missing dependencies: " + err.Error())
+	}
+
+	fmt.Printf("Compiling Epinio on node %d\n", config.GinkgoConfig.ParallelNode)
+	testenv.BuildEpinio()
+
+	testenv.CreateRegistrySecret()
+
+	epinioBinary := testenv.EpinioBinaryPath()
+	err := testenv.EnsureEpinio(epinioBinary)
+	Expect(err).ToNot(HaveOccurred(), "installing epinio")
+
+	out, err := testenv.PatchEpinio()
+	Expect(err).ToNot(HaveOccurred(), out)
+
+	// Now create the default org which we skipped because it would fail before
+	// patching.
+	// NOTE: Unfortunately this prevents us from testing if the `install` command
+	// really creates a default workspace. Needs a better solution that allows
+	// install to do it's thing without needing the patch script to run first.
+	// Eventually is used to retry in case the rollout of the patched deployment
+	// is not completely done yet.
+	fmt.Println("Ensure default workspace exists")
+	testenv.EnsureDefaultWorkspace(epinioBinary)
+
+	fmt.Println("Setup cluster services")
+	testenv.SetupInClusterServices(epinioBinary)
+
+	out, err = helpers.Kubectl("get", "pods", "--namespace", "minibroker", "--selector", "app=minibroker-minibroker")
+	Expect(err).ToNot(HaveOccurred(), out)
+	Expect(out).To(MatchRegexp(`minibroker.*2/2.*Running`))
+
+	fmt.Println("Setup google")
+	err = testenv.SetupGoogleServices(epinioBinary)
+	Expect(err).ToNot(HaveOccurred(), out)
+
+	fmt.Println("SynchronizedBeforeSuite is done, checking Epinio info endpoint")
+	testenv.ExpectGoodInstallation(epinioBinary)
+
+	return []byte(strconv.Itoa(int(time.Now().Unix())))
+}, func(randomSuffix []byte) {
+	var err error
+	testenv.SetRoot("../..")
+
+	nodeSuffix = fmt.Sprintf("%d-%s",
+		config.GinkgoConfig.ParallelNode, string(randomSuffix))
+	nodeTmpDir, err = ioutil.TempDir("", "epinio-"+nodeSuffix)
+	if err != nil {
+		panic("Could not create temp dir: " + err.Error())
+	}
+
+	Expect(os.Getenv("KUBECONFIG")).ToNot(BeEmpty(), "KUBECONFIG environment variable should not be empty")
+
+	// Get config from the installation (API credentials)
+	out, err := testenv.CopyEpinioConfig(nodeTmpDir)
+	Expect(err).ToNot(HaveOccurred(), out)
+	os.Setenv("EPINIO_CONFIG", nodeTmpDir+"/epinio.yaml")
+
+	env = testenv.New(nodeTmpDir, testenv.Root())
+
+	out, err = env.Epinio(nodeTmpDir, "target", "workspace")
+	Expect(err).ToNot(HaveOccurred(), out)
+
+	out, err = proc.Run(testenv.Root(), false, "kubectl", "get", "ingress",
+		"--namespace", "epinio", "epinio",
+		"-o", "jsonpath={.spec.rules[0].host}")
+	Expect(err).ToNot(HaveOccurred(), out)
+
+	serverURL = "https://" + out
+	websocketURL = "wss://" + out
+})
+
+var _ = SynchronizedAfterSuite(func() {
+	if !testenv.SkipCleanup() {
+		fmt.Printf("Deleting tmpdir on node %d\n", config.GinkgoConfig.ParallelNode)
+		testenv.DeleteTmpDir(nodeTmpDir)
+	}
+}, func() { // Runs only on one node after all are done
+	if testenv.SkipCleanup() {
+		fmt.Printf("Found '%s', skipping all cleanup", testenv.SkipCleanupPath())
+	} else {
+		// Delete left-overs no matter what
+		defer func() { _, _ = testenv.CleanupTmp() }()
+	}
+})
+
+var _ = AfterEach(func() {
+	testenv.AfterEachSleep()
+})
+
+func FailWithReport(message string, callerSkip ...int) {
+	// NOTE: Use something like the following if you need to debug failed tests
+	// fmt.Println("\nA test failed. You may find the following information useful for debugging:")
+	// fmt.Println("The cluster pods: ")
+	// out, err := helpers.Kubectl("get pods --all-namespaces")
+	// if err != nil {
+	// 	fmt.Print(err.Error())
+	// } else {
+	// 	fmt.Print(out)
+	// }
+
+	// Ensures the correct line numbers are reported
+	Fail(message, callerSkip[0]+1)
+}

--- a/acceptance/apps/wordpress_test.go
+++ b/acceptance/apps/wordpress_test.go
@@ -1,4 +1,4 @@
-package acceptance_test
+package apps_test
 
 import (
 	"fmt"


### PR DESCRIPTION
Split the Rails and Wordpress tests into a new suite 'apps'.

There is still the external repo wordpress test in the normal test suite.
After this PR the normal suite and the app suite take ~15min each.


fixes #716
