### PR TITLE
Fix AKS/EKS Install Tests

### DIFF
--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -7,12 +7,16 @@ on:
     - cron:  '0 5 * * *'
   workflow_dispatch:
     inputs:
-      aks_domain:
-        description: "AKS_DOMAIN"
-        required: false
-        default: ""
       azure_credentials:
         description: "AZURE_CREDENTIALS"
+        required: false
+        default: ""
+      aks_domain:
+        description: "AKS_DOMAIN to use, managed via Route53's AWS_ZONE_ID"
+        required: false
+        default: ""
+      aws_zone_id:
+        description: "AWS_ZONE_ID"
         required: false
         default: ""
       keep_cluster:
@@ -65,15 +69,17 @@ jobs:
         run: |
           id=$RANDOM
           echo '::set-output name=ID::'$id
-          az aks create --resource-group epinioCI --name epinioCI$id --node-count 1 --generate-ssh-keys
+          az aks create --resource-group epinioCI --name epinioCI$id --node-count 2 --generate-ssh-keys
           az aks get-credentials --resource-group epinioCI --name epinioCI$id --file kubeconfig
+          # list existing clusters
+          az aks list | jq '.[] | .name + " " + (.powerState|tostring)'
 
       - name: Installation Acceptance Tests
         env:
           REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           REGEX: Scenario3
-          AWS_ZONE_ID: ${{ secrets.AWS_ZONE_ID }}
+          AWS_ZONE_ID: ${{ github.events.inputs.aws_zone_id || secrets.AWS_ZONE_ID }}
           AKS_DOMAIN: ${{ github.events.inputs.aks_domain || secrets.AKS_DOMAIN }}
         shell: bash
         run: |
@@ -83,8 +89,10 @@ jobs:
       - name: Delete AKS cluster
         # We always tear down the cluster, to avoid costs. Except when running
         # manually and keep_cluster was set to a non-empty string, like "yes"
-        if: ${{ !github.event.inputs.keep_cluster }}
+        # TODO this was not called, when scheduled and tests failed
+        if: ${{ always() && !github.event.inputs.keep_cluster }}
         shell: bash
         run: |
+          echo "debug keep_cluster: ${{ github.event.inputs.keep_cluster }}"
           id="${{ steps.create-cluster.outputs.ID }}"
           az aks delete --resource-group epinioCI --name epinioCI$id --yes

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -13,6 +13,14 @@ on:
         description: "AWS_SECRET_ACCESS_KEY"
         required: false
         default: ""
+      aws_domain:
+        description: "AWS_DOMAIN to use, managed via Route53's AWS_ZONE_ID"
+        required: false
+        default: ""
+      aws_zone_id:
+        description: "AWS_ZONE_ID"
+        required: false
+        default: ""
 
 env:
   SETUP_GO_VERSION: '^1.13.7'
@@ -56,8 +64,8 @@ jobs:
           REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           REGEX: Scenario4
