### PR TITLE
fix: missing update of the swagger

### DIFF
--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -1102,6 +1102,10 @@
         "origin": {
           "$ref": "#/definitions/ApplicationOrigin"
         },
+        "stage_id": {
+          "type": "string",
+          "x-go-name": "StageID"
+        },
         "status": {
           "$ref": "#/definitions/ApplicationStatus"
         },


### PR DESCRIPTION
Followup to #1162  and #1212 - Swagger spec was not updated.

@richard-cox FYI, with the merging of #1212 the model for apps was __extended__.
A new field `stageid` in the app object itself contains the stage id of the last attempt to stage.
The stage id in the subordinate workload object still exists, and keeps containing the stage id for the running application.

These two ids can be different, i.e. if you have a running application and then staging of a new version of that app fails.
