### PR TITLE
Add error to the Gin context

### DIFF
--- a/internal/api/v1/response/response.go
+++ b/internal/api/v1/response/response.go
@@ -44,6 +44,15 @@ func Error(c *gin.Context, responseErrors errors.APIErrors) {
 		"origin", c.Request.URL.String(),
 		"error", responseErrors)
 
+	// add errors to the Gin context
+	for _, err := range responseErrors.Errors() {
+		if ginErr := c.Error(err); ginErr != nil {
+			tracelog.Logger(c.Request.Context()).Error(ginErr, "ERROR",
+				"origin", c.Request.URL.String(),
+				"error", ginErr)
+		}
+	}
+
 	c.Header("X-Content-Type-Options", "nosniff")
 	c.JSON(responseErrors.FirstStatus(), errors.ErrorResponse{
 		Errors: responseErrors.Errors(),


### PR DESCRIPTION
Fix for https://github.com/epinio/epinio/issues/1130

This PR adds the error to the Gin context, so that the LogFormatter can log them.