### PR TITLE
Show path information for service parameters

### DIFF
--- a/internal/api/v1/services.go
+++ b/internal/api/v1/services.go
@@ -55,14 +55,15 @@ func (sc ServicesController) Show(w http.ResponseWriter, r *http.Request) APIErr
 		return InternalError(err)
 	}
 
-	responseData := map[string]string{
-		"Username": service.User(),
-	}
+	responseData := map[string]string{}
 	for key, value := range serviceDetails {
 		responseData[key] = value
 	}
 
-	err = jsonResponse(w, models.ServiceShowResponse{Details: responseData})
+	err = jsonResponse(w, models.ServiceShowResponse{
+		Username: service.User(),
+		Details:  responseData,
+	})
 	if err != nil {
 		return InternalError(err)
 	}

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -480,12 +480,14 @@ func (c *EpinioClient) ServiceDetails(name string) error {
 	}
 	serviceDetails := resp.Details
 
-	msg := c.ui.Success().
-		WithTable("Parameter", "Value", "Access Path").
-		WithTableRow("Epinio User", resp.Username, "")
+	c.ui.Note().
+		WithStringValue("User", resp.Username).
+		Msg("")
+
+	msg := c.ui.Success()
 
 	if len(serviceDetails) > 0 {
-		msg = msg.WithTableRow("", "", "")
+		msg = msg.WithTable("Parameter", "Value", "Access Path")
 
 		keys := make([]string, 0, len(serviceDetails))
 		for k := range serviceDetails {
@@ -496,9 +498,11 @@ func (c *EpinioClient) ServiceDetails(name string) error {
 			msg = msg.WithTableRow(k, serviceDetails[k],
 				fmt.Sprintf("/services/%s/%s", name, k))
 		}
-	}
 
-	msg.Msg("")
+		msg.Msg("")
+	} else {
+		msg.Msg("No parameters")
+	}
 
 	c.ui.Exclamation().
 		Msg("Beware, the shown access paths are only available in the application's container")

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -480,21 +480,22 @@ func (c *EpinioClient) ServiceDetails(name string) error {
 	}
 	serviceDetails := resp.Details
 
-	msg := c.ui.Success().WithTable("", "", "Access Path")
-	keys := make([]string, 0, len(serviceDetails))
-	for k := range serviceDetails {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		path := ""
-		switch k {
-		case "Status":
-		case "Username":
-		default:
-			path = fmt.Sprintf("/services/%s/%s", name, k)
+	msg := c.ui.Success().
+		WithTable("Parameter", "Value", "Access Path").
+		WithTableRow("Epinio User", resp.Username, "")
+
+	if len(serviceDetails) > 0 {
+		msg = msg.WithTableRow("", "", "")
+
+		keys := make([]string, 0, len(serviceDetails))
+		for k := range serviceDetails {
+			keys = append(keys, k)
 		}
-		msg = msg.WithTableRow(k, serviceDetails[k], path)
+		sort.Strings(keys)
+		for _, k := range keys {
+			msg = msg.WithTableRow(k, serviceDetails[k],
+				fmt.Sprintf("/services/%s/%s", name, k))
+		}
 	}
 
 	msg.Msg("")

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -448,6 +448,9 @@ func (c *EpinioClient) CreateService(name string, dict []string) error {
 		return err
 	}
 
+	c.ui.Exclamation().
+		Msg("Beware, the shown access paths are only available in the application's container")
+
 	c.ui.Success().
 		WithStringValue("Name", name).
 		WithStringValue("Namespace", c.Config.Org).
@@ -495,6 +498,9 @@ func (c *EpinioClient) ServiceDetails(name string) error {
 	}
 
 	msg.Msg("")
+
+	c.ui.Exclamation().
+		Msg("Beware, the shown access paths are only available in the application's container")
 	return nil
 }
 

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -424,11 +424,12 @@ func (c *EpinioClient) CreateService(name string, dict []string) error {
 	msg := c.ui.Note().
 		WithStringValue("Name", name).
 		WithStringValue("Namespace", c.Config.Org).
-		WithTable("Parameter", "Value")
+		WithTable("Parameter", "Value", "Access Path")
 	for i := 0; i < len(dict); i += 2 {
 		key := dict[i]
 		value := dict[i+1]
-		msg = msg.WithTableRow(key, value)
+		path := fmt.Sprintf("/services/%s/%s", name, key)
+		msg = msg.WithTableRow(key, value, path)
 		data[key] = value
 	}
 	msg.Msg("Create Service")
@@ -476,14 +477,21 @@ func (c *EpinioClient) ServiceDetails(name string) error {
 	}
 	serviceDetails := resp.Details
 
-	msg := c.ui.Success().WithTable("", "")
+	msg := c.ui.Success().WithTable("", "", "Access Path")
 	keys := make([]string, 0, len(serviceDetails))
 	for k := range serviceDetails {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		msg = msg.WithTableRow(k, serviceDetails[k])
+		path := ""
+		switch k {
+		case "Status":
+		case "Username":
+		default:
+			path = fmt.Sprintf("/services/%s/%s", name, k)
+		}
+		msg = msg.WithTableRow(k, serviceDetails[k], path)
 	}
 
 	msg.Msg("")

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -121,7 +121,8 @@ type EnvMatchResponse struct {
 
 // ServiceShowResponse contains details about a service
 type ServiceShowResponse struct {
-	Details map[string]string `json:"details,omitempty"`
+	Username string            `json:"user"`
+	Details  map[string]string `json:"details,omitempty"`
 }
 
 // InfoResponse contains information about Epinio and its components


### PR DESCRIPTION
fix #821 

  - Shows access paths for service parameters
  - Shows scope warning, i.e. that the paths are limited in visibility, to the app container

Modified not just `service show`, but also `create-custom`.
:warning: Did not change `create`, as catalog services are getting removed.
