### PR TITLE
Cache users instead of querying the cluster on each request.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ replace github.com/ulikunitz/xz => github.com/ulikunitz/xz v0.5.8
 require (
 	github.com/Azure/go-autorest/autorest v0.11.17 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.10 // indirect
+	github.com/alexander-yu/stream v0.0.0-20190408032938-f6f8149baa3a
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/briandowns/spinner v1.12.0
 	github.com/codeskyblue/kexec v0.0.0-20180119015717-5a4bed90d99a

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alexander-yu/stream v0.0.0-20190408032938-f6f8149baa3a h1:JUrWuppd0SWyI178cfQJES3UfUzPIU2WicYVsBpZl4E=
+github.com/alexander-yu/stream v0.0.0-20190408032938-f6f8149baa3a/go.mod h1:nS9kLerJlh6FPg+VoIaiAw/ypWLJ0Zvo5zgGVRxIPVo=
 github.com/andybalholm/brotli v1.0.0 h1:7UCwP93aiSfvWpapti8g88vVVGp2qqtGyePsSuDafo4=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
@@ -244,6 +246,8 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/gammazero/deque v0.0.0-20190130191400-2afb3858e9c7 h1:D2LrfOPgGHQprIxmsTpxtzhpmF66HoM6rXSmcqaX7h8=
+github.com/gammazero/deque v0.0.0-20190130191400-2afb3858e9c7/go.mod h1:GeIq9qoE43YdGnDXURnmKTnGg15pQz4mYkXSTChbneI=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -538,6 +542,7 @@ github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd
 github.com/klauspost/pgzip v1.2.4 h1:TQ7CNpYKovDOmqzRHKxJh0BeaBI7UdQZYc6p7pMQh1A=
 github.com/klauspost/pgzip v1.2.4/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -742,6 +747,7 @@ github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f/go.mod h1:AuYgA5K
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
@@ -813,6 +819,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/vdemeester/k8s-pkg-credentialprovider v1.19.7/go.mod h1:K2nMO14cgZitdwBqdQps9tInJgcaXcU/7q5F59lpbNI=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
+github.com/workiva/go-datastructures v1.0.50 h1:fIBEgeOEH7fzlx6Nqn+2NyK/JVD5EgDgponNmzoFhyk=
+github.com/workiva/go-datastructures v1.0.50/go.mod h1:ZYLyltToJkj6X5blfbFnTTEbryqb3v6D00JfVYDgUI0=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
@@ -865,6 +873,7 @@ golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -1007,6 +1016,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190322080309-f49334f85ddc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/cli/debug.go
+++ b/internal/cli/debug.go
@@ -3,15 +3,24 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"time"
 
+	"github.com/alexander-yu/stream/minmax"
+	"github.com/alexander-yu/stream/moment"
+	"github.com/alexander-yu/stream/quantile"
 	"github.com/mattn/go-isatty"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/epinio/epinio/internal/cli/usercmd"
 )
 
 var ()
 
 func init() {
 	CmdDebug.AddCommand(CmdDebugTTY)
+	CmdDebug.AddCommand(CmdDebugLoad)
 }
 
 // CmdDebug implements the command: epinio debug
@@ -31,7 +40,7 @@ var CmdDebug = &cobra.Command{
 	},
 }
 
