### PR TITLE
Update minio and minio-operator version

### DIFF
--- a/assets/embedded-files/minio/operator.yaml
+++ b/assets/embedded-files/minio/operator.yaml
@@ -7871,7 +7871,7 @@ spec:
       - env:
         - name: CLUSTER_DOMAIN
           value: cluster.local
-        image: minio/operator:v4.2.2
+        image: minio/operator:v4.2.12
         imagePullPolicy: IfNotPresent
         name: minio-operator
         resources:

--- a/assets/embedded-files/minio/tenant.yaml
+++ b/assets/embedded-files/minio/tenant.yaml
@@ -16,7 +16,7 @@ spec:
   certConfig: {}
   credsSecret:
     name: tenant-creds
-  image: minio/minio:RELEASE.2021-08-25T00-41-18Z
+  image: minio/minio:RELEASE.2021-10-06T23-36-31Z
   imagePullSecret: {}
   mountPath: /export
   pools:


### PR DESCRIPTION
On EKS Minio had some issues to deploy the tenant.
Updating minio and minio-operator version fix this issue.

After some manual tests with the versions currently configured I was not able to provision a tenant pod. I updated minio version and it was the same. So I updated both minio-operator and minio and this seems to have fixed the issue.