### PR TITLE
Specify GKE zone to reduce costs

### DIFF
--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -22,7 +22,7 @@ env:
   SETUP_GO_VERSION: '^1.13.7'
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
-  GKE_ZONE: 'europe-west1'
+  GKE_ZONE: 'europe-west1-b'
   GKE_VERSION: '1.21.4-gke.2300'
   GKE_MACHINE_TYPE: 'n2-standard-4'
 


### PR DESCRIPTION
The GKE zone must be specify, otherwise one node is created in every zone.
That means if I use `--num-nodes=1` with --zone `europe-west1`, I will get 3 nodes:
- europe-west1-b
- europe-west1-c
- europe-west1-d

To really create only one node, we have to be more precise with the zone id like `europe-west1-b`

```
NAME                LOCATION        MASTER_VERSION   MASTER_IP      MACHINE_TYPE   NODE_VERSION     NUM_NODES  STATUS
cluster-epinio    europe-west1    1.20.10-gke.301  xx.xx.xx.xx  n1-standard-2  1.20.10-gke.301  3          RUNNING
cluster2-epinio  europe-west1-b  1.21.4-gke.2300  xx.xx.xx.xx   n2-standard-4  1.21.4-gke.2300  1          RUNNING
```