### PR TITLE
Add a purge step in CI tests when route53 is used

### DIFF
--- a/acceptance/helpers/route53/change.go
+++ b/acceptance/helpers/route53/change.go
@@ -42,11 +42,11 @@ type DNSAnswer struct {
 	Protocol     string   `json:"Protocol"`
 }
 
-func CNAME(record string, value string) ChangeResourceRecordSet {
+func CNAME(record string, value string, action string) ChangeResourceRecordSet {
 	return ChangeResourceRecordSet{
 		Changes: []Change{
 			{
-				Action: "UPSERT",
+				Action: action,
 				ResourceRecordSet: ResourceRecordSet{
 					Name: record,
 					Type: "CNAME",
@@ -60,11 +60,11 @@ func CNAME(record string, value string) ChangeResourceRecordSet {
 	}
 }
 
-func A(record string, value string) ChangeResourceRecordSet {
+func A(record string, value string, action string) ChangeResourceRecordSet {
 	return ChangeResourceRecordSet{
 		Changes: []Change{
 			{
-				Action: "UPSERT",
+				Action: action,
 				ResourceRecordSet: ResourceRecordSet{
 					Name: record,
 					Type: "A",
@@ -78,7 +78,7 @@ func A(record string, value string) ChangeResourceRecordSet {
 	}
 }
 
-func Upsert(zoneID string, change ChangeResourceRecordSet, dir string) (string, error) {
+func Update(zoneID string, change ChangeResourceRecordSet, dir string) (string, error) {
 	b, err := json.MarshalIndent(change, "", " ")
 	if err != nil {
 		return "", err

--- a/acceptance/install/scenario2_test.go
+++ b/acceptance/install/scenario2_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // This test uses AWS route53 to update the system domain's records
-var _ = Describe("<Scenario2>", func() {
+var _ = Describe("<Scenario2> GKE, Letsencrypt, Zero instance", func() {
 	var (
 		flags        []string
 		epinioHelper epinio.Epinio

--- a/acceptance/install/scenario2_test.go
+++ b/acceptance/install/scenario2_test.go
@@ -69,12 +69,12 @@ var _ = Describe("<Scenario2> GKE, Letsencrypt, Zero instance", func() {
 		})
 
 		By("Updating DNS Entries", func() {
-			change := route53.A(domain, loadbalancer)
-			out, err := route53.Upsert(zoneID, change, nodeTmpDir)
+			change := route53.A(domain, loadbalancer, "UPSERT")
+			out, err := route53.Update(zoneID, change, nodeTmpDir)
 			Expect(err).NotTo(HaveOccurred(), out)
 
-			change = route53.A("*."+domain, loadbalancer)
-			out, err = route53.Upsert(zoneID, change, nodeTmpDir)
+			change = route53.A("*."+domain, loadbalancer, "UPSERT")
+			out, err = route53.Update(zoneID, change, nodeTmpDir)
 			Expect(err).NotTo(HaveOccurred(), out)
 		})
 
@@ -128,6 +128,16 @@ var _ = Describe("<Scenario2> GKE, Letsencrypt, Zero instance", func() {
 				"-o", "jsonpath='{.items[*].spec.issuerRef.name}'")
 			Expect(err).NotTo(HaveOccurred(), out)
 			Expect(out).To(Equal("'letsencrypt-production'"))
+		})
+
+		By("Cleaning DNS Entries", func() {
+			change := route53.A(domain, loadbalancer, "DELETE")
+			out, err := route53.Update(zoneID, change, nodeTmpDir)
+			Expect(err).NotTo(HaveOccurred(), out)
+
+			change = route53.A("*."+domain, loadbalancer, "DELETE")
+			out, err = route53.Update(zoneID, change, nodeTmpDir)
+			Expect(err).NotTo(HaveOccurred(), out)
 		})
 	})
 })

--- a/acceptance/install/scenario4_test.go
+++ b/acceptance/install/scenario4_test.go
@@ -74,6 +74,22 @@ var _ = Describe("<Scenario4>", func() {
 			Expect(err).NotTo(HaveOccurred(), out)
 		})
 
+		// Check that DNS entry is correctly propagated
+		By("Checking that DNS entry is correctly propagated", func() {
+			Eventually(func() string {
+				out, err := route53.TestDnsAnswer(zoneID, domain, "CNAME")
+				Expect(err).NotTo(HaveOccurred(), out)
+
+				answer := &route53.DNSAnswer{}
+				err = json.Unmarshal([]byte(out), answer)
+				Expect(err).NotTo(HaveOccurred())
+				if len(answer.RecordData) == 0 {
+					return ""
+				}
+				return answer.RecordData[0]
+			}, "5m", "2s").Should(Equal(loadbalancer + ".")) // CNAME ends with a '.'
+		})
+
 		By("Installing Epinio", func() {
 			out, err := epinioHelper.Install(flags...)
 			Expect(err).NotTo(HaveOccurred(), out)

--- a/acceptance/install/scenario4_test.go
+++ b/acceptance/install/scenario4_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // This test uses AWS route53 to update the system domain's records
-var _ = Describe("<Scenario4>", func() {
+var _ = Describe("<Scenario4> EKS, epinio-ca", func() {
 	var (
 		flags        []string
 		epinioHelper epinio.Epinio

--- a/acceptance/install/scenario4_test.go
+++ b/acceptance/install/scenario4_test.go
@@ -65,12 +65,12 @@ var _ = Describe("<Scenario4> EKS, epinio-ca", func() {
 		})
 
 		By("Updating DNS Entries", func() {
-			change := route53.CNAME(domain, loadbalancer)
-			out, err := route53.Upsert(zoneID, change, nodeTmpDir)
+			change := route53.CNAME(domain, loadbalancer, "UPSERT")
+			out, err := route53.Update(zoneID, change, nodeTmpDir)
 			Expect(err).NotTo(HaveOccurred(), out)
 
-			change = route53.CNAME("*."+domain, loadbalancer)
-			out, err = route53.Upsert(zoneID, change, nodeTmpDir)
+			change = route53.CNAME("*."+domain, loadbalancer, "UPSERT")
+			out, err = route53.Update(zoneID, change, nodeTmpDir)
 			Expect(err).NotTo(HaveOccurred(), out)
 		})
 
@@ -122,6 +122,16 @@ var _ = Describe("<Scenario4> EKS, epinio-ca", func() {
 				Expect(err).ToNot(HaveOccurred(), out)
 				return out
 			}).Should(MatchRegexp("MYVAR"))
+		})
+
+		By("Cleaning DNS Entries", func() {
+			change := route53.CNAME(domain, loadbalancer, "DELETE")
+			out, err := route53.Update(zoneID, change, nodeTmpDir)
+			Expect(err).NotTo(HaveOccurred(), out)
+
+			change = route53.CNAME("*."+domain, loadbalancer, "DELETE")
+			out, err = route53.Update(zoneID, change, nodeTmpDir)
+			Expect(err).NotTo(HaveOccurred(), out)
 		})
 	})
 })

--- a/acceptance/install/scenario5_test.go
+++ b/acceptance/install/scenario5_test.go
@@ -67,12 +67,12 @@ var _ = Describe("<Scenario5> Azure, Letsencrypt", func() {
 		})
 
 		By("Updating DNS Entries", func() {
-			change := route53.A(domain, loadbalancer)
-			out, err := route53.Upsert(zoneID, change, nodeTmpDir)
+			change := route53.A(domain, loadbalancer, "UPSERT")
+			out, err := route53.Update(zoneID, change, nodeTmpDir)
 			Expect(err).NotTo(HaveOccurred(), out)
 
-			change = route53.A("*."+domain, loadbalancer)
-			out, err = route53.Upsert(zoneID, change, nodeTmpDir)
+			change = route53.A("*."+domain, loadbalancer, "UPSERT")
+			out, err = route53.Update(zoneID, change, nodeTmpDir)
 			Expect(err).NotTo(HaveOccurred(), out)
 		})
 
@@ -125,6 +125,16 @@ var _ = Describe("<Scenario5> Azure, Letsencrypt", func() {
 				"-o", "jsonpath='{.items[*].spec.issuerRef.name}'")
 			Expect(err).NotTo(HaveOccurred(), out)
 			Expect(out).To(Equal("'letsencrypt-production'"))
+		})
+
+		By("Cleaning DNS Entries", func() {
+			change := route53.A(domain, loadbalancer, "DELETE")
+			out, err := route53.Update(zoneID, change, nodeTmpDir)
+			Expect(err).NotTo(HaveOccurred(), out)
+
+			change = route53.A("*."+domain, loadbalancer, "DELETE")
+			out, err = route53.Update(zoneID, change, nodeTmpDir)
+			Expect(err).NotTo(HaveOccurred(), out)
 		})
 	})
 })


### PR DESCRIPTION
Some tests use route53 to create/update a DNS entry but this newly created route was not purge at the end.

This fixes #939.