### PR TITLE
ACME Challenge Annotations for Ingresses

### DIFF
--- a/.github/workflows/aks-scenario5.yml
+++ b/.github/workflows/aks-scenario5.yml
@@ -28,7 +28,7 @@ env:
   FLAKE_ATTEMPTS: 1
 
 jobs:
-  acceptance-scenario3:
+  acceptance-scenario5:
     runs-on: windows-latest
 
     steps:
@@ -79,7 +79,7 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           AWS_ZONE_ID: ${{ github.events.inputs.aws_zone_id || secrets.AWS_ZONE_ID }}
           # use a random host name, so we don't collide with our workflows on AKS
-          AKS_DOMAIN: id${{ steps.create-cluster.oututs.ID }}-${{ github.events.inputs.aks_domain || secrets.AKS_DOMAIN }}
+          AKS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.aks_domain || secrets.AKS_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
         shell: bash
         run: |

--- a/deployments/cert_manager.go
+++ b/deployments/cert_manager.go
@@ -388,12 +388,11 @@ const clusterIssuerLetsencrypt = `{
 				"http01" : {
 					"ingress" : {
 						"class" : "traefik",
-						"podTemplate": {
+						"ingressTemplate": {
 							"metadata": {
 								"annotations": {
-									"linkerd.io/inject": "disabled",
 									"traefik.ingress.kubernetes.io/router.tls": "true",
-									"traefik.ingress.kubernetes.io/frontend-entry-points": "https"
+									"traefik.ingress.kubernetes.io/router.entrypoints": "websecure"
 								}
 							}
 						}


### PR DESCRIPTION
Annotate cert-manager's ingresses for LetsEncrypt

Traefik understands the annotations on the ingresses. These ingresses
are created temporarily for the challenge pods so the ACME challenge can
be solved via insecure https, instead of http.

fixes #789
