### PR TITLE
1151 shell to specific instance - part 1 - list application instances

### DIFF
--- a/acceptance/api/v1/application_show_test.go
+++ b/acceptance/api/v1/application_show_test.go
@@ -93,7 +93,7 @@ var _ = Describe("AppShow Endpoint", func() {
 		Consistently(func() int32 {
 			appObj := appFromAPI(namespace, app)
 			return appObj.Workload.Replicas[replica.Name].Restarts
-		}, "5s", "1s").Should(BeNumerically("==", 0))
+		}, "10s", "1s").Should(BeNumerically("==", 0))
 
 		// Kill an app container and see the count increasing
 		out, err = proc.Kubectl("exec",
@@ -104,7 +104,7 @@ var _ = Describe("AppShow Endpoint", func() {
 		Eventually(func() int32 {
 			appObj := appFromAPI(namespace, app)
 			return appObj.Workload.Replicas[replica.Name].Restarts
-		}, "4s", "1s").Should(BeNumerically("==", 1))
+		}, "15s", "1s").Should(BeNumerically("==", 1))
 	})
 
 	It("returns a 404 when the namespace does not exist", func() {

--- a/acceptance/api/v1/application_show_test.go
+++ b/acceptance/api/v1/application_show_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/epinio/epinio/acceptance/helpers/catalog"
 	"github.com/epinio/epinio/acceptance/helpers/proc"
 	v1 "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -40,10 +41,16 @@ var _ = Describe("AppShow Endpoint", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(createdAt.Unix()).To(BeNumerically("<", time.Now().Unix()))
 
-		Expect(appObj.Workload.Restarts).To(BeNumerically("==", 0))
-
 		Expect(appObj.Workload.DesiredReplicas).To(BeNumerically("==", 1))
 		Expect(appObj.Workload.ReadyReplicas).To(BeNumerically("==", 1))
+
+		Expect(len(appObj.Workload.Replicas)).To(Equal(1))
+		var replica *models.PodInfo
+		for _, v := range appObj.Workload.Replicas {
+			replica = v
+			break
+		}
+		Expect(replica.Restarts).To(BeNumerically("==", 0))
 
 		out, err := proc.Kubectl("get", "pods",
 			fmt.Sprintf("--selector=app.kubernetes.io/name=%s", app),
@@ -59,7 +66,7 @@ var _ = Describe("AppShow Endpoint", func() {
 		Expect(err).ToNot(HaveOccurred(), out)
 		Eventually(func() int64 {
 			appObj := appFromAPI(namespace, app)
-			return appObj.Workload.MilliCPUs
+			return appObj.Workload.Replicas[replica.Name].MilliCPUs
 		}, "240s", "1s").Should(BeNumerically(">=", 900))
 		// Kill the "yes" process to bring CPU down again
 		out, err = proc.Kubectl("exec",
@@ -74,7 +81,7 @@ var _ = Describe("AppShow Endpoint", func() {
 		Expect(err).ToNot(HaveOccurred(), out)
 		Eventually(func() int64 {
 			appObj := appFromAPI(namespace, app)
-			return appObj.Workload.MemoryBytes
+			return appObj.Workload.Replicas[replica.Name].MemoryBytes
 		}, "240s", "1s").Should(BeNumerically(">=", 0))
 
 		// Kill a linkerd proxy container and see the count staying unchanged
@@ -85,7 +92,7 @@ var _ = Describe("AppShow Endpoint", func() {
 
 		Consistently(func() int32 {
 			appObj := appFromAPI(namespace, app)
-			return appObj.Workload.Restarts
+			return appObj.Workload.Replicas[replica.Name].Restarts
 		}, "5s", "1s").Should(BeNumerically("==", 0))
 
 		// Kill an app container and see the count increasing
@@ -96,7 +103,7 @@ var _ = Describe("AppShow Endpoint", func() {
 
 		Eventually(func() int32 {
 			appObj := appFromAPI(namespace, app)
-			return appObj.Workload.Restarts
+			return appObj.Workload.Replicas[replica.Name].Restarts
 		}, "4s", "1s").Should(BeNumerically("==", 1))
 	})
 

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -511,6 +511,7 @@ configuration:
 				Expect(out).To(MatchRegexp(`Instances\s*\|\s*2\s*\|`))
 				Expect(out).To(MatchRegexp(`- CREDO\s*\|\s*up\s*\|`))
 				Expect(out).To(MatchRegexp(`- DOGMA\s*\|\s*no\s*\|`))
+				Expect(out).To(MatchRegexp(fmt.Sprintf(" %s-.*|\\s+true\\s+|.*|.*|.*|.*|", appName)))
 
 				By("deleting the app")
 				env.DeleteApp(appName)

--- a/internal/application/workload.go
+++ b/internal/application/workload.go
@@ -481,7 +481,6 @@ func (a *Workload) generatePodInfo(pods []corev1.Pod) map[string]*models.PodInfo
 }
 
 func (a *Workload) populatePodMetrics(podInfos map[string]*models.PodInfo, podMetrics []metricsv1beta1.PodMetrics) error {
-	// Calculate metrics
 	for _, podMetric := range podMetrics {
 		if _, podExists := podInfos[podMetric.Name]; !podExists {
 			continue // should not happen but just making sure metrics match pods

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -546,6 +546,10 @@ func (c *EpinioClient) printAppDetails(app models.App) error {
 }
 
 func (c *EpinioClient) printReplicaDetails(app models.App) error {
+	if app.Workload == nil {
+		return nil
+	}
+
 	if len(app.Workload.Replicas) > 0 {
 		msg := c.ui.Success().WithTable("Name", "Ready", "Memory", "MilliCPUs", "Restarts", "Age")
 		for _, r := range app.Workload.Replicas {

--- a/pkg/api/core/v1/models/app.go
+++ b/pkg/api/core/v1/models/app.go
@@ -36,21 +36,28 @@ type App struct {
 	StatusMessage string                   `json:"statusmessage"`
 }
 
+type PodInfo struct {
+	Name        string `json:"name"`
+	MemoryBytes int64  `json:"memoryBytes"`
+	MilliCPUs   int64  `json:"millicpus"`
+	CreatedAt   string `json:"createdAt,omitempty"`
+	Restarts    int32  `json:"restarts"`
+	Ready       bool   `json:"ready"`
+}
+
 // AppDeployment contains all the information specific to an active
 // application, i.e. one with a deployment in the cluster.
 type AppDeployment struct {
 	// TODO: Readiness and Liveness fields?
-	Active          bool     `json:"active,omitempty"` // app is > 0 replicas
-	CreatedAt       string   `json:"createdAt,omitempty"`
-	Restarts        int32    `json:"restarts"`
-	MemoryBytes     int64    `json:"memoryBytes"`
-	MilliCPUs       int64    `json:"millicpus"`
-	DesiredReplicas int32    `json:"desiredreplicas"`
-	ReadyReplicas   int32    `json:"readyreplicas"`
-	Username        string   `json:"username,omitempty"` // app creator
-	StageID         string   `json:"stage_id,omitempty"` // staging id
-	Status          string   `json:"status,omitempty"`   // app replica status
-	Routes          []string `json:"routes,omitempty"`   // app routes
+	Active          bool                `json:"active,omitempty"` // app is > 0 replicas
+	CreatedAt       string              `json:"createdAt,omitempty"`
+	DesiredReplicas int32               `json:"desiredreplicas"`
+	ReadyReplicas   int32               `json:"readyreplicas"`
+	Replicas        map[string]*PodInfo `json:"replicas"`
+	Username        string              `json:"username,omitempty"` // app creator
+	StageID         string              `json:"stage_id,omitempty"` // staging id
+	Status          string              `json:"status,omitempty"`   // app replica status
+	Routes          []string            `json:"routes,omitempty"`   // app routes
 }
 
 // NewApp returns a new app for name and namespace


### PR DESCRIPTION
This is a preparation for #1151

We first need a way to list application instances. Then the user can request a shell to a specific instance.
This PR changes the endpoint for `epinio app show`, to list the application instances with their metrics.
