### PR TITLE
Use PHP 7.4 instead of 7.3 for wordpress testapp

### DIFF
--- a/acceptance/apps/wordpress_test.go
+++ b/acceptance/apps/wordpress_test.go
@@ -55,7 +55,7 @@ func (w *WordpressApp) CreateDir() error {
 	buildpackYaml := []byte(`
 ---
 php:
-  version: 7.3.x
+  version: 7.4.x
   script: index.php
   webserver: nginx
   webdirectory: htdocs


### PR DESCRIPTION
As it seems that PHP 7.3.x cannot be used anymore:
```
step-create failed to satisfy "php" dependency version constraint "7.3.x":
no compatible versions on "io.buildpacks.stacks.bionic" stack.
Supported versions are: [7.4.26, 7.4.27, 8.0.14, 8.0.15]
```
**NOTE:** this issue can be seen in `acceptance-apps` tests:
```
[8]   🕞  [2f353e4c6a8fdb33-stage-x49bx-pod-8gm4g] step-create Paketo PHP Distribution Buildpack 0.5.0 
[8]   🕞  [2f353e4c6a8fdb33-stage-x49bx-pod-8gm4g] step-create   Resolving PHP version 
[8]   🕞  [2f353e4c6a8fdb33-stage-x49bx-pod-8gm4g] step-create     Candidate version sources (in priority order): 
[8]   🕞  [2f353e4c6a8fdb33-stage-x49bx-pod-8gm4g] step-create       buildpack.yml    -> "7.3.x" 
[8]   🕞  [2f353e4c6a8fdb33-stage-x49bx-pod-8gm4g] step-create       default-versions -> "7.4.*" 
[8]   🕞  [2f353e4c6a8fdb33-stage-x49bx-pod-8gm4g] step-create  
[8]   🕞  [2f353e4c6a8fdb33-stage-x49bx-pod-8gm4g] step-create failed to satisfy "php" dependency version constraint "7.3.x": no compatible versions on "io.buildpacks.stacks.bionic" stack. Supported versions are: [7.4.26, 7.4.27, 8.0.14, 8.0.15] 
[8]   🕞  [2f353e4c6a8fdb33-stage-x49bx-pod-8gm4g] step-create ERROR: failed to build: exit status 1 
[8]   🕞  [2f353e4c6a8fdb33-stage-x49bx-pod-8gm4g] step-results 2022/01/27 20:50:53 Skipping step because a previous step failed 
[8]   2022/01/27 20:50:55 EpinioApiClient "msg"="response is not StatusOK" "error"="Internal Server Error: Tasks Completed: 4 (Failed: 1, Cancelled 0), Skipped: 0" "status"=500 
```