### PR TITLE
Add dockerfile for building epinio-installer

### DIFF
--- a/images/baseimage-Dockerfile
+++ b/images/baseimage-Dockerfile
@@ -1,3 +1,3 @@
 FROM opensuse/leap:15.3
 LABEL org.opencontainers.image.source https://github.com/epinio/epinio
-RUN zypper ref && zypper install --no-recommends -y git tar gzip && rm -fr /var/cache/*
+RUN zypper ref && zypper install --no-recommends -y git tar gzip curl && rm -fr /var/cache/*

--- a/images/installer-Dockerfile
+++ b/images/installer-Dockerfile
@@ -1,0 +1,10 @@
+# Image used by the Epinio Helm Chart
+# Helm and kubectl must be installed in, that's why it differs from epinio-server image
+
+ARG SERVER_IMAGE=splatform/epinio-server
+
+FROM $SERVER_IMAGE
+RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+RUN chmod +x ./kubectl
+RUN mv ./kubectl /usr/local/bin/kubectl

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -5,10 +5,20 @@ set -e
 version="$(git describe --tags)"
 base_image="splatform/epinio-base"
 server_image="splatform/epinio-server"
+installer_image="splatform/epinio-installer"
 
+# Build base image
 docker build -t "${base_image}:${version}" -t "${base_image}:latest" -f images/baseimage-Dockerfile .
 docker push "${base_image}:${version}"
 docker push "${base_image}:latest"
+
+# Build server image
 docker build -t "${server_image}:${version}" -t "${server_image}:latest" --build-arg BASE_IMAGE=${base_image} -f images/Dockerfile .
 docker push "${server_image}:${version}"
 docker push "${server_image}:latest"
+
+# Build installer image
+# This image is used by the Epinio helm chart
+docker build -t "${installer_image}:${version}" -t "${installer_image}:latest" -f images/installer-Dockerfile .
+docker push "${installer_image}:${version}"
+docker push "${installer_image}:latest"


### PR DESCRIPTION
For the Epinio Helm chart, we need an image with epinio  + Helm + kubectl.
This PR adds the Dockerfile for building it, the image will be built each time we release new Epinio version.
I successfully tested the image with [my docker account](https://hub.docker.com/r/juadk/epinio-installer/tags) 
`juadk/epinio-installer:latest`
I was able to deploy Epinio with helm in a k3s cluster.
Part of #936 
`make build-images` works by replacing splatform docker repo by juadk (my repo).
```
vagrant@dev-box:~/epinio> docker images
juadk/epinio-installer    latest               9b806c0c3327   2 minutes ago   436MB
juadk/epinio-installer    v0.1.4-12-g204e91b   9b806c0c3327   2 minutes ago   436MB
juadk/epinio-server       latest               fbd842a519f8   4 hours ago     249MB
juadk/epinio-server       v0.1.4-12-g204e91b   fbd842a519f8   4 hours ago     249MB
juadk/epinio-base         latest               14e239993e6a   6 hours ago     196MB
juadk/epinio-base         v0.1.4-12-g204e91b   14e239993e6a   6 hours ago     196MB
```
