### PR TITLE
Simplify the creation of the Epinio private CA

### DIFF
--- a/deployments/cert_manager.go
+++ b/deployments/cert_manager.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kyokomi/emoji"
 	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -262,32 +261,6 @@ func (cm CertManager) apply(ctx context.Context, c *kubernetes.Cluster, ui *term
 	// Epinio's private CA. Phase 1, the CA root certificate, signed by self
 	// signed.
 
-	// Create an empty secret that the cert manager will fill-in with values.
-	// We do that, because we want to put the "kubed.appscode.com/sync" annotation
-	// as per the docs:
-	// https://cert-manager.io/docs/faq/kubed/#syncing-arbitrary-secrets-across-namespaces-using-kubed
-	rootCAName := "epinio-ca-root"
-
-	emptySecret := v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      rootCAName,
-			Namespace: CertManagerDeploymentID,
-			Annotations: map[string]string{
-				"kubed.appscode.com/sync": fmt.Sprintf("kubed-source-namespace=%s", CertManagerDeploymentID),
-			},
-		},
-		Type: v1.SecretTypeTLS,
-		Data: map[string][]byte{
-			"ca.crt":  nil,
-			"tls.crt": nil,
-			"tls.key": nil,
-		},
-	}
-	err = c.CreateSecret(ctx, CertManagerDeploymentID, emptySecret)
-	if err != nil {
-		return err
-	}
-
 	caCert := fmt.Sprintf(`{
 		"apiVersion" : "cert-manager.io/v1",
 		"kind"       : "Certificate",
@@ -297,7 +270,7 @@ func (cm CertManager) apply(ctx context.Context, c *kubernetes.Cluster, ui *term
 		"spec" : {
 			"isCA"       : true,
 			"commonName" : "epinio-ca",
-			"secretName" : "%s",
+			"secretName" : "epinio-ca-root",
 			"privateKey" : {
 				"algorithm" : "ECDSA",
 				"size"      : 256
@@ -307,7 +280,7 @@ func (cm CertManager) apply(ctx context.Context, c *kubernetes.Cluster, ui *term
 				"kind" : "ClusterIssuer"
 			}
 		}
-	}`, rootCAName, SelfSignedIssuer)
+	}`, SelfSignedIssuer)
 
 	cc, err := c.ClientCertificate()
 	if err != nil {

--- a/deployments/cert_manager.go
+++ b/deployments/cert_manager.go
@@ -35,6 +35,7 @@ const (
 	SelfSignedIssuer        = "selfsigned-issuer"
 	LetsencryptIssuer       = "letsencrypt-production"
 	EpinioCAIssuer          = "epinio-ca"
+	RootCAName              = "epinio-ca-root"
 )
 
 // internalIssuer returns true if the given issuer is an issuer created by Epinio
@@ -270,7 +271,7 @@ func (cm CertManager) apply(ctx context.Context, c *kubernetes.Cluster, ui *term
 		"spec" : {
 			"isCA"       : true,
 			"commonName" : "epinio-ca",
-			"secretName" : "epinio-ca-root",
+			"secretName" : "%s",
 			"privateKey" : {
 				"algorithm" : "ECDSA",
 				"size"      : 256
@@ -280,7 +281,7 @@ func (cm CertManager) apply(ctx context.Context, c *kubernetes.Cluster, ui *term
 				"kind" : "ClusterIssuer"
 			}
 		}
-	}`, SelfSignedIssuer)
+	}`, RootCAName, SelfSignedIssuer)
 
 	cc, err := c.ClientCertificate()
 	if err != nil {
@@ -393,7 +394,7 @@ const clusterIssuerEpinio = `{
 	},
 	"spec" : {
 		"ca" : {
-			"secretName": "epinio-ca-root"
+			"secretName": "` + RootCAName + `"
 		}
 	}
 }`

--- a/deployments/tekton.go
+++ b/deployments/tekton.go
@@ -224,7 +224,7 @@ func (k Tekton) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.UI,
 				strings.Contains(err.Error(), "EOF")
 		}),
 		retry.OnRetry(func(n uint, err error) {
-			ui.Note().Msgf("retrying to apply %s", tektonPipelineYamlPath)
+			ui.Note().Msgf("retrying to apply %s", tektonAWSYamlPath)
 		}),
 		retry.Delay(5*time.Second),
 	)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -188,7 +188,7 @@ func GetConnectionDetails(ctx context.Context, cluster *kubernetes.Cluster, secr
 // the secret in a specific format). It is used to construct the full url to
 // an application image in the form: registryURL/registryNamespace/appImage
 func (d *ConnectionDetails) Store(ctx context.Context, cluster *kubernetes.Cluster, secretNamespace, secretName string) (*corev1.Secret, error) {
-	dockerconfigjson, err := json.Marshal(d)
+	dockerconfigjson, err := json.Marshal(d.DockerConfigJSON)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
we were creating the empty secret to be able to write the Kubed
annotation on it. This was needed for TraefikForwardAuth which we no
longer use. Now we let cert-manager create the secret.

This commit also fixed a log message refering to the wrong yaml