### PR TITLE
Make sure there is an ingressclass for Traefik

### DIFF
--- a/deployments/traefik.go
+++ b/deployments/traefik.go
@@ -137,6 +137,8 @@ func (k Traefik) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI
 		`--set`, `globalArguments=`,
 		`--set-string`, `deployment.podAnnotations.linkerd\.io/inject=enabled`,
 		`--set-string`, `ports.web.redirectTo=websecure`,
+		`--set-string`, `ingressClass.enabled=true`,
+		`--set-string`, `ingressClass.isDefaultClass=true`,
 		`--set-string`, fmt.Sprintf("service.spec.loadBalancerIP=%s", loadBalancerIP),
 	}
 


### PR DESCRIPTION
otherwise the Ingresses created by cert-manager for the challenges,
won't work. That's because they get the new "ingressClass" field which
requires an Ingress Class to exist.

More here:
- https://github.com/traefik/traefik/blob/4235cef1b239bdffdb2fe7c62ebcac83df55781f/docs/content/providers/kubernetes-ingress.md#ingressclass
- https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml#L64
- https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
- https://cert-manager.io/docs/usage/ingress/

Probably cert-manager started adding that field here:

https://github.com/jetstack/cert-manager/commit/57e9e57fbf015783da258e40fe8f932f89f4fdac