### PR TITLE
API client and server logging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,6 +210,7 @@ jobs:
         env:
           REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          FLAKE_ATTEMPTS: 1
           GINKGO_NODES: 1
           REGEX: "<ConfigFile>"
         run: |

--- a/acceptance/api/v1/orgs_test.go
+++ b/acceptance/api/v1/orgs_test.go
@@ -18,6 +18,7 @@ import (
 
 var _ = Describe("Namespaces API Application Endpoints", func() {
 	var org string
+	const jsOK = `{"status":"ok"}`
 	dockerImageURL := "splatform/sample-app"
 
 	BeforeEach(func() {
@@ -119,7 +120,7 @@ var _ = Describe("Namespaces API Application Endpoints", func() {
 				bodyBytes, err := ioutil.ReadAll(response.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.StatusCode).To(Equal(http.StatusCreated), string(bodyBytes))
-				Expect(string(bodyBytes)).To(Equal(""))
+				Expect(string(bodyBytes)).To(Equal(jsOK))
 
 				// And the 2nd attempt should now fail
 				By("creating the same namespace a second time")
@@ -162,7 +163,7 @@ var _ = Describe("Namespaces API Application Endpoints", func() {
 				bodyBytes, err := ioutil.ReadAll(response.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.StatusCode).To(Equal(http.StatusCreated), string(bodyBytes))
-				Expect(string(bodyBytes)).To(Equal(""))
+				Expect(string(bodyBytes)).To(Equal(jsOK))
 			})
 		})
 
@@ -176,7 +177,7 @@ var _ = Describe("Namespaces API Application Endpoints", func() {
 				bodyBytes, err := ioutil.ReadAll(response.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
-				Expect(string(bodyBytes)).To(Equal(""))
+				Expect(string(bodyBytes)).To(Equal(jsOK))
 
 				_, err = helpers.Kubectl("get", "namespace", org)
 				Expect(err).To(HaveOccurred())
@@ -196,7 +197,7 @@ var _ = Describe("Namespaces API Application Endpoints", func() {
 				defer response.Body.Close()
 				bodyBytes, err := ioutil.ReadAll(response.Body)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(string(bodyBytes)).To(Equal(""))
+				Expect(string(bodyBytes)).To(Equal(jsOK))
 
 				env.VerifyOrgNotExist(org)
 			})
@@ -213,12 +214,12 @@ var _ = Describe("Namespaces API Application Endpoints", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
 
-				var namespaces []string
-				err = json.Unmarshal(bodyBytes, &namespaces)
+				resp := models.NamespacesMatchResponse{}
+				err = json.Unmarshal(bodyBytes, &resp)
 				Expect(err).ToNot(HaveOccurred())
 
 				// See global BeforeEach for where this namespace is set up.
-				Expect(namespaces).Should(ContainElements(org))
+				Expect(resp.Names).Should(ContainElements(org))
 			})
 			It("lists no namespaces matching the prefix", func() {
 				response, err := env.Curl("GET", fmt.Sprintf("%s/api/v1/namespacematches/bogus", serverURL),
@@ -230,12 +231,12 @@ var _ = Describe("Namespaces API Application Endpoints", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
 
-				var namespaces []string
-				err = json.Unmarshal(bodyBytes, &namespaces)
+				resp := models.NamespacesMatchResponse{}
+				err = json.Unmarshal(bodyBytes, &resp)
 				Expect(err).ToNot(HaveOccurred())
 
 				// See global BeforeEach for where this namespace is set up.
-				Expect(namespaces).Should(BeEmpty())
+				Expect(resp.Names).Should(BeEmpty())
 			})
 			It("lists all namespaces matching the prefix", func() {
 				response, err := env.Curl("GET", fmt.Sprintf("%s/api/v1/namespacematches/na", serverURL),
@@ -247,12 +248,12 @@ var _ = Describe("Namespaces API Application Endpoints", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
 
-				var namespaces []string
-				err = json.Unmarshal(bodyBytes, &namespaces)
+				resp := models.NamespacesMatchResponse{}
+				err = json.Unmarshal(bodyBytes, &resp)
 				Expect(err).ToNot(HaveOccurred())
 
 				// See global BeforeEach for where this namespace is set up.
-				Expect(namespaces).ShouldNot(BeEmpty())
+				Expect(resp.Names).ShouldNot(BeEmpty())
 			})
 			When("basic auth credentials are not provided", func() {
 				It("returns a 401 response", func() {

--- a/acceptance/api/v1/services_mutation_test.go
+++ b/acceptance/api/v1/services_mutation_test.go
@@ -15,6 +15,7 @@ import (
 
 var _ = Describe("Services API Application Endpoints, Mutations", func() {
 	var org string
+	const jsOK = `{"status":"ok"}`
 	dockerImageURL := "splatform/sample-app"
 
 	BeforeEach(func() {
@@ -252,7 +253,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 				bodyBytes, err := ioutil.ReadAll(response.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.StatusCode).To(Equal(http.StatusCreated), string(bodyBytes))
-				Expect(string(bodyBytes)).To(Equal(""))
+				Expect(string(bodyBytes)).To(Equal(jsOK))
 
 				out, err := env.Epinio("", "service", "list")
 				Expect(err).ToNot(HaveOccurred(), out)
@@ -276,7 +277,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 				bodyBytes, err := ioutil.ReadAll(response.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.StatusCode).To(Equal(http.StatusCreated), string(bodyBytes))
-				Expect(string(bodyBytes)).To(Equal(""))
+				Expect(string(bodyBytes)).To(Equal(jsOK))
 
 				// Explicit wait in the test itself for the service to be provisioned/appear.
 				// This takes the place of the `service list` command in the previous test,
@@ -446,7 +447,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 				bodyBytes, err := ioutil.ReadAll(response.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.StatusCode).To(Equal(http.StatusCreated), string(bodyBytes))
-				Expect(string(bodyBytes)).To(Equal(""))
+				Expect(string(bodyBytes)).To(Equal(jsOK))
 			})
 		})
 	})
@@ -878,7 +879,7 @@ var _ = Describe("Services API Application Endpoints, Mutations", func() {
 						bodyBytes, err := ioutil.ReadAll(response.Body)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
-						Expect(string(bodyBytes)).To(Equal(""))
+						Expect(string(bodyBytes)).To(Equal(jsOK))
 					})
 				})
 

--- a/acceptance/api/v1/services_test.go
+++ b/acceptance/api/v1/services_test.go
@@ -76,8 +76,9 @@ var _ = Describe("Services API Application Endpoints", func() {
 			bodyBytes, err := ioutil.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			var service map[string]string
-			err = json.Unmarshal(bodyBytes, &service)
+			var data models.ServiceShowResponse
+			err = json.Unmarshal(bodyBytes, &data)
+			service := data.Details
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service["Class"]).To(Equal("mariadb"))
 			Expect(service["Status"]).To(Equal("Provisioned"))

--- a/helpers/tracelog/logger.go
+++ b/helpers/tracelog/logger.go
@@ -14,6 +14,7 @@ import (
 )
 
 type CtxLoggerKey struct{}
+type UserLoggerKey struct{}
 
 // Logger returns the logger from the context, the server injects a logger into
 // each request.
@@ -24,6 +25,11 @@ func Logger(ctx context.Context) logr.Logger {
 		return NewLogger().WithName("fallback")
 	}
 	return log
+}
+
+// WithLogger returns a copy of the context with the given logger
+func WithLogger(ctx context.Context, log logr.Logger) context.Context {
+	return context.WithValue(ctx, CtxLoggerKey{}, log)
 }
 
 // TraceLevel returns the trace-level argument
@@ -37,21 +43,6 @@ func LoggerFlags(pf *flag.FlagSet, argToEnv map[string]string) {
 	pf.IntP("trace-level", "", 0, "Only print trace messages at or above this level (0 to 5, default 0, print nothing)")
 	viper.BindPFlag("trace-level", pf.Lookup("trace-level"))
 	argToEnv["trace-level"] = "TRACE_LEVEL"
-}
-
-// NewServerLogger creates a new logger for server subcommand
-func NewServerLogger() logr.Logger {
-	return NewLogger().WithName("epinio")
-}
-
-// NewClientLogger creates a new logger with our setup
-func NewClientLogger() logr.Logger {
-	return NewLogger().WithName("EpinioClient")
-}
-
-// NewInstallClientLogger creates a new logger for the install subcommand
-func NewInstallClientLogger() logr.Logger {
-	return NewLogger().WithName("InstallClient")
 }
 
 // NewLogger creates a new logger with our setup. It only prints messages below

--- a/internal/api/v1/applications.go
+++ b/internal/api/v1/applications.go
@@ -77,6 +77,12 @@ func (hc ApplicationsController) Create(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		return InternalError(err)
 	}
+
+	err = jsonResponse(w, models.ResponseOK)
+	if err != nil {
+		return InternalError(err)
+	}
+
 	return nil
 }
 
@@ -151,13 +157,7 @@ func (hc ApplicationsController) Index(w http.ResponseWriter, r *http.Request) A
 		return InternalError(err)
 	}
 
-	js, err := json.Marshal(apps)
-	if err != nil {
-		return InternalError(err)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
+	err = jsonResponse(w, apps)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -209,13 +209,7 @@ func (hc ApplicationsController) Show(w http.ResponseWriter, r *http.Request) AP
 		app.Status = `Inactive, without workload. Launch via "epinio app push"`
 	}
 
-	js, err := json.Marshal(app)
-	if err != nil {
-		return InternalError(err)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
+	err = jsonResponse(w, app)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -269,13 +263,7 @@ func (hc ApplicationsController) ServiceApps(w http.ResponseWriter, r *http.Requ
 		}
 	}
 
-	js, err := json.Marshal(appsOf)
-	if err != nil {
-		return InternalError(err)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
+	err = jsonResponse(w, appsOf)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -350,6 +338,11 @@ func (hc ApplicationsController) Update(w http.ResponseWriter, r *http.Request) 
 		return InternalError(err)
 	}
 
+	err = jsonResponse(w, models.ResponseOK)
+	if err != nil {
+		return InternalError(err)
+	}
+
 	return nil
 }
 
@@ -403,6 +396,10 @@ func (hc ApplicationsController) Running(w http.ResponseWriter, r *http.Request)
 		return InternalError(err)
 	}
 
+	err = jsonResponse(w, models.ResponseOK)
+	if err != nil {
+		return InternalError(err)
+	}
 	return nil
 }
 
@@ -639,12 +636,7 @@ func (hc ApplicationsController) Delete(w http.ResponseWriter, r *http.Request) 
 		return InternalError(err)
 	}
 
-	js, err := json.Marshal(response)
-	if err != nil {
-		return InternalError(err)
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
+	err = jsonResponse(w, response)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/internal/api/v1/env.go
+++ b/internal/api/v1/env.go
@@ -57,13 +57,7 @@ func (hc ApplicationsController) EnvIndex(w http.ResponseWriter, r *http.Request
 		return InternalError(err)
 	}
 
-	js, err := json.Marshal(environment)
-	if err != nil {
-		return InternalError(err)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
+	err = jsonResponse(w, environment)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -127,13 +121,7 @@ func (hc ApplicationsController) EnvMatch(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	js, err := json.Marshal(matches)
-	if err != nil {
-		return InternalError(err)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
+	err = jsonResponse(w, models.EnvMatchResponse{Names: matches})
 	if err != nil {
 		return InternalError(err)
 	}
@@ -193,6 +181,11 @@ func (hc ApplicationsController) EnvSet(w http.ResponseWriter, r *http.Request) 
 	}
 
 	err = application.EnvironmentSet(ctx, cluster, app, setRequest)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	err = jsonResponse(w, models.ResponseOK)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -257,13 +250,7 @@ func (hc ApplicationsController) EnvShow(w http.ResponseWriter, r *http.Request)
 
 	// Not found => Returns a nil object
 
-	js, err := json.Marshal(&match)
-	if err != nil {
-		return InternalError(err)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
+	err = jsonResponse(w, match)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -312,6 +299,11 @@ func (hc ApplicationsController) EnvUnset(w http.ResponseWriter, r *http.Request
 	}
 
 	err = application.EnvironmentUnset(ctx, cluster, app, varName)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	err = jsonResponse(w, models.ResponseOK)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/internal/api/v1/errors.go
+++ b/internal/api/v1/errors.go
@@ -80,7 +80,11 @@ func (m MultiError) FirstStatus() int {
 
 // InternalError constructs an API error for server internal issues, from a lower-level error
 func InternalError(err error, details ...string) APIError {
-	return NewAPIError(err.Error(), strings.Join(details, ", "), http.StatusInternalServerError)
+	return NewAPIError(
+		err.Error(),
+		strings.Join(details, ", ")+fmt.Sprintf("\nServer Backtrace: %+v", err),
+		http.StatusInternalServerError,
+	)
 }
 
 // NewInternalError constructs an API error for server internal issues, from a message

--- a/internal/api/v1/info.go
+++ b/internal/api/v1/info.go
@@ -1,10 +1,10 @@
 package v1
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/internal/api/v1/models"
 	"github.com/epinio/epinio/internal/version"
 )
 
@@ -29,22 +29,13 @@ func (hc InfoController) Info(w http.ResponseWriter, r *http.Request) APIErrors 
 
 	platform := cluster.GetPlatform()
 
-	info := struct {
-		Version     string
-		KubeVersion string
-		Platform    string
-	}{
+	info := models.InfoResponse{
 		Version:     version.Version,
 		Platform:    platform.String(),
 		KubeVersion: kubeVersion,
 	}
 
-	js, err := json.Marshal(info)
-	if err != nil {
-		return InternalError(err)
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
+	err = jsonResponse(w, info)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/internal/api/v1/models/models.go
+++ b/internal/api/v1/models/models.go
@@ -5,6 +5,15 @@
 // TODO: Give even the most simple requests and responses properly named types.
 package models
 
+type Response struct {
+	Status string `json:"status"`
+}
+
+var ResponseOK = Response{"ok"}
+
+type Request struct {
+}
+
 // ServiceResponse represents the data of a single service instance
 type ServiceResponse struct {
 	Name      string   `json:"name"`
@@ -106,4 +115,36 @@ type DeployResponse struct {
 // ApplicationDeleteResponse represents the server's response to a successful app deletion
 type ApplicationDeleteResponse struct {
 	UnboundServices []string `json:"unboundservices"`
+}
+
+// EnvMatchResponse contains the list of names for matching envs
+type EnvMatchResponse struct {
+	Names []string `json:"names,omitempty"`
+}
+
+// ServiceShowResponse contains details about a service
+type ServiceShowResponse struct {
+	Details map[string]string `json:"details,omitempty"`
+}
+
+// InfoResponse contains information about Epinio and its components
+type InfoResponse struct {
+	Version     string `json:"version,omitempty"`
+	KubeVersion string `json:"kube_version,omitempty"`
+	Platform    string `json:"platform,omitempty"`
+}
+
+// NamespaceCreateRequest contains the name of the namespace that should be created
+type NamespaceCreateRequest struct {
+	Name string `json:"name,omitempty"`
+}
+
+// NamespacesMatchResponse contains the list of names for matching namespaces
+type NamespacesMatchResponse struct {
+	Names []string `json:"names,omitempty"`
+}
+
+// ServiceAppsResponse returns a list of apps per service
+type ServiceAppsResponse struct {
+	AppsOf map[string]AppList `json:"apps_of,omitempty"`
 }

--- a/internal/api/v1/organizations.go
+++ b/internal/api/v1/organizations.go
@@ -57,12 +57,7 @@ func (oc NamespacesController) Match(w http.ResponseWriter, r *http.Request) API
 
 	log.Info("deliver matches", "found", matches)
 
-	js, err := json.Marshal(matches)
-	if err != nil {
-		return InternalError(err)
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
+	err = jsonResponse(w, models.NamespacesMatchResponse{Names: matches})
 	if err != nil {
 		return InternalError(err)
 	}
@@ -115,12 +110,7 @@ func (oc NamespacesController) Index(w http.ResponseWriter, r *http.Request) API
 		})
 	}
 
-	js, err := json.Marshal(namespaces)
-	if err != nil {
-		return InternalError(err)
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
+	err = jsonResponse(w, namespaces)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -170,8 +160,10 @@ func (oc NamespacesController) Create(w http.ResponseWriter, r *http.Request) AP
 		return InternalError(err)
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	_, err = w.Write([]byte{})
+
+	err = jsonResponse(w, models.ResponseOK)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -225,7 +217,8 @@ func (oc NamespacesController) Delete(w http.ResponseWriter, r *http.Request) AP
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, err = w.Write([]byte{})
+
+	err = jsonResponse(w, models.ResponseOK)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/internal/api/v1/servicebindings.go
+++ b/internal/api/v1/servicebindings.go
@@ -181,8 +181,7 @@ func (hc ServicebindingsController) Delete(w http.ResponseWriter, r *http.Reques
 		return InternalError(err)
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write([]byte{})
+	err = jsonResponse(w, models.ResponseOK)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/internal/api/v1/serviceclasses.go
+++ b/internal/api/v1/serviceclasses.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
@@ -27,12 +26,7 @@ func (scc ServiceClassesController) Index(w http.ResponseWriter, r *http.Request
 		return InternalError(err)
 	}
 
-	js, err := json.Marshal(serviceClasses)
-	if err != nil {
-		return InternalError(err)
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
+	err = jsonResponse(w, serviceClasses)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/internal/api/v1/serviceplans.go
+++ b/internal/api/v1/serviceplans.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
@@ -40,12 +39,7 @@ func (spc ServicePlansController) Index(w http.ResponseWriter, r *http.Request) 
 		return InternalError(err)
 	}
 
-	js, err := json.Marshal(servicePlans)
-	if err != nil {
-		return InternalError(err)
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
+	err = jsonResponse(w, servicePlans)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/internal/api/v1/services.go
+++ b/internal/api/v1/services.go
@@ -67,12 +67,7 @@ func (sc ServicesController) Show(w http.ResponseWriter, r *http.Request) APIErr
 		responseData[key] = value
 	}
 
-	js, err := json.Marshal(responseData)
-	if err != nil {
-		return InternalError(err)
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
+	err = jsonResponse(w, models.ServiceShowResponse{Details: responseData})
 	if err != nil {
 		return InternalError(err)
 	}
@@ -124,12 +119,7 @@ func (sc ServicesController) Index(w http.ResponseWriter, r *http.Request) APIEr
 		})
 	}
 
-	js, err := json.Marshal(responseData)
-	if err != nil {
-		return InternalError(err)
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
+	err = jsonResponse(w, responseData)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -199,8 +189,10 @@ func (sc ServicesController) CreateCustom(w http.ResponseWriter, r *http.Request
 		return InternalError(err)
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	_, err = w.Write([]byte{})
+
+	err = jsonResponse(w, models.ResponseOK)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -312,8 +304,10 @@ func (sc ServicesController) Create(w http.ResponseWriter, r *http.Request) APIE
 		}
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	_, err = w.Write([]byte{})
+
+	err = jsonResponse(w, models.ResponseOK)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -396,13 +390,7 @@ func (sc ServicesController) Delete(w http.ResponseWriter, r *http.Request) APIE
 		return InternalError(err)
 	}
 
-	js, err := json.Marshal(models.DeleteResponse{BoundApps: boundAppNames})
-	if err != nil {
-		return InternalError(err)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
+	err = jsonResponse(w, models.DeleteResponse{BoundApps: boundAppNames})
 	if err != nil {
 		return InternalError(err)
 	}

--- a/internal/api/v1/stage.go
+++ b/internal/api/v1/stage.go
@@ -304,6 +304,11 @@ func (hc ApplicationsController) Staged(w http.ResponseWriter, r *http.Request) 
 		return InternalError(err)
 	}
 
+	err = jsonResponse(w, models.ResponseOK)
+	if err != nil {
+		return InternalError(err)
+	}
+
 	return nil
 }
 

--- a/internal/cli/clients/apps_create.go
+++ b/internal/cli/clients/apps_create.go
@@ -1,9 +1,8 @@
 package clients
 
 import (
-	"encoding/json"
+	"net/http"
 
-	api "github.com/epinio/epinio/internal/api/v1"
 	"github.com/epinio/epinio/internal/api/v1/models"
 )
 
@@ -22,11 +21,12 @@ func (c *EpinioClient) AppCreate(appName string) error {
 	details.Info("create application")
 
 	request := models.ApplicationCreateRequest{Name: appName}
-	b, err := json.Marshal(request)
-	if err != nil {
-		return nil
-	}
-	_, err = c.post(api.Routes.Path("AppCreate", c.Config.Org), string(b))
+
+	_, err := c.API.AppCreate(
+		request,
+		c.Config.Org,
+		func(response *http.Response, _ []byte, err error) error { return err },
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -53,7 +53,7 @@ func NewEpinioClient(ctx context.Context) (*EpinioClient, error) {
 	}
 	serverURL := apiClient.URL
 
-	logger := tracelog.NewClientLogger().V(3)
+	logger := tracelog.NewLogger().WithName("EpinioClient").V(3)
 
 	log := logger.WithName("New")
 	log.Info("Ingress API", "url", serverURL)

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -1,35 +1,29 @@
-// Package clients contains all the CLI commands for the client
+// Package clients provides Epinio CLI's main functions:
+// Functionality can be split into at least:
+// * the "admin client", which installs Epinio and updates configs
+// * the "user client", which talks to the API server
+// * the Epinio API server, which also includes the web UI server
 package clients
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"mime/multipart"
 	"net/http"
-	"net/url"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/avast/retry-go"
-	"github.com/epinio/epinio/helpers"
 	"github.com/epinio/epinio/helpers/kubernetes/tailer"
 	"github.com/epinio/epinio/helpers/termui"
 	"github.com/epinio/epinio/helpers/tracelog"
 	api "github.com/epinio/epinio/internal/api/v1"
 	"github.com/epinio/epinio/internal/api/v1/models"
+	"github.com/epinio/epinio/internal/cli/clients/epinioapi"
 	"github.com/epinio/epinio/internal/cli/config"
 	"github.com/epinio/epinio/internal/cli/logprinter"
-	"github.com/epinio/epinio/internal/duration"
-	"github.com/epinio/epinio/internal/services"
 
 	"github.com/go-logr/logr"
 	"github.com/gorilla/websocket"
@@ -40,21 +34,10 @@ import (
 // EpinioClient provides functionality for talking to a
 // Epinio installation on Kubernetes
 type EpinioClient struct {
-	Config      *config.Config
-	Log         logr.Logger
-	ui          *termui.UI
-	serverURL   string
-	wsServerURL string
-}
-
-type PushParams struct {
-	Instances    *int32
-	Services     []string
-	Docker       string
-	GitRev       string
-	BuilderImage string
-	Name         string
-	Path         string
+	Config *config.Config
+	Log    logr.Logger
+	ui     *termui.UI
+	API    *epinioapi.Client
 }
 
 func NewEpinioClient(ctx context.Context) (*EpinioClient, error) {
@@ -64,12 +47,11 @@ func NewEpinioClient(ctx context.Context) (*EpinioClient, error) {
 	}
 
 	uiUI := termui.NewUI()
-	epClient, err := getEpinioAPIClient(ctx)
+	apiClient, err := getEpinioAPIClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-	serverURL := epClient.URL
-	wsServerURL := epClient.WsURL
+	serverURL := apiClient.URL
 
 	logger := tracelog.NewClientLogger().V(3)
 
@@ -78,11 +60,10 @@ func NewEpinioClient(ctx context.Context) (*EpinioClient, error) {
 	log.Info("Config API", "url", configConfig.API)
 
 	epinioClient := &EpinioClient{
-		ui:          uiUI,
-		Config:      configConfig,
-		Log:         logger,
-		serverURL:   serverURL,
-		wsServerURL: wsServerURL,
+		API:    apiClient,
+		ui:     uiUI,
+		Config: configConfig,
+		Log:    logger,
 	}
 	return epinioClient, nil
 }
@@ -103,13 +84,8 @@ func (c *EpinioClient) EnvList(ctx context.Context, appName string) error {
 		return err
 	}
 
-	jsonResponse, err := c.get(api.Routes.Path("EnvList", c.Config.Org, appName))
+	eVariables, err := c.API.EnvList(c.Config.Org, appName)
 	if err != nil {
-		return err
-	}
-
-	var eVariables models.EnvVariableList
-	if err := json.Unmarshal(jsonResponse, &eVariables); err != nil {
 		return err
 	}
 
@@ -149,12 +125,7 @@ func (c *EpinioClient) EnvSet(ctx context.Context, appName, envName, envValue st
 		},
 	}
 
-	js, err := json.Marshal(request)
-	if err != nil {
-		return err
-	}
-
-	_, err = c.post(api.Routes.Path("EnvSet", c.Config.Org, appName), string(js))
+	_, err := c.API.EnvSet(request, c.Config.Org, appName)
 	if err != nil {
 		return err
 	}
@@ -180,13 +151,8 @@ func (c *EpinioClient) EnvShow(ctx context.Context, appName, envName string) err
 		return err
 	}
 
-	jsonResponse, err := c.get(api.Routes.Path("EnvShow", c.Config.Org, appName, envName))
+	eVariable, err := c.API.EnvShow(c.Config.Org, appName, envName)
 	if err != nil {
-		return err
-	}
-
-	var eVariable models.EnvVariable
-	if err := json.Unmarshal(jsonResponse, &eVariable); err != nil {
 		return err
 	}
 
@@ -214,7 +180,7 @@ func (c *EpinioClient) EnvUnset(ctx context.Context, appName, envName string) er
 		return err
 	}
 
-	_, err := c.delete(api.Routes.Path("EnvUnset", c.Config.Org, appName, envName))
+	_, err := c.API.EnvUnset(c.Config.Org, appName, envName)
 	if err != nil {
 		return err
 	}
@@ -231,17 +197,13 @@ func (c *EpinioClient) EnvMatching(ctx context.Context, appName, prefix string) 
 	log.Info("start")
 	defer log.Info("return")
 
-	jsonResponse, err := c.get(api.Routes.Path("EnvMatch", c.Config.Org, appName, prefix))
+	resp, err := c.API.EnvMatch(c.Config.Org, appName, prefix)
 	if err != nil {
+		// TODO log that we dropped an error
 		return []string{}
 	}
 
-	var evNames []string
-	if err := json.Unmarshal(jsonResponse, &evNames); err != nil {
-		return []string{}
-	}
-
-	return evNames
+	return resp.Names
 }
 
 // ServicePlans gets all service classes in the cluster, for the
@@ -252,15 +214,10 @@ func (c *EpinioClient) ServicePlans(serviceClassName string) error {
 	defer log.Info("return")
 	details := log.V(1) // NOTE: Increment of level, not absolute.
 
-	c.ui.Note().
-		Msg("Listing service plans")
+	c.ui.Note().Msg("Listing service plans")
 
-	jsonResponse, err := c.get(api.Routes.Path("ServicePlans", serviceClassName))
+	servicePlans, err := c.API.ServicePlans(serviceClassName)
 	if err != nil {
-		return err
-	}
-	var servicePlans services.ServicePlanList
-	if err := json.Unmarshal(jsonResponse, &servicePlans); err != nil {
 		return err
 	}
 
@@ -295,12 +252,8 @@ func (c *EpinioClient) ServicePlanMatching(ctx context.Context, serviceClassName
 	// Ask for all service plans of a service class. Filtering is local.
 	// TODO: Create new endpoint (compare `EnvMatch`) and move filtering to the server.
 
-	jsonResponse, err := c.get(api.Routes.Path("ServicePlans", serviceClassName))
+	servicePlans, err := c.API.ServicePlans(serviceClassName)
 	if err != nil {
-		return result
-	}
-	var servicePlans services.ServicePlanList
-	if err := json.Unmarshal(jsonResponse, &servicePlans); err != nil {
 		return result
 	}
 
@@ -327,12 +280,8 @@ func (c *EpinioClient) ServiceClassMatching(ctx context.Context, prefix string) 
 	// Ask for all service classes. Filtering is local.
 	// TODO: Create new endpoint (compare `EnvMatch`) and move filtering to the server.
 
-	jsonResponse, err := c.get(api.Routes.Path("ServiceClasses"))
+	serviceClasses, err := c.API.ServiceClasses()
 	if err != nil {
-		return result
-	}
-	var serviceClasses services.ServiceClassList
-	if err := json.Unmarshal(jsonResponse, &serviceClasses); err != nil {
 		return result
 	}
 
@@ -358,12 +307,8 @@ func (c *EpinioClient) ServiceClasses() error {
 	c.ui.Note().
 		Msg("Listing service classes")
 
-	jsonResponse, err := c.get(api.Routes.Path("ServiceClasses"))
+	serviceClasses, err := c.API.ServiceClasses()
 	if err != nil {
-		return err
-	}
-	var serviceClasses services.ServiceClassList
-	if err := json.Unmarshal(jsonResponse, &serviceClasses); err != nil {
 		return err
 	}
 
@@ -396,12 +341,8 @@ func (c *EpinioClient) Services() error {
 
 	details.Info("list services")
 
-	jsonResponse, err := c.get(api.Routes.Path("Services", c.Config.Org))
+	response, err := c.API.Services(c.Config.Org)
 	if err != nil {
-		return err
-	}
-	var response models.ServiceResponseList
-	if err := json.Unmarshal(jsonResponse, &response); err != nil {
 		return err
 	}
 
@@ -432,12 +373,8 @@ func (c *EpinioClient) ServiceMatching(ctx context.Context, prefix string) []str
 	// Ask for all services. Filtering is local.
 	// TODO: Create new endpoint (compare `EnvMatch`) and move filtering to the server.
 
-	jsonResponse, err := c.get(api.Routes.Path("Services", c.Config.Org))
+	response, err := c.API.Services(c.Config.Org)
 	if err != nil {
-		return result
-	}
-	var response models.ServiceResponseList
-	if err := json.Unmarshal(jsonResponse, &response); err != nil {
 		return result
 	}
 
@@ -475,18 +412,8 @@ func (c *EpinioClient) BindService(serviceName, appName string) error {
 		Names: []string{serviceName},
 	}
 
-	js, err := json.Marshal(request)
+	br, err := c.API.ServiceBindingCreate(request, c.Config.Org, appName)
 	if err != nil {
-		return err
-	}
-
-	b, err := c.post(api.Routes.Path("ServiceBindingCreate", c.Config.Org, appName), string(js))
-	if err != nil {
-		return err
-	}
-
-	br := &models.BindResponse{}
-	if err := json.Unmarshal(b, br); err != nil {
 		return err
 	}
 
@@ -526,8 +453,7 @@ func (c *EpinioClient) UnbindService(serviceName, appName string) error {
 		return err
 	}
 
-	_, err := c.delete(api.Routes.Path("ServiceBindingDelete",
-		c.Config.Org, appName, serviceName))
+	_, err := c.API.ServiceBindingDelete(c.Config.Org, appName, serviceName)
 	if err != nil {
 		return err
 	}
@@ -560,14 +486,7 @@ func (c *EpinioClient) DeleteService(name string, unbind bool) error {
 		Unbind: unbind,
 	}
 
-	js, err := json.Marshal(request)
-	if err != nil {
-		return err
-	}
-
-	jsonResponse, err := c.curlWithCustomErrorHandling(
-		api.Routes.Path("ServiceDelete", c.Config.Org, name),
-		"DELETE", string(js),
+	deleteResponse, err := c.API.ServiceDelete(request, c.Config.Org, name,
 		func(response *http.Response, bodyBytes []byte, err error) error {
 			// nothing special for internal errors and the like
 			if response.StatusCode != http.StatusBadRequest {
@@ -599,27 +518,18 @@ func (c *EpinioClient) DeleteService(name string, unbind bool) error {
 			return errors.New(http.StatusText(response.StatusCode))
 		})
 	if err != nil {
-		if err.Error() != "Bad Request" {
-			return err
-		}
-		return nil
+		return err
 	}
 
-	if len(jsonResponse) > 0 {
-		var deleteResponse models.DeleteResponse
-		if err := json.Unmarshal(jsonResponse, &deleteResponse); err != nil {
-			return err
-		}
-		if len(deleteResponse.BoundApps) > 0 {
-			sort.Strings(deleteResponse.BoundApps)
-			msg := c.ui.Note().WithTable("Previously Bound To")
+	if len(deleteResponse.BoundApps) > 0 {
+		sort.Strings(deleteResponse.BoundApps)
+		msg := c.ui.Note().WithTable("Previously Bound To")
 
-			for _, app := range deleteResponse.BoundApps {
-				msg = msg.WithTableRow(app)
-			}
-
-			msg.Msg("")
+		for _, app := range deleteResponse.BoundApps {
+			msg = msg.WithTableRow(app)
 		}
+
+		msg.Msg("")
 	}
 
 	c.ui.Success().
@@ -657,18 +567,13 @@ func (c *EpinioClient) CreateService(name, class, plan string, data string, wait
 		WaitForProvision: waitForProvision,
 	}
 
-	js, err := json.Marshal(request)
-	if err != nil {
-		return err
-	}
-
 	if waitForProvision {
 		c.ui.Note().KeeplineUnder(1).Msg("Provisioning...")
 		s := c.ui.Progressf("Provisioning")
 		defer s.Stop()
 	}
 
-	_, err = c.post(api.Routes.Path("ServiceCreate", c.Config.Org), string(js))
+	_, err := c.API.ServiceCreate(request, c.Config.Org)
 	if err != nil {
 		return err
 	}
@@ -719,13 +624,7 @@ func (c *EpinioClient) CreateCustomService(name string, dict []string) error {
 		Data: data,
 	}
 
-	js, err := json.Marshal(request)
-	if err != nil {
-		return err
-	}
-
-	_, err = c.post(api.Routes.Path("ServiceCreateCustom", c.Config.Org),
-		string(js))
+	_, err := c.API.ServiceCreateCustom(request, c.Config.Org)
 	if err != nil {
 		return err
 	}
@@ -753,14 +652,11 @@ func (c *EpinioClient) ServiceDetails(name string) error {
 		return err
 	}
 
-	jsonResponse, err := c.get(api.Routes.Path("ServiceShow", c.Config.Org, name))
+	resp, err := c.API.ServiceShow(c.Config.Org, name)
 	if err != nil {
 		return err
 	}
-	var serviceDetails map[string]string
-	if err := json.Unmarshal(jsonResponse, &serviceDetails); err != nil {
-		return err
-	}
+	serviceDetails := resp.Details
 
 	msg := c.ui.Success().WithTable("", "")
 	keys := make([]string, 0, len(serviceDetails))
@@ -782,33 +678,15 @@ func (c *EpinioClient) Info() error {
 	log.Info("start")
 	defer log.Info("return")
 
-	var (
-		epinioVersion string
-		platform      string
-		kubeVersion   string
-	)
-
-	if jsonResponse, err := c.get(api.Routes.Path("Info")); err == nil {
-		v := struct {
-			Version     string
-			KubeVersion string
-			Platform    string
-		}{}
-		if err := json.Unmarshal(jsonResponse, &v); err == nil {
-			epinioVersion = v.Version
-			platform = v.Platform
-			kubeVersion = v.KubeVersion
-		} else {
-			return err
-		}
-	} else {
+	v, err := c.API.Info()
+	if err != nil {
 		return err
 	}
 
 	c.ui.Success().
-		WithStringValue("Platform", platform).
-		WithStringValue("Kubernetes Version", kubeVersion).
-		WithStringValue("Epinio Version", epinioVersion).
+		WithStringValue("Platform", v.Platform).
+		WithStringValue("Kubernetes Version", v.KubeVersion).
+		WithStringValue("Epinio Version", v.Version).
 		Msg("Epinio Environment")
 
 	return nil
@@ -827,13 +705,8 @@ func (c *EpinioClient) AppsMatching(ctx context.Context, prefix string) []string
 	// Ask for all apps. Filtering is local.
 	// TODO: Create new endpoint (compare `EnvMatch`) and move filtering to the server.
 
-	jsonResponse, err := c.get(api.Routes.Path("Apps", c.Config.Org))
+	apps, err := c.API.Apps(c.Config.Org)
 	if err != nil {
-		return result
-	}
-
-	var apps models.AppList
-	if err := json.Unmarshal(jsonResponse, &apps); err != nil {
 		return result
 	}
 
@@ -873,20 +746,15 @@ func (c *EpinioClient) Apps(all bool) error {
 
 	details.Info("list applications")
 
-	var jsonResponse []byte
+	var apps models.AppList
 	var err error
 
 	if all {
-		jsonResponse, err = c.get(api.Routes.Path("AllApps"))
+		apps, err = c.API.AllApps()
 	} else {
-		jsonResponse, err = c.get(api.Routes.Path("Apps", c.Config.Org))
+		apps, err = c.API.Apps(c.Config.Org)
 	}
 	if err != nil {
-		return err
-	}
-
-	var apps models.AppList
-	if err := json.Unmarshal(jsonResponse, &apps); err != nil {
 		return err
 	}
 
@@ -938,12 +806,8 @@ func (c *EpinioClient) AppShow(appName string) error {
 
 	details.Info("show application")
 
-	jsonResponse, err := c.get(api.Routes.Path("AppShow", c.Config.Org, appName))
+	app, err := c.API.AppShow(c.Config.Org, appName)
 	if err != nil {
-		return err
-	}
-	var app models.App
-	if err := json.Unmarshal(jsonResponse, &app); err != nil {
 		return err
 	}
 
@@ -966,12 +830,8 @@ func (c *EpinioClient) AppStageID(appName string) (string, error) {
 	log.Info("start")
 	defer log.Info("return")
 
-	jsonResponse, err := c.get(api.Routes.Path("AppShow", c.Config.Org, appName))
+	app, err := c.API.AppShow(c.Config.Org, appName)
 	if err != nil {
-		return "", err
-	}
-	var app models.App
-	if err := json.Unmarshal(jsonResponse, &app); err != nil {
 		return "", err
 	}
 
@@ -1000,14 +860,8 @@ func (c *EpinioClient) AppUpdate(appName string, instances int32) error {
 
 	details.Info("update application")
 
-	data, err := json.Marshal(models.UpdateAppRequest{
-		Instances: instances,
-	})
-	if err != nil {
-		return err
-	}
-	_, err = c.patch(
-		api.Routes.Path("AppUpdate", c.Config.Org, appName), string(data))
+	req := models.UpdateAppRequest{Instances: instances}
+	_, err := c.API.AppUpdate(req, c.Config.Org, appName)
 	if err != nil {
 		return err
 	}
@@ -1042,6 +896,7 @@ func (c *EpinioClient) AppUpdate(appName string, instances int32) error {
 // 5. The main thread returns
 // When the connection is closed (e.g. from the server side), the process is the
 // same but starts from #2 above.
+// TODO move into transport package
 func (c *EpinioClient) AppLogs(appName, stageID string, follow bool, interrupt chan bool) error {
 	log := c.Log.WithName("Apps").WithValues("Namespace", c.Config.Org, "Application", appName)
 	log.Info("start")
@@ -1074,7 +929,7 @@ func (c *EpinioClient) AppLogs(appName, stageID string, follow bool, interrupt c
 		endpoint = api.Routes.Path("StagingLogs", c.Config.Org, stageID)
 	}
 	webSocketConn, resp, err := websocket.DefaultDialer.Dial(
-		fmt.Sprintf("%s/%s?%s", c.wsServerURL, endpoint, strings.Join(urlArgs, "&")), headers)
+		fmt.Sprintf("%s/%s?%s", c.API.WsURL, endpoint, strings.Join(urlArgs, "&")), headers)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Failed to connect to websockets endpoint. Response was = %+v\nThe error is", resp))
 	}
@@ -1142,7 +997,6 @@ func (c *EpinioClient) CreateOrg(org string) error {
 	log := c.Log.WithName("CreateNamespace").WithValues("Namespace", org)
 	log.Info("start")
 	defer log.Info("return")
-	details := log.V(1) // NOTE: Increment of level, not absolute.
 
 	c.ui.Note().
 		WithStringValue("Name", org).
@@ -1153,29 +1007,7 @@ func (c *EpinioClient) CreateOrg(org string) error {
 		return fmt.Errorf("%s: %s", "org name incorrect", strings.Join(errorMsgs, "\n"))
 	}
 
-	err := retry.Do(
-		func() error {
-			details.Info("create org", "org", org)
-			_, err := c.post(api.Routes.Path("Namespaces"), fmt.Sprintf(`{ "name": "%s" }`, org))
-			return err
-		},
-		retry.RetryIf(func(err error) bool {
-			emsg := err.Error()
-			details.Info("create error", "error", emsg)
-
-			retry := helpers.Retryable(err.Error())
-
-			details.Info("create error", "retry", retry)
-			return retry
-		}),
-		retry.OnRetry(func(n uint, err error) {
-			details.Info("create org retry", "n", n)
-			c.ui.Note().Msgf("Retrying (%d/%d) after %s", n, duration.RetryMax, err.Error())
-		}),
-		retry.Delay(time.Second),
-		retry.Attempts(duration.RetryMax),
-	)
-
+	_, err := c.API.NamespaceCreate(models.NamespaceCreateRequest{Name: org})
 	if err != nil {
 		return err
 	}
@@ -1195,7 +1027,7 @@ func (c *EpinioClient) DeleteOrg(org string) error {
 		WithStringValue("Name", org).
 		Msg("Deleting namespace...")
 
-	_, err := c.delete(api.Routes.Path("NamespaceDelete", org))
+	_, err := c.API.NamespaceDelete(org)
 	if err != nil {
 		return err
 	}
@@ -1223,12 +1055,8 @@ func (c *EpinioClient) Delete(ctx context.Context, appname string) error {
 	s := c.ui.Progressf("Deleting %s in %s", appname, c.Config.Org)
 	defer s.Stop()
 
-	jsonResponse, err := c.delete(api.Routes.Path("AppDelete", c.Config.Org, appname))
+	response, err := c.API.AppDelete(c.Config.Org, appname)
 	if err != nil {
-		return err
-	}
-	var response *models.ApplicationDeleteResponse
-	if err := json.Unmarshal(jsonResponse, &response); err != nil {
 		return err
 	}
 
@@ -1258,14 +1086,12 @@ func (c *EpinioClient) OrgsMatching(prefix string) []string {
 
 	result := []string{}
 
-	jsonResponse, err := c.get(api.Routes.Path("NamespacesMatch", prefix))
+	resp, err := c.API.NamespacesMatch(prefix)
 	if err != nil {
-		log.Info("failed", "error", err)
 		return result
 	}
 
-	log.Info("response", "raw", jsonResponse)
-	_ = json.Unmarshal(jsonResponse, &result)
+	result = resp.Names
 
 	log.Info("matches", "found", result)
 	return result
@@ -1280,13 +1106,9 @@ func (c *EpinioClient) Orgs() error {
 	c.ui.Note().Msg("Listing namespaces")
 
 	details.Info("list namespaces")
-	jsonResponse, err := c.get(api.Routes.Path("Namespaces"))
-	if err != nil {
-		return err
-	}
 
-	var namespaces models.NamespaceList
-	if err := json.Unmarshal(jsonResponse, &namespaces); err != nil {
+	namespaces, err := c.API.Namespaces()
+	if err != nil {
 		return err
 	}
 
@@ -1303,220 +1125,6 @@ func (c *EpinioClient) Orgs() error {
 	}
 
 	msg.Msg("Epinio Namespaces:")
-
-	return nil
-}
-
-// Push pushes an app
-// * validate
-// * upload
-// * stage
-// * (tail logs)
-// * wait for pipelinerun
-// * deploy
-// * wait for app
-func (c *EpinioClient) Push(ctx context.Context, params PushParams) error {
-	name := params.Name
-	source := params.Path
-
-	appRef := models.AppRef{Name: name, Org: c.Config.Org}
-	log := c.Log.
-		WithName("Push").
-		WithValues("Name", appRef.Name,
-			"Namespace", appRef.Org,
-			"Sources", source)
-	log.Info("start")
-	defer log.Info("return")
-	details := log.V(1) // NOTE: Increment of level, not absolute. Visible via TRACE_LEVEL=2
-
-	sourceToShow := source
-	if params.GitRev != "" {
-		sourceToShow = fmt.Sprintf("%s @ %s", sourceToShow, params.GitRev)
-	}
-
-	msg := c.ui.Note().
-		WithStringValue("Name", appRef.Name).
-		WithStringValue("Sources", sourceToShow).
-		WithStringValue("Namespace", appRef.Org)
-
-	if err := c.TargetOk(); err != nil {
-		return err
-	}
-
-	services := uniqueStrings(params.Services)
-
-	if len(services) > 0 {
-		sort.Strings(services)
-		msg = msg.WithStringValue("Services:", strings.Join(services, ", "))
-	}
-
-	msg.Msg("About to push an application with given name and sources into the specified namespace")
-
-	c.ui.Exclamation().
-		Timeout(duration.UserAbort()).
-		Msg("Hit Enter to continue or Ctrl+C to abort (deployment will continue automatically in 5 seconds)")
-
-	details.Info("validate app name")
-	errorMsgs := validation.IsDNS1123Subdomain(appRef.Name)
-	if len(errorMsgs) > 0 {
-		return fmt.Errorf("%s: %s", "app name incorrect", strings.Join(errorMsgs, "\n"))
-	}
-
-	c.ui.Normal().Msg("Create the application resource ...")
-
-	request := models.ApplicationCreateRequest{Name: appRef.Name}
-	js, err := json.Marshal(request)
-	if err != nil {
-		return err
-	}
-	_, err = c.curlWithCustomErrorHandling(
-		api.Routes.Path("AppCreate", appRef.Org), "POST", string(js), func(
-			response *http.Response, _ []byte, err error) error {
-			if response.StatusCode == http.StatusConflict {
-				c.ui.Normal().Msg("Application exists, updating ...")
-				return nil
-			}
-			return err
-		},
-	)
-	if err != nil {
-		return err
-	}
-
-	var blobUID string
-	if params.GitRev == "" && params.Docker == "" {
-		c.ui.Normal().Msg("Collecting the application sources ...")
-
-		tmpDir, tarball, err := helpers.Tar(source)
-		defer func() {
-			if tmpDir != "" {
-				_ = os.RemoveAll(tmpDir)
-			}
-		}()
-		if err != nil {
-			return err
-		}
-
-		c.ui.Normal().Msg("Uploading application code ...")
-
-		details.Info("upload code")
-		upload, err := c.uploadCode(appRef, tarball)
-		if err != nil {
-			return err
-		}
-		log.V(3).Info("upload response", "response", upload)
-
-		blobUID = upload.BlobUID
-	} else if params.GitRev != "" {
-		gitRef := models.GitRef{
-			URL:      source,
-			Revision: params.GitRev,
-		}
-		response, err := c.importGit(appRef, gitRef)
-		if err != nil {
-			return errors.Wrap(err, "importing git remote")
-		}
-		blobUID = response.BlobUID
-	}
-
-	stageID := ""
-	var stageResponse *models.StageResponse
-	if params.Docker == "" {
-		c.ui.Normal().Msg("Staging application ...")
-		req := models.StageRequest{
-			App:          appRef,
-			BlobUID:      blobUID,
-			BuilderImage: params.BuilderImage,
-		}
-		details.Info("staging code", "Blob", blobUID)
-		stageResponse, err = c.stageCode(req)
-		if err != nil {
-			return err
-		}
-		stageID = stageResponse.Stage.ID
-		log.V(3).Info("stage response", "response", stageResponse)
-
-		details.Info("start tailing logs", "StageID", stageResponse.Stage.ID)
-		err = c.stageLogs(details, appRef, stageResponse.Stage.ID)
-		if err != nil {
-			return err
-		}
-	}
-
-	c.ui.Normal().Msg("Deploying application ...")
-	deployRequest := models.DeployRequest{
-		App:       appRef,
-		Instances: params.Instances,
-	}
-	// If docker param is specified, then we just take it into ImageURL
-	// If not, we take the one from the staging response
-	if params.Docker != "" {
-		deployRequest.ImageURL = params.Docker
-	} else {
-		deployRequest.ImageURL = stageResponse.ImageURL
-		deployRequest.Stage = models.StageRef{ID: stageID}
-	}
-
-	deployResponse, err := c.deployCode(deployRequest)
-	if err != nil {
-		return err
-	}
-
-	details.Info("wait for application resources")
-	err = c.waitForApp(appRef)
-	if err != nil {
-		return errors.Wrap(err, "waiting for app failed")
-	}
-
-	// TODO : This services work should be moved into the stage
-	// request, and server side.
-
-	if len(services) > 0 {
-		c.ui.Note().Msg("Binding Services")
-
-		// Application is up, bind the services.
-		// This will restart the application.
-		// TODO: See #347 for future work
-
-		request := models.BindRequest{
-			Names: services,
-		}
-
-		js, err := json.Marshal(request)
-		if err != nil {
-			return err
-		}
-
-		b, err := c.post(api.Routes.Path("ServiceBindingCreate", appRef.Org, appRef.Name), string(js))
-		if err != nil {
-			return err
-		}
-
-		br := &models.BindResponse{}
-		if err := json.Unmarshal(b, br); err != nil {
-			return err
-		}
-
-		msg := c.ui.Note()
-		text := "Done"
-		if len(br.WasBound) > 0 {
-			text = text + ", With Already Bound Services"
-			msg = msg.WithTable("Name")
-
-			for _, wasbound := range br.WasBound {
-				msg = msg.WithTableRow(wasbound)
-			}
-		}
-
-		msg.Msg(text)
-	}
-
-	c.ui.Success().
-		WithStringValue("Name", appRef.Name).
-		WithStringValue("Namespace", appRef.Org).
-		WithStringValue("Route", fmt.Sprintf("https://%s", deployResponse.Route)).
-		WithStringValue("Builder Image", params.BuilderImage).
-		Msg("App is online.")
 
 	return nil
 }
@@ -1556,188 +1164,6 @@ func (c *EpinioClient) Target(org string) error {
 	c.ui.Success().Msg("Namespace targeted.")
 
 	return nil
-}
-
-func (c *EpinioClient) ServicesToApps(ctx context.Context, org string) (map[string]models.AppList, error) {
-	// Determine apps bound to services
-	// (inversion of services bound to apps)
-	// Literally query apps in the org for their services and invert.
-
-	jsonResponse, err := c.get(api.Routes.Path("ServiceApps", c.Config.Org))
-	if err != nil {
-		return nil, err
-	}
-
-	var appsOf map[string]models.AppList
-	if err := json.Unmarshal(jsonResponse, &appsOf); err != nil {
-		return nil, err
-	}
-
-	return appsOf, nil
-}
-
-func (c *EpinioClient) get(endpoint string) ([]byte, error) {
-	return c.curl(endpoint, "GET", "")
-}
-
-func (c *EpinioClient) post(endpoint string, data string) ([]byte, error) {
-	return c.curl(endpoint, "POST", data)
-}
-
-func (c *EpinioClient) patch(endpoint string, data string) ([]byte, error) {
-	return c.curl(endpoint, "PATCH", data)
-}
-
-func (c *EpinioClient) delete(endpoint string) ([]byte, error) {
-	return c.curl(endpoint, "DELETE", "")
-}
-
-// upload the given path as param "file" in a multipart form
-func (c *EpinioClient) upload(endpoint string, path string) ([]byte, error) {
-	uri := fmt.Sprintf("%s/%s", c.serverURL, endpoint)
-
-	// open the tarball
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to open tarball")
-	}
-	defer file.Close()
-
-	// create multipart form
-	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
-	part, err := writer.CreateFormFile("file", filepath.Base(file.Name()))
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create multiform part")
-	}
-
-	_, err = io.Copy(part, file)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to write to multiform part")
-	}
-
-	err = writer.Close()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to close multiform")
-	}
-
-	// make the request
-	request, err := http.NewRequest("POST", uri, body)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to build request")
-	}
-
-	request.SetBasicAuth(c.Config.User, c.Config.Password)
-	request.Header.Add("Content-Type", writer.FormDataContentType())
-
-	response, err := (&http.Client{}).Do(request)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to POST to upload")
-	}
-	defer response.Body.Close()
-
-	bodyBytes, _ := ioutil.ReadAll(response.Body)
-	if response.StatusCode == http.StatusCreated {
-		return bodyBytes, nil
-	}
-
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server status code: %s\n%s", http.StatusText(response.StatusCode), string(bodyBytes))
-	}
-
-	// object was not created, but status was ok?
-	return bodyBytes, nil
-}
-
-func formatError(bodyBytes []byte, response *http.Response) error {
-	var eResponse api.ErrorResponse
-	if err := json.Unmarshal(bodyBytes, &eResponse); err != nil {
-		return errors.Wrapf(err, "cannot parse JSON response: '%s'", bodyBytes)
-	}
-
-	titles := make([]string, 0, len(eResponse.Errors))
-	for _, e := range eResponse.Errors {
-		titles = append(titles, e.Title)
-	}
-	t := strings.Join(titles, ", ")
-
-	if response.StatusCode == http.StatusInternalServerError {
-		return errors.Errorf("%s: %s", http.StatusText(response.StatusCode), t)
-	}
-	return errors.New(t)
-}
-
-func (c *EpinioClient) curl(endpoint, method, requestBody string) ([]byte, error) {
-	uri := fmt.Sprintf("%s/%s", c.serverURL, endpoint)
-	c.Log.Info(fmt.Sprintf("%s %s", method, uri))
-	c.Log.V(1).Info(requestBody)
-	request, err := http.NewRequest(method, uri, strings.NewReader(requestBody))
-	if err != nil {
-		return []byte{}, err
-	}
-
-	request.SetBasicAuth(c.Config.User, c.Config.Password)
-	response, err := (&http.Client{}).Do(request)
-	if err != nil {
-		castedErr, ok := err.(*url.Error)
-		if !ok {
-			return []byte{}, errors.New("couldn't cast request Error!")
-		}
-		if castedErr.Timeout() {
-			return []byte{}, errors.New("request cancelled or timed out")
-		}
-
-		return []byte{}, errors.Wrap(err, "making the request")
-	}
-	defer response.Body.Close()
-
-	bodyBytes, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return []byte{}, errors.Wrap(err, "reading response body")
-	}
-
-	if response.StatusCode == http.StatusCreated {
-		return bodyBytes, nil
-	}
-
-	if response.StatusCode != http.StatusOK {
-		return []byte{}, formatError(bodyBytes, response)
-	}
-
-	return bodyBytes, nil
-}
-
-func (c *EpinioClient) curlWithCustomErrorHandling(endpoint, method, requestBody string,
-	f func(response *http.Response, bodyBytes []byte, err error) error) ([]byte, error) {
-
-	uri := fmt.Sprintf("%s/%s", c.serverURL, endpoint)
-	request, err := http.NewRequest(method, uri, strings.NewReader(requestBody))
-	if err != nil {
-		return []byte{}, err
-	}
-
-	request.SetBasicAuth(c.Config.User, c.Config.Password)
-
-	response, err := (&http.Client{}).Do(request)
-	if err != nil {
-		return []byte{}, err
-	}
-	defer response.Body.Close()
-
-	bodyBytes, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return []byte{}, err
-	}
-
-	if response.StatusCode == http.StatusCreated {
-		return bodyBytes, nil
-	}
-
-	if response.StatusCode != http.StatusOK {
-		return []byte{}, f(response, bodyBytes, formatError(bodyBytes, response))
-	}
-
-	return bodyBytes, nil
 }
 
 func (c *EpinioClient) TargetOk() error {

--- a/internal/cli/clients/epinioapi/apps.go
+++ b/internal/cli/clients/epinioapi/apps.go
@@ -1,0 +1,255 @@
+package epinioapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	api "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/internal/api/v1/models"
+)
+
+// AppCreate creates an application resource
+func (c *Client) AppCreate(req models.ApplicationCreateRequest, org string, f errorFunc) (models.Response, error) {
+	var resp models.Response
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		return resp, nil
+	}
+
+	data, err := c.doWithCustomErrorHandling(
+		api.Routes.Path("AppCreate", org),
+		"POST",
+		string(b),
+		f,
+	)
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// Apps returns a list of all apps in an org
+func (c *Client) Apps(org string) (models.AppList, error) {
+	var resp models.AppList
+
+	data, err := c.get(api.Routes.Path("Apps", org))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// AllApps returns a list of all apps
+func (c *Client) AllApps() (models.AppList, error) {
+	var resp models.AppList
+
+	data, err := c.get(api.Routes.Path("AllApps"))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// AppShow shows an app
+func (c *Client) AppShow(org string, appName string) (models.App, error) {
+	var resp models.App
+
+	data, err := c.get(api.Routes.Path("AppShow", org, appName))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// AppUpdate updates an app
+func (c *Client) AppUpdate(req models.UpdateAppRequest, org string, appName string) (models.Response, error) {
+	var resp models.Response
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		return resp, nil
+	}
+
+	data, err := c.patch(api.Routes.Path("AppUpdate", org, appName), string(b))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// AppDelete deletes an app
+func (c *Client) AppDelete(org string, name string) (models.ApplicationDeleteResponse, error) {
+	resp := models.ApplicationDeleteResponse{}
+
+	data, err := c.delete(api.Routes.Path("AppDelete", org, name))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// AppUpload uploads a tarball for the named app, which is later used in staging
+func (c *Client) AppUpload(org string, name string, tarball string) (models.UploadResponse, error) {
+	resp := models.UploadResponse{}
+
+	data, err := c.upload(api.Routes.Path("AppUpload", org, name), tarball)
+	if err != nil {
+		return resp, errors.Wrap(err, "can't upload archive")
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, errors.Wrap(err, "response body is not JSON")
+	}
+
+	return resp, nil
+}
+
+// AppImportGit asks the server to import a git repo and put in into the blob store
+func (c *Client) AppImportGit(app models.AppRef, gitRef models.GitRef) (*models.ImportGitResponse, error) {
+	data := url.Values{}
+	data.Set("giturl", gitRef.URL)
+	data.Set("gitrev", gitRef.Revision)
+
+	url := fmt.Sprintf("%s/%s", c.URL, api.Routes.Path("AppImportGit", app.Org, app.Name))
+	request, err := http.NewRequest("POST", url, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, errors.Wrap(err, "constructing the request")
+	}
+	request.SetBasicAuth(c.user, c.password)
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))
+
+	response, err := (&http.Client{}).Do(request)
+	if err != nil {
+		return nil, errors.Wrap(err, "making the request to import git")
+	}
+
+	defer response.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading the response body")
+	}
+	if response.StatusCode != http.StatusCreated && response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected server status code: %s\n%s", http.StatusText(response.StatusCode),
+			string(bodyBytes))
+	}
+
+	resp := &models.ImportGitResponse{}
+	if err := json.Unmarshal(bodyBytes, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// AppStage stages an app
+func (c *Client) AppStage(req models.StageRequest) (*models.StageResponse, error) {
+	out, err := json.Marshal(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't marshal stage request")
+	}
+
+	b, err := c.post(api.Routes.Path("AppStage", req.App.Org, req.App.Name), string(out))
+	if err != nil {
+		return nil, errors.Wrap(err, "can't stage app")
+	}
+
+	// returns staging ID
+	resp := &models.StageResponse{}
+	if err := json.Unmarshal(b, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// AppDeploy deploys a staged app
+func (c *Client) AppDeploy(req models.DeployRequest) (*models.DeployResponse, error) {
+	out, err := json.Marshal(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't marshal deploy request")
+	}
+
+	b, err := c.post(api.Routes.Path("AppDeploy", req.App.Org, req.App.Name), string(out))
+	if err != nil {
+		return nil, errors.Wrap(err, "can't deploy app")
+	}
+
+	// returns app default route
+	resp := &models.DeployResponse{}
+	if err := json.Unmarshal(b, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// StagingComplete checks if the staging process is complete
+func (c *Client) StagingComplete(org string, id string) (models.Response, error) {
+	resp := models.Response{}
+
+	data, err := c.get(api.Routes.Path("StagingComplete", org, id))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// AppRunning checks if the app is running
+func (c *Client) AppRunning(app models.AppRef) (models.Response, error) {
+	resp := models.Response{}
+
+	data, err := c.get(api.Routes.Path("AppRunning", app.Org, app.Name))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}

--- a/internal/cli/clients/epinioapi/client.go
+++ b/internal/cli/clients/epinioapi/client.go
@@ -1,0 +1,21 @@
+// Package epinioapi connects to the Epinio API's endpoints
+package epinioapi
+
+import (
+	"github.com/go-logr/logr"
+)
+
+// Client provides functionality for talking to an Epinio API
+// server
+type Client struct {
+	log      logr.Logger
+	URL      string
+	WsURL    string // only stored here for the memo, the websocket client is not part of the epinioapi, yet.
+	user     string
+	password string
+}
+
+// New returns a new Epinio API client
+func New(log logr.Logger, url string, wsURL string, user string, password string) *Client {
+	return &Client{log: log, URL: url, WsURL: wsURL, user: user, password: password}
+}

--- a/internal/cli/clients/epinioapi/envs.go
+++ b/internal/cli/clients/epinioapi/envs.go
@@ -1,0 +1,95 @@
+package epinioapi
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+
+	api "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/internal/api/v1/models"
+)
+
+// EnvList returns a list of all env vars for an app
+func (c *Client) EnvList(org string, appName string) (models.EnvVariableList, error) {
+	var resp models.EnvVariableList
+
+	data, err := c.get(api.Routes.Path("EnvList", org, appName))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// EnvSet set env vars for an app
+func (c *Client) EnvSet(req models.EnvVariableList, org string, appName string) (models.Response, error) {
+	resp := models.Response{}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		return resp, nil
+	}
+
+	data, err := c.post(api.Routes.Path("EnvSet", org, appName), string(b))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, errors.Wrap(err, "response body is not JSON")
+	}
+
+	return resp, nil
+}
+
+// EnvShow shows an env variable
+func (c *Client) EnvShow(org string, appName string, envName string) (models.EnvVariable, error) {
+	resp := models.EnvVariable{}
+
+	data, err := c.get(api.Routes.Path("EnvShow", org, appName, envName))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// EnvUnset removes an env var
+func (c *Client) EnvUnset(org string, appName string, envName string) (models.Response, error) {
+	resp := models.Response{}
+
+	data, err := c.delete(api.Routes.Path("EnvUnset", org, appName, envName))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// EnvMatch returns all env vars matching the prefix
+func (c *Client) EnvMatch(org string, appName string, prefix string) (models.EnvMatchResponse, error) {
+	resp := models.EnvMatchResponse{}
+
+	data, err := c.get(api.Routes.Path("EnvMatch", org, appName, prefix))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}

--- a/internal/cli/clients/epinioapi/http.go
+++ b/internal/cli/clients/epinioapi/http.go
@@ -1,0 +1,184 @@
+package epinioapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	api "github.com/epinio/epinio/internal/api/v1"
+
+	"github.com/pkg/errors"
+)
+
+func (c *Client) get(endpoint string) ([]byte, error) {
+	return c.do(endpoint, "GET", "")
+}
+
+func (c *Client) post(endpoint string, data string) ([]byte, error) {
+	return c.do(endpoint, "POST", data)
+}
+
+func (c *Client) patch(endpoint string, data string) ([]byte, error) {
+	return c.do(endpoint, "PATCH", data)
+}
+
+func (c *Client) delete(endpoint string) ([]byte, error) {
+	return c.do(endpoint, "DELETE", "")
+}
+
+// upload the given path as param "file" in a multipart form
+func (c *Client) upload(endpoint string, path string) ([]byte, error) {
+	uri := fmt.Sprintf("%s/%s", c.URL, endpoint)
+
+	// open the tarball
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open tarball")
+	}
+	defer file.Close()
+
+	// create multipart form
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", filepath.Base(file.Name()))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create multiform part")
+	}
+
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to write to multiform part")
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to close multiform")
+	}
+
+	// make the request
+	request, err := http.NewRequest("POST", uri, body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build request")
+	}
+
+	request.SetBasicAuth(c.user, c.password)
+	request.Header.Add("Content-Type", writer.FormDataContentType())
+
+	response, err := (&http.Client{}).Do(request)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to POST to upload")
+	}
+	defer response.Body.Close()
+
+	bodyBytes, _ := ioutil.ReadAll(response.Body)
+	if response.StatusCode == http.StatusCreated {
+		return bodyBytes, nil
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server status code: %s\n%s", http.StatusText(response.StatusCode), string(bodyBytes))
+	}
+
+	// object was not created, but status was ok?
+	return bodyBytes, nil
+}
+
+func (c *Client) do(endpoint, method, requestBody string) ([]byte, error) {
+	uri := fmt.Sprintf("%s/%s", c.URL, endpoint)
+	c.log.Info(fmt.Sprintf("%s %s", method, uri))
+	c.log.V(1).Info(requestBody)
+	request, err := http.NewRequest(method, uri, strings.NewReader(requestBody))
+	if err != nil {
+		return []byte{}, err
+	}
+
+	request.SetBasicAuth(c.user, c.password)
+	response, err := (&http.Client{}).Do(request)
+	if err != nil {
+		castedErr, ok := err.(*url.Error)
+		if !ok {
+			return []byte{}, errors.New("couldn't cast request Error!")
+		}
+		if castedErr.Timeout() {
+			return []byte{}, errors.New("request cancelled or timed out")
+		}
+
+		return []byte{}, errors.Wrap(err, "making the request")
+	}
+	defer response.Body.Close()
+
+	bodyBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return []byte{}, errors.Wrap(err, "reading response body")
+	}
+
+	if response.StatusCode == http.StatusCreated {
+		return bodyBytes, nil
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return []byte{}, formatError(bodyBytes, response)
+	}
+
+	return bodyBytes, nil
+}
+
+type errorFunc = func(response *http.Response, bodyBytes []byte, err error) error
+
+func (c *Client) doWithCustomErrorHandling(endpoint, method, requestBody string, f errorFunc) ([]byte, error) {
+
+	uri := fmt.Sprintf("%s/%s", c.URL, endpoint)
+	request, err := http.NewRequest(method, uri, strings.NewReader(requestBody))
+	if err != nil {
+		return []byte{}, err
+	}
+
+	request.SetBasicAuth(c.user, c.password)
+
+	response, err := (&http.Client{}).Do(request)
+	if err != nil {
+		return []byte{}, err
+	}
+	defer response.Body.Close()
+
+	bodyBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	if response.StatusCode == http.StatusCreated {
+		return bodyBytes, nil
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return []byte{}, f(response, bodyBytes, formatError(bodyBytes, response))
+	}
+
+	return bodyBytes, nil
+}
+
+func formatError(bodyBytes []byte, response *http.Response) error {
+	var eResponse api.ErrorResponse
+	if err := json.Unmarshal(bodyBytes, &eResponse); err != nil {
+		return errors.Wrapf(err, "cannot parse JSON response: '%s'", bodyBytes)
+	}
+
+	titles := make([]string, 0, len(eResponse.Errors))
+	for _, e := range eResponse.Errors {
+		titles = append(titles, e.Title)
+	}
+	t := strings.Join(titles, ", ")
+
+	if response.StatusCode == http.StatusInternalServerError {
+		return errors.Errorf("%s: %s", http.StatusText(response.StatusCode), t)
+	}
+	return errors.New(t)
+}

--- a/internal/cli/clients/epinioapi/info.go
+++ b/internal/cli/clients/epinioapi/info.go
@@ -1,0 +1,24 @@
+package epinioapi
+
+import (
+	"encoding/json"
+
+	api "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/internal/api/v1/models"
+)
+
+// Info returns information about Epinio and its components
+func (c *Client) Info() (models.InfoResponse, error) {
+	var resp models.InfoResponse
+
+	data, err := c.get(api.Routes.Path("Info"))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}

--- a/internal/cli/clients/epinioapi/namespaces.go
+++ b/internal/cli/clients/epinioapi/namespaces.go
@@ -1,0 +1,106 @@
+package epinioapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/avast/retry-go"
+
+	"github.com/epinio/epinio/helpers"
+	api "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/internal/api/v1/models"
+	"github.com/epinio/epinio/internal/duration"
+)
+
+// NamespaceCreate creates a namespace
+func (c *Client) NamespaceCreate(req models.NamespaceCreateRequest) (models.Response, error) {
+	var resp models.Response
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		return resp, nil
+	}
+
+	details := c.log.V(1) // NOTE: Increment of level, not absolute.
+
+	var data []byte
+	err = retry.Do(
+		func() error {
+			details.Info("create org", "org", req.Name)
+			data, err = c.post(api.Routes.Path("Namespaces"), string(b))
+			return err
+		},
+		retry.RetryIf(func(err error) bool {
+			retry := helpers.Retryable(err.Error())
+
+			details.Info("create error", "error", err.Error(), "retry", retry)
+			return retry
+		}),
+		retry.OnRetry(func(n uint, err error) {
+			details.WithValues(
+				"tries", fmt.Sprintf("%d/%d", n, duration.RetryMax),
+				"error", err.Error(),
+			).Info("Retrying to create namespace")
+		}),
+		retry.Delay(time.Second),
+		retry.Attempts(duration.RetryMax),
+	)
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// NamespaceDelete deletes a namespace
+func (c *Client) NamespaceDelete(org string) (models.Response, error) {
+	resp := models.Response{}
+
+	data, err := c.delete(api.Routes.Path("NamespaceDelete", org))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// NamespacesMatch returns all matching namespaces for the prefix
+func (c *Client) NamespacesMatch(prefix string) (models.NamespacesMatchResponse, error) {
+	resp := models.NamespacesMatchResponse{}
+
+	data, err := c.get(api.Routes.Path("NamespacesMatch", prefix))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// Namespaces returns a list of namespaces
+func (c *Client) Namespaces() (models.NamespaceList, error) {
+	resp := models.NamespaceList{}
+
+	data, err := c.get(api.Routes.Path("Namespaces"))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}

--- a/internal/cli/clients/epinioapi/services.go
+++ b/internal/cli/clients/epinioapi/services.go
@@ -127,6 +127,8 @@ func (c *Client) ServiceDelete(req models.DeleteRequest, org string, name string
 func (c *Client) ServiceCreate(req models.CatalogCreateRequest, org string) (models.Response, error) {
 	resp := models.Response{}
 
+	c.log.V(5).WithValues("request", req, "org", org).Info("requesting ServiceCreate")
+
 	b, err := json.Marshal(req)
 	if err != nil {
 		return resp, nil
@@ -136,6 +138,8 @@ func (c *Client) ServiceCreate(req models.CatalogCreateRequest, org string) (mod
 	if err != nil {
 		return resp, err
 	}
+
+	c.log.V(5).WithValues("response", req, "org", org).Info("received ServiceCreate")
 
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return resp, errors.Wrap(err, "response body is not JSON")
@@ -148,6 +152,8 @@ func (c *Client) ServiceCreate(req models.CatalogCreateRequest, org string) (mod
 func (c *Client) ServiceCreateCustom(req models.CustomCreateRequest, org string) (models.Response, error) {
 	resp := models.Response{}
 
+	c.log.V(5).WithValues("request", req, "org", org).Info("requesting ServiceCreateCustom")
+
 	b, err := json.Marshal(req)
 	if err != nil {
 		return resp, nil
@@ -157,6 +163,8 @@ func (c *Client) ServiceCreateCustom(req models.CustomCreateRequest, org string)
 	if err != nil {
 		return resp, err
 	}
+
+	c.log.V(5).WithValues("response", req, "org", org).Info("received ServiceCreateCustom")
 
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return resp, errors.Wrap(err, "response body is not JSON")

--- a/internal/cli/clients/epinioapi/services.go
+++ b/internal/cli/clients/epinioapi/services.go
@@ -1,0 +1,198 @@
+package epinioapi
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+
+	api "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/internal/api/v1/models"
+	"github.com/epinio/epinio/internal/services"
+)
+
+// ServicePlans returns a list of service plans for a given serviceclass name
+func (c *Client) ServicePlans(name string) (services.ServicePlanList, error) {
+	resp := services.ServicePlanList{}
+
+	data, err := c.get(api.Routes.Path("ServicePlans", name))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// ServiceClasses reutrns a list of service classes
+func (c *Client) ServiceClasses() (services.ServiceClassList, error) {
+	resp := services.ServiceClassList{}
+
+	data, err := c.get(api.Routes.Path("ServiceClasses"))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// Services returns a list of services
+func (c *Client) Services(org string) (models.ServiceResponseList, error) {
+	resp := models.ServiceResponseList{}
+
+	data, err := c.get(api.Routes.Path("Services", org))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// ServiceBindingCreate creates a binding from an app to a serviceclass
+func (c *Client) ServiceBindingCreate(req models.BindRequest, org string, appName string) (models.BindResponse, error) {
+	resp := models.BindResponse{}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		return resp, nil
+	}
+
+	data, err := c.post(api.Routes.Path("ServiceBindingCreate", org, appName), string(b))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, errors.Wrap(err, "response body is not JSON")
+	}
+
+	return resp, nil
+}
+
+// ServiceBindingDelete deletes a binding from an app to a serviceclass
+func (c *Client) ServiceBindingDelete(org string, appName string, serviceName string) (models.Response, error) {
+	resp := models.Response{}
+
+	data, err := c.delete(api.Routes.Path("ServiceBindingDelete", org, appName, serviceName))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// ServiceDelete deletes a service
+func (c *Client) ServiceDelete(req models.DeleteRequest, org string, name string, f errorFunc) (models.DeleteResponse, error) {
+	resp := models.DeleteResponse{}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		return resp, nil
+	}
+
+	data, err := c.doWithCustomErrorHandling(
+		api.Routes.Path("ServiceDelete", org, name),
+		"DELETE", string(b), f)
+	if err != nil {
+		if err.Error() != "Bad Request" {
+			return resp, err
+		}
+		return resp, nil
+	}
+
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return resp, errors.Wrap(err, "response body is not JSON")
+		}
+	}
+
+	return resp, nil
+}
+
+// ServiceCreate creates a service from the catalog
+func (c *Client) ServiceCreate(req models.CatalogCreateRequest, org string) (models.Response, error) {
+	resp := models.Response{}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		return resp, nil
+	}
+
+	data, err := c.post(api.Routes.Path("ServiceCreate", org), string(b))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, errors.Wrap(err, "response body is not JSON")
+	}
+
+	return resp, nil
+}
+
+// ServiceCreateCustom creates a custom service
+func (c *Client) ServiceCreateCustom(req models.CustomCreateRequest, org string) (models.Response, error) {
+	resp := models.Response{}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		return resp, nil
+	}
+
+	data, err := c.post(api.Routes.Path("ServiceCreateCustom", org), string(b))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, errors.Wrap(err, "response body is not JSON")
+	}
+
+	return resp, nil
+}
+
+// ServiceShow shows a service
+func (c *Client) ServiceShow(org string, name string) (models.ServiceShowResponse, error) {
+	var resp models.ServiceShowResponse
+
+	data, err := c.get(api.Routes.Path("ServiceShow", org, name))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// ServiceApps lists all the apps by services
+func (c *Client) ServiceApps(org string) (models.ServiceAppsResponse, error) {
+	resp := models.ServiceAppsResponse{}
+
+	data, err := c.get(api.Routes.Path("ServiceApps", org))
+	if err != nil {
+		return resp, err
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, errors.Wrap(err, "response body is not JSON")
+	}
+
+	return resp, nil
+}

--- a/internal/cli/clients/install_client.go
+++ b/internal/cli/clients/install_client.go
@@ -51,7 +51,7 @@ func NewInstallClient(ctx context.Context, options *kubernetes.InstallationOptio
 	}
 	uiUI := termui.NewUI()
 
-	logger := tracelog.NewInstallClientLogger()
+	logger := tracelog.NewLogger().WithName("EpinioInstaller")
 	installClient := &InstallClient{
 		kubeClient: cluster,
 		ui:         uiUI,

--- a/internal/cli/clients/push.go
+++ b/internal/cli/clients/push.go
@@ -94,6 +94,7 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error {
 		appRef.Org,
 		func(response *http.Response, _ []byte, err error) error {
 			if response.StatusCode == http.StatusConflict {
+				details.WithValues("response", response).Info("app exists conflict")
 				c.ui.Normal().Msg("Application exists, updating ...")
 				return nil
 			}
@@ -128,7 +129,10 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error {
 		log.V(3).Info("upload response", "response", upload)
 
 		blobUID = upload.BlobUID
+
 	} else if params.GitRev != "" {
+		c.ui.Normal().Msg("Importing the application sources from Git ...")
+
 		gitRef := models.GitRef{
 			URL:      source,
 			Revision: params.GitRev,
@@ -143,7 +147,8 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error {
 	stageID := ""
 	var stageResponse *models.StageResponse
 	if params.Docker == "" {
-		c.ui.Normal().Msg("Staging application ...")
+		c.ui.Normal().Msg("Staging application via docker image ...")
+
 		req := models.StageRequest{
 			App:          appRef,
 			BlobUID:      blobUID,

--- a/internal/cli/clients/push.go
+++ b/internal/cli/clients/push.go
@@ -1,96 +1,235 @@
 package clients
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"net/url"
-	"strconv"
+	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/avast/retry-go"
-	"github.com/epinio/epinio/helpers"
-	api "github.com/epinio/epinio/internal/api/v1"
-	"github.com/epinio/epinio/internal/api/v1/models"
-	"github.com/epinio/epinio/internal/duration"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
+
+	"github.com/epinio/epinio/helpers"
+	"github.com/epinio/epinio/internal/api/v1/models"
+	"github.com/epinio/epinio/internal/duration"
 )
 
-func (c *EpinioClient) uploadCode(app models.AppRef, tarball string) (*models.UploadResponse, error) {
-	b, err := c.upload(api.Routes.Path("AppUpload", app.Org, app.Name), tarball)
-	if err != nil {
-		return nil, errors.Wrap(err, "can't upload archive")
-	}
-
-	// returns the source blob's UUID
-	upload := &models.UploadResponse{}
-	if err := json.Unmarshal(b, upload); err != nil {
-		return nil, err
-	}
-
-	return upload, nil
+type PushParams struct {
+	Instances    *int32
+	Services     []string
+	Docker       string
+	GitRev       string
+	BuilderImage string
+	Name         string
+	Path         string
 }
 
-// importGit asks the server to import a git repo and put in into the blob store
-func (c *EpinioClient) importGit(app models.AppRef, gitRef models.GitRef) (*models.ImportGitResponse, error) {
-	data := url.Values{}
-	data.Set("giturl", gitRef.URL)
-	data.Set("gitrev", gitRef.Revision)
+// Push pushes an app
+// * validate
+// * upload
+// * stage
+// * (tail logs)
+// * wait for pipelinerun
+// * deploy
+// * wait for app
+func (c *EpinioClient) Push(ctx context.Context, params PushParams) error {
+	name := params.Name
+	source := params.Path
 
-	url := fmt.Sprintf("%s/%s", c.serverURL, api.Routes.Path("AppImportGit", app.Org, app.Name))
-	request, err := http.NewRequest("POST", url, strings.NewReader(data.Encode()))
+	appRef := models.AppRef{Name: name, Org: c.Config.Org}
+	log := c.Log.
+		WithName("Push").
+		WithValues("Name", appRef.Name,
+			"Namespace", appRef.Org,
+			"Sources", source)
+	log.Info("start")
+	defer log.Info("return")
+	details := log.V(1) // NOTE: Increment of level, not absolute. Visible via TRACE_LEVEL=2
+
+	sourceToShow := source
+	if params.GitRev != "" {
+		sourceToShow = fmt.Sprintf("%s @ %s", sourceToShow, params.GitRev)
+	}
+
+	msg := c.ui.Note().
+		WithStringValue("Name", appRef.Name).
+		WithStringValue("Sources", sourceToShow).
+		WithStringValue("Namespace", appRef.Org)
+
+	if err := c.TargetOk(); err != nil {
+		return err
+	}
+
+	services := uniqueStrings(params.Services)
+
+	if len(services) > 0 {
+		sort.Strings(services)
+		msg = msg.WithStringValue("Services:", strings.Join(services, ", "))
+	}
+
+	msg.Msg("About to push an application with given name and sources into the specified namespace")
+
+	c.ui.Exclamation().
+		Timeout(duration.UserAbort()).
+		Msg("Hit Enter to continue or Ctrl+C to abort (deployment will continue automatically in 5 seconds)")
+
+	details.Info("validate app name")
+	errorMsgs := validation.IsDNS1123Subdomain(appRef.Name)
+	if len(errorMsgs) > 0 {
+		return fmt.Errorf("%s: %s", "app name incorrect", strings.Join(errorMsgs, "\n"))
+	}
+
+	c.ui.Normal().Msg("Create the application resource ...")
+
+	request := models.ApplicationCreateRequest{Name: appRef.Name}
+
+	_, err := c.API.AppCreate(
+		request,
+		appRef.Org,
+		func(response *http.Response, _ []byte, err error) error {
+			if response.StatusCode == http.StatusConflict {
+				c.ui.Normal().Msg("Application exists, updating ...")
+				return nil
+			}
+			return err
+		},
+	)
 	if err != nil {
-		return nil, errors.Wrap(err, "constructing the request")
+		return err
 	}
-	request.SetBasicAuth(c.Config.User, c.Config.Password)
-	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	request.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))
 
-	response, err := (&http.Client{}).Do(request)
+	var blobUID string
+	if params.GitRev == "" && params.Docker == "" {
+		c.ui.Normal().Msg("Collecting the application sources ...")
+
+		tmpDir, tarball, err := helpers.Tar(source)
+		defer func() {
+			if tmpDir != "" {
+				_ = os.RemoveAll(tmpDir)
+			}
+		}()
+		if err != nil {
+			return err
+		}
+
+		c.ui.Normal().Msg("Uploading application code ...")
+
+		details.Info("upload code")
+		upload, err := c.API.AppUpload(appRef.Org, appRef.Name, tarball)
+		if err != nil {
+			return err
+		}
+		log.V(3).Info("upload response", "response", upload)
+
+		blobUID = upload.BlobUID
+	} else if params.GitRev != "" {
+		gitRef := models.GitRef{
+			URL:      source,
+			Revision: params.GitRev,
+		}
+		response, err := c.API.AppImportGit(appRef, gitRef)
+		if err != nil {
+			return errors.Wrap(err, "importing git remote")
+		}
+		blobUID = response.BlobUID
+	}
+
+	stageID := ""
+	var stageResponse *models.StageResponse
+	if params.Docker == "" {
+		c.ui.Normal().Msg("Staging application ...")
+		req := models.StageRequest{
+			App:          appRef,
+			BlobUID:      blobUID,
+			BuilderImage: params.BuilderImage,
+		}
+		details.Info("staging code", "Blob", blobUID)
+		stageResponse, err = c.API.AppStage(req)
+		if err != nil {
+			return err
+		}
+		stageID = stageResponse.Stage.ID
+		log.V(3).Info("stage response", "response", stageResponse)
+
+		details.Info("start tailing logs", "StageID", stageResponse.Stage.ID)
+		err = c.stageLogs(details, appRef, stageResponse.Stage.ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	c.ui.Normal().Msg("Deploying application ...")
+	deployRequest := models.DeployRequest{
+		App:       appRef,
+		Instances: params.Instances,
+	}
+	// If docker param is specified, then we just take it into ImageURL
+	// If not, we take the one from the staging response
+	if params.Docker != "" {
+		deployRequest.ImageURL = params.Docker
+	} else {
+		deployRequest.ImageURL = stageResponse.ImageURL
+		deployRequest.Stage = models.StageRef{ID: stageID}
+	}
+
+	deployResponse, err := c.API.AppDeploy(deployRequest)
 	if err != nil {
-		return nil, errors.Wrap(err, "making the request to import git")
+		return err
 	}
 
-	defer response.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(response.Body)
+	details.Info("wait for application resources")
+	err = c.waitForApp(appRef)
 	if err != nil {
-		return nil, errors.Wrap(err, "reading the response body")
-	}
-	if response.StatusCode != http.StatusCreated && response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected server status code: %s\n%s", http.StatusText(response.StatusCode),
-			string(bodyBytes))
+		return errors.Wrap(err, "waiting for app failed")
 	}
 
-	importResponse := &models.ImportGitResponse{}
-	if err := json.Unmarshal(bodyBytes, importResponse); err != nil {
-		return nil, err
+	// TODO : This services work should be moved into the stage
+	// request, and server side.
+
+	if len(services) > 0 {
+		c.ui.Note().Msg("Binding Services")
+
+		// Application is up, bind the services.
+		// This will restart the application.
+		// TODO: See #347 for future work
+
+		request := models.BindRequest{
+			Names: services,
+		}
+
+		br, err := c.API.ServiceBindingCreate(request, appRef.Org, appRef.Name)
+		if err != nil {
+			return err
+		}
+
+		msg := c.ui.Note()
+		text := "Done"
+		if len(br.WasBound) > 0 {
+			text = text + ", With Already Bound Services"
+			msg = msg.WithTable("Name")
+
+			for _, wasbound := range br.WasBound {
+				msg = msg.WithTableRow(wasbound)
+			}
+		}
+
+		msg.Msg(text)
 	}
 
-	return importResponse, nil
-}
+	c.ui.Success().
+		WithStringValue("Name", appRef.Name).
+		WithStringValue("Namespace", appRef.Org).
+		WithStringValue("Route", fmt.Sprintf("https://%s", deployResponse.Route)).
+		WithStringValue("Builder Image", params.BuilderImage).
+		Msg("App is online.")
 
-func (c *EpinioClient) stageCode(req models.StageRequest) (*models.StageResponse, error) {
-	out, err := json.Marshal(req)
-	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal stage request")
-	}
-
-	b, err := c.post(api.Routes.Path("AppStage", req.App.Org, req.App.Name), string(out))
-	if err != nil {
-		return nil, errors.Wrap(err, "can't stage app")
-	}
-
-	// returns staging ID
-	stage := &models.StageResponse{}
-	if err := json.Unmarshal(b, stage); err != nil {
-		return nil, err
-	}
-
-	return stage, nil
+	return nil
 }
 
 func (c *EpinioClient) stageLogs(details logr.Logger, appRef models.AppRef, stageID string) error {
@@ -120,33 +259,13 @@ func (c *EpinioClient) stageLogs(details logr.Logger, appRef models.AppRef, stag
 	return err
 }
 
-func (c *EpinioClient) deployCode(req models.DeployRequest) (*models.DeployResponse, error) {
-	out, err := json.Marshal(req)
-	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal deploy request")
-	}
-
-	b, err := c.post(api.Routes.Path("AppDeploy", req.App.Org, req.App.Name), string(out))
-	if err != nil {
-		return nil, errors.Wrap(err, "can't deploy app")
-	}
-
-	// returns app default route
-	deploy := &models.DeployResponse{}
-	if err := json.Unmarshal(b, deploy); err != nil {
-		return nil, err
-	}
-
-	return deploy, nil
-}
-
 func (c *EpinioClient) waitForPipelineRun(app models.AppRef, id string) error {
 	c.ui.ProgressNote().KeeplineUnder(1).Msg("Running staging")
 
 	return retry.Do(
 		func() error {
-			out, err := c.get(api.Routes.Path("StagingComplete", app.Org, id))
-			return errors.Wrap(err, string(out))
+			_, err := c.API.StagingComplete(app.Org, id)
+			return err
 		},
 		retry.RetryIf(func(err error) bool {
 			return helpers.Retryable(err.Error())
@@ -164,7 +283,7 @@ func (c *EpinioClient) waitForApp(app models.AppRef) error {
 
 	return retry.Do(
 		func() error {
-			_, err := c.get(api.Routes.Path("AppRunning", app.Org, app.Name))
+			_, err := c.API.AppRunning(app)
 			return err
 		},
 		retry.RetryIf(func(err error) bool {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,5 +1,5 @@
 // Package cli contains all definitions pertaining to the user-visible
-// commands of the epinio client
+// commands of the epinio client. It provides the viper/cobra setup.
 package cli
 
 import (

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -326,7 +326,7 @@ func ServiceCreateCustom(cmd *cobra.Command, args []string) error {
 
 	err = client.CreateCustomService(args[0], args[1:])
 	if err != nil {
-		return errors.Wrap(err, "error creating service")
+		return errors.Wrap(err, "error creating custom service")
 	}
 
 	return nil

--- a/internal/services/catalog_service.go
+++ b/internal/services/catalog_service.go
@@ -44,9 +44,9 @@ type ServiceClassList []ServiceClass
 
 // ServicePlan represents a service plan managed by Service catalog
 type ServicePlan struct {
-	Name        string
-	Description string
-	Free        bool
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Free        bool   `json:"free,omitempty"`
 }
 
 // ServicePlanList represents a collection of service plans


### PR DESCRIPTION
* the cli/clients package is now the cli-client for Epinio,
  cli/clients/epinioapi is the API client library for the Epinio API
* cli/client uses epinioapi package for talking to the endpoints
* server always uses jsonResponse when answering requests
* every endpoint returns a json body
* adds more request/response structs
* adds generic response struct as an intermediate, until endpoints
  answer with the affected resource itself


refers to #775 - preparing for common request/response logging