### PR TITLE
Switch release workflow to goreleaser

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,60 @@
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - '🤖 dependencies'
+
+exclude-labels:
+  - apparently external cause
+  - chore
+  - devops admin
+  - duplicate
+  - invalid
+  - later
+  - overcome by events
+  - spike
+  - wontfix
+  - do not log
+  - question
+  - QA
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+template: |
+
+  # New Features
+
+  $CHANGES
+
+  # Usage
+
+  More info can be found in the [installation instructions](https://docs.epinio.io/installation/installation.html).
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+      - 'breaking'
+  minor:
+    labels:
+      - 'minor'
+      - 'feature'
+      - 'enhancement'
+      - 'dependencies'
+  patch:
+    labels:
+      - 'patch'
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'chore'
+  default: patch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ on:
     - cron:  '0 0 * * *'
 
 env:
-  SETUP_GO_VERSION: '^1.17.2'
+  SETUP_GO_VERSION: '1.17'
   GINKGO_NODES: 8
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,71 +5,71 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      -
+        name: Checkout
         uses: actions/checkout@v2
         with:
           submodules: recursive
           fetch-depth: 0
-      - name: Fetch Branch
-        id: branch
-        run: |
-          raw=$(git branch -r --contains ${{ github.ref }} | grep origin/main)
-          branch=${raw##*/}
-          echo "::set-output name=BRANCH_NAME::$branch"
-      - name: Setup Go
+      -
+        name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.2'
-      - name: Build Epinio
-        if: steps.branch.outputs.BRANCH_NAME == 'main'
-        run: |
-          make build-all-small
-      - name: Login to Docker Hub
+          go-version: '1.17'
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      -
+        name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
           password: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
-      - name: Build Epinio images
-        if: steps.branch.outputs.BRANCH_NAME == 'main'
-        run: |
-          make build-images
-      - name: Create CHECKSUMS
-        if: steps.branch.outputs.BRANCH_NAME == 'main'
-        run: ( cd dist ; sha256sum -b epinio* > SHA256SUM.txt )
-      - name: Generate Changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.3
+      -
+        name: Login to GitHub Docker Registry
+        uses: docker/login-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          verbose: "true"
-          excludeLabels: "apparently external cause,chore,devops admin,duplicate,invalid,later,overcome by events,spike,wontfix,do not log,question,QA"
-          pullRequests: "false"
-          onlyLastTag: "true"
-          stripGeneratorNotice: "true"
-          issuesWoLabels: "true"
-          stripHeaders: "true"
-      - name: Release Epinio
-        uses: softprops/action-gh-release@v1
-        if: steps.branch.outputs.BRANCH_NAME == 'main'
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      -
+        name: Get current tag
+        id: get_tag
+        run: echo ::set-output name=TAG::${GITHUB_REF/refs\/heads\//}
+      -
+        uses: release-drafter/release-drafter@v5
         with:
-          files: ./dist/*
-          body_path: ./CHANGELOG.md
+          name: "${{ steps.get_tag.outputs.TAG }}"
+          tag: ${{ steps.get_tag.outputs.TAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Allow to release Epinio Helm chart automatically when we release Epinio.
       # The latest tag is sent to the Helm chart repo.
-      - name: Get the last tag
-        id: last-tag
-        run: |
-          tag=$(git -P tag | tail -1)
-          echo '::set-output name=TAG::'$tag
-      - name: Repository Dispatch
+      -
+        name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.CHART_REPO_ACCESS_TOKEN }}
           repository: epinio/helm-charts
           event-type: epinio-release
-          client-payload: '{"ref": "${{ steps.last-tag.outputs.TAG }}"}'
+          client-payload: '{"ref": "${{ steps.get_tag.outputs.TAG }}"}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,94 @@
+---
+project_name: epinio
+
+archives:
+  - name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    replacements:
+      amd64: x86_64
+    format: binary
+    format_overrides:
+      - goos: windows
+        format: zip
+
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - id: epinio
+    main: ./main.go
+    binary: epinio
+    ldflags:
+      - -w -s
+      - -X "github.com/epinio/epinio/internal/version.Version={{ .Tag }}"
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - arm
+
+changelog:
+  ## Delegate Changelog to release-drafter
+  skip: true
+
+env:
+  - CGO_ENABLED=0
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+dockers:
+  -
+    # ID of the image, needed if you want to filter by it later on (e.g. on custom publishers).
+    id: epinio
+
+    # GOOS of the built binaries/packages that should be used.
+    goos: linux
+
+    # GOARCH of the built binaries/packages that should be used.
+    goarch: amd64
+
+    # IDs to filter the binaries/packages.
+    ids:
+    - epinio
+
+    # Templates of the Docker image names.
+    image_templates:
+    - "splatform/epinio-server:{{ .Tag }}"
+    - "splatform/epinio-server:latest"
+    - "ghcr.io/epinio/epinio-server:{{ .Tag }}"
+    - "ghcr.io/epinio/epinio-server:latest"
+
+    # Skips the docker push.
+    #skip_push: "true"
+
+    # Path to the Dockerfile (from the project root).
+    dockerfile: images/Dockerfile
+
+    use: docker
+
+    # Template of the docker build flags.
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/epinio/epinio"
+    - "--build-arg=DIST_BINARY=epinio"
+    - "--build-arg=BASE_IMAGE=gcr.io/distroless/static:nonroot"
+    - "--platform=linux/amd64"
+
+    # If your Dockerfile copies files other than binaries and packages,
+    # you should list them here as well.
+    # Note that GoReleaser will create the same structure inside a temporary
+    # folder, so if you add `foo/bar.json` here, on your Dockerfile you can
+    # `COPY foo/bar.json /whatever.json`.
+    # Also note that the paths here are relative to the folder in which
+    # GoReleaser is being run (usually the repository root folder).
+    # This field does not support wildcards, you can add an entire folder here
+    # and use wildcards when you `COPY`/`ADD` in your Dockerfile.
+    extra_files: []

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ build-linux-s390x: build-s390x
 build-s390x:
 	GOARCH="s390x" GOOS="linux" CGO_ENABLED=$(CGO_ENABLED) go build $(BUILD_ARGS) -ldflags '$(LDFLAGS)' -o dist/epinio-linux-s390x
 
-build-images:
+build-images: build-linux-amd64
 	@./scripts/build-images.sh
 
 compress:

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,19 +1,9 @@
 ARG BASE_IMAGE=splatform/epinio-base
 
 ################
-FROM golang:1.17.5 AS build
-WORKDIR /go/src/github.com/epinio
-
-# for caching
-COPY go.mod ./
-COPY go.sum ./
-RUN go mod download
-
-COPY . .
-
-RUN LDFLAGS="$LDFLAGS -s -w" make build-linux-amd64
-
-################
 FROM $BASE_IMAGE
-COPY --from=build /go/src/github.com/epinio/dist/epinio-linux-amd64 /epinio
+# default, if running outside of gorelease with a self-compiled binary
+ARG DIST_BINARY=dist/epinio-linux-amd64
+
+COPY ${DIST_BINARY} /epinio
 ENTRYPOINT ["/epinio"]


### PR DESCRIPTION
* use release-drafter
* publish image to github container registry, too
* works for any pushed tag that starts with 'v', no longer limited to
  main branch. Release branches are possible now, e.g. a 0.3.1 tag on a 0.3.x branch
* use the same go version (1.17.latest) in tests and release
* modify build-image target, so it could still work locally, if docker
  credentials allow pushing to splatform