### PR TITLE
Logging fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/epinio/epinio
 go 1.15
 
 require (
+	github.com/alron/ginlogr v0.0.4
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/briandowns/spinner v1.18.0
 	github.com/epinio/application v0.0.0-20211220165956-754df54dce77
@@ -10,8 +11,9 @@ require (
 	github.com/gin-contrib/sessions v0.0.4
 	github.com/gin-gonic/gin v1.7.7
 	github.com/go-git/go-git/v5 v5.4.2
-	github.com/go-logr/logr v1.2.0
+	github.com/go-logr/logr v1.2.2
 	github.com/go-logr/stdr v1.2.0
+	github.com/go-logr/zapr v1.2.2
 	github.com/go-playground/validator/v10 v10.10.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/google/gofuzz v1.2.0 // indirect
@@ -32,6 +34,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.0
 	github.com/ugorji/go v1.2.6 // indirect
+	go.uber.org/zap v1.19.0
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alron/ginlogr v0.0.4 h1:nfa4gpcAlnesW9zYTPVZB9aGFWQibej4CDis5Rub8CI=
+github.com/alron/ginlogr v0.0.4/go.mod h1:8NHyKViu6z4T+s4gJJQuyuieXCal6zkplq6FnCMLTFc=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.1 h1:KqhlKozYbRtJvsPrrEeXcO+N2l6NYT5A2QAFmSULpEc=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
@@ -112,6 +114,7 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -234,6 +237,7 @@ github.com/gin-contrib/sessions v0.0.4 h1:gq4fNa1Zmp564iHP5G6EBuktilEos8VKhe2sza
 github.com/gin-contrib/sessions v0.0.4/go.mod h1:pQ3sIyviBBGcxgyR8mkeJuXbeV3h3NYmhJADQTq5+Vo=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
+github.com/gin-gonic/gin v1.5.0/go.mod h1:Nd6IXA8m5kNZdNEHMBd93KT+mdY3+bewLgRvmCsR2Do=
 github.com/gin-gonic/gin v1.7.4/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
 github.com/gin-gonic/gin v1.7.7 h1:3DoBmSbJbZAWqXJC3SLjAPfutPJJRN1U5pALB7EeTTs=
 github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=
@@ -263,11 +267,14 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
-github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.2 h1:ahHml/yUpnlb96Rp8HCvtYVPY8ZYpxq3g7UYchIYwbs=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/stdr v1.2.0 h1:j4LrlVXgrbIWO83mmQUnK0Hi+YnbD+vzrE1z/EphbFE=
 github.com/go-logr/stdr v1.2.0/go.mod h1:YkVgnZu1ZjjL7xTxrfm/LLZBfkhTqSR1ydtm6jTKKwI=
 github.com/go-logr/zapr v0.4.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
+github.com/go-logr/zapr v1.2.2 h1:5YNlIL6oZLydaV4dOFjL8YpgXF/tPeTbnpatnu3cq6o=
+github.com/go-logr/zapr v1.2.2/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
 github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
 github.com/go-openapi/analysis v0.18.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
@@ -314,9 +321,11 @@ github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2K
 github.com/go-openapi/validate v0.19.8/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/locales v0.14.0 h1:u50s323jtVGugKlcYeyzC0etD1HifMjqmJqb8WugfUU=
 github.com/go-playground/locales v0.14.0/go.mod h1:sawfccIbzZTqEDETgFXqTho0QybSa7l++s0DH+LDiLs=
+github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/universal-translator v0.18.0 h1:82dyy6p4OuJq4/CByFNOn/jYrnRPArHwAcmLoJZxyho=
 github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl+lu/H90nyDXpg0fqeB/AQUGNTVA=
@@ -507,6 +516,7 @@ github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFF
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -549,6 +559,7 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kyokomi/emoji v2.2.4+incompatible h1:np0woGKwx9LiHAQmwZx79Oc0rHpNw3o+3evou4BEPv4=
 github.com/kyokomi/emoji v2.2.4+incompatible/go.mod h1:mZ6aGCD7yk8j6QY6KICwnZ2pxoszVseX1DNoGtU2tBA=
+github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
@@ -579,6 +590,7 @@ github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
@@ -858,12 +870,16 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5/go.mod h1:nmDLcffg48OtT/PSW0Hg7FvpRQsQh5OSqIylirxKC7o=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
+go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
+go.uber.org/zap v1.19.0 h1:mZQZefskPPCMIBCSEH0v2/iUqqLrYtaeqwD6FUGUnFE=
 go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -910,6 +926,7 @@ golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRu
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -1033,6 +1050,7 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1045,6 +1063,7 @@ golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1363,6 +1382,9 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
+gopkg.in/go-playground/validator.v9 v9.29.1/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
+gopkg.in/go-playground/validator.v9 v9.30.2/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/helpers/kubernetes/tailer/watcher.go
+++ b/helpers/kubernetes/tailer/watcher.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/epinio/epinio/helpers/tracelog"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
@@ -34,7 +34,7 @@ func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp,
 	containerFilter *regexp.Regexp, containerExcludeFilter *regexp.Regexp,
 	containerState ContainerState, labelSelector labels.Selector) (chan *Target, chan *Target, error) {
 
-	logger := tracelog.NewLogger().WithName("pod-watch").V(4)
+	logger := requestctx.Logger(ctx).WithName("pod-watch").V(4)
 
 	logger.Info("create")
 	watcher, err := i.Watch(ctx, metav1.ListOptions{Watch: true, LabelSelector: labelSelector.String()})

--- a/helpers/tracelog/logger.go
+++ b/helpers/tracelog/logger.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/stdr"
+	"github.com/go-logr/zapr"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // TraceLevel returns the trace-level argument
@@ -33,4 +36,20 @@ func LoggerFlags(pf *flag.FlagSet, argToEnv map[string]string) {
 func NewLogger() logr.Logger {
 	stdr.SetVerbosity(TraceLevel())
 	return stdr.New(log.New(os.Stderr, "", log.LstdFlags)).V(1) // NOTE: Increment of level, not absolute.
+}
+
+// NewZapLogger creates a new zap logger with our setup. It only prints messages below
+// Zap uses semantically named levels for logging (DebugLevel, InfoLevel, WarningLevel, ...).
+// Logr uses arbitrary numeric levels. By default logr's V(0) is zap's InfoLevel and V(1) is zap's DebugLevel (which is numerically -1).
+// Zap does not have named levels that are more verbose than DebugLevel, but it's possible to fake it.
+//
+// https://github.com/go-logr/zapr#increasing-verbosity
+func NewZapLogger() logr.Logger {
+	zc := zap.NewProductionConfig()
+	zc.Level = zap.NewAtomicLevelAt(zapcore.Level(TraceLevel() * -1))
+	z, err := zc.Build()
+	if err != nil {
+		return NewLogger()
+	}
+	return zapr.NewLogger(z)
 }

--- a/helpers/tracelog/logger.go
+++ b/helpers/tracelog/logger.go
@@ -3,7 +3,6 @@
 package tracelog
 
 import (
-	"context"
 	"log"
 	"os"
 
@@ -12,24 +11,6 @@ import (
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
-
-type CtxLoggerKey struct{}
-
-// Logger returns the logger from the context, the server injects a logger into
-// each request.
-func Logger(ctx context.Context) logr.Logger {
-	log, ok := ctx.Value(CtxLoggerKey{}).(logr.Logger)
-	if !ok {
-		// this should not happen, but let's be cautious
-		return NewLogger().WithName("fallback")
-	}
-	return log
-}
-
-// WithLogger returns a copy of the context with the given logger
-func WithLogger(ctx context.Context, log logr.Logger) context.Context {
-	return context.WithValue(ctx, CtxLoggerKey{}, log)
-}
 
 // TraceLevel returns the trace-level argument
 func TraceLevel() int {

--- a/internal/api/v1/application/deploy.go
+++ b/internal/api/v1/application/deploy.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
-	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
@@ -42,7 +41,7 @@ type deployParam struct {
 // It creates the deployment, service and ingress (kube) resources for the app
 func (hc Controller) Deploy(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
-	log := tracelog.Logger(ctx)
+	log := requestctx.Logger(ctx)
 
 	namespace := c.Param("namespace")
 	name := c.Param("app")

--- a/internal/api/v1/application/importgit.go
+++ b/internal/api/v1/application/importgit.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/epinio/epinio/helpers"
 	"github.com/epinio/epinio/helpers/kubernetes"
-	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/helmchart"
@@ -25,7 +24,7 @@ import (
 // of the repo and puts it on S3.
 func (hc Controller) ImportGit(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
-	log := tracelog.Logger(ctx)
+	log := requestctx.Logger(ctx)
 
 	namespace := c.Param("namespace")
 	name := c.Param("app")

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -19,7 +19,6 @@ import (
 	"github.com/epinio/epinio/helpers/cahash"
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/helpers/randstr"
-	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
@@ -98,7 +97,7 @@ func ensurePVC(ctx context.Context, cluster *kubernetes.Cluster, ar models.AppRe
 // It creates a Job resource to stage the app
 func (hc Controller) Stage(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
-	log := tracelog.Logger(ctx)
+	log := requestctx.Logger(ctx)
 
 	namespace := c.Param("namespace")
 	name := c.Param("app")

--- a/internal/api/v1/application/upload.go
+++ b/internal/api/v1/application/upload.go
@@ -2,7 +2,6 @@ package application
 
 import (
 	"github.com/epinio/epinio/helpers/kubernetes"
-	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/helmchart"
@@ -17,7 +16,7 @@ import (
 // it creates the k8s resources needed for staging
 func (hc Controller) Upload(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
-	log := tracelog.Logger(ctx)
+	log := requestctx.Logger(ctx)
 
 	namespace := c.Param("namespace")
 	name := c.Param("app")

--- a/internal/api/v1/env/index.go
+++ b/internal/api/v1/env/index.go
@@ -2,9 +2,9 @@ package env
 
 import (
 	"github.com/epinio/epinio/helpers/kubernetes"
-	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
@@ -17,7 +17,7 @@ import (
 // associated with that application
 func (hc Controller) Index(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
-	log := tracelog.Logger(ctx)
+	log := requestctx.Logger(ctx)
 
 	namespaceName := c.Param("namespace")
 	appName := c.Param("app")

--- a/internal/api/v1/env/match.go
+++ b/internal/api/v1/env/match.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
-	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
@@ -21,7 +21,7 @@ import (
 // with prefix
 func (hc Controller) Match(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
-	log := tracelog.Logger(ctx)
+	log := requestctx.Logger(ctx)
 
 	namespaceName := c.Param("namespace")
 	appName := c.Param("app")

--- a/internal/api/v1/env/set.go
+++ b/internal/api/v1/env/set.go
@@ -2,9 +2,9 @@ package env
 
 import (
 	"github.com/epinio/epinio/helpers/kubernetes"
-	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
@@ -16,7 +16,7 @@ import (
 // and add/modifies the variable in the  application's environment.
 func (hc Controller) Set(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
-	log := tracelog.Logger(ctx)
+	log := requestctx.Logger(ctx)
 
 	namespaceName := c.Param("namespace")
 	appName := c.Param("app")

--- a/internal/api/v1/env/show.go
+++ b/internal/api/v1/env/show.go
@@ -2,9 +2,9 @@ package env
 
 import (
 	"github.com/epinio/epinio/helpers/kubernetes"
-	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
@@ -17,7 +17,7 @@ import (
 // the variable's value in the application's environment.
 func (hc Controller) Show(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
-	log := tracelog.Logger(ctx)
+	log := requestctx.Logger(ctx)
 
 	namespaceName := c.Param("namespace")
 	appName := c.Param("app")

--- a/internal/api/v1/env/unset.go
+++ b/internal/api/v1/env/unset.go
@@ -2,9 +2,9 @@ package env
 
 import (
 	"github.com/epinio/epinio/helpers/kubernetes"
-	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/gin-gonic/gin"
@@ -15,7 +15,7 @@ import (
 // variable from the application's environment.
 func (hc Controller) Unset(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
-	log := tracelog.Logger(ctx)
+	log := requestctx.Logger(ctx)
 
 	namespaceName := c.Param("namespace")
 	appName := c.Param("app")

--- a/internal/api/v1/namespace/match.go
+++ b/internal/api/v1/namespace/match.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
-	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
@@ -16,7 +16,7 @@ import (
 // It returns a list of all Epinio-controlled namespaces matching the prefix pattern.
 func (oc Controller) Match(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
-	log := tracelog.Logger(ctx)
+	log := requestctx.Logger(ctx)
 
 	log.Info("match namespaces")
 	defer log.Info("return")

--- a/internal/api/v1/response/response.go
+++ b/internal/api/v1/response/response.go
@@ -4,7 +4,7 @@ package response
 import (
 	"net/http"
 
-	"github.com/epinio/epinio/helpers/tracelog"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 
@@ -13,43 +13,49 @@ import (
 
 // OK reports a generic success
 func OK(c *gin.Context) {
-	tracelog.Logger(c.Request.Context()).Info("OK",
+	requestctx.Logger(c.Request.Context()).Info("OK",
 		"origin", c.Request.URL.String(),
-		"returning", models.ResponseOK)
+		"returning", models.ResponseOK,
+	)
 
 	c.JSON(http.StatusOK, models.ResponseOK)
 }
 
 // OKReturn reports a success with some data
 func OKReturn(c *gin.Context, response interface{}) {
-	tracelog.Logger(c.Request.Context()).Info("OK",
+	requestctx.Logger(c.Request.Context()).Info("OK",
 		"origin", c.Request.URL.String(),
-		"returning", response)
+		"returning", response,
+	)
 
 	c.JSON(http.StatusOK, response)
 }
 
 // Created reports successful creation of a resource.
 func Created(c *gin.Context) {
-	tracelog.Logger(c.Request.Context()).Info("CREATED",
+	requestctx.Logger(c.Request.Context()).Info("CREATED",
 		"origin", c.Request.URL.String(),
-		"returning", models.ResponseOK)
+		"returning", models.ResponseOK,
+	)
 
 	c.JSON(http.StatusCreated, models.ResponseOK)
 }
 
 // Error reports the specified errors
 func Error(c *gin.Context, responseErrors errors.APIErrors) {
-	tracelog.Logger(c.Request.Context()).Info("ERROR",
+	requestctx.Logger(c.Request.Context()).Info("ERROR",
 		"origin", c.Request.URL.String(),
-		"error", responseErrors)
+		"error", responseErrors,
+	)
 
 	// add errors to the Gin context
 	for _, err := range responseErrors.Errors() {
 		if ginErr := c.Error(err); ginErr != nil {
-			tracelog.Logger(c.Request.Context()).Error(ginErr, "ERROR",
+			requestctx.Logger(c.Request.Context()).Error(
+				ginErr, "ERROR",
 				"origin", c.Request.URL.String(),
-				"error", ginErr)
+				"error", ginErr,
+			)
 		}
 	}
 

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -6,18 +6,17 @@ import (
 	"reflect"
 	"runtime"
 
-	"github.com/epinio/epinio/helpers/routes"
-	"github.com/epinio/epinio/helpers/tracelog"
+	"github.com/gin-gonic/gin"
 
+	"github.com/epinio/epinio/helpers/routes"
 	"github.com/epinio/epinio/internal/api/v1/application"
 	"github.com/epinio/epinio/internal/api/v1/env"
 	"github.com/epinio/epinio/internal/api/v1/namespace"
 	"github.com/epinio/epinio/internal/api/v1/response"
-
 	"github.com/epinio/epinio/internal/api/v1/service"
 	"github.com/epinio/epinio/internal/api/v1/servicebinding"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/pkg/api/core/v1/errors"
-	"github.com/gin-gonic/gin"
 )
 
 const (
@@ -38,8 +37,11 @@ func funcName(i interface{}) string {
 func errorHandler(action APIActionFunc) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if errors := action(c); errors != nil {
-			tracelog.Logger(c.Request.Context()).V(1).
-				Info("responding with json error response", "action", funcName(action), "errors", errors)
+			requestctx.Logger(c.Request.Context()).Info(
+				"responding with json error response",
+				"action", funcName(action),
+				"errors", errors,
+			)
 			response.Error(c, errors)
 		}
 	}

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/helpers/kubernetes/tailer"
-	"github.com/epinio/epinio/helpers/tracelog"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/duration"
 	"github.com/epinio/epinio/internal/helmchart"
 	"github.com/epinio/epinio/internal/namespaces"
@@ -339,7 +339,7 @@ func Unstage(ctx context.Context, cluster *kubernetes.Cluster, appRef models.App
 // When stageID is an empty string, no staging logs are returned. If it is set,
 // then only logs from that staging process are returned.
 func Logs(ctx context.Context, logChan chan tailer.ContainerLogLine, wg *sync.WaitGroup, cluster *kubernetes.Cluster, follow bool, app, stageID, namespace string) error {
-	logger := tracelog.NewLogger().WithName("logs-backend").V(2)
+	logger := requestctx.Logger(ctx).WithName("logs-backend").V(2)
 	selector := labels.NewSelector()
 
 	var selectors [][]string

--- a/internal/application/ingresses.go
+++ b/internal/application/ingresses.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
-	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/auth"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/names"
 	"github.com/epinio/epinio/internal/routes"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
@@ -113,7 +113,7 @@ func SyncIngresses(ctx context.Context, cluster *kubernetes.Cluster, appRef mode
 	}
 
 	// Ensure desired routes
-	log := tracelog.Logger(ctx)
+	log := requestctx.Logger(ctx)
 	desiredRoutesMap := map[string]bool{}
 	for _, desiredRoute := range desiredRoutes {
 		desiredRoutesMap[desiredRoute] = true

--- a/internal/cli/server/requestctx/context.go
+++ b/internal/cli/server/requestctx/context.go
@@ -1,7 +1,12 @@
 // Package requestctx provides access to special fields in the http request's context
 package requestctx
 
-import "context"
+import (
+	"context"
+
+	"github.com/epinio/epinio/helpers/tracelog"
+	"github.com/go-logr/logr"
+)
 
 // IDKey is the unique key to lookup the request ID from the request's context
 type IDKey struct{}
@@ -9,28 +14,46 @@ type IDKey struct{}
 // UserKey is the unique key to lookup the username from the request's context
 type UserKey struct{}
 
-// ContextWithUser adds the user name to the context
-func ContextWithUser(ctx context.Context, val string) context.Context {
+// LoggerKey is the unique key to lookup the logger from the request's context
+type LoggerKey struct{}
+
+// WithUser adds the user name to the context
+func WithUser(ctx context.Context, val string) context.Context {
 	return context.WithValue(ctx, UserKey{}, val)
 }
 
 // User returns the user name from the context
 func User(ctx context.Context) string {
-	val, ok := ctx.Value(UserKey{}).(string)
-	if ok {
-		return val
-	}
-	return ""
+	return extractString(ctx, UserKey{})
 }
 
-// ContextWithID adds the user name to the context
-func ContextWithID(ctx context.Context, val string) context.Context {
+// WithID adds the request ID to the context
+func WithID(ctx context.Context, val string) context.Context {
 	return context.WithValue(ctx, IDKey{}, val)
 }
 
-// ID returns the user name from the context
+// ID returns the request ID from the context
 func ID(ctx context.Context) string {
-	val, ok := ctx.Value(IDKey{}).(string)
+	return extractString(ctx, IDKey{})
+}
+
+// WithLogger returns a copy of the context with the given logger
+func WithLogger(ctx context.Context, log logr.Logger) context.Context {
+	return context.WithValue(ctx, LoggerKey{}, log)
+}
+
+// Logger returns the logger from the context
+func Logger(ctx context.Context) logr.Logger {
+	log, ok := ctx.Value(LoggerKey{}).(logr.Logger)
+	if !ok {
+		// this should not happen, but let's be cautious
+		return tracelog.NewLogger().WithName("fallback")
+	}
+	return log
+}
+
+func extractString(ctx context.Context, key interface{}) string {
+	val, ok := ctx.Value(key).(string)
 	if ok {
 		return val
 	}

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -90,7 +90,7 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 
 	// Register api routes
 	{
-		apiRoutesGroup := router.Group(apiv1.Root, authMiddleware, sessionMiddlewaress)
+		apiRoutesGroup := router.Group(apiv1.Root, authMiddleware, sessionMiddleware)
 		apiv1.Lemon(apiRoutesGroup)
 	}
 
@@ -223,7 +223,7 @@ func authMiddleware(ctx *gin.Context) {
 // the authMiddleware calls "ctx.Abort()" in that case.
 // We only set the user in session upon successful authentication
 // (either basic auth or cookie based).
-func sessionMiddlewaress(ctx *gin.Context) {
+func sessionMiddleware(ctx *gin.Context) {
 	session := sessions.Default(ctx)
 	requestContext := ctx.Request.Context()
 	user := requestctx.User(requestContext)


### PR DESCRIPTION
#### Disclaimer
The `|` in the copy/pasted logs come from _k9s_ :dog: They're not present in the logs!

#### Related discussion
https://github.com/epinio/epinio/discussions/1205

---


This PR adds a bunch of fixes, cleanup and new "features" about logging, in particular:
- fixes the problem of the fallback logger
- small refactor on how to fetch the logger from the Context
- fix/alignment of the Gin logger with the actual logger
- added the possibility to enable JSON structured logs with the `output` flag (with Zap)

A brief explanation with some examples.

These were the **original logs**

```
│ 2022/02/11 09:40:47 AuthMiddleware: "level"=2 "msg"="Basic auth authentication"                                                                                                                                                   │
│ 2022/02/11 09:40:47 fallback: "level"=2 "msg"="responding with json error response" "action"="github.com/epinio/epinio/internal/api/v1/application.Controller.Create-fm" "errors"="Application 'samplejava' already exists"       │
│ 2022/02/11 09:40:47 fallback: "level"=1 "msg"="ERROR" "origin"="/api/v1/namespaces/workspace/applications" "error"="Application 'samplejava' already exists"                                                                      │
│ 2022/02/11 09:40:47 fallback: "msg"="ERROR" "error"="Application 'samplejava' already exists" "origin"="/api/v1/namespaces/workspace/applications" "error"="Application 'samplejava' already exists"                              │
│ Method: POST | Path: /api/v1/namespaces/workspace/applications | User: admin | IP: 10.42.0.1 | Timestamp: 2022-02-11T09:40:47Z | Latency: 20.333858ms | Status: 409 | Message: Error #01: Application 'samplejava' already exists │
│                                                                                                                                                                                                                                   │
│ 2022/02/11 09:40:47 AuthMiddleware: "level"=2 "msg"="Basic auth authentication"                                                                                                                                                   │
│ 2022/02/11 09:40:47 fallback: "level"=1 "msg"="OK" "origin"="/api/v1/namespaces/workspace/applications/samplejava" "returning"={"status":"ok"}                                                                                    │
│ Method: PATCH | Path: /api/v1/namespaces/workspace/applications/samplejava | User: admin | IP: 10.42.0.1 | Timestamp: 2022-02-11T09:40:47Z | Latency: 196.721287ms | Status: 200 | Message:                                       │
│ 2022/02/11 09:40:47 AuthMiddleware: "level"=2 "msg"="Basic auth authentication"                                                                                                                                                   │
│ 2022/02/11 09:40:47 fallback: "level"=1 "msg"="processing upload" "namespace"="workspace" "app"="samplejava"                                                                                                                      │
│ 2022/02/11 09:40:48 fallback: "level"=1 "msg"="uploaded app" "namespace"="workspace" "app"="samplejava" "blobUID"="0f657f20-33e2-44bb-be67-3455d76d5d08"                                                                          │
│ 2022/02/11 09:40:48 fallback: "level"=1 "msg"="OK" "origin"="/api/v1/namespaces/workspace/applications/samplejava/store" "returning"={"blobuid":"0f657f20-33e2-44bb-be67-3455d76d5d08"}                                           │
│ Method: POST | Path: /api/v1/namespaces/workspace/applications/samplejava/store | User: admin | IP: 10.42.0.1 | Timestamp: 2022-02-11T09:40:48Z | Latency: 409.910355ms | Status: 200 | Message:                                  │
│ 2022/02/11 09:40:48 AuthMiddleware: "level"=2 "msg"="Basic auth authentication"   
```

As you can see there is an inconsistent logging structure from the Gin logging and the "normal" logger.
This was fixed introducing [this middleware wrapper](https://github.com/alron/ginlogr) that wraps our logger:

https://github.com/epinio/epinio/compare/logging-fixes?expand=1#diff-deb288d5fa72a009ad58dde04cc2c803b5aace68cfa7b9810d05ae2502190ecdR74-R75

```golang
ginLogger := ginlogr.Ginlogr(logger, time.RFC3339, true)
ginRecoveryLogger := ginlogr.RecoveryWithLogr(logger, time.RFC3339, true, true)
```

Also there was no requestID, so I've added an `initContextMiddleware` that will inject the logger in the context and will initialize the requestID

```golang
// initContextMiddleware initialize the Request Context injecting the logger and the requestID
func initContextMiddleware(logger logr.Logger) gin.HandlerFunc {
	return func(ctx *gin.Context) {
		reqCtx := ctx.Request.Context()

		requestID := uuid.NewString()
		baseLogger := logger.WithValues("requestId", requestID)

		reqCtx = requestctx.WithID(reqCtx, requestID)
		reqCtx = requestctx.WithLogger(reqCtx, baseLogger)
		ctx.Request = ctx.Request.WithContext(reqCtx)
	}
}
```

With these the logs will result having the same structure and the requestID

```
│ 2022/02/11 10:36:55 EpinioServer/AuthMiddleware: "level"=2 "msg"="Basic auth authentication" "requestId"="5117c9bc-4e71-4412-a6b1-dfd6bf55012a"                                                                                   │
│ 2022/02/11 10:36:55 EpinioServer: "level"=1 "msg"="responding with json error response" "requestId"="5117c9bc-4e71-4412-a6b1-dfd6bf55012a" "action"="github.com/epinio/epinio/internal/api/v1/application.Controller.Create-fm" " │
│ 2022/02/11 10:36:55 EpinioServer: "level"=1 "msg"="ERROR" "requestId"="5117c9bc-4e71-4412-a6b1-dfd6bf55012a" "origin"="/api/v1/namespaces/workspace/applications" "error"="Application 'samplejava' already exists"               │
│ 2022/02/11 10:36:55 EpinioServer: "msg"="ERROR" "error"="Application 'samplejava' already exists" "requestId"="5117c9bc-4e71-4412-a6b1-dfd6bf55012a" "origin"="/api/v1/namespaces/workspace/applications" "error"="Application 's │
│ 2022/02/11 10:36:55 EpinioServer: "msg"="Error" "error"="Application 'samplejava' already exists"                                                                                                                                 │
│ 2022/02/11 10:36:55 EpinioServer/AuthMiddleware: "level"=2 "msg"="Basic auth authentication" "requestId"="8d882751-9e99-408d-aea3-7719c79ebfff"                                                                                   │
│ 2022/02/11 10:36:55 EpinioServer: "level"=1 "msg"="OK" "requestId"="8d882751-9e99-408d-aea3-7719c79ebfff" "origin"="/api/v1/namespaces/workspace/applications/samplejava" "returning"={"status":"ok"}                             │
│ 2022/02/11 10:36:55 EpinioServer: "level"=1 "msg"="/api/v1/namespaces/workspace/applications/samplejava" "status"=200 "method"="PATCH" "path"="/api/v1/namespaces/workspace/applications/samplejava" "query"="" "ip"="10.42.0.1"  │
│ 2022/02/11 10:36:56 EpinioServer/AuthMiddleware: "level"=2 "msg"="Basic auth authentication" "requestId"="8592308f-4540-4840-8e4e-4b04a1b80f35"                                                                                   │
│ 2022/02/11 10:36:56 EpinioServer: "level"=1 "msg"="processing upload" "requestId"="8592308f-4540-4840-8e4e-4b04a1b80f35" "namespace"="workspace" "app"="samplejava"                                                               │
│ 2022/02/11 10:36:56 EpinioServer: "level"=1 "msg"="uploaded app" "requestId"="8592308f-4540-4840-8e4e-4b04a1b80f35" "namespace"="workspace" "app"="samplejava" "blobUID"="8c372c5f-6b53-4c15-833c-3ab5f9e3ae64"                   │
│ 2022/02/11 10:36:56 EpinioServer: "level"=1 "msg"="OK" "requestId"="8592308f-4540-4840-8e4e-4b04a1b80f35" "origin"="/api/v1/namespaces/workspace/applications/samplejava/store" "returning"={"blobuid":"8c372c5f-6b53-4c15-833c-3 │
│ 2022/02/11 10:36:56 EpinioServer: "level"=1 "msg"="/api/v1/namespaces/workspace/applications/samplejava/store" "status"=200 "method"="POST" "path"="/api/v1/namespaces/workspace/applications/samplejava/store" "query"="" "ip"=" │
│ 2022/02/11 10:36:56 EpinioServer/AuthMiddleware: "level"=2 "msg"="Basic auth authentication" "requestId"="9bf2991f-d116-46f5-9afa-44f94bf3fa9c"    
```

Since it's practical and it comes at no cost I've added the possibility to enable the JSON logging, with [Zap](https://github.com/uber-go/zap).
You just need to set the `output` flag, or `OUTPUT` env variable to `json` (`text`, or anything else will fallback to the standard logger).


```
│ {"level":"error","ts":1644575438.1856356,"logger":"EpinioServer","caller":"ginlogr@v0.0.4/logr.go:45","msg":"Error","error":"Application 'samplejava' already exists","stacktrace":"github.com/alron/ginlogr.Ginlogr.func1\n\t/ho │
│ {"level":"debug","ts":1644575438.188637,"logger":"EpinioServer.AuthMiddleware","caller":"server/server.go:153","msg":"Basic auth authentication","requestId":"542e3a16-7d65-40a0-a415-2b2f3e7465e8"}                              │
│ {"level":"info","ts":1644575438.3915923,"logger":"EpinioServer","caller":"response/response.go:16","msg":"OK","requestId":"542e3a16-7d65-40a0-a415-2b2f3e7465e8","origin":"/api/v1/namespaces/workspace/applications/samplejava", │
│ {"level":"info","ts":1644575438.391642,"logger":"EpinioServer","caller":"ginlogr@v0.0.4/logr.go:48","msg":"/api/v1/namespaces/workspace/applications/samplejava","status":200,"method":"PATCH","path":"/api/v1/namespaces/workspa │
│ {"level":"debug","ts":1644575438.579254,"logger":"EpinioServer.AuthMiddleware","caller":"server/server.go:153","msg":"Basic auth authentication","requestId":"1fede7aa-d503-44e4-98b3-f1cb76d85acb"}                              │
│ {"level":"info","ts":1644575438.5793169,"logger":"EpinioServer","caller":"application/upload.go:24","msg":"processing upload","requestId":"1fede7aa-d503-44e4-98b3-f1cb76d85acb","namespace":"workspace","app":"samplejava"}      │
│ {"level":"Level(-2)","ts":1644575438.5793352,"logger":"EpinioServer","caller":"application/upload.go:26","msg":"parsing multipart form","requestId":"1fede7aa-d503-44e4-98b3-f1cb76d85acb"}                                       │
│ {"level":"info","ts":1644575438.7923715,"logger":"EpinioServer","caller":"application/upload.go:56","msg":"uploaded app","requestId":"1fede7aa-d503-44e4-98b3-f1cb76d85acb","namespace":"workspace","app":"samplejava","blobUID": │
│ {"level":"info","ts":1644575438.7924032,"logger":"EpinioServer","caller":"response/response.go:26","msg":"OK","requestId":"1fede7aa-d503-44e4-98b3-f1cb76d85acb","origin":"/api/v1/namespaces/workspace/applications/samplejava/s │
│ {"level":"info","ts":1644575438.792451,"logger":"EpinioServer","caller":"ginlogr@v0.0.4/logr.go:48","msg":"/api/v1/namespaces/workspace/applications/samplejava/store","status":200,"method":"POST","path":"/api/v1/namespaces/wo │
│ {"level":"debug","ts":1644575438.976646,"logger":"EpinioServer.AuthMiddleware","caller":"server/server.go:153","msg":"Basic auth authentication","requestId":"a116c7eb-a049-4f1e-8e20-e0770c228fb3"}                              │
│ {"level":"info","ts":1644575438.9784613,"logger":"EpinioServer","caller":"application/stage.go:136","msg":"staging app","requestId":"a116c7eb-a049-4f1e-8e20-e0770c228fb3","namespace":"workspace","app":{"app":{"name":"sampleja │
│ {"level":"info","ts":1644575440.188066,"logger":"EpinioServer","caller":"application/stage.go:239","msg":"staged app","requestId":"a116c7eb-a049-4f1e-8e20-e0770c228fb3","namespace":"epinio-staging","app":{"name":"samplejava", │
│ {"level":"info","ts":1644575440.1881363,"logger":"EpinioServer","caller":"response/response.go:26","msg":"OK","requestId":"a116c7eb-a049-4f1e-8e20-e0770c228fb3","origin":"/api/v1/namespaces/workspace/applications/samplejava/s │
│ {"level":"info","ts":1644575440.1881955,"logger":"EpinioServer","caller":"ginlogr@v0.0.4/logr.go:48","msg":"/api/v1/namespaces/workspace/applications/samplejava/stage","status":200,"method":"POST","path":"/api/v1/namespaces/w │
│ {"level":"debug","ts":1644575440.377277,"logger":"EpinioServer.AuthMiddleware","caller":"server/server.go:153","msg":"Basic auth authentication","requestId":"6e1874da-5da8-4866-bd7e-4a531a347387"}                              │
│ {"level":"debug","ts":1644575440.5758495,"logger":"EpinioServer.AuthMiddleware","caller":"server/server.go:153","msg":"Basic auth authentication","requestId":"ca5f2433-d20b-427b-aa1f-6f634cc80559"}
```


To add more context the `fallback` issue was fixed retrieving the logger from the context, without creating another one:

```golang
// before
logger := tracelog.NewLogger()

// after
logger := requestctx.Logger(ctx)
```
