### PR TITLE
Fix golangci-lint workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,14 +14,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Generate Golang
+        run: |
+          export PATH=$PATH:/home/runner/go/bin/
+          make embed_files
+
+      - id: configfile
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "::set-output name=file::.golangci.yml"
+          else
+            echo "::set-output name=file::.golangci-schedule.yml"
+          fi
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.39
+          version: v1.42.1
 
-          args: --timeout=10m
+          args: --timeout=10m --config=${{ steps.configfile.outputs.file }}
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # The condition sets this to true for scheduled events.
-          only-new-issues: ${{ !github.event.schedule }}
+          # The condition sets this to true for PR events.
+          only-new-issues: "${{ github.event_name == 'pull_request'}}"

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -32,7 +32,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.42.1
+          version: v1.42
 
           args: --timeout=10m --config=${{ steps.configfile.outputs.file }}
 

--- a/.golangci-schedule.yml
+++ b/.golangci-schedule.yml
@@ -17,6 +17,8 @@ linters-settings:
     threshold: 400
   revive:
     rules:
+    - name: indent-error-flow
+      severity: warning
     - name: blank-imports
       severity: warning
     - name: unexported-return
@@ -24,15 +26,10 @@ linters-settings:
 
 issues:
   exclude-rules:
-  # TODO convert the regex to errcheck's new ignore file
-  - linters: [errcheck]
-    text: "Error return value of .((os\\.)?std(out|err)\\..*|.*Close|.*Flush|os\\.Remove(All)?|.*printf?|os\\.(Un)?Setenv|viper.BindPFlag|viper.BindEnv). is not checked"
   # Exclude some linters from running on tests files.
   - linters:
     - gocyclo
     - dupl
-    - errcheck
-    - gosec
     path: _test\.go
   # Exclude unparam warning for handleError()
   - linters:
@@ -47,7 +44,6 @@ linters:
   - govet
   - staticcheck
   - deadcode
-  - errcheck
   - varcheck
   - unparam
   - ineffassign
@@ -56,7 +52,6 @@ linters:
   - dupl
   - goimports
   - revive
-  - gosec
   - gosimple
   - typecheck
   - unused


### PR DESCRIPTION
The workflow didn't work previously, because the generated files were
missing.

This PR adds detection for schedule vs. pull_request events.
In schedule mode, we use a relaxed config, to avoid to many warnings.
In PR mode the config is stricter, so new code lints.
The PR mode config is also in the default config location and should be
picked up by IDEs.


refers to #757