### PR TITLE
Reduce epinio docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 acceptance/
-dist/
 docs/
 images/
 output/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,31 +43,6 @@ snapshot:
 dockers:
   -
     # ID of the image, needed if you want to filter by it later on (e.g. on custom publishers).
-    id: epinio-base
-
-    # Templates of the Docker image names.
-    image_templates:
-    - "splatform/epinio-base:{{ .Tag }}"
-    - "splatform/epinio-base:latest"
-    - "ghcr.io/epinio/epinio-base:{{ .Tag }}"
-    - "ghcr.io/epinio/epinio-base:latest"
-
-    # Path to the Dockerfile (from the project root).
-    dockerfile: images/baseimage-Dockerfile
-
-    use: docker
-
-    # Template of the docker build flags.
-    build_flag_templates:
-    - "--pull"
-    - "--label=org.opencontainers.image.created={{.Date}}"
-    - "--label=org.opencontainers.image.title={{.ProjectName}}-base"
-    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-    - "--label=org.opencontainers.image.version={{.Version}}"
-    - "--label=org.opencontainers.image.source=https://github.com/epinio/epinio"
-    - "--platform=linux/amd64"
-  -
-    # ID of the image, needed if you want to filter by it later on (e.g. on custom publishers).
     id: epinio
 
     # GOOS of the built binaries/packages that should be used.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,8 +57,6 @@ dockers:
 
     # Templates of the Docker image names.
     image_templates:
-    - "splatform/epinio-server:{{ .Tag }}"
-    - "splatform/epinio-server:latest"
     - "ghcr.io/epinio/epinio-server:{{ .Tag }}"
     - "ghcr.io/epinio/epinio-server:latest"
 

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ fmt:
 check:
 	golangci-lint run
 
-patch-epinio-deployment:
+patch-epinio-deployment: build-images
 	@./scripts/patch-epinio-deployment.sh
 
 ########################################################################
@@ -171,7 +171,7 @@ minikube-delete:
 setup_chart_museum:
 	@./scripts/setup-chart-museum.sh
 
-prepare_environment_k3d: build-linux-amd64 build-images setup_chart_museum
+prepare_environment_k3d: build-linux-amd64 setup_chart_museum
 	@./scripts/prepare-environment-k3d.sh
 
 unprepare_environment_k3d:

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ minikube-delete:
 setup_chart_museum:
 	@./scripts/setup-chart-museum.sh
 
-prepare_environment_k3d: build-linux-amd64 setup_chart_museum
+prepare_environment_k3d: build-linux-amd64 build-images setup_chart_museum
 	@./scripts/prepare-environment-k3d.sh
 
 unprepare_environment_k3d:

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,7 +1,9 @@
-ARG BASE_IMAGE=splatform/epinio-base
+FROM alpine as certs
+RUN apk --update --no-cache add ca-certificates
 
-################
-FROM $BASE_IMAGE
+FROM scratch
+COPY --from=certs /etc/ssl/certs /etc/ssl/certs
+
 # default, if running outside of gorelease with a self-compiled binary
 ARG DIST_BINARY=dist/epinio-linux-amd64
 

