### PR TITLE
Centralize duplicated code

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -77,6 +77,7 @@ var CmdAppList = &cobra.Command{
 		}
 
 		err = client.Apps(all)
+		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error listing apps")
 	},
 }
@@ -107,6 +108,7 @@ var CmdAppCreate = &cobra.Command{
 		}
 
 		err = client.AppCreate(args[0], m.Configuration)
+		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error creating app")
 	},
 }
@@ -127,6 +129,7 @@ var CmdAppShow = &cobra.Command{
 		}
 
 		err = client.AppShow(args[0])
+		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error showing app")
 	},
 }
@@ -165,6 +168,7 @@ var CmdAppLogs = &cobra.Command{
 		}
 
 		err = client.AppLogs(args[0], stageID, follow, nil)
+		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error streaming application logs")
 	},
 }
@@ -197,11 +201,8 @@ var CmdAppUpdate = &cobra.Command{
 		}
 
 		err = client.AppUpdate(args[0], m.Configuration)
-		if err != nil {
-			return errors.Wrap(err, "error updating the app")
-		}
-
-		return nil
+		// Note: errors.Wrap (nil, "...") == nil
+		return errors.Wrap(err, "error updating the app")
 	},
 }
 
@@ -221,6 +222,7 @@ var CmdAppManifest = &cobra.Command{
 		}
 
 		err = client.AppManifest(args[0], args[1])
+		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error getting app manifest")
 	},
 }

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/epinio/epinio/internal/cli/usercmd"
@@ -26,7 +25,7 @@ var CmdApp = &cobra.Command{
 		if err := cmd.Usage(); err != nil {
 			return err
 		}
-		return fmt.Errorf(`Unknown method "%s"`, args[0])
+		return fmt.Errorf(`unknown method "%s"`, args[0])
 	},
 }
 
@@ -78,19 +77,16 @@ var CmdAppList = &cobra.Command{
 		}
 
 		err = client.Apps(all)
-		if err != nil {
-			return errors.Wrap(err, "error listing apps")
-		}
-
-		return nil
+		return errors.Wrap(err, "error listing apps")
 	},
 }
 
 // CmdAppCreate implements the command: epinio apps create
 var CmdAppCreate = &cobra.Command{
-	Use:   "create NAME",
-	Short: "Create just the app, without creating a workload",
-	Args:  cobra.ExactArgs(1),
+	Use:               "create NAME",
+	Short:             "Create just the app, without creating a workload",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
@@ -111,33 +107,16 @@ var CmdAppCreate = &cobra.Command{
 		}
 
 		err = client.AppCreate(args[0], m.Configuration)
-		if err != nil {
-			return errors.Wrap(err, "error creating app")
-		}
-
-		return nil
-	},
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		app, err := usercmd.New()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		matches := app.AppsMatching(context.Background(), toComplete)
-
-		return matches, cobra.ShellCompDirectiveNoFileComp
+		return errors.Wrap(err, "error creating app")
 	},
 }
 
 // CmdAppShow implements the command: epinio apps show
 var CmdAppShow = &cobra.Command{
-	Use:   "show NAME",
-	Short: "Describe the named application",
-	Args:  cobra.ExactArgs(1),
+	Use:               "show NAME",
+	Short:             "Describe the named application",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
@@ -148,25 +127,7 @@ var CmdAppShow = &cobra.Command{
 		}
 
 		err = client.AppShow(args[0])
-		if err != nil {
-			return errors.Wrap(err, "error showing app")
-		}
-
-		return nil
-	},
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		app, err := usercmd.New()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		matches := app.AppsMatching(context.Background(), toComplete)
-
-		return matches, cobra.ShellCompDirectiveNoFileComp
+		return errors.Wrap(err, "error showing app")
 	},
 }
 
@@ -204,21 +165,18 @@ var CmdAppLogs = &cobra.Command{
 		}
 
 		err = client.AppLogs(args[0], stageID, follow, nil)
