### PR TITLE
Ingress class name

### DIFF
--- a/internal/api/v1/application/deploy.go
+++ b/internal/api/v1/application/deploy.go
@@ -250,7 +250,6 @@ func newAppService(app models.AppRef, username string) *v1.Service {
 			Name:      names.ServiceName(app.Name),
 			Namespace: app.Namespace,
 			Annotations: map[string]string{
-				"kubernetes.io/ingress.class":                      "traefik",
 				"traefik.ingress.kubernetes.io/router.entrypoints": "websecure",
 				"traefik.ingress.kubernetes.io/router.tls":         "true",
 			},

--- a/internal/application/ingresses.go
+++ b/internal/application/ingresses.go
@@ -185,8 +185,10 @@ func SyncIngresses(ctx context.Context, cluster *kubernetes.Cluster, appRef mode
 // completeIngress takes an Ingress as created by the routes#ToIngress
 // method and fills in more data needed for Epinio.
 func completeIngress(ingress *networkingv1.Ingress, appRef models.AppRef, username string) *networkingv1.Ingress {
-	t := "traefik"
-	ingress.Spec.IngressClassName = &t
+	name := viper.GetString("ingress-class-name")
+	if name != "" {
+		ingress.Spec.IngressClassName = &name
+	}
 
 	ingress.ObjectMeta.Annotations = map[string]string{
 		"traefik.ingress.kubernetes.io/router.entrypoints": "websecure",

--- a/internal/application/ingresses.go
+++ b/internal/application/ingresses.go
@@ -185,10 +185,12 @@ func SyncIngresses(ctx context.Context, cluster *kubernetes.Cluster, appRef mode
 // completeIngress takes an Ingress as created by the routes#ToIngress
 // method and fills in more data needed for Epinio.
 func completeIngress(ingress *networkingv1.Ingress, appRef models.AppRef, username string) *networkingv1.Ingress {
+	t := "traefik"
+	ingress.Spec.IngressClassName = &t
+
 	ingress.ObjectMeta.Annotations = map[string]string{
 		"traefik.ingress.kubernetes.io/router.entrypoints": "websecure",
 		"traefik.ingress.kubernetes.io/router.tls":         "true",
-		"kubernetes.io/ingress.class":                      "traefik",
 	}
 
 	ingress.ObjectMeta.Labels = map[string]string{

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -44,6 +44,10 @@ func init() {
 	flags.String("output", "text", "(OUTPUT) logs output format [text,json]")
 	viper.BindPFlag("output", flags.Lookup("output"))
 	viper.BindEnv("output", "OUTPUT")
+
+	flags.String("ingress-class-name", "", "(INGRESS_CLASS_NAME) Name of the ingress class to use for apps. Leave empty to add no ingressClassName to the ingress.")
+	viper.BindPFlag("ingress-class-name", flags.Lookup("ingress-class-name"))
+	viper.BindEnv("ingress-class-name", "INGRESS_CLASS_NAME")
 }
 
 // CmdServer implements the command: epinio server


### PR DESCRIPTION
Use the [ingressClassName](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) when creating the applications ingresses.


This also switches the class to nginx for testing. Only the workload's ingress is affected.

TODO

- [x] add option to choose class

Refers to https://github.com/epinio/epinio/issues/1178