### PR TITLE
Better match GET service to GET services.

### DIFF
--- a/acceptance/api/v1/services_test.go
+++ b/acceptance/api/v1/services_test.go
@@ -164,9 +164,9 @@ var _ = Describe("Services API Application Endpoints", func() {
 			bodyBytes, err := ioutil.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			var data models.ServiceShowResponse
+			var data models.ServiceResponse
 			err = json.Unmarshal(bodyBytes, &data)
-			service := data.Details
+			service := data.Configuration.Details
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service["username"]).To(Equal("epinio-user"))
 		})
@@ -230,9 +230,9 @@ var _ = Describe("Services API Application Endpoints", func() {
 			bodyBytesGet, err := ioutil.ReadAll(responseGet.Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			var data models.ServiceShowResponse
+			var data models.ServiceResponse
 			err = json.Unmarshal(bodyBytesGet, &data)
-			service := data.Details
+			service := data.Configuration.Details
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service["user"]).To(Equal("ci/cd"))
@@ -299,9 +299,9 @@ var _ = Describe("Services API Application Endpoints", func() {
 			bodyBytesGet, err := ioutil.ReadAll(responseGet.Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			var data models.ServiceShowResponse
+			var data models.ServiceResponse
 			err = json.Unmarshal(bodyBytesGet, &data)
-			service := data.Details
+			service := data.Configuration.Details
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service["put_key1"]).To(Equal("put_value"))

--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -1769,7 +1769,7 @@
     "ServiceShowResponse": {
       "description": "",
       "schema": {
-        "$ref": "#/definitions/ServiceShowResponse"
+        "$ref": "#/definitions/ServiceResponse"
       }
     },
     "ServiceUnbindReponse": {

--- a/internal/api/v1/docs/service.go
+++ b/internal/api/v1/docs/service.go
@@ -75,7 +75,7 @@ type ServiceShowParam struct {
 // swagger:response ServiceShowResponse
 type ServiceShowResponse struct {
 	// in: body
-	Body models.ServiceShowResponse
+	Body models.ServiceResponse
 }
 
 // swagger:route POST /namespaces/{Namespace}/services service ServiceCreate

--- a/internal/api/v1/service/show.go
+++ b/internal/api/v1/service/show.go
@@ -51,10 +51,16 @@ func (sc Controller) Show(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	response.OKReturn(c, models.ServiceShowResponse{
-		Username:  service.User(),
-		Details:   serviceDetails,
-		BoundApps: appNames,
+	response.OKReturn(c, models.ServiceResponse{
+		Meta: models.ServiceRef{
+			Name:      service.Name(),
+			Namespace: service.Namespace(),
+		},
+		Configuration: models.ServiceShowResponse{
+			Username:  service.User(),
+			Details:   serviceDetails,
+			BoundApps: appNames,
+		},
 	})
 	return nil
 }

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -367,13 +367,13 @@ func (c *EpinioClient) ServiceDetails(name string) error {
 	if err != nil {
 		return err
 	}
-	serviceDetails := resp.Details
-	boundApps := resp.BoundApps
+	serviceDetails := resp.Configuration.Details
+	boundApps := resp.Configuration.BoundApps
 
 	sort.Strings(boundApps)
 
 	c.ui.Note().
-		WithStringValue("User", resp.Username).
+		WithStringValue("User", resp.Configuration.Username).
 		WithStringValue("Used-By", strings.Join(boundApps, ", ")).
 		Msg("")
 

--- a/pkg/api/core/v1/client/services.go
+++ b/pkg/api/core/v1/client/services.go
@@ -171,8 +171,8 @@ func (c *Client) ServiceUpdate(req models.ServiceUpdateRequest, namespace, name 
 }
 
 // ServiceShow shows a service
-func (c *Client) ServiceShow(namespace string, name string) (models.ServiceShowResponse, error) {
-	var resp models.ServiceShowResponse
+func (c *Client) ServiceShow(namespace string, name string) (models.ServiceResponse, error) {
+	var resp models.ServiceResponse
 
 	data, err := c.get(api.Routes.Path("ServiceShow", namespace, name))
 	if err != nil {


### PR DESCRIPTION
fix #1104 - response structure for service show

upgraded to full `ServiceResponse`.
swagger spec updated to same.
tests reworked to match.
