### PR TITLE
Fix error when CRD doesn't have a conditions field yet

### DIFF
--- a/deployments/tekton.go
+++ b/deployments/tekton.go
@@ -14,7 +14,6 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -180,17 +179,8 @@ func (k Tekton) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI,
 		"taskruns.tekton.dev",
 		"tasks.tekton.dev",
 	} {
-		message := fmt.Sprintf("Establish CRD %s", crd)
-		out, err := helpers.WaitForCommandCompletion(ui, message,
-			func() (string, error) {
-				return helpers.Kubectl("wait",
-					"--for", "condition=established",
-					"--timeout", strconv.Itoa(int(k.Timeout.Seconds()))+"s",
-					"crd/"+crd)
-			},
-		)
-		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("%s failed:\n%s", message, out))
+		if err := c.WaitForCRD(ctx, ui, crd, k.Timeout); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("failed waiting for CRD %s to become available", crd))
 		}
 	}
 


### PR DESCRIPTION
We got this error randomly in CI:

```
error: .status.conditions accessor error: <nil> is of the type <nil>, expected []interface{}
```

possibly originating here:

https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go#L137

This commit is re-using existing code to wait for CRDs. We no longer
check conditions but it works as is in existing code. If this ever
fails, we may need to extend the WaitForCRD function to also check the
conditions field for establishment.