### PR TITLE
Enable cross CI to release helm chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,17 @@ jobs:
           prerelease: "true"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Allow to release Epinio Helm chart automatically when we release Epinio.
+      # The latest tag is sent to the Helm chart repo.
+      - name: Get the last tag
+        id: last-tag
+        run: |
+          tag=$(git -P tag | tail -1)
+          echo '::set-output name=TAG::'$tag
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.CHART_REPO_ACCESS_TOKEN }}
+          repository: epinio/epinio-helm-chart
+          event-type: epinio-release
+          client-payload: '{"ref": "${{ steps.last-tag.outputs.TAG }}"}'


### PR DESCRIPTION
This PR adds a repository dispatch action to send an API call to the [epinio/epinio-helm-chart ](https://github.com/epinio/epinio-helm-chart)repo.
The latest Epinio tag is sent and it is used for automatically update the appVersion chart field.
See also https://github.com/epinio/epinio-helm-chart/pull/1