### PR TITLE
Fix 1175 - Move staging scripts to config map

### DIFF
--- a/internal/helmchart/constants.go
+++ b/internal/helmchart/constants.go
@@ -5,4 +5,8 @@ const (
 	StagingNamespace              = "epinio-staging"
 	EpinioNamespace               = "epinio"
 	EpinioCertificateName         = "epinio"
+	EpinioStageScriptsName        = "epinio-stage-scripts"
+	EpinioStageDownload           = "download"
+	EpinioStageUnpack             = "unpack"
+	EpinioStageBuild              = "build"
 )


### PR DESCRIPTION
Fix #1175 See also https://github.com/epinio/helm-charts/pull/93

feat: import helm chart having the stage scripts as config map.
feat: support function to retrieve config maps
feat: constants describing the config map and keys for stage scripts
feat: replace builtin scripts with scripts loaded from config map