### PR TITLE
Tweak the changelog generator's configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,21 @@ jobs:
         uses: heinrichreimer/github-changelog-generator-action@v2.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          verbose: "true"
+          issueLineLabels:
+          - "ALL"
+          excludeLabels:
+            - "apparently external cause"
+            - "chore"
+            - "devops admin"
+            - "duplicate"
+            - "invalid"
+            - "later"
+            - "overcome by events"
+            - "spike"
+            - "wontfix"
+            - "do not log"
+            - "question"
           pullRequests: "false"
           onlyLastTag: "true"
           stripGeneratorNotice: "true"


### PR DESCRIPTION
fix #713 

Tweaked the configuration of the changelog generator used to create our release notes

  - Activated display of labels at each reported ticket

  - Added list of labels to exclude from the notes.

    The label 'do not log' is new. It is added to serve as a general
    indicator of exclusion, for issues where none of the more specific
    excluding labels apply.

The labels triggering exclusion are:

|Label|Label|Label|Label|
|---|---|---|---|
|apparently external cause	|chore	|devops admin|duplicate|
|invalid		|later		|overcome by events	||
|spike		|wontfix		|do not log||

TODO: Note the exclusion in the label descriptions in github. To be done after this PR is accepted and merged.