-          AWS_ZONE_ID: ${{ secrets.AWS_ZONE_ID }}
-          AWS_DOMAIN: ${{ secrets.AWS_DOMAIN }}
+          AWS_ZONE_ID: ${{ github.events.inputs.aws_zone_id || secrets.AWS_ZONE_ID }}
+          AWS_DOMAIN: ${{ github.events.inputs.aks_domain || secrets.AWS_DOMAIN }}
         run: |
           export KUBECONFIG=$PWD/kubeconfig-epinio-ci
           make test-acceptance-install

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Opinionated platform that runs on Kubernetes, that takes you from App to URL in one step.
 
 [![godoc](https://pkg.go.dev/badge/epinio/epinio)](https://pkg.go.dev/github.com/epinio/epinio/internal/api/v1)
-[![CI](https://github.com/epinio/epinio/workflows/CI/badge.svg)](https://github.com/epinio/epinio/actions/workflows/main.yml?query=event%3Aschedule)
+[![CI](https://github.com/epinio/epinio/workflows/CI/badge.svg?event=schedule)](https://github.com/epinio/epinio/actions/workflows/main.yml?query=event%3Aschedule)
 [![AKS-CI](https://github.com/epinio/epinio/actions/workflows/aks.yml/badge.svg?event=schedule)](https://github.com/epinio/epinio/actions/workflows/aks.yml)
 [![EKS-CI](https://github.com/epinio/epinio/actions/workflows/eks.yml/badge.svg?event=schedule)](https://github.com/epinio/epinio/actions/workflows/eks.yml)
 [![golangci-lint](https://github.com/epinio/epinio/actions/workflows/golangci-lint.yml/badge.svg?event=schedule)](https://github.com/epinio/epinio/actions/workflows/golangci-lint.yml)

--- a/acceptance/apps/rails_test.go
+++ b/acceptance/apps/rails_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -97,6 +98,8 @@ var _ = Describe("RubyOnRails", func() {
 		// Change Rails database configuration to match the service name
 		out, err = proc.Run(rails.Dir, false, "sed", "-i", fmt.Sprintf("s/mydb/%s/", serviceName), "config/database.yml")
 		Expect(err).ToNot(HaveOccurred(), out)
+
+		os.Setenv("EPINIO_TIMEOUT_MULTIPLIER", "2")
 	})
 
 	AfterEach(func() {

--- a/acceptance/install/scenario3_test.go
+++ b/acceptance/install/scenario3_test.go
@@ -101,6 +101,8 @@ var _ = Describe("<Scenario3>", func() {
 		// Now create the default org which we skipped because
 		// it would fail before patching.
 		testenv.EnsureDefaultWorkspace(testenv.EpinioBinaryPath())
+		out, err := epinioHelper.Run("target", testenv.DefaultWorkspace)
+		Expect(err).ToNot(HaveOccurred(), out)
 
 		By("Creating a custom service and pushing an app", func() {
 			out, err := epinioHelper.Run("service", "create-custom", serviceName, "mariadb", "10-3-22")

--- a/acceptance/install/scenario3_test.go
+++ b/acceptance/install/scenario3_test.go
@@ -2,7 +2,6 @@ package install_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -17,7 +16,6 @@ import (
 
 var _ = Describe("<Scenario3>", func() {
 	var (
-		appDir       string
 		appName      = catalog.NewAppName()
 		domain       string
 		epinioHelper epinio.Epinio
@@ -45,15 +43,9 @@ var _ = Describe("<Scenario3>", func() {
 			"--tls-issuer=private-ca",
 			"--system-domain=" + domain,
 		}
-
-		var err error
-		appDir, err = ioutil.TempDir("", "epinio-app")
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		os.RemoveAll(appDir)
-
 		out, err := epinioHelper.Uninstall()
 		Expect(err).NotTo(HaveOccurred(), out)
 	})

--- a/acceptance/install/scenario4_test.go
+++ b/acceptance/install/scenario4_test.go
@@ -86,6 +86,8 @@ var _ = Describe("<Scenario4>", func() {
 		// Now create the default org which we skipped because
 		// it would fail before patching.
 		testenv.EnsureDefaultWorkspace(testenv.EpinioBinaryPath())
+		out, err := epinioHelper.Run("target", testenv.DefaultWorkspace)
+		Expect(err).ToNot(HaveOccurred(), out)
 
 		By("Pushing an app with Env vars", func() {
 			out, err := epinioHelper.Run("apps", "create", appName)

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -1630,15 +1630,19 @@ func (c *EpinioClient) upload(endpoint string, path string) ([]byte, error) {
 func formatError(bodyBytes []byte, response *http.Response) error {
 	var eResponse api.ErrorResponse
 	if err := json.Unmarshal(bodyBytes, &eResponse); err != nil {
-		return err
+		return errors.Wrapf(err, "cannot parse JSON response: '%s'", bodyBytes)
 	}
 
+	titles := make([]string, 0, len(eResponse.Errors))
+	for _, e := range eResponse.Errors {
+		titles = append(titles, e.Title)
+	}
+	t := strings.Join(titles, ", ")
+
 	if response.StatusCode == http.StatusInternalServerError {
-		return errors.New(fmt.Sprintf("%s: %s",
-			http.StatusText(response.StatusCode),
-			eResponse.Errors[0].Title))
+		return errors.Errorf("%s: %s", http.StatusText(response.StatusCode), t)
 	} else {
-		return errors.New(eResponse.Errors[0].Title)
+		return errors.New(t)
 	}
 }
 


### PR DESCRIPTION
refers to #757

The tests didn't not target the namespace. This somehow (?) worked, until we renamed 'org' to 'namespace', which made the routes so similiar, that a "Method not supported" error was reported by the httprouter.
