### PR TITLE
New endpoint to list all services, across namespaces

### DIFF
--- a/acceptance/api/v1/services_test.go
+++ b/acceptance/api/v1/services_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 var _ = Describe("Services API Application Endpoints", func() {
+	containerImageURL := "splatform/sample-app"
+
 	var org string
 	var svc1, svc2 string
 
@@ -67,6 +69,85 @@ var _ = Describe("Services API Application Endpoints", func() {
 			bodyBytes, err := ioutil.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.StatusCode).To(Equal(http.StatusNotFound), string(bodyBytes))
+		})
+	})
+
+	Describe("GET /api/v1/services", func() {
+		var org1 string
+		var org2 string
+		var service1 string
+		var service2 string
+		var app1 string
+
+		// Setting up:
+		// org1 service1 app1
+		// org2 service1
+		// org2 service2
+
+		BeforeEach(func() {
+			org1 = catalog.NewOrgName()
+			org2 = catalog.NewOrgName()
+			service1 = catalog.NewServiceName()
+			service2 = catalog.NewServiceName()
+			app1 = catalog.NewAppName()
+
+			env.SetupAndTargetOrg(org1)
+			env.MakeService(service1)
+			env.MakeContainerImageApp(app1, 1, containerImageURL)
+			env.BindAppService(app1, service1, org1)
+
+			env.SetupAndTargetOrg(org2)
+			env.MakeService(service1) // separate from org1.service1
+			env.MakeService(service2)
+		})
+
+		AfterEach(func() {
+			env.TargetOrg(org2)
+			env.DeleteService(service1)
+			env.DeleteService(service2)
+
+			env.TargetOrg(org1)
+			env.DeleteApp(app1)
+			env.DeleteService(service1)
+		})
+
+		It("lists all services belonging to all namespaces", func() {
+			// But we care only about the three we know about from the setup.
+
+			response, err := env.Curl("GET", fmt.Sprintf("%s%s/services",
+				serverURL, api.Root), strings.NewReader(""))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+
+			defer response.Body.Close()
+			bodyBytes, err := ioutil.ReadAll(response.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+			var services models.ServiceResponseList
+			err = json.Unmarshal(bodyBytes, &services)
+			Expect(err).ToNot(HaveOccurred())
+
+			// `services` contains all services. Not just the two we are looking for, from
+			// the setup of this test. Everything which still exists from other tests
+			// executing concurrently, or not cleaned by previous tests, or the setup, or
+			// ... So, we cannot be sure that the two services are in the two first
+			// elements of the slice.
+
+			var serviceRefs [][]string
+			for _, s := range services {
+				serviceRefs = append(serviceRefs, []string{
+					s.Meta.Name,
+					s.Meta.Namespace,
+					strings.Join(s.BoundApps, ", "),
+				})
+			}
+			Expect(serviceRefs).To(ContainElements(
+				[]string{service1, org1, app1},
+				[]string{service1, org2, ""},
+				[]string{service2, org2, ""},
+			))
+
 		})
 	})
 

--- a/acceptance/api/v1/services_test.go
+++ b/acceptance/api/v1/services_test.go
@@ -33,6 +33,7 @@ var _ = Describe("Services API Application Endpoints", func() {
 	})
 
 	AfterEach(func() {
+		env.TargetOrg(org)
 		env.DeleteService(svc1)
 		env.DeleteService(svc2)
 	})

--- a/acceptance/api/v1/services_test.go
+++ b/acceptance/api/v1/services_test.go
@@ -51,8 +51,8 @@ var _ = Describe("Services API Application Endpoints", func() {
 			var data models.ServiceResponseList
 			err = json.Unmarshal(bodyBytes, &data)
 			Expect(err).ToNot(HaveOccurred())
-			serviceNames = append(serviceNames, data[0].Name)
-			serviceNames = append(serviceNames, data[1].Name)
+			serviceNames = append(serviceNames, data[0].Meta.Name)
+			serviceNames = append(serviceNames, data[1].Meta.Name)
 			Expect(serviceNames).Should(ContainElements(svc1, svc2))
 		})
 

--- a/internal/api/v1/application/fullindex.go
+++ b/internal/api/v1/application/fullindex.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// Index handles the API endpoint GET /applications
+// FullIndex handles the API endpoint GET /applications
 // It lists all the known applications in all namespaces, with and without workload.
 func (hc Controller) FullIndex(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -107,6 +107,7 @@ var Routes = routes.NamedRoutes{
 	// List, show, create and delete services
 	"ServiceApps": get("/namespaces/:org/serviceapps", errorHandler(service.Controller{}.ServiceApps)),
 	//
+	"AllServices":   get("/services", errorHandler(service.Controller{}.FullIndex)),
 	"Services":      get("/namespaces/:org/services", errorHandler(service.Controller{}.Index)),
 	"ServiceShow":   get("/namespaces/:org/services/:service", errorHandler(service.Controller{}.Show)),
 	"ServiceCreate": post("/namespaces/:org/services", errorHandler(service.Controller{}.Create)),

--- a/internal/api/v1/service/serviceapps.go
+++ b/internal/api/v1/service/serviceapps.go
@@ -44,13 +44,17 @@ func (hc Controller) ServiceApps(c *gin.Context) apierror.APIErrors {
 	return nil
 }
 
+// serviceKey constructs a single key string from service and namespace names, for the
+// `servicesToApps` map, when used for services and apps across all namespaces. It uses
+// ASCII NUL (\000) as the separator character. NUL is forbidden to occur in the names
+// themselves. This should make it impossible to construct two different pairs of
+// service/namespace names which map to the same key.
 func serviceKey(name, namespace string) string {
 	return fmt.Sprintf("%s\000%s", name, namespace)
 }
 
-// servicesToApps is a helper to Index and Delete. It produces a map
-// from service instances names to application names, the apps bound
-// to each service.
+// servicesToApps is a helper to Index and Delete. It produces a map from service
+// instances names to application names, the apps bound to each service.
 func servicesToApps(ctx context.Context, cluster *kubernetes.Cluster, namespace string) (map[string]models.AppList, error) {
 	// Determine apps bound to services
 	// (inversion of services bound to apps)

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -17,6 +17,8 @@ func init() {
 	CmdService.AddCommand(CmdServiceBind)
 	CmdService.AddCommand(CmdServiceUnbind)
 	CmdService.AddCommand(CmdServiceList)
+
+	CmdServiceList.Flags().Bool("all", false, "list all services")
 }
 
 // CmdService implements the command: epinio service
@@ -162,8 +164,9 @@ var CmdServiceUnbind = &cobra.Command{
 
 // CmdServiceList implements the command: epinio service list
 var CmdServiceList = &cobra.Command{
-	Use:   "list",
-	Short: "Lists all services",
+	Use:   "list [--all]",
+	Short: "Lists services",
+	Long:  "Lists services in the targeted namespace, or all",
 	RunE:  ServiceList,
 }
 
@@ -193,7 +196,12 @@ func ServiceList(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "error initializing cli")
 	}
 
-	err = client.Services()
+	all, err := cmd.Flags().GetBool("all")
+	if err != nil {
+		return errors.Wrap(err, "error reading option --all")
+	}
+
+	err = client.Services(all)
 	if err != nil {
 		return errors.Wrap(err, "error listing services")
 	}

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -1,4 +1,4 @@
-// Package auth collects structures and functions around the domains
+// Package domain collects structures and functions around the domains
 // the client works with.
 package domain
 

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -49,11 +49,10 @@ func Lookup(ctx context.Context, kubeClient *kubernetes.Cluster, org, service st
 }
 
 // List returns a ServiceList of all available Services
-func List(ctx context.Context, kubeClient *kubernetes.Cluster, org string) (ServiceList, error) {
-	labelSelector := fmt.Sprintf("app.kubernetes.io/name=epinio, epinio.suse.org/namespace=%s", org)
+func List(ctx context.Context, cluster *kubernetes.Cluster, namespace string) (ServiceList, error) {
 
-	secrets, err := kubeClient.Kubectl.CoreV1().
-		Secrets(org).List(ctx,
+	secrets, err := cluster.Kubectl.CoreV1().
+		Secrets(namespace).List(ctx,
 		metav1.ListOptions{
 			LabelSelector: labelSelector,
 		})
@@ -66,16 +65,16 @@ func List(ctx context.Context, kubeClient *kubernetes.Cluster, org string) (Serv
 
 	for _, s := range secrets.Items {
 		service := s.ObjectMeta.Labels["epinio.suse.org/service"]
-		org := s.ObjectMeta.Labels["epinio.suse.org/namespace"]
+		namespace := s.ObjectMeta.Labels["epinio.suse.org/namespace"]
 		username := s.ObjectMeta.Labels["app.kubernetes.io/created-by"]
 
 		secretName := s.ObjectMeta.Name
 
 		result = append(result, &Service{
 			SecretName: secretName,
-			OrgName:    org,
+			OrgName:    namespace,
 			Service:    service,
-			kubeClient: kubeClient,
+			kubeClient: cluster,
 			Username:   username,
 		})
 	}
@@ -83,14 +82,14 @@ func List(ctx context.Context, kubeClient *kubernetes.Cluster, org string) (Serv
 	return result, nil
 }
 
-// CreateService creates a new  service instance from org,
+// CreateService creates a new  service instance from namespace,
 // name, and a map of parameters.
-func CreateService(ctx context.Context, kubeClient *kubernetes.Cluster, name, org, username string,
+func CreateService(ctx context.Context, cluster *kubernetes.Cluster, name, namespace, username string,
 	data map[string]string) (*Service, error) {
 
-	secretName := serviceResourceName(org, name)
+	secretName := serviceResourceName(namespace, name)
 
-	_, err := kubeClient.GetSecret(ctx, org, secretName)
+	_, err := cluster.GetSecret(ctx, namespace, secretName)
 	if err == nil {
 		return nil, errors.New("Service of this name already exists.")
 	}
@@ -102,11 +101,11 @@ func CreateService(ctx context.Context, kubeClient *kubernetes.Cluster, name, or
 		sdata[k] = []byte(v)
 	}
 
-	err = kubeClient.CreateLabeledSecret(ctx, org, secretName, sdata,
+	err = cluster.CreateLabeledSecret(ctx, namespace, secretName, sdata,
 		map[string]string{
 			// "epinio.suse.org/service-type": "custom",
 			"epinio.suse.org/service":      name,
-			"epinio.suse.org/namespace":    org,
+			"epinio.suse.org/namespace":    namespace,
 			"app.kubernetes.io/name":       "epinio",
 			"app.kubernetes.io/created-by": username,
 			// "app.kubernetes.io/version":     cmd.Version
@@ -119,9 +118,9 @@ func CreateService(ctx context.Context, kubeClient *kubernetes.Cluster, name, or
 	}
 	return &Service{
 		SecretName: secretName,
-		OrgName:    org,
+		OrgName:    namespace,
 		Service:    name,
-		kubeClient: kubeClient,
+		kubeClient: cluster,
 	}, nil
 }
 
@@ -135,7 +134,7 @@ func (s *Service) User() string {
 	return s.Username
 }
 
-// Org returns the service instance's organization
+// Org returns the service instance's namespace
 func (s *Service) Org() string {
 	return s.OrgName
 }
@@ -144,8 +143,8 @@ func (s *Service) Org() string {
 // to the application. This is actually the instance's secret itself,
 // independent of the application.
 func (s *Service) GetBinding(ctx context.Context, appName string, _ string) (*corev1.Secret, error) {
-	kubeClient := s.kubeClient
-	serviceSecret, err := kubeClient.GetSecret(ctx, s.OrgName, s.SecretName)
+	cluster := s.kubeClient
+	serviceSecret, err := cluster.GetSecret(ctx, s.OrgName, s.SecretName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, errors.New("service does not exist")
@@ -183,7 +182,7 @@ func (s *Service) Details(ctx context.Context) (map[string]string, error) {
 }
 
 // serviceResourceName returns a name for a kube service resource
-// representing the org and service
-func serviceResourceName(org, service string) string {
-	return fmt.Sprintf("service.org-%s.svc-%s", org, service)
+// representing the namespace and service
+func serviceResourceName(namespace, service string) string {
+	return fmt.Sprintf("service.org-%s.svc-%s", namespace, service)
 }

--- a/pkg/api/core/v1/models/app.go
+++ b/pkg/api/core/v1/models/app.go
@@ -86,7 +86,9 @@ func (al AppList) Swap(i, j int) {
 // indices in the AppList and returns true if the condition holds, and
 // else false.
 func (al AppList) Less(i, j int) bool {
-	return al[i].Meta.Name < al[j].Meta.Name
+	return (al[i].Meta.Org < al[j].Meta.Org) ||
+		((al[i].Meta.Org == al[j].Meta.Org) &&
+			(al[i].Meta.Name < al[j].Meta.Name))
 }
 
 // AppRef references an App by name and org

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -16,10 +16,16 @@ var ResponseOK = Response{"ok"}
 type Request struct {
 }
 
+// ServiceRef references a Service by name and namespace
+type ServiceRef struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
 // ServiceResponse represents the data of a single service instance
 type ServiceResponse struct {
-	Name      string   `json:"name"`
-	BoundApps []string `json:"boundapps"`
+	Meta      ServiceRef `json:"meta"`
+	BoundApps []string   `json:"boundapps"`
 }
 
 // ServiceResponseList represents a collection of service instance

--- a/pkg/api/core/v1/models/sort.go
+++ b/pkg/api/core/v1/models/sort.go
@@ -17,5 +17,5 @@ func (srl ServiceResponseList) Swap(i, j int) {
 // indices in the ServiceResponseList and returns true if the
 // condition holds, and else false.
 func (srl ServiceResponseList) Less(i, j int) bool {
-	return srl[i].Name < srl[j].Name
+	return srl[i].Meta.Name < srl[j].Meta.Name
 }

--- a/pkg/api/core/v1/models/sort.go
+++ b/pkg/api/core/v1/models/sort.go
@@ -17,5 +17,8 @@ func (srl ServiceResponseList) Swap(i, j int) {
 // indices in the ServiceResponseList and returns true if the
 // condition holds, and else false.
 func (srl ServiceResponseList) Less(i, j int) bool {
-	return srl[i].Meta.Name < srl[j].Meta.Name
+	// Comparison is done on the namespace names first, and then on the service names.
+	return (srl[i].Meta.Namespace < srl[j].Meta.Namespace) ||
+		((srl[i].Meta.Namespace == srl[j].Meta.Namespace) &&
+			(srl[i].Meta.Name < srl[j].Meta.Name))
 }


### PR DESCRIPTION
Fix #943 

The new API test for `/services` fails.
I am currently unable to see why.
The new cli test does work, and it uses the exact same sort of setup and teardown.

Both use the service1 name for separate services in the org1 and org2 namespaces, and a service2 just in org2.
At this point I am not even sure which of the deletion is failing thinking that the service does not exist (already gone ? never created?)

I am placing this into review and hope somebody else sees what is going wrong with it.

With a bit of custom tracing it seems to be the services from the outermost before/after clauses which make the trouble.
Ah! That comes with its own org, of course, and I am targeting my orgs, so the client looks at the wrong org when it tries to delete.

Fix coming. ... 

