### PR TITLE
Make github repositories configurable and add notes

### DIFF
--- a/scripts/remove-github-action-runner.sh
+++ b/scripts/remove-github-action-runner.sh
@@ -2,7 +2,7 @@
 
 # This script can be used to remove a Github Action Runner on an openSUSE or SLE
 # distro. It will unconfigure the service and unregister the runner.
-# Copy the scritpt to runner:/home/<user> and run it as <user>.
+# Copy the script to runner:/home/<user> and run it as <user>.
 # It requires GITHUB_REPOSITORY_URL (https) and GITHUB_RUNNER_TOKEN to be set
 # e.g. export GITHUB_REPOSITORY_URL=https://github.com/epinio/epinio
 # and  export GITHUB_RUNNER_TOKEN=<current token from github settings/actions/runners/new>

--- a/scripts/remove-github-action-runner.sh
+++ b/scripts/remove-github-action-runner.sh
@@ -11,20 +11,15 @@
 
 set -e
 
-if [ -z "$GITHUB_REPOSITORY_URL" ]; then
-  echo "The variable GITHUB_REPOSITORY_URL is empty. Exiting"
+if [ -z "$GITHUB_REPOSITORY_URL" ] || [ -z "$GITHUB_RUNNER_TOKEN" ]; then
+  echo "Script requires GITHUB_REPOSITORY_URL and GITHUB_RUNNER_TOKEN to be set. Exiting"
   exit 1
 fi
 
-if [ -z "$GITHUB_RUNNER_TOKEN" ]; then
-  echo "The variable GITHUB_RUNNER_TOKEN is empty. Exiting"
-  exit 1
-fi
-
-REPOSITORY_NAME=$(echo $GITHUB_REPOSITORY_URL | cut -d '/' -f 4- | sed -e 's|/$||g' -e 's|/|-|g')
-ACTIONS_RUNNER_SERVICE=actions.runner.$REPOSITORY_NAME.`hostname`.service
+REPOSITORY_NAME=$(echo "$GITHUB_REPOSITORY_URL" | cut -d '/' -f 4- | sed -e 's|/$||g' -e 's|/|-|g')
+ACTIONS_RUNNER_SERVICE=actions.runner."$REPOSITORY_NAME".`hostname`.service
 
 cd actions-runner
-sudo systemctl stop $ACTIONS_RUNNER_SERVICE
+sudo systemctl stop "$ACTIONS_RUNNER_SERVICE"
 sudo ./svc.sh uninstall
-./config.sh remove --token $GITHUB_RUNNER_TOKEN
+./config.sh remove --token "$GITHUB_RUNNER_TOKEN"

--- a/scripts/remove-github-action-runner.sh
+++ b/scripts/remove-github-action-runner.sh
@@ -2,15 +2,29 @@
 
 # This script can be used to remove a Github Action Runner on an openSUSE or SLE
 # distro. It will unconfigure the service and unregister the runner.
+# Copy the scritpt to runner:/home/<user> and run it as <user>.
+# It requires GITHUB_REPOSITORY_URL (https) and GITHUB_RUNNER_TOKEN to be set
+# e.g. export GITHUB_REPOSITORY_URL=https://github.com/epinio/epinio
+# and  export GITHUB_RUNNER_TOKEN=<current token from github settings/actions/runners/new>
+# Note: You can use the same token to add or remove multiple runners,
+#       while it will expire after 1h.
 
 set -e
+
+if [ -z "$GITHUB_REPOSITORY_URL" ]; then
+  echo "The variable GITHUB_REPOSITORY_URL is empty. Exiting"
+  exit 1
+fi
 
 if [ -z "$GITHUB_RUNNER_TOKEN" ]; then
   echo "The variable GITHUB_RUNNER_TOKEN is empty. Exiting"
   exit 1
 fi
 
+REPOSITORY_NAME=$(echo $GITHUB_REPOSITORY_URL | cut -d '/' -f 4- | sed -e 's|/$||g' -e 's|/|-|g')
+ACTIONS_RUNNER_SERVICE=actions.runner.$REPOSITORY_NAME.`hostname`.service
+
 cd actions-runner
-sudo systemctl stop actions.runner.epinio-epinio.`hostname`.service
+sudo systemctl stop $ACTIONS_RUNNER_SERVICE
 sudo ./svc.sh uninstall
 ./config.sh remove --token $GITHUB_RUNNER_TOKEN

