### PR TITLE
Add timeout for zypper to succeed and option cleanup

### DIFF
--- a/scripts/remove-github-action-runner.sh
+++ b/scripts/remove-github-action-runner.sh
@@ -16,7 +16,7 @@ if [ -z "$GITHUB_REPOSITORY_URL" ] || [ -z "$GITHUB_RUNNER_TOKEN" ]; then
   exit 1
 fi
 
-REPOSITORY_NAME=$(echo "$GITHUB_REPOSITORY_URL" | cut -d '/' -f 4- | sed -e 's|/$||g' -e 's|/|-|g')
+REPOSITORY_NAME=$(echo "$GITHUB_REPOSITORY_URL" | cut -d '/' -f 4- | sed -e 's|/$||' -e 's|/|-|g')
 ACTIONS_RUNNER_SERVICE=actions.runner."$REPOSITORY_NAME".`hostname`.service
 
 cd actions-runner

--- a/scripts/setup-github-action-runner.sh
+++ b/scripts/setup-github-action-runner.sh
@@ -17,16 +17,16 @@ if [ -z "$GITHUB_REPOSITORY_URL" ] || [ -z "$GITHUB_RUNNER_TOKEN" ]; then
   exit 1
 fi
 
-REPOSITORY_NAME=$(echo "$GITHUB_REPOSITORY_URL" | cut -d '/' -f 4- | sed -e 's|/$||g' -e 's|/|-|g')
+REPOSITORY_NAME=$(echo "$GITHUB_REPOSITORY_URL" | cut -d '/' -f 4- | sed -e 's|/$||' -e 's|/|-|g')
 ACTIONS_RUNNER_SERVICE=actions.runner."$REPOSITORY_NAME".`hostname`.service
 
 # Install needed packages
 rpms="make gcc docker libicu wget fping"
-sudo zypper --gpg-auto-import-keys ref
+sudo ZYPP_LOCK_TIMEOUT=300 zypper --gpg-auto-import-keys ref
 grep SLES /etc/os-release \
   && rpms+=" git-core"    \
   || rpms+=" git"
-sudo zypper --non-interactive in -y $rpms
+sudo ZYPP_LOCK_TIMEOUT=300 zypper --non-interactive in -y $rpms
 
 # Enable docker service
 sudo systemctl enable docker


### PR DESCRIPTION
Already tested within terraform. Zypper command can only run exclusive. With the timeout - instead of the script exiting - zypper will wait up to 300s for any other zypper process to finish.