### PR TITLE
CI: add S3 storage tests in EKS

### DIFF
--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -35,6 +35,7 @@ on:
 env:
   SETUP_GO_VERSION: '^1.17.2'
   GINKGO_NODES: 1
+  FLAKE_ATTEMPTS: 1
   AWS_REGION: 'us-east-2'
   AWS_MACHINE_TYPE: 't3.xlarge'
   KUBECONFIG_NAME: 'kubeconfig-epinio-ci'
@@ -115,6 +116,8 @@ jobs:
           REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           AWS_ZONE_ID: ${{ github.events.inputs.aws_zone_id || secrets.AWS_ZONE_ID }}
+          AWS_ACCESS_KEY_ID: ${{ github.event.inputs.aws_id || secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ github.event.inputs.aws_key || secrets.AWS_SECRET_ACCESS_KEY }}
           # Use a random host name, so we don't collide with our workflows on EKS
           AWS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.aws_domain || secrets.AWS_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3


### PR DESCRIPTION
Also in this commit:
- remove the 2 stages installation
- test the app deletion (on S3 storage)

This should fixe #994

**NOTE :** the removal of the 2 stages installation has been removed, as this adds an issue with Route53 DNS update. Anyway, this part will be changed with the new installer, so better to wait for it.