### PR TITLE
fix: sporadic AKS CI timeout

### DIFF
--- a/scripts/patch-epinio-deployment.sh
+++ b/scripts/patch-epinio-deployment.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-timeout=240s
+timeout=480s
 
 # This script should be used while doing development on Epinio.
 # When running `epinio install`, the Epinio Deployment will try to apply


### PR DESCRIPTION
The patching stage sporadically fails on AKS because of timeout.

Note: I've checked the AKS CI failures and they all fails on the same command or near, for a timeout issue.