### PR TITLE
Add the client/server version of Epinio in `info`

### DIFF
--- a/internal/cli/usercmd/info.go
+++ b/internal/cli/usercmd/info.go
@@ -1,5 +1,9 @@
 package usercmd
 
+import (
+	"github.com/epinio/epinio/internal/version"
+)
+
 // Info displays information about environment
 func (c *EpinioClient) Info() error {
 	log := c.Log.WithName("Info")
@@ -14,7 +18,8 @@ func (c *EpinioClient) Info() error {
 	c.ui.Success().
 		WithStringValue("Platform", v.Platform).
 		WithStringValue("Kubernetes Version", v.KubeVersion).
-		WithStringValue("Epinio Version", v.Version).
+		WithStringValue("Epinio Server Version", v.Version).
+		WithStringValue("Epinio Client Version", version.Version).
 		Msg("Epinio Environment")
 
 	return nil


### PR DESCRIPTION
I think that this could be useful to ensure that we have the same version on both client/server side, or at least compatible versions.
I had the issue sometimes during my test because I used de-synchronized versions, with a mix of `epinio version` (that shows the client/binary version) and `epinio info` (that shows the server infos) we can have the informations, but adding also the client version in `info` command is easy and doesn't hurt IMHO,

Tested on my lab:
```
ldevulder@go-dev:~/epinio> dist/epinio-linux-amd64 config update

🚢 Updating the stored credentials from the current cluster
Config: /home/ldevulder/.config/epinio/config.yaml

✔️  Ok
ldevulder@go-dev:~/epinio> dist/epinio-linux-amd64 info

✔️  Epinio Environment
Platform: k3s
Kubernetes Version: v1.21.9+k3s1
Epinio Server Version: v0.4.0-10-g69f7efb3
Epinio Client Version: v0.4.0-18-g578d3c0f
```