### PR TITLE
fix: check `Server Version` in acceptance tests

### DIFF
--- a/acceptance/install/scenario1_test.go
+++ b/acceptance/install/scenario1_test.go
@@ -106,7 +106,7 @@ var _ = Describe("<Scenario1> GKE, epinio-ca", func() {
 			Eventually(func() string {
 				out, _ := epinioHelper.Run("info")
 				return out
-			}, "2m", "2s").Should(ContainSubstring("Epinio Version:"))
+			}, "2m", "2s").Should(ContainSubstring("Epinio Server Version:"))
 		})
 
 		By("Pushing an app", func() {

--- a/acceptance/install/scenario2_test.go
+++ b/acceptance/install/scenario2_test.go
@@ -129,7 +129,7 @@ var _ = Describe("<Scenario2> GKE, Letsencrypt-staging, Zero instance", func() {
 			Eventually(func() string {
 				out, _ := epinioHelper.Run("info")
 				return out
-			}, "2m", "2s").Should(ContainSubstring("Epinio Version:"))
+			}, "2m", "2s").Should(ContainSubstring("Epinio Server Version:"))
 		})
 
 		By("Pushing an app with zero instances", func() {

--- a/acceptance/install/scenario3_test.go
+++ b/acceptance/install/scenario3_test.go
@@ -144,7 +144,7 @@ var _ = Describe("<Scenario3> RKE, Private CA, Service, on External Registry", f
 			Eventually(func() string {
 				out, _ := epinioHelper.Run("info")
 				return out
-			}, "2m", "2s").Should(ContainSubstring("Epinio Version:"))
+			}, "2m", "2s").Should(ContainSubstring("Epinio Server Version:"))
 		})
 
 		By("Creating a service and pushing an app", func() {

--- a/acceptance/install/scenario4_test.go
+++ b/acceptance/install/scenario4_test.go
@@ -120,7 +120,7 @@ var _ = Describe("<Scenario4> EKS, epinio-ca, on S3 storage", func() {
 			Eventually(func() string {
 				out, _ := epinioHelper.Run("info")
 				return out
-			}, "2m", "2s").Should(ContainSubstring("Epinio Version:"))
+			}, "2m", "2s").Should(ContainSubstring("Epinio Server Version:"))
 		})
 
 		By("Pushing an app with Env vars", func() {

--- a/acceptance/install/scenario5_test.go
+++ b/acceptance/install/scenario5_test.go
@@ -127,7 +127,7 @@ var _ = Describe("<Scenario5> Azure, Letsencrypt-staging", func() {
 			Eventually(func() string {
 				out, _ := epinioHelper.Run("info")
 				return out
-			}, "2m", "2s").Should(ContainSubstring("Epinio Version:"))
+			}, "2m", "2s").Should(ContainSubstring("Epinio Server Version:"))
 		})
 
 		By("Pushing an app", func() {

--- a/acceptance/install/scenario6_test.go
+++ b/acceptance/install/scenario6_test.go
@@ -106,7 +106,7 @@ var _ = Describe("<Scenario6> Azure, epinio-ca", func() {
 			Eventually(func() string {
 				out, _ := epinioHelper.Run("info")
 				return out
-			}, "2m", "2s").Should(ContainSubstring("Epinio Version:"))
+			}, "2m", "2s").Should(ContainSubstring("Epinio Server Version:"))
 		})
 
 		By("Pushing an app", func() {


### PR DESCRIPTION
As the `info` command now exports both Client and Server version.