### PR TITLE
Add CI scenario 7 - RKE

### DIFF
--- a/.github/workflows/rke.yaml
+++ b/.github/workflows/rke.yaml
@@ -1,0 +1,73 @@
+name: RKE-CI
+
+on:
+  schedule:
+    - cron:  '0 2 * * *'
+
+env:
+  SETUP_GO_VERSION: '^1.13.7'
+  GINKGO_NODES: 1
+  FLAKE_ATTEMPTS: 1
+
+jobs:
+  acceptance-scenario7:
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get All Git Tags
+        run: git fetch --force --prune --unshallow --tags
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+
+      - name: Setup Ginkgo Test Framework
+        run: go install github.com/onsi/ginkgo/ginkgo@v1.16.2
+
+      - name: Cache Tools
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/tools
+          key: ${{ runner.os }}-tools
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Install Tools
+        run: make tools-install
+
+      - name: Add Tools to PATH
+        run: |
+          echo "`pwd`/output/bin" >> $GITHUB_PATH
+
+      - name: Clean runner
+        id: clean-runner
+        run: |
+          make acceptance-cluster-delete
+
+      - name: Create RKE cluster
+        id: create-cluster
+        run: |
+          curl -sfL https://get.rke2.io | sudo sh -
+          sudo sh -c "echo RKE2_KUBECONFIG_MODE=0644 > /etc/sysconfig/rke2-server"
+          sudo systemctl enable --now rke2-server
+
+      - name: Installation Acceptance Tests
+        env:
+          REGEX: Scenario7
+          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
+          make test-acceptance-install
+
+      - name: Delete RKE cluster
+        if: ${{ always() }}
+        run: |
+          sudo sh /usr/local/bin/rke2-uninstall.sh

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ REGEX ?= ""
 
 acceptance-cluster-delete:
 	k3d cluster delete epinio-acceptance
+	@if test -f /usr/local/bin/rke2-uninstall.sh; then sudo sh /usr/local/bin/rke2-uninstall.sh; fi
 
 acceptance-cluster-delete-kind:
 	kind delete cluster --name epinio-acceptance

