### PR TITLE
CLI doc generation script, and hugo fixup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,13 +104,8 @@ generate:
 	go generate ./...
 
 # Assumes that the `docs` checkout is a sibling of the `epinio` checkout
-# perl -pi - Fixes ${HOME} references to proper `~`.
-# sed -i   - Fixes the cross-links to match hierarchy and mdbook expectations.
 generate-cli-docs:
-	rm -f ../docs/src/references/cli/*
-	go run internal/cli/docs/generate-cli-docs.go ../docs/src/references/cli/
-	perl -pi -e "s@${HOME}@~@" ../docs/src/references/cli/*md
-	sed -i 's@(\.\./\(.*\))@(\1.md)@' ../docs/src/references/cli/*md
+	@./scripts/cli-docs-generate.sh ../docs/src/references/cli
 
 lint: embed_files
 	go vet ./...

--- a/scripts/cli-docs-generate.sh
+++ b/scripts/cli-docs-generate.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+destination="$1"
+
+echo Generating into ${destination} ...
+
+rm -f "${destination}"/*
+
+go run internal/cli/docs/generate-cli-docs.go "${destination}"/
+
+# Fix ${HOME} references to proper `~`.
+perl -pi -e "s@${HOME}@~@" "${destination}"/*md
+
+# Fix the cross-links to match hierarchy and mdbook expectations.
+sed -i 's@(\.\./\(.*\))@(\1.md)@' "${destination}"/*md
+
+# Drop the HUGO specific annotations from file heads
+for md in "${destination}"/*md
+do
+    tail --lines +6 $md > $$
+    mv $$ $md
+done
+
+echo /Done
+exit


### PR DESCRIPTION
No ticket. The code for generating the cli docs is moved into a script, as it is becoming to large for the Makefile.
Added a third post-processing step removing the hugo-related annotations from the front of the files.

Sibling to https://github.com/epinio/docs/pull/24