-// CmdDebug implements the command: epinio debug tty
+// CmdDebugTTY implements the command: epinio debug tty
 var CmdDebugTTY = &cobra.Command{
 	Use:   "tty",
 	Short: "Running In a Terminal?",
@@ -46,6 +55,104 @@ var CmdDebugTTY = &cobra.Command{
 		} else {
 			fmt.Println("Is Not Terminal")
 		}
+		return nil
+	},
+}
+
+// CmdDebugLoad implements the command: epinio debug load
+var CmdDebugLoad = &cobra.Command{
+	Use:   "load count millis",
+	Short: "Generate server load",
+	Long:  `Generate server load and collect response statistics`,
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		count, err := strconv.Atoi(args[0])
+		if err != nil {
+			return errors.Wrap(err, "bad count")
+		}
+		millis, err := strconv.Atoi(args[1])
+		if err != nil {
+			return errors.Wrap(err, "bad millis")
+		}
+
+		client, err := usercmd.New()
+		if err != nil {
+			return errors.Wrap(err, "error initializing cli")
+		}
+
+		timing := make(chan time.Duration, 10000)
+
+		// Load Engine
+		// - naive, trivial: ping every X milliseconds
+
+		// TODO:
+		// - jitter (randomization)
+		// - multiple streams (same load per stream)
+		// - streams with different loads
+		// - general user simulation driven by some distribution
+		//   + distribution driven user creation/deletion (streams)
+
+		go func(timing chan time.Duration) {
+			// millis and count are from outer scope.
+			delta := time.Duration(millis) * time.Millisecond
+
+			// Two unmeasured initial calls as warmup
+			client.API.Info() // nolint:errcheck // Result is irrelevant
+			client.API.Info() // nolint:errcheck // Result is irrelevant
+
+			for k := 0; k < count; k++ {
+				start := time.Now()
+				client.API.Info() // nolint:errcheck // Result is irrelevant
+				timing <- time.Since(start)
+				time.Sleep(delta)
+			}
+			close(timing)
+		}(timing)
+
+		// Receiver and statistics engine (streaming)
+
+		quants, _ := quantile.NewGlobalQuantile()
+		max := minmax.NewGlobalMax()
+		min := minmax.NewGlobalMin()
+		mean := moment.NewGlobalMean()
+		stdv := moment.NewGlobalStd()
+		moment.Init(mean) // nolint:errcheck
+		moment.Init(stdv) // nolint:errcheck
+
+		pings := 0
+		for duration := range timing {
+			pings++
+
+			fmt.Fprintf(os.Stderr, "\r\033[2K%dms %d/%d", millis, count, pings)
+
+			dmilli := float64(duration.Milliseconds())
+
+			mean.Push(dmilli)   // nolint:errcheck
+			stdv.Push(dmilli)   // nolint:errcheck
+			min.Push(dmilli)    // nolint:errcheck
+			max.Push(dmilli)    // nolint:errcheck
+			quants.Push(dmilli) // nolint:errcheck
+		}
+
+		fmt.Fprintf(os.Stderr, "\r\033[2K")
+
+		minv, _ := min.Value()        // nolint:errcheck
+		maxv, _ := max.Value()        // nolint:errcheck
+		avgv, _ := mean.Value()       // nolint:errcheck
+		varv, _ := stdv.Value()       // nolint:errcheck
+		tenv, _ := quants.Value(0.1)  // nolint:errcheck
+		fifv, _ := quants.Value(0.5)  // nolint:errcheck
+		ninv, _ := quants.Value(0.9)  // nolint:errcheck
+		niiv, _ := quants.Value(0.99) // nolint:errcheck
+
+		reqs := 1000 / millis
+
+		fmt.Printf("pings___ millis req/s_ | min___     max___ | mean_____  stdvar_ | 10%%____ 50%%____ 90%%____ 99%%____\n")
+		fmt.Printf("%8d %6d %6d | %6.0f ... %6.0f | %9.4f  %7.4f | %7.3f %7.3f %7.3f %7.3f\n",
+			pings, millis, reqs, minv, maxv, avgv, varv, tenv, fifv, ninv, niiv)
+
 		return nil
 	},
 }

--- a/scripts/measure-server-times.sh
+++ b/scripts/measure-server-times.sh
@@ -1,0 +1,40 @@
+#/bin/bash
+
+trial(){
+    echo >2 "$@"
+    ep debug load "$@"
+}
+
+#     count millis
+
+trial 100   1000
+trial 100   500
+trial 100   200
+trial 100   100
+trial 100   50
+trial 100   20
+trial 100   10
+trial 100   5
+trial 100   2
+trial 100   1
+
+trial 10    10
+trial 20    10
+trial 30    10
+trial 40    10
+trial 50    10
+trial 60    10
+trial 70    10
+trial 80    10
+trial 90    10
+
+trial 1000  1000
+trial 1000  500
+trial 1000  200
+trial 1000  100
+trial 1000  50
+trial 1000  20
+trial 1000  10
+trial 1000  5
+trial 1000  2
+trial 1000  1

--- a/scripts/measure-server-times.sh
+++ b/scripts/measure-server-times.sh
@@ -1,40 +1,47 @@
 #/bin/bash
 
 trial(){
-    echo >2 "$@"
+    echo 1>&2 "$@"
     ep debug load "$@"
 }
 
-#     count millis
+sep() {
+    echo '________ ________ ______ ________ | ______     ________ | __________  __________ | __________ __________ __________ __________'
+}
 
-trial 100   1000
-trial 100   500
-trial 100   200
-trial 100   100
-trial 100   50
-trial 100   20
-trial 100   10
-trial 100   5
-trial 100   2
-trial 100   1
-
-trial 10    10
-trial 20    10
-trial 30    10
-trial 40    10
-trial 50    10
-trial 60    10
-trial 70    10
-trial 80    10
-trial 90    10
-
-trial 1000  1000
-trial 1000  500
-trial 1000  200
-trial 1000  100
-trial 1000  50
-trial 1000  20
-trial 1000  10
-trial 1000  5
-trial 1000  2
-trial 1000  1
+#     count millis streams
+#
+trial 100   1000 1
+trial 100   500  1
+trial 100   200  1
+trial 100   100  1
+trial 100   50   1
+trial 100   20   1
+trial 100   10   1
+trial 100   5    1
+trial 100   2    1
+trial 100   1    1
+sep
+#
+trial 100   1000 1
+trial 100   1000 2
+trial 100   1000 5
+trial 100   1000 10
+trial 100   1000 20
+trial 100   1000 50
+trial 100   1000 100
+trial 100   1000 200
+trial 100   1000 500
+trial 100   1000 1000
+sep
+#
+trial 100   100  1
+trial 100   100  2
+trial 100   100  5
+trial 100   100  10
+trial 100   100  20
+trial 100   100  50
+trial 100   100  100
+trial 100   100  200
+trial 100   100  500
+trial 100   100  1000


### PR DESCRIPTION
Fix #927

First, a basic load generator for the server, collecting response statistics. Also an initial script invoking for the generator for a matrix of counts and delays.

See https://github.com/epinio/epinio/issues/927#issuecomment-952624065 for the baseline performance of the unmodified server, without any kind of caching.
