### PR TITLE
Fix CI trigger on AKS, EKS, GKE and RKE

### DIFF
--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -2,6 +2,8 @@ name: AKS-CI
 
 on:
   pull_request:
+    branches: [ main ]
+    types: [ ready_for_review ]
     paths:
       - 'acceptance/install/scenario5_test.go'
       - '.github/workflows/aks.yml'
@@ -35,7 +37,34 @@ env:
   AKS_MACHINE_TYPE: 'Standard_D3_v2'
 
 jobs:
+  linter:
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get All Git Tags
+        run: git fetch --force --prune --unshallow --tags
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+      - name: Cache Tools
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/tools
+          key: ${{ runner.os }}-tools
+      - name: Install Tools
+        run: make tools-install
+      - name: Add Tools to PATH
+        run: |
+          echo "`pwd`/output/bin" >> $GITHUB_PATH
+      - name: Lint Epinio
+        run: make lint
+
   acceptance-scenario5:
+    needs:
+      - linter
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -2,6 +2,8 @@ name: EKS-CI
 
 on:
   pull_request:
+    branches: [ main ]
+    types: [ ready_for_review ]
     paths:
       - 'acceptance/install/scenario4_test.go'
       - '.github/workflows/eks.yml'
@@ -38,7 +40,34 @@ env:
   KUBECONFIG_NAME: 'kubeconfig-epinio-ci'
 
 jobs:
+  linter:
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get All Git Tags
+        run: git fetch --force --prune --unshallow --tags
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+      - name: Cache Tools
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/tools
+          key: ${{ runner.os }}-tools
+      - name: Install Tools
+        run: make tools-install
+      - name: Add Tools to PATH
+        run: |
+          echo "`pwd`/output/bin" >> $GITHUB_PATH
+      - name: Lint Epinio
+        run: make lint
+
   acceptance-scenario4:
+    needs:
+      - linter
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -2,6 +2,8 @@ name: GKE-CI
 
 on:
   pull_request:
+    branches: [ main ]
+    types: [ ready_for_review ]
     paths:
       - 'acceptance/install/scenario2_test.go'
       - '.github/workflows/gke.yml'
@@ -27,7 +29,34 @@ env:
   GKE_MACHINE_TYPE: 'n2-standard-4'
 
 jobs:
+  linter:
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get All Git Tags
+        run: git fetch --force --prune --unshallow --tags
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+      - name: Cache Tools
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/tools
+          key: ${{ runner.os }}-tools
+      - name: Install Tools
+        run: make tools-install
+      - name: Add Tools to PATH
+        run: |
+          echo "`pwd`/output/bin" >> $GITHUB_PATH
+      - name: Lint Epinio
+        run: make lint
+
   acceptance-scenario2:
+    needs:
+      - linter
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -2,6 +2,8 @@ name: RKE-CI
 
 on:
   pull_request:
+    branches: [ main ]
+    types: [ ready_for_review ]
     paths:
       - 'acceptance/install/scenario3_test.go'
       - '.github/workflows/rke.yml'
@@ -20,7 +22,34 @@ env:
   FLAKE_ATTEMPTS: 1
 
 jobs:
+  linter:
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get All Git Tags
+        run: git fetch --force --prune --unshallow --tags
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+      - name: Cache Tools
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/tools
+          key: ${{ runner.os }}-tools
+      - name: Install Tools
+        run: make tools-install
+      - name: Add Tools to PATH
+        run: |
+          echo "`pwd`/output/bin" >> $GITHUB_PATH
+      - name: Lint Epinio
+        run: make lint
+
   acceptance-scenario3:
+    needs:
+      - linter
     runs-on: self-hosted
 
     steps:


### PR DESCRIPTION
CI will be triggered only if linter result is OK and when the PR is set to "Ready To Review". This will avoid long CI tests on each push and also limit the Public Cloud costs.