### PR TITLE
Revert "Rebuild image instead of copying binary during patching"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ fmt:
 check:
 	golangci-lint run
 
-patch-epinio-deployment: build-images
+patch-epinio-deployment:
 	@./scripts/patch-epinio-deployment.sh
 
 ########################################################################
@@ -171,7 +171,7 @@ minikube-delete:
 setup_chart_museum:
 	@./scripts/setup-chart-museum.sh
 
-prepare_environment_k3d: build-linux-amd64 setup_chart_museum
+prepare_environment_k3d: build-linux-amd64 build-images setup_chart_museum
 	@./scripts/prepare-environment-k3d.sh
 
 unprepare_environment_k3d:

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -6,4 +6,4 @@ version="$(git describe --tags)"
 image="ghcr.io/epinio/epinio-server"
 
 # Build image
-docker build -t "${image}:${version}" -f images/Dockerfile .
+docker build -t "${image}:${version}" -t "${image}:latest" -f images/Dockerfile .

--- a/scripts/patch-epinio-deployment.sh
+++ b/scripts/patch-epinio-deployment.sh
@@ -39,8 +39,66 @@ if [ -z "$EPINIO_BINARY_TAG" ]; then
   exit 1
 fi
 
-echo "Import latest docker container in k3d"
-k3d image import -c epinio-acceptance ghcr.io/epinio/epinio-server:${EPINIO_BINARY_TAG}
+echo "Creating the PVC"
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: epinio-binary
+  namespace: epinio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+EOF
+
+echo "Creating the dummy copier Pod"
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: epinio-copier
+  namespace: epinio
+  annotations:
+    linkerd.io/inject: disabled
+spec:
+  volumes:
+    - name: epinio-binary
+      persistentVolumeClaim:
+        claimName: epinio-binary
+  containers:
+    - name: copier
+      image: busybox:stable
+      command: ["/bin/sh", "-ec", "trap : TERM INT; sleep infinity & wait"]
+      volumeMounts:
+        - mountPath: "/epinio"
+          name: epinio-binary
+EOF
+
+echo "Waiting for dummy pod to be ready"
+kubectl wait --for=condition=ready --timeout=$timeout pod -n epinio epinio-copier
+
+echo "Copying the binary on the PVC"
+# Notes
+# 1. kubectl cp breaks because of the colon in `pod:path`. Thus the more complex tar construction.
+# 2. Cannot use absolute paths, i.e. `/foo`. This is a disk-relative path on Windows, and gets
+#    expanded weirdly by the kubectl commands.
+#    Relative paths are ok, as the default CWD in the container is the root (`/`).
+#    I.e. `foo` is `/foo` pod-side.
+
+( cd       "$(dirname  "${EPINIO_BINARY_PATH}")"
+  tar cf - "$(basename "${EPINIO_BINARY_PATH}")"
+) | kubectl exec -i -n epinio -c copier epinio-copier -- tar xf -
+kubectl exec -i -n epinio -c copier epinio-copier -- mv "$(basename "${EPINIO_BINARY_PATH}")" epinio/epinio
+kubectl exec -i -n epinio -c copier epinio-copier -- chmod ugo+x epinio/epinio
+kubectl exec -i -n epinio -c copier epinio-copier -- ls -l epinio
+
+echo "Deleting the epinio-copier to avoid multi-attach issue between pods"
+kubectl delete pod -n epinio epinio-copier
 
 # On Windows the shasum command is not in the path
 [[ $(uname -s) =~ "MINGW64_NT" ]] && SHASUM=/bin/core_perl/shasum
@@ -48,19 +106,35 @@ k3d image import -c epinio-acceptance ghcr.io/epinio/epinio-server:${EPINIO_BINA
 # https://stackoverflow.com/a/5773761
 EPINIO_BINARY_HASH=($(${SHASUM:=shasum} ${EPINIO_BINARY_PATH}))
 
-echo "Patching the epinio-server deployment to use the latest container"
+echo "Patching the epinio-server deployment to use the copied binary"
 PATCH=$(cat <<EOF
 { "spec": { "template": {
       "metadata": {
         "annotations": {
-          "binary-hash": "${EPINIO_BINARY_HASH}",
-          "kubectl.kubernetes.io/restartedAt": "$(date)"
+          "binary-hash": "${EPINIO_BINARY_HASH}"
         }
       },
       "spec": {
+        "volumes": [
+        {
+          "name":"epinio-binary",
+          "persistentVolumeClaim": {
+            "claimName": "epinio-binary"
+          }
+        }],
         "containers": [{
           "name": "epinio-server",
-          "image": "ghcr.io/epinio/epinio-server:${EPINIO_BINARY_TAG}"
+          "image": "ghcr.io/epinio/epinio-server:latest",
+          "command": [
+            "/epinio-binary/epinio",
+            "server"
+          ],
+          "volumeMounts": [
+            {
+              "name": "epinio-binary",
+              "mountPath": "/epinio-binary"
+            }
+          ]
         }]
       }
     }

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -50,8 +50,10 @@ helm upgrade --install \
 	epinio-installer epinio-chartmuseum/epinio-installer \
 	--wait
 
+echo "Importing locally built epinio server image"
+k3d image import -c epinio-acceptance ghcr.io/epinio/epinio-server:latest
+
 # Patch Epinio
-./scripts/build-images.sh
 ./scripts/patch-epinio-deployment.sh
 
 "${EPINIO_BINARY}" config update


### PR DESCRIPTION
This fixes the issue of failing CI on public cloud providers.

Even though we are reverting the patching, the git defined Docker image
is still tested on our regular github actions ci runners, so the
testing coverage is better then before.

This reverts commit 9e372d96ae363ba7dbc73537d7ac13837016151c.