### PR TITLE
fix: revert introduction of `issueLineLabels`.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           verbose: "true"
-          issueLineLabels: "ALL"
           excludeLabels: "apparently external cause,chore,devops admin,duplicate,invalid,later,overcome by events,spike,wontfix,do not log,question"
           pullRequests: "false"
           onlyLastTag: "true"


### PR DESCRIPTION
Sigh. Seems to crash the generator as configured.