### PR TITLE
small fix: followup to PR 1014, regenerate swagger docs

### DIFF
--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -1377,11 +1377,11 @@
       "description": "ServiceResponse represents the data of a single service instance",
       "type": "object",
       "properties": {
+        "configuration": {
+          "$ref": "#/definitions/ServiceShowResponse"
+        },
         "meta": {
           "$ref": "#/definitions/ServiceRef"
-        },
-        "spec": {
-          "$ref": "#/definitions/ServiceShowResponse"
         }
       },
       "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"


### PR DESCRIPTION
Fix #1014 ... Forgot to regen the swagger docs after renaming the `Spec` field to `Configuration`. This PR fixes that.