### PR TITLE
Make epinio server unaware of the force-kube-internal-registry-tls flag

### DIFF
--- a/assets/embedded-files/epinio/server.yaml
+++ b/assets/embedded-files/epinio/server.yaml
@@ -203,8 +203,6 @@ spec:
               value: ##tls_issuer##
             - name: TRACE_LEVEL
               value: "##trace_level##"
-            - name: FORCE_KUBE_INTERNAL_REGISTRY_TLS
-              value: "##force_kube_internal_registry_tls##"
           image: splatform/epinio-server:##current_epinio_version##
           livenessProbe:
             httpGet:

--- a/deployments/registry.go
+++ b/deployments/registry.go
@@ -178,6 +178,12 @@ func (k Registry) apply(ctx context.Context, c *kubernetes.Cluster, ui *termui.U
 		`--set`, `auth.htpasswd=` + htpasswd,
 		`--set`, fmt.Sprintf("domain=%s.%s", RegistryDeploymentID, domain),
 		`--set`, fmt.Sprintf(`createNodePort=%v`, !options.GetBoolNG("force-kube-internal-registry-tls")),
+		// When force=true, registry doesn't get a node port service
+		// In this case install_client.go shouldn't write a localhost url in the connection details
+		// (because nothing listens there).
+		// Then deploy.go doesn't need to check the flag, only the "localURL" for existence. Because
+		// if there is a localhost url in the secret, it means the flag was false, the registry has
+		// a node port service and the user wants us to tell Kubernetes to use it.
 	}
 
 	log.Info("assembled helm command", "command", strings.Join(append([]string{`helm`}, helmArgs...), " "))

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -23,10 +23,6 @@ func init() {
 	viper.BindPFlag("tls-issuer", flags.Lookup("tls-issuer"))
 	viper.BindEnv("tls-issuer", "TLS_ISSUER")
 
-	flags.Bool("force-kube-internal-registry-tls", false, "(FORCE_KUBE_INTERNAL_REGISTRY_TLS) Kubernetes accesses the internal registry over TLS")
-	viper.BindPFlag("force-kube-internal-registry-tls", flags.Lookup("force-kube-internal-registry-tls"))
-	viper.BindEnv("force-kube-internal-registry-tls", "FORCE_KUBE_INTERNAL_REGISTRY_TLS")
-
 	flags.String("access-control-allow-origin", "", "(ACCESS_CONTROL_ALLOW_ORIGIN) Domains allowed to use the API")
 	viper.BindPFlag("access-control-allow-origin", flags.Lookup("access-control-allow-origin"))
 	viper.BindEnv("access-control-allow-origin", "ACCESS_CONTROL_ALLOW_ORIGIN")

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -53,10 +53,8 @@ var _ = Describe("ConnectionDetails", func() {
 			BeforeEach(func() {
 				details = &registry.ConnectionDetails{
 					Namespace: "myorg",
-					DockerConfigJSON: &registry.DockerConfigJSON{
-						Auths: map[string]registry.ContainerRegistryAuth{
-							"http://127.0.0.1/": {},
-						},
+					RegistryCredentials: []registry.RegistryCredentials{
+						{URL: "http://127.0.0.1/"},
 					},
 				}
 			})
@@ -70,11 +68,9 @@ var _ = Describe("ConnectionDetails", func() {
 			BeforeEach(func() {
 				details = &registry.ConnectionDetails{
 					Namespace: "myorg",
-					DockerConfigJSON: &registry.DockerConfigJSON{
-						Auths: map[string]registry.ContainerRegistryAuth{
-							"http://127.0.0.1/":       {},
-							"registry.hub.docker.com": {},
-						},
+					RegistryCredentials: []registry.RegistryCredentials{
+						{URL: "http://127.0.0.1/"},
+						{URL: "registry.hub.docker.com"},
 					},
 				}
 			})
@@ -92,10 +88,8 @@ var _ = Describe("ConnectionDetails", func() {
 			BeforeEach(func() {
 				details = &registry.ConnectionDetails{
 					Namespace: "myorg",
-					DockerConfigJSON: &registry.DockerConfigJSON{
-						Auths: map[string]registry.ContainerRegistryAuth{
-							"registry.hub.docker.com": {},
-						},
+					RegistryCredentials: []registry.RegistryCredentials{
+						{URL: "registry.hub.docker.com"},
 					},
 				}
 			})
@@ -109,11 +103,9 @@ var _ = Describe("ConnectionDetails", func() {
 			BeforeEach(func() {
 				details = &registry.ConnectionDetails{
 					Namespace: "myorg",
-					DockerConfigJSON: &registry.DockerConfigJSON{
-						Auths: map[string]registry.ContainerRegistryAuth{
-							"http://127.0.0.1/":       {},
-							"registry.hub.docker.com": {},
-						},
+					RegistryCredentials: []registry.RegistryCredentials{
+						{URL: "http://127.0.0.1/"},
+						{URL: "registry.hub.docker.com"},
 					},
 				}
 			})
@@ -132,10 +124,8 @@ var _ = Describe("ConnectionDetails", func() {
 			BeforeEach(func() {
 				details = &registry.ConnectionDetails{
 					Namespace: "myorg",
-					DockerConfigJSON: &registry.DockerConfigJSON{
-						Auths: map[string]registry.ContainerRegistryAuth{
-							"registry.hub.docker.com": {},
-						},
+					RegistryCredentials: []registry.RegistryCredentials{
+						{URL: "registry.hub.docker.com"},
 					},
 				}
 				imageURL = "splatform/my-app"
@@ -155,11 +145,9 @@ var _ = Describe("ConnectionDetails", func() {
 				BeforeEach(func() {
 					details = &registry.ConnectionDetails{
 						Namespace: "myorg",
-						DockerConfigJSON: &registry.DockerConfigJSON{
-							Auths: map[string]registry.ContainerRegistryAuth{
-								publicRegistryURL: {},
-								"127.0.0.1:30500": {},
-							},
+						RegistryCredentials: []registry.RegistryCredentials{
+							{URL: publicRegistryURL},
+							{URL: "127.0.0.1:30500"},
 						},
 					}
 					imageURL = publicRegistryURL + "/apps/my-app"
@@ -174,11 +162,9 @@ var _ = Describe("ConnectionDetails", func() {
 				BeforeEach(func() {
 					details = &registry.ConnectionDetails{
 						Namespace: "myorg",
-						DockerConfigJSON: &registry.DockerConfigJSON{
-							Auths: map[string]registry.ContainerRegistryAuth{
-								"registry.hub.docker.com": {},
-								"127.0.0.1:30500":         {},
-							},
+						RegistryCredentials: []registry.RegistryCredentials{
+							{URL: "registry.hub.docker.com"},
+							{URL: "127.0.0.1:30500"},
 						},
 					}
 					imageURL = "otherregistry.com/apps/my-app"


### PR DESCRIPTION
This will allow the declarative installer to use the registry localhost trick.
Now the epinio server relies only on the existence of a localhost url in the
connection details secret to decide wether to rewrite the image url or
not.

It's up to the installer (any of them) to decide if a localhost url
should be in the secret. Our current installer uses the force-kube**
flag, the declarative installer can simply allow an array of registry
urls to be passed through helm values.