### PR TITLE
Reduce kube calls when retrieving apps across all namespaces

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -578,6 +578,7 @@ var _ = Describe("Apps", func() {
 			app2 = catalog.NewAppName()
 			env.MakeDockerImageApp(app2, 1, dockerImageURL)
 		})
+
 		AfterEach(func() {
 			env.TargetOrg(org2)
 			env.DeleteApp(app2)
@@ -585,6 +586,7 @@ var _ = Describe("Apps", func() {
 			env.TargetOrg(org1)
 			env.DeleteApp(app1)
 		})
+
 		It("lists all applications belonging to all namespaces", func() {
 			// But we care only about the two we know about from the setup.
 


### PR DESCRIPTION
Fixes #805 

 - before: ask for namespaces, per namespace asks for apps, per app ask for state
 - now: ask for apps, per app ask for state