### PR TITLE
Fix RKE2 installation for CI

### DIFF
--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Create RKE cluster
         id: create-cluster
         run: |
-          curl -sfL https://get.rke2.io | sudo sh -
+          curl -sfL https://get.rke2.io | sudo INSTALL_RKE2_METHOD=tar sh -
           sudo sh -c "echo RKE2_KUBECONFIG_MODE=0644 > /etc/sysconfig/rke2-server"
           sudo systemctl enable --now rke2-server
 


### PR DESCRIPTION
See https://github.com/rancher/rke2/issues/2377 for more information.

This should fixed the failing RKE-CI: https://github.com/epinio/epinio/runs/4876802845?check_suite_focus=true