-		if err != nil {
-			return errors.Wrap(err, "error streaming application logs")
-		}
-
-		return nil
+		return errors.Wrap(err, "error streaming application logs")
 	},
 }
 
 // CmdAppUpdate implements the command: epinio apps update
 // It scales the named app
 var CmdAppUpdate = &cobra.Command{
-	Use:   "update NAME",
-	Short: "Update the named application",
-	Long:  "Update the running application's attributes (e.g. instances)",
-	Args:  cobra.ExactArgs(1),
+	Use:               "update NAME",
+	Short:             "Update the named application",
+	Long:              "Update the running application's attributes (e.g. instances)",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
@@ -245,27 +203,14 @@ var CmdAppUpdate = &cobra.Command{
 
 		return nil
 	},
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		app, err := usercmd.New()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		matches := app.AppsMatching(context.Background(), toComplete)
-
-		return matches, cobra.ShellCompDirectiveNoFileComp
-	},
 }
 
 // CmdAppManifest implements the command: epinio apps manifest
 var CmdAppManifest = &cobra.Command{
-	Use:   "manifest NAME MANIFESTPATH",
-	Short: "Save state of the named application as a manifest",
-	Args:  cobra.ExactArgs(2),
+	Use:               "manifest NAME MANIFESTPATH",
+	Short:             "Save state of the named application as a manifest",
+	Args:              cobra.ExactArgs(2),
+	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
@@ -276,24 +221,6 @@ var CmdAppManifest = &cobra.Command{
 		}
 
 		err = client.AppManifest(args[0], args[1])
-		if err != nil {
-			return errors.Wrap(err, "error getting app manifest")
-		}
-
-		return nil
-	},
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		app, err := usercmd.New()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		matches := app.AppsMatching(context.Background(), toComplete)
-
-		return matches, cobra.ShellCompDirectiveNoFileComp
+		return errors.Wrap(err, "error getting app manifest")
 	},
 }

--- a/internal/cli/commons.go
+++ b/internal/cli/commons.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/epinio/epinio/internal/cli/usercmd"
+	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -41,4 +43,36 @@ func CreateKubeClient(configPath string) kubernetes.Interface {
 	ExitfIfError(err, "an unexpected error occurred")
 
 	return clientset
+}
+
+// matchingAppsFinder return a list of matching apps from the provided partial command
+func matchingAppsFinder(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	app, err := usercmd.New()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	matches := app.AppsMatching(toComplete)
+
+	return matches, cobra.ShellCompDirectiveNoFileComp
+}
+
+// matchingNamespaceFinder return a list of matching namespaces from the provided partial command
+func matchingNamespaceFinder(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	app, err := usercmd.New()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	matches := app.NamespacesMatching(toComplete)
+
+	return matches, cobra.ShellCompDirectiveNoFileComp
 }

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"context"
-
 	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -12,9 +10,10 @@ var ()
 
 // CmdAppDelete implements the command: epinio app delete
 var CmdAppDelete = &cobra.Command{
-	Use:   "delete NAME",
-	Short: "Deletes an application",
-	Args:  cobra.ExactArgs(1),
+	Use:               "delete NAME",
+	Short:             "Deletes an application",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
@@ -29,18 +28,5 @@ var CmdAppDelete = &cobra.Command{
 		}
 
 		return nil
-	},
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		app, err := usercmd.New()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		matches := app.AppsMatching(context.Background(), toComplete)
-
-		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
 }

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -36,10 +36,11 @@ func init() {
 
 // CmdEnvList implements the command: epinio app env list
 var CmdEnvList = &cobra.Command{
-	Use:   "list APPNAME",
-	Short: "Lists application environment",
-	Long:  "Lists environment variables of named application",
-	Args:  cobra.ExactArgs(1),
+	Use:               "list APPNAME",
+	Short:             "Lists application environment",
+	Long:              "Lists environment variables of named application",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
@@ -54,20 +55,6 @@ var CmdEnvList = &cobra.Command{
 		}
 
 		return nil
-	},
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		app, err := usercmd.New()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		matches := app.AppsMatching(context.Background(), toComplete)
-
-		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
 }
 
@@ -106,7 +93,7 @@ var CmdEnvSet = &cobra.Command{
 		}
 
 		// #args == 0: application name.
