### PR TITLE
feat: implement fix for manpage cross links to work in the mdbook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,10 +99,13 @@ generate:
 	go generate ./...
 
 # Assumes that the `docs` checkout is a sibling of the `epinio` checkout
+# perl -pi - Fixes ${HOME} references to proper `~`.
+# sed -i   - Fixes the cross-links to match hierarchy and mdbook expectations.
 generate-cli-docs:
 	rm -f ../docs/src/references/cli/*
 	go run internal/cli/docs/generate-cli-docs.go ../docs/src/references/cli/
 	perl -pi -e "s@${HOME}@~@" ../docs/src/references/cli/*md
+	sed -i 's@(\.\./\(.*\))@(\1.md)@' ../docs/src/references/cli/*md
 
 lint: embed_files
 	go vet ./...


### PR DESCRIPTION
Code PR for https://github.com/epinio/docs/pull/19
Controlling ticket #820 

The change adds a post processing stage to the manpage generation which fixes the cross-links between the manpages to work for our mdbook.