--- a/scripts/setup-github-action-runner.sh
+++ b/scripts/setup-github-action-runner.sh
@@ -3,7 +3,7 @@
 # This script can be used to create a Github Action Runner on an openSUSE or SLE
 # distro. It installs all the needed dependencies to run the acceptance tests
 # and sets up docker and the runner as a service itself.
-# Copy the scritpt to runner:/home/<user> and run it as <user>.
+# Copy the script to runner:/home/<user> and run it as <user>.
 # It requires GITHUB_REPOSITORY_URL (https) and GITHUB_RUNNER_TOKEN to be set
 # e.g. export GITHUB_REPOSITORY_URL=https://github.com/epinio/epinio
 # and  export GITHUB_RUNNER_TOKEN=<current token from github settings/actions/runners/new>

--- a/scripts/setup-github-action-runner.sh
+++ b/scripts/setup-github-action-runner.sh
@@ -3,13 +3,27 @@
 # This script can be used to create a Github Action Runner on an openSUSE or SLE
 # distro. It installs all the needed dependencies to run the acceptance tests
 # and sets up docker and the runner as a service itself.
+# Copy the scritpt to runner:/home/<user> and run it as <user>.
+# It requires GITHUB_REPOSITORY_URL (https) and GITHUB_RUNNER_TOKEN to be set
+# e.g. export GITHUB_REPOSITORY_URL=https://github.com/epinio/epinio
+# and  export GITHUB_RUNNER_TOKEN=<current token from github settings/actions/runners/new>
+# Note: You can use the same token to add or remove multiple runners,
+#       while it will expire after 1h.
 
 set -e
+
+if [ -z "$GITHUB_REPOSITORY_URL" ]; then
+  echo "The variable GITHUB_REPOSITORY_URL is empty. Exiting"
+  exit 1
+fi
 
 if [ -z "$GITHUB_RUNNER_TOKEN" ]; then
   echo "The variable GITHUB_RUNNER_TOKEN is empty. Exiting"
   exit 1
 fi
+
+REPOSITORY_NAME=$(echo $GITHUB_REPOSITORY_URL | cut -d '/' -f 4- | sed -e 's|/$||g' -e 's|/|-|g')
+ACTIONS_RUNNER_SERVICE=actions.runner.$REPOSITORY_NAME.`hostname`.service
 
 # Install needed packages
 rpms="make gcc docker libicu wget fping"
@@ -38,12 +52,12 @@ tar xzf ./actions-runner-linux-x64-2.278.0.tar.gz
 
 # Make non-interactive
 sed -i 's/Runner.Listener configure/Runner.Listener configure --unattended/' config.sh
-./config.sh --url https://github.com/epinio/epinio --token $GITHUB_RUNNER_TOKEN
+./config.sh --url $GITHUB_REPOSITORY_URL --token $GITHUB_RUNNER_TOKEN
 
 # Configure and enable Service
 sudo ./svc.sh install
-sudo sed -i '/^\[Service\]/a RestartSec=5s' /etc/systemd/system/actions.runner.epinio-epinio.`hostname`.service
-sudo sed -i '/^\[Service\]/a Restart=always' /etc/systemd/system/actions.runner.epinio-epinio.`hostname`.service
+sudo sed -i '/^\[Service\]/a RestartSec=5s' /etc/systemd/system/$ACTIONS_RUNNER_SERVICE
+sudo sed -i '/^\[Service\]/a Restart=always' /etc/systemd/system/$ACTIONS_RUNNER_SERVICE
 sudo systemctl daemon-reload
-sudo systemctl enable actions.runner.epinio-epinio.`hostname`.service
-sudo systemctl start actions.runner.epinio-epinio.`hostname`.service
+sudo systemctl enable $ACTIONS_RUNNER_SERVICE
+sudo systemctl start $ACTIONS_RUNNER_SERVICE


### PR DESCRIPTION
Tested with terraform already. Scripts can be configured to work with any repository, while e.g.
`export GITHUB_REPOSITORY_URL=https://github.com/epinio` will make it become an "Organization" runner, or
`export GITHUB_REPOSITORY_URL=https://github.com/epinio/epinio` a runner within the epinio repo
and in general, scripts can be reused for any repository.