-		matches := app.AppsMatching(context.Background(), toComplete)
+		matches := app.AppsMatching(toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
@@ -150,7 +137,7 @@ var CmdEnvShow = &cobra.Command{
 		}
 
 		// #args == 0: application name.
-		matches := app.AppsMatching(context.Background(), toComplete)
+		matches := app.AppsMatching(toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
@@ -158,10 +145,11 @@ var CmdEnvShow = &cobra.Command{
 
 // CmdEnvUnset implements the command: epinio app env unset
 var CmdEnvUnset = &cobra.Command{
-	Use:   "unset APPNAME NAME",
-	Short: "Shrink application environment",
-	Long:  "Remove environment variable from named application",
-	Args:  cobra.ExactArgs(2),
+	Use:               "unset APPNAME NAME",
+	Short:             "Shrink application environment",
+	Long:              "Remove environment variable from named application",
+	Args:              cobra.ExactArgs(2),
+	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
@@ -177,21 +165,5 @@ var CmdEnvUnset = &cobra.Command{
 		}
 
 		return nil
-	},
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		// TODO: match EV names for arg 1 completion
-
-		app, err := usercmd.New()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		matches := app.AppsMatching(context.Background(), toComplete)
-
-		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
 }

--- a/internal/cli/namespaces.go
+++ b/internal/cli/namespaces.go
@@ -88,9 +88,10 @@ var CmdNamespaceCreate = &cobra.Command{
 
 // CmdNamespaceDelete implements the command: epinio namespace delete
 var CmdNamespaceDelete = &cobra.Command{
-	Use:   "delete NAME",
-	Short: "Deletes an epinio-controlled namespace",
-	Args:  cobra.ExactArgs(1),
+	Use:               "delete NAME",
+	Short:             "Deletes an epinio-controlled namespace",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: matchingNamespaceFinder,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		force, err := cmd.Flags().GetBool("force")
 		if err != nil {
@@ -120,27 +121,14 @@ var CmdNamespaceDelete = &cobra.Command{
 
 		return nil
 	},
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		app, err := usercmd.New()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		matches := app.NamespacesMatching(toComplete)
-
-		return matches, cobra.ShellCompDirectiveNoFileComp
-	},
 }
 
 // CmdNamespaceShow implements the command: epinio namespace show
 var CmdNamespaceShow = &cobra.Command{
-	Use:   "show NAME",
-	Short: "Shows the details of an epinio-controlled namespace",
-	Args:  cobra.ExactArgs(1),
+	Use:               "show NAME",
+	Short:             "Shows the details of an epinio-controlled namespace",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: matchingNamespaceFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
@@ -155,20 +143,6 @@ var CmdNamespaceShow = &cobra.Command{
 		}
 
 		return nil
-	},
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		app, err := usercmd.New()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		matches := app.NamespacesMatching(toComplete)
-
-		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
 }
 

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -133,7 +133,7 @@ var CmdServiceBind = &cobra.Command{
 
 		if len(args) == 1 {
 			// #args == 1: app name.
-			matches := app.AppsMatching(context.Background(), toComplete)
+			matches := app.AppsMatching(toComplete)
 			return matches, cobra.ShellCompDirectiveNoFileComp
 		}
 
@@ -164,7 +164,7 @@ var CmdServiceUnbind = &cobra.Command{
 
 		if len(args) == 1 {
 			// #args == 1: app name.
-			matches := app.AppsMatching(context.Background(), toComplete)
+			matches := app.AppsMatching(toComplete)
 			return matches, cobra.ShellCompDirectiveNoFileComp
 		}
 

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -10,9 +10,10 @@ var ()
 
 // CmdTarget implements the command: epinio target
 var CmdTarget = &cobra.Command{
-	Use:   "target [namespace]",
-	Short: "Targets an epinio-controlled namespace.",
-	Args:  cobra.MaximumNArgs(1),
+	Use:               "target [namespace]",
+	Short:             "Targets an epinio-controlled namespace.",
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: matchingNamespaceFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
@@ -32,19 +33,5 @@ var CmdTarget = &cobra.Command{
 		}
 
 		return nil
-	},
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		app, err := usercmd.New()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		matches := app.NamespacesMatching(toComplete)
-
-		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
 }

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -55,7 +55,7 @@ func (c *EpinioClient) AppCreate(appName string, appConfig models.ApplicationUpd
 
 // AppsMatching returns all Epinio apps having the specified prefix
 // in their name.
-func (c *EpinioClient) AppsMatching(ctx context.Context, prefix string) []string {
+func (c *EpinioClient) AppsMatching(prefix string) []string {
 	log := c.Log.WithName("AppsMatching").WithValues("PrefixToMatch", prefix)
 	log.Info("start")
 	defer log.Info("return")


### PR DESCRIPTION
Many `ValidArgsFunction` were doing the same check, so this PR centralize the two most common func in the `commons` file.