### PR TITLE
Install sets epinio timeout multiplier on server

### DIFF
--- a/assets/embedded-files/epinio/server.yaml
+++ b/assets/embedded-files/epinio/server.yaml
@@ -212,6 +212,8 @@ spec:
           env:
             - name: TRACE_LEVEL
               value: "##trace_level##"
+            - name: EPINIO_TIMEOUT_MULTIPLIER
+              value: "##epinio_timeout_multiplier##"
             - name: TLS_ISSUER
               value: ##tls_issuer##
             - name: USE_INTERNAL_REGISTRY_NODE_PORT

--- a/deployments/epinio.go
+++ b/deployments/epinio.go
@@ -306,6 +306,8 @@ func (k Epinio) applyEpinioConfigYaml(ctx context.Context, c *kubernetes.Cluster
 
 	re = regexp.MustCompile(`##trace_level##`)
 	renderedFileContents = re.ReplaceAll(renderedFileContents, []byte(strconv.Itoa(viper.GetInt("trace-level"))))
+	re = regexp.MustCompile(`##epinio_timeout_multiplier##`)
+	renderedFileContents = re.ReplaceAll(renderedFileContents, []byte(strconv.Itoa(viper.GetInt("timeout-multiplier"))))
 
 	tmpFilePath, err := helpers.CreateTmpFile(string(renderedFileContents))
 	if err != nil {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -49,9 +49,6 @@ var CmdConfigColors = &cobra.Command{
 		}
 		return nil
 	},
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Hello, World!")
-	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 


### PR DESCRIPTION
The server understands the value, but we didn't propagate from
the install command to the server deployment.


fixes #757