### PR TITLE
Add external registry test

### DIFF
--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -101,8 +101,8 @@ jobs:
       - name: Installation Acceptance Tests
         env:
           REGEX: Scenario3
-          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          REGISTRY_USERNAME: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
         run: |
           export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
           make test-acceptance-install

--- a/acceptance/install/scenario3_test.go
+++ b/acceptance/install/scenario3_test.go
@@ -3,6 +3,7 @@ package install_test
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,15 +14,17 @@ import (
 	"github.com/epinio/epinio/acceptance/testenv"
 )
 
-var _ = Describe("<Scenario3> RKE, Private CA, Service", func() {
+var _ = Describe("<Scenario3> RKE, Private CA, Service, on External Registry", func() {
 	var (
-		flags        []string
-		epinioHelper epinio.Epinio
-		appName      = catalog.NewAppName()
-		serviceName  = catalog.NewServiceName()
-		loadbalancer string
-		metallbURL   string
-		localpathURL string
+		flags            []string
+		epinioHelper     epinio.Epinio
+		serviceName      = catalog.NewServiceName()
+		appName          string
+		loadbalancer     string
+		metallbURL       string
+		localpathURL     string
+		registryUsername string
+		registryPassword string
 		// testenv.New is not needed for VerifyAppServiceBound helper :shrug:
 		env      testenv.EpinioEnv
 		domainIP = "192.168.1.240" // Set it to an arbitrary private IP
@@ -32,11 +35,21 @@ var _ = Describe("<Scenario3> RKE, Private CA, Service", func() {
 
 		metallbURL = "https://raw.githubusercontent.com/google/metallb/v0.10.3/manifests/metallb.yaml"
 		localpathURL = "https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.20/deploy/local-path-storage.yaml"
+		appName = "externalregtest"
 
+		registryUsername = os.Getenv("REGISTRY_USERNAME")
+		Expect(registryUsername).ToNot(BeEmpty())
+
+		registryPassword = os.Getenv("REGISTRY_PASSWORD")
+		Expect(registryPassword).ToNot(BeEmpty())
 		flags = []string{
 			"--system-domain", fmt.Sprintf("%s.omg.howdoi.website", domainIP),
 			"--skip-cert-manager",
 			"--tls-issuer=private-ca",
+			"--external-registry-url=registry.hub.docker.com",
+			"--external-registry-username=" + registryUsername,
+			"--external-registry-password=" + registryPassword,
+			"--external-registry-namespace=splatform",
 		}
 
 	})


### PR DESCRIPTION
This PR adds new options to test the external registry feature in the RKE CI scenario.
Fix #999 
The images pushed by the app deployment is this [one](https://registry.hub.docker.com/r/splatform/workspace-externalregtest)
I've hard-coded the app name only for that test to avoid flood/pollution in our docker hub registry.