--- a/acceptance/install/scenario7_test.go
+++ b/acceptance/install/scenario7_test.go
@@ -1,0 +1,126 @@
+package install_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/epinio/epinio/acceptance/helpers/catalog"
+	"github.com/epinio/epinio/acceptance/helpers/epinio"
+	"github.com/epinio/epinio/acceptance/helpers/proc"
+	"github.com/epinio/epinio/acceptance/testenv"
+)
+
+var _ = Describe("<Scenario7> RKE, Private CA", func() {
+	var (
+		flags        []string
+		epinioHelper epinio.Epinio
+		appName      = catalog.NewAppName()
+		loadbalancer string
+		metallbURL   string
+		localpathURL string
+	)
+
+	BeforeEach(func() {
+		epinioHelper = epinio.NewEpinioHelper(testenv.EpinioBinaryPath())
+
+		metallbURL = "https://raw.githubusercontent.com/google/metallb/v0.10.3/manifests/metallb.yaml"
+		localpathURL = "https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.20/deploy/local-path-storage.yaml"
+
+		flags = []string{
+			"--skip-default-namespace",
+			"--skip-cert-manager",
+			"--tls-issuer=private-ca",
+		}
+	})
+
+	AfterEach(func() {
+		out, err := epinioHelper.Uninstall()
+		Expect(err).NotTo(HaveOccurred(), out)
+	})
+
+	It("installs with loadbalancer IP and pushes an app with env vars", func() {
+		By("Installing MetalLB", func() {
+			out, err := proc.RunW("kubectl", "create", "namespace", "metallb-system")
+			Expect(err).NotTo(HaveOccurred(), out)
+
+			out, err = proc.RunW("kubectl", "apply", "-f", metallbURL)
+			Expect(err).NotTo(HaveOccurred(), out)
+
+			out, err = proc.RunW("kubectl", "apply", "-f", testenv.TestAssetPath("config-metallb-rke.yml"))
+			Expect(err).NotTo(HaveOccurred(), out)
+		})
+
+		By("Configuring local-path storage", func() {
+			out, err := proc.RunW("kubectl", "apply", "-f", localpathURL)
+			Expect(err).NotTo(HaveOccurred(), out)
+
+			value := `{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}`
+			out, err = proc.RunW("kubectl", "patch", "storageclass", "local-path", "-p", value)
+			Expect(err).NotTo(HaveOccurred(), out)
+		})
+
+		By("Installing CertManager", func() {
+			out, err := epinioHelper.Run("install-cert-manager")
+			Expect(err).NotTo(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("CertManager deployed"))
+
+			// Create certificate secret and cluster_issuer
+			out, err = proc.RunW("kubectl", "apply", "-f", testenv.TestAssetPath("cluster-issuer-private-ca.yml"))
+			Expect(err).NotTo(HaveOccurred(), out)
+		})
+
+		By("Installing Epinio", func() {
+			out, err := epinioHelper.Install(flags...)
+			Expect(err).NotTo(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("Epinio installed."))
+
+			out, err = testenv.PatchEpinio()
+			Expect(err).ToNot(HaveOccurred(), out)
+		})
+
+		By("Checking Loadbalancer IP", func() {
+			out, err := proc.RunW("kubectl", "get", "service", "-n", "traefik", "traefik", "-o", "json")
+			Expect(err).NotTo(HaveOccurred(), out)
+
+			status := &testenv.LoadBalancerHostname{}
+			err = json.Unmarshal([]byte(out), status)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status.Status.LoadBalancer.Ingress).To(HaveLen(1))
+			loadbalancer = status.Status.LoadBalancer.Ingress[0].IP
+			Expect(loadbalancer).ToNot(BeEmpty())
+		})
+
+		// Now create the default org which we skipped because
+		// it would fail before patching.
+		testenv.EnsureDefaultWorkspace(testenv.EpinioBinaryPath())
+		out, err := epinioHelper.Run("target", testenv.DefaultWorkspace)
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		By("Pushing an app with Env vars", func() {
+			out, err := epinioHelper.Run("apps", "create", appName)
+			Expect(err).NotTo(HaveOccurred(), out)
+
+			out, err = epinioHelper.Run("apps", "env", "set", appName, "MYVAR", "myvalue")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			out, err = epinioHelper.Run("push",
+				"--name", appName,
+				"--path", testenv.AssetPath("sample-app"))
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			Eventually(func() string {
+				out, err := proc.RunW("kubectl", "get", "deployment", "--namespace", testenv.DefaultWorkspace, appName, "-o", "jsonpath={.spec.template.spec.containers[0].env}")
+				Expect(err).ToNot(HaveOccurred(), out)
+				return out
+			}).Should(MatchRegexp("MYVAR"))
+
+			// Verify cluster_issuer is used
+			out, err = proc.RunW("kubectl", "get", "certificate",
+				"-n", testenv.DefaultWorkspace, appName, "-o", "jsonpath='{.spec.issuerRef.name}'")
+			Expect(err).NotTo(HaveOccurred(), out)
+			Expect(out).To(Equal("'private-ca'"))
+		})
+	})
+})

--- a/assets/tests/config-metallb-rke.yml
+++ b/assets/tests/config-metallb-rke.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 192.168.1.240-192.168.1.241


### PR DESCRIPTION
See #902.

This PR adds Epinio CI test on RKE (it uses self-hosted runners) with these settings:
- use MetaLB for the load-balancer, with a private IPs range (so not routed)
- there is no DNS (because of private IPs), so it uses the Magic DNS method to install Epinio
- it keep the check of the Traefik IP, not needed but could be a good idea to check that the LB is correctly configured
- it test a Private CA like the Scenario3 in AKS, but RKE test has less timeout issue, so more chance to pass each night