### PR TITLE
Remove kubectl/curl/helm from base image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+acceptance/
+dist/
+docs/
+images/
+output/
+
+contrib/
+tmp/
+.envrc

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,5 +1,6 @@
 ARG BASE_IMAGE=splatform/epinio-base
 
+################
 FROM ruby:3.0.1 AS tools
 WORKDIR /workdir
 COPY . .
@@ -7,14 +8,21 @@ RUN apt-get update && apt-get install -y python3-venv
 RUN ./scripts/tools-install.sh helm
 RUN cp output/bin/helm /helm
 
+################
 FROM golang:1.16.3 AS build
 WORKDIR /go/src/github.com/epinio
+
+# for caching
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download
 
 COPY . .
 COPY --from=tools /helm /usr/bin/helm
 
 RUN make build-all-small
 
+################
 FROM $BASE_IMAGE
 COPY --from=build /go/src/github.com/epinio/dist/epinio-linux-amd64 /epinio
 ENTRYPOINT ["/epinio"]

--- a/images/baseimage-Dockerfile
+++ b/images/baseimage-Dockerfile
@@ -1,14 +1,3 @@
 FROM opensuse/leap:15.3
 LABEL org.opencontainers.image.source https://github.com/epinio/epinio
-RUN zypper ref && zypper install --no-recommends -y git curl tar gzip && rm -fr /var/cache/*
-
-# Get kubectl
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
-  mv kubectl /usr/bin/kubectl && \
-  chmod +x /usr/bin/kubectl
-
-# Get helm
-RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 && \
-  chmod 700 get_helm.sh && \
-  ./get_helm.sh && \
-  rm get_helm.sh
+RUN zypper ref && zypper install --no-recommends -y git tar gzip && rm -fr /var/cache/*

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -172,6 +172,7 @@ var CmdInstallCertManager = &cobra.Command{
 // It adds epinio to the targeted cluster
 func install(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
+	ExitfIfError(checkDependencies(), "Cannot operate")
 
 	skipTraefik, err := cmd.Flags().GetBool("skip-traefik")
 	if err != nil {
@@ -263,6 +264,7 @@ func install(cmd *cobra.Command, args []string) error {
 // It adds epinio's ingress controller to the targeted cluster
 func installIngress(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
+	ExitfIfError(checkDependencies(), "Cannot operate")
 
 	installClient, installCleanup, err := clients.NewInstallClient(cmd.Context(), &traefikOptions)
 	defer func() {
@@ -287,6 +289,7 @@ func installIngress(cmd *cobra.Command, args []string) error {
 // It adds epinio's cert manager to the targeted cluster
 func installCertManager(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
+	ExitfIfError(checkDependencies(), "Cannot operate")
 
 	installClient, installCleanup, err := clients.NewInstallClient(cmd.Context(), &certManagerOptions)
 	defer func() {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,8 +39,6 @@ var rootCmd = &cobra.Command{
 // Execute executes the root command.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	ExitfIfError(checkDependencies(), "Cannot operate")
-
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -18,6 +18,7 @@ var CmdUninstall = &cobra.Command{
 // It removes epinio from a configured cluster
 func Uninstall(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
+	ExitfIfError(checkDependencies(), "Cannot operate")
 
 	installClient, _, err := clients.NewInstallClient(cmd.Context(), nil)
 	if err != nil {


### PR DESCRIPTION
* epinio image does not need kubectl/helm for running the server
* only few cli commands (install*/uninstall) need helm/kubectl
* linkerd image installs it's own versions of kubectl
* adds .dockerignore, so  COPY . .' doesn't copy too much data (this just improves speed though).


With the fixes from https://github.com/epinio/epinio/pull/761/files this brings the uncompressed image size down to 235MB, from 474MB. 🎉 

fixes #730