### PR TITLE
Fix to use namespace key for default namespace

### DIFF
--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -53,7 +53,7 @@ func LoadFrom(file string) (*Config, error) {
 	v.SetEnvPrefix("EPINIO")
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
-	v.SetDefault("org", "workspace")
+	v.SetDefault("namespace", "workspace")
 
 	// Use empty defaults in viper to allow NeededOptions defaults to apply
 	v.SetDefault("user", "")


### PR DESCRIPTION
Leftover from previous rename