### PR TITLE
Fix AKS CI in patching stage

### DIFF
--- a/scripts/patch-epinio-deployment.sh
+++ b/scripts/patch-epinio-deployment.sh
@@ -129,10 +129,6 @@ read -r -d '' PATCH <<EOF
 EOF
 kubectl patch deployment -n epinio epinio-server -p "${PATCH}"
 
-
-echo "Ensuring the deployment is restarted"
-kubectl rollout restart deployment -n epinio epinio-server
-
 # https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#-em-status-em-
 echo "Waiting for the rollout of the deployment to complete"
 kubectl rollout status deployment -n epinio epinio-server  --timeout=$timeout


### PR DESCRIPTION
The `rollout restart` is not needed, as it is automatically triggered after the `patch` command, and as it fails on AKS better to remove it.

Manually tested successfully on AKS, EKS and k3s.

Note: the `rollout status` is kept, as after a patch a rollout is trigger, and this is the way to ensure that the deployment is done.