### PR TITLE
Return staging logs in order when fetched by `app logs` command

### DIFF
--- a/helpers/kubernetes/tailer/tailer.go
+++ b/helpers/kubernetes/tailer/tailer.go
@@ -52,9 +52,9 @@ func (t *Tail) Start(ctx context.Context, logChan chan ContainerLogLine, follow 
 	t.logger.Info("starting the tail for pod " + t.PodName)
 	var m string
 	if t.Options.Namespace {
-		m = fmt.Sprintf("Now tracking %s %s › %s ", t.Namespace, t.PodName, t.ContainerName)
+		m = fmt.Sprintf("now tracking %s %s › %s ", t.Namespace, t.PodName, t.ContainerName)
 	} else {
-		m = fmt.Sprintf("Now tracking %s › %s ", t.PodName, t.ContainerName)
+		m = fmt.Sprintf("now tracking %s › %s ", t.PodName, t.ContainerName)
 	}
 	t.logger.Info(m)
 

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -386,6 +386,10 @@ func Logs(ctx context.Context, logChan chan tailer.ContainerLogLine, wg *sync.Wa
 		PodQuery:              regexp.MustCompile(".*"),
 	}
 
+	if stageID != "" {
+		config.Ordered = true
+	}
+
 	if follow {
 		logger.Info("stream")
 		return tailer.StreamLogs(ctx, logChan, wg, config, cluster)


### PR DESCRIPTION
Fix #1196 

feat: Extend tailer backend with ordered mode for fetching logs
note: stream mode ignores ordering flag
feat: activate ordered mode when retrieving staging logs
      (affects only log command, which fetches)
      (streamed staging logs on push ignore this)

  - Containers are retrieved in order (init before main)
  - In ordered mode the logs are fetched and returned serially, not concurrently