### PR TITLE
Provide previous app image to tekton for re-use.

### DIFF
--- a/assets/embedded-files/tekton/buildpacks-task.yaml
+++ b/assets/embedded-files/tekton/buildpacks-task.yaml
@@ -26,6 +26,8 @@ spec:
   params:
     - name: APP_IMAGE
       description: The name of where to store the app image.
+    - name: PREVIOUS_IMAGE
+      description: The name of the previous app image. Currently active.
     - name: BUILDER_IMAGE
       description: The image on which builds will run (must include lifecycle and compatible buildpacks).
     - name: SOURCE_SUBPATH
@@ -135,7 +137,7 @@ spec:
         - "-report=/layers/report.toml"
         - "-process-type=$(params.PROCESS_TYPE)"
         - "-skip-restore=$(params.SKIP_RESTORE)"
-        - "-previous-image=$(params.APP_IMAGE)"
+        - "-previous-image=$(params.PREVIOUS_IMAGE)"
         - "-run-image=$(params.RUN_IMAGE)"
         - "$(params.APP_IMAGE)"
       volumeMounts:

--- a/assets/embedded-files/tekton/stage-pipeline.yaml
+++ b/assets/embedded-files/tekton/stage-pipeline.yaml
@@ -16,6 +16,9 @@ spec:
     - name: APP_IMAGE
       type: string
       description: "The image as built and pushed by Tekton (uses Kube internal service DNS)"
+    - name: PREVIOUS_IMAGE
+      type: string
+      description: "The image from the previous staging run"
     - name: AWS_SCRIPT
       type: string
       # https://hub.tekton.dev/tekton/task/aws-cli
@@ -70,6 +73,8 @@ spec:
       value: app
     - name: APP_IMAGE
       value: "$(params.APP_IMAGE)"
+    - name: PREVIOUS_IMAGE
+      value: "$(params.PREVIOUS_IMAGE)"
     - name: ENV_VARS
       value: ["$(params.ENV_VARS[*])"]
     workspaces:

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -346,6 +346,7 @@ func newPipelineRun(app stageParam) *v1beta1.PipelineRun {
 				"app.kubernetes.io/part-of":    app.Namespace,
 				"app.kubernetes.io/created-by": app.Username,
 				models.EpinioStageIDLabel:      app.Stage.ID,
+				models.EpinioStageIDPrevious:   app.PreviousStageID,
 				models.EpinioStageBlobUIDLabel: app.BlobUID,
 				"app.kubernetes.io/managed-by": "epinio",
 				"app.kubernetes.io/component":  "staging",

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -167,7 +167,8 @@ func (hc Controller) Stage(c *gin.Context) apierror.APIErrors {
 	}
 
 	// Determine stage id of currently running deployment, fallback to itself when no such exists.
-	previousID, err := application.PreviousStageID(ctx, cluster, req.App)
+	// From the view of the new build we are about to create this is the previous id.
+	previousID, err := application.StageID(ctx, cluster, req.App)
 	if err != nil {
 		return apierror.InternalError(err, "failed to determine active application stage id")
 	}

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -167,7 +167,7 @@ func (hc Controller) Stage(c *gin.Context) apierror.APIErrors {
 	}
 
 	// Determine stage id of currently running deployment, fallback to itself when no such exists.
-	previousID, err := application.PreviousStageId(ctx, cluster, req.App)
+	previousID, err := application.PreviousStageID(ctx, cluster, req.App)
 	if err != nil {
 		return apierror.InternalError(err, "failed to determine active application stage id")
 	}

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -245,7 +245,11 @@ func deleteStagePVC(ctx context.Context, cluster *kubernetes.Cluster, appRef mod
 		PersistentVolumeClaims(deployments.TektonStagingNamespace).Delete(ctx, appRef.MakePVCName(), metav1.DeleteOptions{})
 }
 
-func PreviousStageId(ctx context.Context, cluster *kubernetes.Cluster, appRef models.AppRef) (string, error) {
+// PreviousStageID returns the stage ID of the previous build, if one exists. It returns an empty string otherwise.
+// This method relies on the presence of a workload to get the previous id. There is the case that staging has
+// happened, yet there is no workload. Ee.g. by calling the "staging" endpoint but not calling the "deploy"
+// endpoint. Since our client doesn't support that scenario, this method doesn't support it either.
+func PreviousStageID(ctx context.Context, cluster *kubernetes.Cluster, appRef models.AppRef) (string, error) {
 	wl := NewWorkload(cluster, appRef)
 
 	deployment, err := wl.Deployment(ctx)

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -261,13 +261,7 @@ func PreviousStageID(ctx context.Context, cluster *kubernetes.Cluster, appRef mo
 		return "", nil
 	}
 
-	workload := wl.Get(ctx, deployment)
-	if workload == nil {
-		// No workload. No id
-		return "", nil
-	}
-
-	return workload.StageID, nil
+	return wl.GetStageID(ctx, deployment), nil
 }
 
 // Unstage removes staging resources. It deletes either all PipelineRuns of the

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -245,11 +245,11 @@ func deleteStagePVC(ctx context.Context, cluster *kubernetes.Cluster, appRef mod
 		PersistentVolumeClaims(deployments.TektonStagingNamespace).Delete(ctx, appRef.MakePVCName(), metav1.DeleteOptions{})
 }
 
-// PreviousStageID returns the stage ID of the previous build, if one exists. It returns an empty string otherwise.
+// StageID returns the stage ID of the currently running build, if one exists. It returns an empty string otherwise.
 // This method relies on the presence of a workload to get the previous id. There is the case that staging has
 // happened, yet there is no workload. Ee.g. by calling the "staging" endpoint but not calling the "deploy"
 // endpoint. Since our client doesn't support that scenario, this method doesn't support it either.
-func PreviousStageID(ctx context.Context, cluster *kubernetes.Cluster, appRef models.AppRef) (string, error) {
+func StageID(ctx context.Context, cluster *kubernetes.Cluster, appRef models.AppRef) (string, error) {
 	return NewWorkload(cluster, appRef).GetStageID(ctx)
 }
 

--- a/internal/application/workload.go
+++ b/internal/application/workload.go
@@ -353,6 +353,14 @@ func (a *Workload) Restarts(ctx context.Context) (int32, error) {
 	return restarts, nil
 }
 
+// GetStageID is a specialization of Get coming after, to determine and deliver only the StageId of the workload.
+// Nothing else.
+func (a *Workload) GetStageID(ctx context.Context, deployment *appsv1.Deployment) string {
+	// Query application deployment for stageID
+
+	return deployment.Spec.Template.ObjectMeta.Labels["epinio.suse.org/stage-id"]
+}
+
 // Get returns the state of the app deployment encoded in the workload.
 func (a *Workload) Get(ctx context.Context, deployment *appsv1.Deployment) *models.AppDeployment {
 

--- a/pkg/api/core/v1/models/app.go
+++ b/pkg/api/core/v1/models/app.go
@@ -5,6 +5,7 @@ import (
 )
 
 const (
+	EpinioStageIDPrevious   = "epinio.suse.org/previous-stage-id"
 	EpinioStageIDLabel      = "epinio.suse.org/stage-id"
 	EpinioStageBlobUIDLabel = "epinio.suse.org/blob-uid"
 


### PR DESCRIPTION
fix #975 

consider it draft, with some more testing needed to confirm that the proper information is passed around.
it does not seem to break pushing, and on second push the `image not message` seen in any first push is gone.

the second commit extends the code a bit to attach the previous stage-id to the new pipelinerun resource, as a label.
confirmed with this that the existing code truly puts in the previous stage id for the run to reuse.