--- a/images/baseimage-Dockerfile
+++ b/images/baseimage-Dockerfile
@@ -1,3 +1,0 @@
-FROM opensuse/leap:15.3
-LABEL org.opencontainers.image.source https://github.com/epinio/epinio
-RUN zypper ref && zypper install --no-recommends -y git tar gzip curl && rm -fr /var/cache/*

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -8,10 +8,6 @@ server_image="splatform/epinio-server"
 
 # Build base image
 docker build -t "${base_image}:${version}" -t "${base_image}:latest" -f images/baseimage-Dockerfile .
-docker push "${base_image}:${version}"
-docker push "${base_image}:latest"
 
 # Build server image
 docker build -t "${server_image}:${version}" -t "${server_image}:latest" --build-arg BASE_IMAGE=${base_image} -f images/Dockerfile .
-docker push "${server_image}:${version}"
-docker push "${server_image}:latest"

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -3,11 +3,7 @@
 set -e
 
 version="$(git describe --tags)"
-base_image="splatform/epinio-base"
-server_image="splatform/epinio-server"
+image="splatform/epinio-server"
 
-# Build base image
-docker build -t "${base_image}:${version}" -t "${base_image}:latest" -f images/baseimage-Dockerfile .
-
-# Build server image
-docker build -t "${server_image}:${version}" -t "${server_image}:latest" --build-arg BASE_IMAGE=${base_image} -f images/Dockerfile .
+# Build image
+docker build -t "${image}:${version}" -t "${image}:latest" -f images/Dockerfile .

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -3,7 +3,7 @@
 set -e
 
 version="$(git describe --tags)"
-image="splatform/epinio-server"
+image="ghcr.io/epinio/epinio-server"
 
 # Build image
 docker build -t "${image}:${version}" -t "${image}:latest" -f images/Dockerfile .

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -6,4 +6,4 @@ version="$(git describe --tags)"
 image="ghcr.io/epinio/epinio-server"
 
 # Build image
-docker build -t "${image}:${version}" -t "${image}:latest" -f images/Dockerfile .
+docker build -t "${image}:${version}" -f images/Dockerfile .

--- a/scripts/patch-epinio-deployment.sh
+++ b/scripts/patch-epinio-deployment.sh
@@ -39,66 +39,8 @@ if [ -z "$EPINIO_BINARY_TAG" ]; then
   exit 1
 fi
 
-echo "Creating the PVC"
-cat <<EOF | kubectl apply -f -
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: epinio-binary
-  namespace: epinio
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 100Mi
-EOF
-
-echo "Creating the dummy copier Pod"
-cat <<EOF | kubectl apply -f -
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: epinio-copier
-  namespace: epinio
-  annotations:
-    linkerd.io/inject: disabled
-spec:
-  volumes:
-    - name: epinio-binary
-      persistentVolumeClaim:
-        claimName: epinio-binary
-  containers:
-    - name: copier
-      image: busybox:stable
-      command: ["/bin/sh", "-ec", "trap : TERM INT; sleep infinity & wait"]
-      volumeMounts:
-        - mountPath: "/epinio"
-          name: epinio-binary
-EOF
-
-echo "Waiting for dummy pod to be ready"
-kubectl wait --for=condition=ready --timeout=$timeout pod -n epinio epinio-copier
-
-echo "Copying the binary on the PVC"
-# Notes
-# 1. kubectl cp breaks because of the colon in `pod:path`. Thus the more complex tar construction.
-# 2. Cannot use absolute paths, i.e. `/foo`. This is a disk-relative path on Windows, and gets
-#    expanded weirdly by the kubectl commands.
-#    Relative paths are ok, as the default CWD in the container is the root (`/`).
-#    I.e. `foo` is `/foo` pod-side.
-
-( cd       "$(dirname  "${EPINIO_BINARY_PATH}")"
-  tar cf - "$(basename "${EPINIO_BINARY_PATH}")"
-) | kubectl exec -i -n epinio -c copier epinio-copier -- tar xf -
-kubectl exec -i -n epinio -c copier epinio-copier -- mv "$(basename "${EPINIO_BINARY_PATH}")" epinio/epinio
-kubectl exec -i -n epinio -c copier epinio-copier -- chmod ugo+x epinio/epinio
-kubectl exec -i -n epinio -c copier epinio-copier -- ls -l epinio
-
-echo "Deleting the epinio-copier to avoid multi-attach issue between pods"
-kubectl delete pod -n epinio epinio-copier
+echo "Import latest docker container in k3d"
+k3d image import -c epinio-acceptance ghcr.io/epinio/epinio-server:${EPINIO_BINARY_TAG}
 
 # On Windows the shasum command is not in the path
 [[ $(uname -s) =~ "MINGW64_NT" ]] && SHASUM=/bin/core_perl/shasum
@@ -106,22 +48,17 @@ kubectl delete pod -n epinio epinio-copier
 # https://stackoverflow.com/a/5773761
 EPINIO_BINARY_HASH=($(${SHASUM:=shasum} ${EPINIO_BINARY_PATH}))
 
-echo "Patching the epinio-server deployment to use the copied binary"
+echo "Patching the epinio-server deployment to use the latest container"
 PATCH=$(cat <<EOF
 { "spec": { "template": {
       "metadata": {
         "annotations": {
-          "binary-hash": "${EPINIO_BINARY_HASH}"
+          "binary-hash": "${EPINIO_BINARY_HASH}",
+          "kubectl.kubernetes.io/restartedAt": "$(date)"
         }
       },
       "spec": {
         "volumes": [
-          {
-            "name":"epinio-binary",
-            "persistentVolumeClaim": {
-              "claimName": "epinio-binary"
-            }
-          },
           {
             "name": "tmp-volume",
             "emptyDir": {}
@@ -129,16 +66,8 @@ PATCH=$(cat <<EOF
         ],
         "containers": [{
           "name": "epinio-server",
-          "image": "ghcr.io/epinio/epinio-server:latest",
-          "command": [
-            "/epinio-binary/epinio",
-            "server"
-          ],
+          "image": "ghcr.io/epinio/epinio-server:${EPINIO_BINARY_TAG}",
           "volumeMounts": [
-            {
-              "name": "epinio-binary",
-              "mountPath": "/epinio-binary"
-            },
             {
               "mountPath": "/tmp",
               "name": "tmp-volume"

--- a/scripts/patch-epinio-deployment.sh
+++ b/scripts/patch-epinio-deployment.sh
@@ -21,7 +21,7 @@ timeout=480s
 # and the correct binary is in place.
 
 export EPINIO_BINARY_PATH="${EPINIO_BINARY_PATH:-dist/epinio-linux-amd64}"
-export EPINIO_BINARY_TAG="${EPINIO_BINARY_TAG:-$(git describe --tags --abbrev=0)}"
+export EPINIO_BINARY_TAG="${EPINIO_BINARY_TAG:-$(git describe --tags)}"
 
 echo
 echo Configuration
@@ -129,7 +129,7 @@ PATCH=$(cat <<EOF
         ],
         "containers": [{
           "name": "epinio-server",
-          "image": "splatform/epinio-server:${EPINIO_BINARY_TAG}",
+          "image": "splatform/epinio-server:latest",
           "command": [
             "/epinio-binary/epinio",
             "server"

--- a/scripts/patch-epinio-deployment.sh
+++ b/scripts/patch-epinio-deployment.sh
@@ -129,7 +129,7 @@ PATCH=$(cat <<EOF
         ],
         "containers": [{
           "name": "epinio-server",
-          "image": "splatform/epinio-server:latest",
+          "image": "ghcr.io/epinio/epinio-server:latest",
           "command": [
             "/epinio-binary/epinio",
             "server"

--- a/scripts/patch-epinio-deployment.sh
+++ b/scripts/patch-epinio-deployment.sh
@@ -58,21 +58,9 @@ PATCH=$(cat <<EOF
         }
       },
       "spec": {
-        "volumes": [
-          {
-            "name": "tmp-volume",
-            "emptyDir": {}
-          }
-        ],
         "containers": [{
           "name": "epinio-server",
-          "image": "ghcr.io/epinio/epinio-server:${EPINIO_BINARY_TAG}",
-          "volumeMounts": [
-            {
-              "mountPath": "/tmp",
-              "name": "tmp-volume"
-            }
-          ]
+          "image": "ghcr.io/epinio/epinio-server:${EPINIO_BINARY_TAG}"
         }]
       }
     }

--- a/scripts/patch-epinio-deployment.sh
+++ b/scripts/patch-epinio-deployment.sh
@@ -121,6 +121,10 @@ PATCH=$(cat <<EOF
             "persistentVolumeClaim": {
               "claimName": "epinio-binary"
             }
+          },
+          {
+            "name": "tmp-volume",
+            "emptyDir": {}
           }
         ],
         "containers": [{
@@ -134,6 +138,10 @@ PATCH=$(cat <<EOF
             {
               "name": "epinio-binary",
               "mountPath": "/epinio-binary"
+            },
+            {
+              "mountPath": "/tmp",
+              "name": "tmp-volume"
             }
           ]
         }]

--- a/scripts/patch-epinio-deployment.sh
+++ b/scripts/patch-epinio-deployment.sh
@@ -129,7 +129,7 @@ PATCH=$(cat <<EOF
         ],
         "containers": [{
           "name": "epinio-server",
-          "image": "splatform/epinio-base:${EPINIO_BINARY_TAG}",
+          "image": "splatform/epinio-server:${EPINIO_BINARY_TAG}",
           "command": [
             "/epinio-binary/epinio",
             "server"

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -50,10 +50,8 @@ helm upgrade --install \
 	epinio-installer epinio-chartmuseum/epinio-installer \
 	--wait
 
-echo "Importing locally built epinio server image"
-k3d image import -c epinio-acceptance ghcr.io/epinio/epinio-server:latest
-
 # Patch Epinio
+./scripts/build-images.sh
 ./scripts/patch-epinio-deployment.sh
 
 "${EPINIO_BINARY}" config update

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -51,7 +51,7 @@ helm upgrade --install \
 	--wait
 
 echo "Importing locally built epinio server image"
-k3d image import -c epinio-acceptance splatform/epinio-server:latest
+k3d image import -c epinio-acceptance ghcr.io/epinio/epinio-server:latest
 
 # Patch Epinio
 ./scripts/patch-epinio-deployment.sh

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -50,6 +50,9 @@ helm upgrade --install \
 	epinio-installer epinio-chartmuseum/epinio-installer \
 	--wait
 
+echo "Importing locally built epinio server image"
+k3d image import -c epinio-acceptance splatform/epinio-server:latest
+
 # Patch Epinio
 ./scripts/patch-epinio-deployment.sh
 


### PR DESCRIPTION
 We use `FROM scratch` instead of OpenSUSE as base for epinio-server. The image size is reduced from 236MB in v0.4.0 to 47MB.

scratch does not provide a readable write dir so we provide one via
volume mount.

This does have the advantage that we properly split the tmp dir from the
node.
The tmp dir is needed to pull an app from git.

The remaining penalty of scratch is that we can not shell into it
easily, but there are workarounds for it which we can document.

Fixes #1145 