### PR TITLE
feat: CORS

### DIFF
--- a/assets/embedded-files/epinio/server.yaml
+++ b/assets/embedded-files/epinio/server.yaml
@@ -193,16 +193,18 @@ spec:
         - command: ["/epinio", "server"]
           args: ["--port", "80"]
           env:
-            - name: TRACE_LEVEL
-              value: "##trace_level##"
+            - name: ACCESS_CONTROL_ALLOW_ORIGIN
+              value: "##access_control_allow_origin##"
             - name: EPINIO_TIMEOUT_MULTIPLIER
               value: "##epinio_timeout_multiplier##"
-            - name: TLS_ISSUER
-              value: ##tls_issuer##
-            - name: USE_INTERNAL_REGISTRY_NODE_PORT
-              value: "##use_internal_registry_node_port##"
             - name: SESSION_KEY
               value: "##epinio_session_key##"
+            - name: TLS_ISSUER
+              value: ##tls_issuer##
+            - name: TRACE_LEVEL
+              value: "##trace_level##"
+            - name: USE_INTERNAL_REGISTRY_NODE_PORT
+              value: "##use_internal_registry_node_port##"
           image: splatform/epinio-server:##current_epinio_version##
           livenessProbe:
             httpGet:

--- a/deployments/epinio.go
+++ b/deployments/epinio.go
@@ -140,7 +140,9 @@ func (k Epinio) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI,
 
 	issuer := options.GetStringNG("tls-issuer")
 	nodePort := options.GetBoolNG("use-internal-registry-node-port")
-	if out, err := k.applyEpinioConfigYaml(ctx, c, ui, issuer, nodePort); err != nil {
+	accessControlAllowOrigin := options.GetStringNG("access-control-allow-origin")
+
+	if out, err := k.applyEpinioConfigYaml(ctx, c, ui, issuer, nodePort, accessControlAllowOrigin); err != nil {
 		return errors.Wrap(err, out)
 	}
 
@@ -255,7 +257,7 @@ func (k Epinio) Upgrade(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 }
 
 // Replaces ##current_epinio_version## with version.Version and applies the embedded yaml
-func (k Epinio) applyEpinioConfigYaml(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, issuer string, nodePort bool) (string, error) {
+func (k Epinio) applyEpinioConfigYaml(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI, issuer string, nodePort bool, accessControlAllowOrigin string) (string, error) {
 	yamlPathOnDisk, err := helpers.ExtractFile(epinioServerYaml)
 
 	if err != nil {
@@ -285,6 +287,9 @@ func (k Epinio) applyEpinioConfigYaml(ctx context.Context, c *kubernetes.Cluster
 
 	re = regexp.MustCompile(`##use_internal_registry_node_port##`)
 	renderedFileContents = re.ReplaceAll(renderedFileContents, []byte(strconv.FormatBool(nodePort)))
+
+	re = regexp.MustCompile(`##access_control_allow_origin##`)
+	renderedFileContents = re.ReplaceAll(renderedFileContents, []byte(accessControlAllowOrigin))
 
 	re = regexp.MustCompile(`##trace_level##`)
 	renderedFileContents = re.ReplaceAll(renderedFileContents, []byte(strconv.Itoa(viper.GetInt("trace-level"))))

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -110,6 +110,13 @@ var neededOptions = kubernetes.InstallationOptions{
 		Default:     true,
 		Value:       true,
 	},
+	{
+		Name:        "access-control-allow-origin",
+		Description: "Domain allowed to access the API. Comma-separated.",
+		Type:        kubernetes.StringType,
+		Default:     "",
+		Value:       "",
+	},
 	ingressServiceIPOption,
 	{
 		Name:        "s3-access-key-id",

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -26,6 +26,10 @@ func init() {
 	flags.Bool("use-internal-registry-node-port", true, "(USE_INTERNAL_REGISTRY_NODE_PORT) Use the internal registry via a node port")
 	viper.BindPFlag("use-internal-registry-node-port", flags.Lookup("use-internal-registry-node-port"))
 	viper.BindEnv("use-internal-registry-node-port", "USE_INTERNAL_REGISTRY_NODE_PORT")
+
+	flags.String("access-control-allow-origin", "", "(ACCESS_CONTROL_ALLOW_ORIGIN) Domains allowed to use the API")
+	viper.BindPFlag("access-control-allow-origin", flags.Lookup("access-control-allow-origin"))
+	viper.BindEnv("access-control-allow-origin", "ACCESS_CONTROL_ALLOW_ORIGIN")
 }
 
 // CmdServer implements the command: epinio server

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/epinio/epinio/helpers/termui"
+	"github.com/spf13/viper"
 
 	"github.com/epinio/epinio/helpers/tracelog"
 	apiv1 "github.com/epinio/epinio/internal/api/v1"
@@ -67,6 +68,14 @@ func Start(wg *sync.WaitGroup, port int, _ *termui.UI, logger logr.Logger) (*htt
 	router := gin.New()
 	router.HandleMethodNotAllowed = true
 	router.Use(gin.Recovery())
+
+	// Do not set header if nothing is specified.
+	accessControlAllowOrigin := viper.GetString("access-control-allow-origin")
+	if accessControlAllowOrigin != "" {
+		router.Use(func(ctx *gin.Context) {
+			ctx.Header("Access-Control-Allow-Origin", accessControlAllowOrigin)
+		})
+	}
 
 	// No authentication, no logging, no session. This is the healthcheck.
 	router.GET("/ready", func(c *gin.Context) {


### PR DESCRIPTION
  - install option `--access-control-allow-origin` becomes server deployment env variable `ACCESS_CONTROL_ALLOW_ORIGIN`.
  - Above EV becomes server option `access-control-allow-origin`.
  - gin middleware places option value into response header `Access-Control-Allow-Origin`.

Default is the empty string. No header is set in that case.
Installer, or user has to choose the allowed domains (user can patch server deployment).
