### PR TITLE
Remove unsed function 'assetPath' from helpers

### DIFF
--- a/helpers/helpers_suite_test.go
+++ b/helpers/helpers_suite_test.go
@@ -1,8 +1,6 @@
 package helpers_test
 
 import (
-	"os"
-	"path"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -12,14 +10,4 @@ import (
 func TestHelpers(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Helpers Suite")
-}
-
-// assetPath returns the full path to a file in "fixtures" directory
-func assetPath(fileName string) string {
-	currentPath, err := os.Getwd()
-	if err != nil {
-		panic(err.Error())
-	}
-
-	return path.Join(currentPath, "..", "assets", "tests", fileName)
 }


### PR DESCRIPTION
Golint now returns this error:
```
golangci-lint run
helpers/helpers_suite_test.go:18:6: `assetPath` is unused (deadcode)
func assetPath(fileName string) string {
     ^
```

This is because this `assetPath` function is not used anymore, so can be removed.