### PR TITLE
fix: unwanted retry of `namespace create` for existing namespace

### DIFF
--- a/pkg/api/core/v1/client/namespaces.go
+++ b/pkg/api/core/v1/client/namespaces.go
@@ -13,7 +13,7 @@ func (c *Client) NamespaceCreate(req models.NamespaceCreateRequest) (models.Resp
 
 	b, err := json.Marshal(req)
 	if err != nil {
-		return resp, nil
+		return resp, err
 	}
 
 	data, err := c.post(api.Routes.Path("Namespaces"), string(b))


### PR DESCRIPTION
fix #1081 

- retry removed completely
- became superfluous again, with initial namespace creation moved to external installer