### PR TITLE
API: Extended namespace listing, namespace matching

### DIFF
--- a/internal/api/v1/models/namespace.go
+++ b/internal/api/v1/models/namespace.go
@@ -1,0 +1,32 @@
+package models
+
+// Namespace has all the namespace properties, i.e. name, app names, and service names
+// It is used in the CLI and API responses.
+type Namespace struct {
+	Name     string   `json:"name,omitempty"`
+	Apps     []string `json:"apps,omitempty"`
+	Services []string `json:"services,omitempty"`
+}
+
+// NamespaceList is a collection of namespaces
+type NamespaceList []Namespace
+
+// Implement the Sort interface for namespace slices
+
+// Len (Sort interface) returns the length of the NamespaceList
+func (al NamespaceList) Len() int {
+	return len(al)
+}
+
+// Swap (Sort interface) exchanges the contents of specified indices
+// in the NamespaceList
+func (al NamespaceList) Swap(i, j int) {
+	al[i], al[j] = al[j], al[i]
+}
+
+// Less (Sort interface) compares the contents of the specified
+// indices in the NamespaceList and returns true if the condition holds, and
+// else false.
+func (al NamespaceList) Less(i, j int) bool {
+	return al[i].Name < al[j].Name
+}

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -81,8 +81,12 @@ var Routes = routes.NamedRoutes{
 	"AppRunning":      get("/namespaces/:org/applications/:app/running", errorHandler(ApplicationsController{}.Running)),
 
 	// See env.go
-	"EnvList":  get("/namespaces/:org/applications/:app/environment", errorHandler(ApplicationsController{}.EnvIndex)),
-	"EnvMatch": get("/namespaces/:org/applications/:app/environment/:env/match/:pattern", errorHandler(ApplicationsController{}.EnvMatch)),
+	"EnvList": get("/namespaces/:org/applications/:app/environment", errorHandler(ApplicationsController{}.EnvIndex)),
+
+	// Note, the second registration catches calls with an empty pattern!
+	"EnvMatch":  get("/namespaces/:org/applications/:app/environment/:env/match/:pattern", errorHandler(ApplicationsController{}.EnvMatch)),
+	"EnvMatch0": get("/namespaces/:org/applications/:app/environment/:env/match", errorHandler(ApplicationsController{}.EnvMatch)),
+
 	"EnvSet":   post("/namespaces/:org/applications/:app/environment", errorHandler(ApplicationsController{}.EnvSet)),
 	"EnvShow":  get("/namespaces/:org/applications/:app/environment/:env", errorHandler(ApplicationsController{}.EnvShow)),
 	"EnvUnset": delete("/namespaces/:org/applications/:app/environment/:env", errorHandler(ApplicationsController{}.EnvUnset)),
@@ -93,10 +97,14 @@ var Routes = routes.NamedRoutes{
 	"ServiceBindingDelete": delete("/namespaces/:org/applications/:app/servicebindings/:service",
 		errorHandler(ServicebindingsController{}.Delete)),
 
-	// List, create, show and delete organizations
-	"Orgs":      get("/namespaces", errorHandler(OrganizationsController{}.Index)),
-	"OrgCreate": post("/namespaces", errorHandler(OrganizationsController{}.Create)),
-	"OrgDelete": delete("/namespaces/:org", errorHandler(OrganizationsController{}.Delete)),
+	// List, create, show and delete namespaces
+	"Namespaces":      get("/namespaces", errorHandler(NamespacesController{}.Index)),
+	"NamespaceCreate": post("/namespaces", errorHandler(NamespacesController{}.Create)),
+	"NamespaceDelete": delete("/namespaces/:org", errorHandler(NamespacesController{}.Delete)),
+
+	// Note, the second registration catches calls with an empty pattern!
+	"NamespacesMatch":  get("/namespacematches/:pattern", errorHandler(NamespacesController{}.Match)),
+	"NamespacesMatch0": get("/namespacematches", errorHandler(NamespacesController{}.Match)),
 
 	// List, show, create and delete services, catalog and custom
 	"ServiceApps": get("/namespaces/:org/serviceapps", errorHandler(ApplicationsController{}.ServiceApps)),

--- a/internal/cli/orgs.go
+++ b/internal/cli/orgs.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -15,8 +16,8 @@ var (
 	force bool
 )
 
-// CmdOrg implements the command: epinio namespace
-var CmdOrg = &cobra.Command{
+// CmdNamespace implements the command: epinio namespace
+var CmdNamespace = &cobra.Command{
 	Use:           "namespace",
 	Aliases:       []string{"namespaces"},
 	Short:         "Epinio-controlled namespaces",
@@ -34,16 +35,16 @@ var CmdOrg = &cobra.Command{
 
 func init() {
 
-	flags := CmdOrgDelete.Flags()
+	flags := CmdNamespaceDelete.Flags()
 	flags.BoolVarP(&force, "force", "f", false, "force namespace deletion")
 
-	CmdOrg.AddCommand(CmdOrgCreate)
-	CmdOrg.AddCommand(CmdOrgList)
-	CmdOrg.AddCommand(CmdOrgDelete)
+	CmdNamespace.AddCommand(CmdNamespaceCreate)
+	CmdNamespace.AddCommand(CmdNamespaceList)
+	CmdNamespace.AddCommand(CmdNamespaceDelete)
 }
 
-// CmdOrgs implements the command: epinio namespace list
-var CmdOrgList = &cobra.Command{
+// CmdNamespaces implements the command: epinio namespace list
+var CmdNamespaceList = &cobra.Command{
 	Use:   "list",
 	Short: "Lists all epinio-controlled namespaces",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -63,8 +64,8 @@ var CmdOrgList = &cobra.Command{
 	},
 }
 
-// CmdOrgCreate implements the command: epinio namespace create
-var CmdOrgCreate = &cobra.Command{
+// CmdNamespaceCreate implements the command: epinio namespace create
+var CmdNamespaceCreate = &cobra.Command{
 	Use:   "create NAME",
 	Short: "Creates an epinio-controlled namespace",
 	Args:  cobra.ExactArgs(1),
@@ -85,8 +86,8 @@ var CmdOrgCreate = &cobra.Command{
 	},
 }
 
-// CmdOrgDelete implements the command: epinio namespace delete
-var CmdOrgDelete = &cobra.Command{
+// CmdNamespaceDelete implements the command: epinio namespace delete
+var CmdNamespaceDelete = &cobra.Command{
 	Use:   "delete NAME",
 	Short: "Deletes an epinio-controlled namespace",
 	Args:  cobra.ExactArgs(1),
@@ -119,9 +120,23 @@ var CmdOrgDelete = &cobra.Command{
 
 		return nil
 	},
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		app, err := clients.NewEpinioClient(context.Background())
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		matches := app.OrgsMatching(toComplete)
+
+		return matches, cobra.ShellCompDirectiveNoFileComp
+	},
 }
 
-// askConfirmation is a helper for CmdOrgDelete to confirm a deletion request
+// askConfirmation is a helper for CmdNamespaceDelete to confirm a deletion request
 func askConfirmation(cmd *cobra.Command) bool {
 	reader := bufio.NewReader(os.Stdin)
 	for {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -79,7 +79,7 @@ func init() {
 	rootCmd.AddCommand(CmdInstallCertManager)
 	rootCmd.AddCommand(CmdUninstall)
 	rootCmd.AddCommand(CmdInfo)
-	rootCmd.AddCommand(CmdOrg)
+	rootCmd.AddCommand(CmdNamespace)
 	rootCmd.AddCommand(CmdPush)
 	rootCmd.AddCommand(CmdApp)
 	rootCmd.AddCommand(CmdTarget)


### PR DESCRIPTION
Fix #769 

chore: Further (internal) renames org/namespace
feat: Extended namespace index endpoint
feat: New and separate namespace match endpoint
feat: Extended `namespace delete` command with command completion.
fix: Env name match handler.

The extended `Index` endpoint delivers an array of namespace objects.
The objects carry not only the namespace name, but also arrays of
apps and services (names only) in the namespace.

namespace matching for command completion going through index endpoint
would now compute lots of superfluous data. The new endpoint does just
as the old index did, generate a list of namespace names.
New, it does the matching server side.

Note the double registration of the match endpoint with and without pattern.
The second catches invokation with empty string as the pattern!

Applied the double registration to the env match endpoint also, as fix.