### PR TITLE
fix: VERSION in Makefile shouldn't be quoted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 # Epinio Version: "v0.1.6-16-ge5ad0849-2021-11-18T10-00-27"
 
 VSUFFIX ?= 
-VERSION ?= "$(shell git describe --tags)$(VSUFFIX)"
+VERSION ?= $(shell git describe --tags)$(VSUFFIX)
 CGO_ENABLED ?= 0
 export LDFLAGS += -X github.com/epinio/epinio/internal/version.Version=$(VERSION)
 


### PR DESCRIPTION
With current v0.2.1 we have:
```
ldevulder@epinio-k3s:~/epinio> dist/epinio-linux-amd64 version
Epinio Version: "v0.2.1"
Go Version: go1.17.2
```

With this fix we now have (tested locally):
```
ldevulder@epinio-k3s:~/epinio> dist/epinio-linux-amd64 version
Epinio Version: v0.2.1
Go Version: go1.17.2
```