### PR TITLE
Fix linter warnings

### DIFF
--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -62,8 +62,8 @@ var _ = Describe("Config", func() {
 			Expect(config).To(MatchRegexp(`Certificates.*\|.*Present`))
 			Expect(config).To(MatchRegexp(fmt.Sprintf(`API User Name.*\|.*%s`, env.EpinioUser)))
 			Expect(config).To(MatchRegexp(fmt.Sprintf(`API Password.*\|.*%s`, env.EpinioPassword)))
-			Expect(config).To(MatchRegexp(fmt.Sprintf(`API Url.*\| https://epinio.*`)))
-			Expect(config).To(MatchRegexp(fmt.Sprintf(`WSS Url.*\| wss://epinio.*`)))
+			Expect(config).To(MatchRegexp(`API Url.*\| https://epinio.*`))
+			Expect(config).To(MatchRegexp(`WSS Url.*\| wss://epinio.*`))
 		})
 	})
 

--- a/acceptance/install/config_test.go
+++ b/acceptance/install/config_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Install with <ConfigFile> and push a PHP app", func() {
 	})
 
 	AfterEach(func() {
-		epinioHelper.Uninstall()
+		_, _ = epinioHelper.Uninstall()
 
 		err := os.Remove(configFile)
 		Expect(err).NotTo(HaveOccurred())

--- a/acceptance/install/suite_test.go
+++ b/acceptance/install/suite_test.go
@@ -20,7 +20,7 @@ func TestAcceptance(t *testing.T) {
 }
 
 var (
-	nodeSuffix, nodeTmpDir string
+	nodeTmpDir string
 )
 
 var _ = SynchronizedBeforeSuite(func() []byte {

--- a/acceptance/testenv/epinio.go
+++ b/acceptance/testenv/epinio.go
@@ -143,7 +143,6 @@ func ExpectGoodInstallation(epinioBinary string) {
 		gomega.MatchRegexp("Kubernetes Version: v1.21"),
 		gomega.MatchRegexp("Kubernetes Version: v1.20"),
 		gomega.MatchRegexp("Kubernetes Version: v1.19")))
-	gomega.Expect(info).To(gomega.MatchRegexp("Gitea Version: unavailable"))
 }
 
 func CheckDependencies() error {

--- a/acceptance/testenv/epinio.go
+++ b/acceptance/testenv/epinio.go
@@ -16,8 +16,6 @@ import (
 )
 
 const (
-	networkName         = "epinio-acceptance"
-	registryMirrorEnv   = "EPINIO_REGISTRY_CONFIG"
 	registryUsernameEnv = "REGISTRY_USERNAME"
 	registryPasswordEnv = "REGISTRY_PASSWORD"
 

--- a/deployments/epinio.go
+++ b/deployments/epinio.go
@@ -106,7 +106,7 @@ func (k Epinio) PostDeleteCheck(ctx context.Context, c *kubernetes.Cluster, ui *
 	return nil
 }
 
-func (k Epinio) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, options kubernetes.InstallationOptions, upgrade bool) error {
+func (k Epinio) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, options kubernetes.InstallationOptions, _ bool) error {
 	if err := c.CreateNamespace(ctx, EpinioDeploymentID, map[string]string{
 		kubernetes.EpinioDeploymentLabelKey: kubernetes.EpinioDeploymentLabelValue,
 	}, map[string]string{"linkerd.io/inject": "enabled"}); err != nil {
@@ -185,7 +185,6 @@ func (k Epinio) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI,
 		return errors.Wrap(err, fmt.Sprintf("%s failed", message))
 	}
 
-	message = "Installing Application CRD"
 	if out, err := helpers.KubectlApplyEmbeddedYaml(applicationCRDYaml); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Installing %s failed:\n%s", applicationCRDYaml, out))
 	}

--- a/deployments/kubed.go
+++ b/deployments/kubed.go
@@ -100,7 +100,7 @@ func (k Kubed) Delete(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI)
 	return nil
 }
 
-func (k Kubed) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, options kubernetes.InstallationOptions, upgrade bool) error {
+func (k Kubed) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, _ kubernetes.InstallationOptions, upgrade bool) error {
 	action := "install"
 	if upgrade {
 		action = "upgrade"

--- a/deployments/linkerd.go
+++ b/deployments/linkerd.go
@@ -30,7 +30,6 @@ const (
 	LinkerdDeploymentID     = "linkerd"
 	linkerdVersion          = "2.10.2"
 	linkerdRolesYAML        = "linkerd/rbac.yaml"
-	linkerdInstallJobYAML   = "linkerd/install-job.yaml"
 	linkerdUninstallJobYAML = "linkerd/uninstall-job.yaml"
 	linkerdImage            = "splatform/epinio-linkerd"
 )
@@ -87,7 +86,7 @@ func (k Linkerd) Delete(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 	return nil
 }
 
-func (k Linkerd) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, options kubernetes.InstallationOptions, upgrade bool) error {
+func (k Linkerd) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, _ kubernetes.InstallationOptions, _ bool) error {
 	linkerdJobName := "linkerd-install"
 	if err := c.CreateNamespace(ctx, LinkerdDeploymentID, map[string]string{
 		kubernetes.EpinioDeploymentLabelKey: kubernetes.EpinioDeploymentLabelValue,

--- a/deployments/minibroker.go
+++ b/deployments/minibroker.go
@@ -96,7 +96,7 @@ func (k Minibroker) Delete(ctx context.Context, c *kubernetes.Cluster, ui *termu
 	return nil
 }
 
-func (k Minibroker) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, options kubernetes.InstallationOptions, upgrade bool) error {
+func (k Minibroker) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, _ kubernetes.InstallationOptions, upgrade bool) error {
 	action := "install"
 	if upgrade {
 		action = "upgrade"

--- a/deployments/registry.go
+++ b/deployments/registry.go
@@ -164,7 +164,7 @@ func (k Registry) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 
 	log.Info("system domain", "domain", domain)
 
-	if k.createCertificate(ctx, c, options, ui, log); err != nil {
+	if err := k.createCertificate(ctx, c, options, ui, log); err != nil {
 		return errors.Wrap(err, "creating Registry TLS certificate")
 	}
 

--- a/deployments/service_catalog.go
+++ b/deployments/service_catalog.go
@@ -96,7 +96,7 @@ func (k ServiceCatalog) Delete(ctx context.Context, c *kubernetes.Cluster, ui *t
 	return nil
 }
 
-func (k ServiceCatalog) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, options kubernetes.InstallationOptions, upgrade bool) error {
+func (k ServiceCatalog) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, _ kubernetes.InstallationOptions, upgrade bool) error {
 	action := "install"
 	if upgrade {
 		action = "upgrade"

--- a/helpers/embedded_files.go
+++ b/helpers/embedded_files.go
@@ -64,7 +64,6 @@ func KubectlDeleteEmbeddedYaml(yamlPath string, ignoreMissing bool) (string, err
 			"--ignore-not-found=true",
 			"--wait=false",
 			"--filename", yamlPathOnDisk)
-	} else {
-		return Kubectl("delete", "--filename", yamlPathOnDisk)
 	}
+	return Kubectl("delete", "--filename", yamlPathOnDisk)
 }

--- a/helpers/exec.go
+++ b/helpers/exec.go
@@ -117,7 +117,7 @@ func ExecToSuccessWithTimeout(funk ExternalFuncWithString, timeout, interval tim
 	for {
 		select {
 		case <-timeoutChan:
-			return "", errors.New(fmt.Sprintf("Timed out after %s", timeout.String()))
+			return "", errors.Errorf("Timed out after %s", timeout.String())
 		default:
 			if out, err := funk(); err != nil {
 				time.Sleep(interval)

--- a/helpers/kubernetes/cluster.go
+++ b/helpers/kubernetes/cluster.go
@@ -62,7 +62,7 @@ type Platform interface {
 	ExternalIPs() []string
 }
 
-var SupportedPlatforms []Platform = []Platform{
+var SupportedPlatforms = []Platform{
 	kind.NewPlatform(),
 	k3s.NewPlatform(),
 	ibm.NewPlatform(),
@@ -292,9 +292,8 @@ func (c *Cluster) WaitForCRD(ctx context.Context, ui *termui.UI, CRDName string,
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return false, nil
-			} else {
-				return false, err
 			}
+			return false, err
 		}
 
 		return true, nil
@@ -313,9 +312,8 @@ func (c *Cluster) WaitForSecret(ctx context.Context, namespace, secretName strin
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return false, nil
-			} else {
-				return false, err
 			}
+			return false, err
 		}
 		return true, nil
 	})
@@ -470,9 +468,8 @@ func (c *Cluster) WaitForPodBySelectorRunning(ctx context.Context, ui *termui.UI
 			events, err2 := c.GetPodEvents(ctx, namespace, pod.Name)
 			if err2 != nil {
 				return errors.Wrap(err, err2.Error())
-			} else {
-				return errors.New(fmt.Sprintf("Failed waiting for %s: %s\nPod Events: \n%s", pod.Name, err.Error(), events))
 			}
+			return fmt.Errorf("Failed waiting for %s: %s\nPod Events: \n%s", pod.Name, err.Error(), events)
 		}
 	}
 	return nil
@@ -493,7 +490,7 @@ func (c *Cluster) GetPodEventsWithSelector(ctx context.Context, namespace, selec
 		return "", err
 	}
 	if len(podList.Items) < 1 {
-		return "", errors.New(fmt.Sprintf("Couldn't find Pod with selector '%s' in namespace %s", selector, namespace))
+		return "", errors.Errorf("Couldn't find Pod with selector '%s' in namespace %s", selector, namespace)
 	}
 	podName := podList.Items[0].Name
 

--- a/internal/api/v1/applications.go
+++ b/internal/api/v1/applications.go
@@ -451,7 +451,7 @@ func (hc ApplicationsController) Logs(w http.ResponseWriter, r *http.Request) {
 	hc.conn = conn
 	err = hc.streamPodLogs(ctx, org, appName, stageID, cluster, follow)
 	if err != nil {
-		log.V(1).Error(err, "error occured after upgrading the websockets connection")
+		log.V(1).Error(err, "error occurred after upgrading the websockets connection")
 		return
 	}
 

--- a/internal/api/v1/errors.go
+++ b/internal/api/v1/errors.go
@@ -83,7 +83,7 @@ func InternalError(err error, details ...string) APIError {
 	return NewAPIError(err.Error(), strings.Join(details, ", "), http.StatusInternalServerError)
 }
 
-// InternalError constructs an API error for server internal issues, from a message
+// NewInternalError constructs an API error for server internal issues, from a message
 func NewInternalError(msg string, details ...string) APIError {
 	return NewAPIError(msg, strings.Join(details, ", "), http.StatusInternalServerError)
 }

--- a/internal/api/v1/organizations.go
+++ b/internal/api/v1/organizations.go
@@ -18,7 +18,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-// InfoController represents all functionality of the API related to organizations
+// OrganizationsController represents all functionality of the API related to namespaces
 type OrganizationsController struct {
 }
 
@@ -103,7 +103,10 @@ func (oc OrganizationsController) Create(w http.ResponseWriter, r *http.Request)
 	}
 
 	w.WriteHeader(http.StatusCreated)
-	w.Write([]byte{})
+	_, err = w.Write([]byte{})
+	if err != nil {
+		return InternalError(err)
+	}
 
 	return nil
 }
@@ -208,7 +211,7 @@ func deleteApps(ctx context.Context, cluster *kubernetes.Cluster, gitea *gitea.C
 	//
 	//        i. The command waiting for all runners to complete
 	//           (z) ensures that an empty channel means that no
-	//           errors occured, there can be no stragglers to
+	//           errors occurred, there can be no stragglers to
 	//           wait for at (3b1).
 	//
 	//        ii. The error channel has capacity according to the

--- a/internal/api/v1/serviceclasses.go
+++ b/internal/api/v1/serviceclasses.go
@@ -32,7 +32,10 @@ func (scc ServiceClassesController) Index(w http.ResponseWriter, r *http.Request
 		return InternalError(err)
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(js)
+	_, err = w.Write(js)
+	if err != nil {
+		return InternalError(err)
+	}
 
 	return nil
 }

--- a/internal/api/v1/stage.go
+++ b/internal/api/v1/stage.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/viper"
 	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
-	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	tekton "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -63,7 +62,7 @@ func (app *stageParam) ImageURL(registryURL string) string {
 
 // ensurePVC is a helper creating the kube PVC associated with an
 // application, if needed, i.e. not already present.
-func (c ApplicationsController) ensurePVC(ctx context.Context, cluster *kubernetes.Cluster, pvcName string) error {
+func (hc ApplicationsController) ensurePVC(ctx context.Context, cluster *kubernetes.Cluster, pvcName string) error {
 	_, err := cluster.Kubectl.CoreV1().PersistentVolumeClaims(deployments.TektonStagingNamespace).Get(ctx, pvcName, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) { // Unknown error, irrelevant to non-existence
 		return err
@@ -144,7 +143,7 @@ func (hc ApplicationsController) Stage(w http.ResponseWriter, r *http.Request) A
 
 	log.Info("staging app", "org", org, "app", req)
 
-	cs, err := versioned.NewForConfig(cluster.RestConfig)
+	cs, err := tekton.NewForConfig(cluster.RestConfig)
 	if err != nil {
 		return InternalError(err, "failed to get access to a tekton client")
 	}

--- a/internal/application/workload.go
+++ b/internal/application/workload.go
@@ -55,7 +55,7 @@ func (a *Workload) EnvironmentChange(ctx context.Context, varNames []string) err
 		//       EVs not in varNames, and add only entries for varNames
 		//       not in Env, this is way more complex for what is likely
 		//       just 10 entries. I expect any gain in perf to be
-		//       neglibible, and completely offset by the complexity of
+		//       negligible, and completely offset by the complexity of
 		//       understanding and maintaining it later. Full removal
 		//       and re-adding is much simpler to understand, and should
 		//       be fast enough.

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -115,7 +115,7 @@ func (c *EpinioClient) EnvList(ctx context.Context, appName string) error {
 	return nil
 }
 
-// EnvUnset adds or modifies the specified environment variable in the
+// EnvSet adds or modifies the specified environment variable in the
 // named application, with the given value. A workload is restarted.
 func (c *EpinioClient) EnvSet(ctx context.Context, appName, envName, envValue string) error {
 	log := c.Log.WithName("Env")
@@ -150,7 +150,7 @@ func (c *EpinioClient) EnvSet(ctx context.Context, appName, envName, envValue st
 	return nil
 }
 
-// EnvUnset shows the value of the specified environment variable in
+// EnvShow shows the value of the specified environment variable in
 // the named application.
 func (c *EpinioClient) EnvShow(ctx context.Context, appName, envName string) error {
 	log := c.Log.WithName("Env")
@@ -798,14 +798,11 @@ func (c *EpinioClient) Info() error {
 	log.Info("start")
 	defer log.Info("return")
 
-	// TODO: Extend the epinio API to get the gitea version
-	// information again. Or remove it entirely.
-	// Note: See also Spike #699 for possible full removal of Gitea
-
-	giteaVersion := "unavailable"
-	epinioVersion := "unavailable"
-	platform := "unknown"
-	kubeVersion := "unknown"
+	var (
+		epinioVersion string
+		platform      string
+		kubeVersion   string
+	)
 
 	if jsonResponse, err := c.get(api.Routes.Path("Info")); err == nil {
 		v := struct {
@@ -827,7 +824,6 @@ func (c *EpinioClient) Info() error {
 	c.ui.Success().
 		WithStringValue("Platform", platform).
 		WithStringValue("Kubernetes Version", kubeVersion).
-		WithStringValue("Gitea Version", giteaVersion).
 		WithStringValue("Epinio Version", epinioVersion).
 		Msg("Epinio Environment")
 
@@ -1414,7 +1410,7 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error {
 		log.V(3).Info("stage response", "response", stageResponse)
 
 		details.Info("start tailing logs", "StageID", stageResponse.Stage.ID)
-		err = c.stageLogs(ctx, details, appRef, stageResponse.Stage.ID)
+		err = c.stageLogs(details, appRef, stageResponse.Stage.ID)
 		if err != nil {
 			return err
 		}
@@ -1441,7 +1437,7 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error {
 	}
 
 	details.Info("wait for application resources")
-	err = c.waitForApp(ctx, appRef)
+	err = c.waitForApp(appRef)
 	if err != nil {
 		return errors.Wrap(err, "waiting for app failed")
 	}
@@ -1637,9 +1633,8 @@ func formatError(bodyBytes []byte, response *http.Response) error {
 		return errors.New(fmt.Sprintf("%s: %s",
 			http.StatusText(response.StatusCode),
 			eResponse.Errors[0].Title))
-	} else {
-		return errors.New(eResponse.Errors[0].Title)
 	}
+	return errors.New(eResponse.Errors[0].Title)
 }
 
 func (c *EpinioClient) curl(endpoint, method, requestBody string) ([]byte, error) {

--- a/internal/cli/orgs.go
+++ b/internal/cli/orgs.go
@@ -94,7 +94,7 @@ var CmdOrgDelete = &cobra.Command{
 			return err
 		}
 		if !force {
-			cmd.Printf("You are about to delete namespace %s and everything it includeds, i.e. applications, services, etc. Are you sure? (y/n): ", args[0])
+			cmd.Printf("You are about to delete namespace %s and everything it includes, i.e. applications, services, etc. Are you sure? (y/n): ", args[0])
 			if !askConfirmation(cmd) {
 				return errors.New("Cancelled by user")
 			}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -21,7 +21,6 @@ import (
 
 var (
 	flagConfigFile string
-	kubeconfig     string
 )
 
 // NewEpinioCLI returns the main `epinio` cli.
@@ -33,7 +32,7 @@ var rootCmd = &cobra.Command{
 	Use:           "epinio",
 	Short:         "Epinio cli",
 	Long:          `epinio cli is the official command line interface for Epinio PaaS `,
-	Version:       fmt.Sprintf("%s", version.Version),
+	Version:       version.Version,
 	SilenceErrors: true,
 }
 

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -67,7 +67,7 @@ var CmdServer = &cobra.Command{
 }
 
 // startEpinioServer is a helper which initializes and start the API server
-func startEpinioServer(wg *sync.WaitGroup, port int, ui *termui.UI, logger logr.Logger) (*http.Server, string, error) {
+func startEpinioServer(wg *sync.WaitGroup, port int, _ *termui.UI, logger logr.Logger) (*http.Server, string, error) {
 	listener, err := net.Listen("tcp", "0.0.0.0:"+strconv.Itoa(port))
 	if err != nil {
 		return nil, "", err

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -1,4 +1,4 @@
-// Package filesystem allows enables the use of either embeded assets
+// Package filesystem allows enables the use of either embedded assets
 // (with statik) or files from the real filesystem. This is useful to
 // be able to develop the app using files on the disk before we ship
 // it as a single binary.

--- a/internal/services/catalog_service.go
+++ b/internal/services/catalog_service.go
@@ -320,9 +320,8 @@ func CatalogServiceLookup(ctx context.Context, cluster *kubernetes.Cluster, org,
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
-		} else {
-			return nil, err
 		}
+		return nil, err
 	}
 
 	spec := serviceInstance.Object["spec"].(map[string]interface{})
@@ -450,9 +449,8 @@ func (s *CatalogService) lookupBinding(ctx context.Context, bindingName, org str
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
-		} else {
-			return nil, err
 		}
+		return nil, err
 	}
 
 	return serviceBinding, nil
@@ -568,9 +566,8 @@ func (s *CatalogService) Status(ctx context.Context) (string, error) {
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return "Not Found", nil
-		} else {
-			return "", err
 		}
+		return "", err
 	}
 
 	status := serviceInstance.Object["status"].(map[string]interface{})

--- a/internal/services/custom_service.go
+++ b/internal/services/custom_service.go
@@ -72,9 +72,8 @@ func CustomServiceLookup(ctx context.Context, kubeClient *kubernetes.Cluster, or
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
-		} else {
-			return nil, err
 		}
+		return nil, err
 	}
 	username := s.ObjectMeta.Labels["app.kubernetes.io/created-by"]
 

--- a/internal/web/applications_controller.go
+++ b/internal/web/applications_controller.go
@@ -18,7 +18,7 @@ type ApplicationsController struct {
 }
 
 // setCurrentOrgInCookie is a helper for creating cookies to persist system state in the browser
-func setCurrentOrgInCookie(org, cookieName string, w http.ResponseWriter) error {
+func setCurrentOrgInCookie(org, cookieName string, w http.ResponseWriter) {
 	cookie := http.Cookie{
 		Name:    cookieName,
 		Value:   org,
@@ -26,8 +26,6 @@ func setCurrentOrgInCookie(org, cookieName string, w http.ResponseWriter) error 
 		Expires: time.Now().Add(365 * 24 * time.Hour),
 	}
 	http.SetCookie(w, &cookie)
-
-	return nil
 }
 
 // getOrgs tries to decide what the current organization is.
@@ -70,9 +68,8 @@ func getOrgs(w http.ResponseWriter, r *http.Request) (string, []string, error) {
 			restOrgs := otherOrgs(currentOrg, orgs)
 			setCurrentOrgInCookie(currentOrg, "currentOrg", w)
 			return currentOrg, restOrgs, nil
-		} else {
-			return "", []string{}, err
 		}
+		return "", []string{}, err
 	}
 	orgExists := func(cookieOrg string, orgs []organizations.Organization) bool {
 		for _, org := range orgs {


### PR DESCRIPTION
This fixes some of the linter warnings. 


I create another PR to create a seperate workflow for the scheduled lint,  so it can drop e.g. errcheck to avoid warnings for old code. The other workflow, for PRs, will have more checks, for new code.

refers to #757