### PR TITLE
Simplify CI and fix outside_pr CI

### DIFF
--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -47,9 +47,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -71,6 +68,10 @@ jobs:
       - name: Lint Epinio
         run: make lint
 
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1
+
   acceptance-scenario5:
     needs:
       - linter
@@ -81,9 +82,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v2

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -47,9 +47,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -71,6 +68,10 @@ jobs:
       - name: Lint Epinio
         run: make lint
 
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1
+
   acceptance-scenario6:
     needs:
       - linter
@@ -81,9 +82,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v2

--- a/.github/workflows/container-image-sample-app.yml
+++ b/.github/workflows/container-image-sample-app.yml
@@ -23,4 +23,3 @@ jobs:
         run: pack build splatform/sample-app:latest --builder paketobuildpacks/builder:full --path ./assets/sample-app
       - name: Docker push image
         run: docker push splatform/sample-app:latest
-      

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -51,9 +51,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -75,6 +72,10 @@ jobs:
       - name: Lint Epinio
         run: make lint
 
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1
+
   acceptance-scenario4:
     needs:
       - linter
@@ -85,9 +86,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v2

--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -38,9 +38,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -62,6 +59,10 @@ jobs:
       - name: Lint Epinio
         run: make lint
 
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1
+
   acceptance-scenario2:
     needs:
       - linter
@@ -72,9 +73,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v2

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -38,9 +38,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -62,6 +59,10 @@ jobs:
       - name: Lint Epinio
         run: make lint
 
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1
+
   acceptance-scenario1:
     needs:
       - linter
@@ -72,9 +73,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ on:
     - cron:  '0 0 * * *'
 
 env:
-  SETUP_GO_VERSION: '1.17'
+  SETUP_GO_VERSION: '^1.17.2'
   GINKGO_NODES: 8
 
 jobs:
@@ -28,9 +28,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v2
@@ -56,6 +54,10 @@ jobs:
       - name: Unit Tests
         run: make test
 
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1
+
   acceptance-cli:
     needs:
       - linter
@@ -66,9 +68,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v2
@@ -103,12 +103,18 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
         run: |
-          make acceptance-cluster-delete
           make acceptance-cluster-setup
           export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
           make prepare_environment_k3d
           make test-acceptance-cli
-          make acceptance-cluster-delete
+
+      - name: Cleanup k3d cluster
+        if: always()
+        run: make acceptance-cluster-delete
+
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1
 
   acceptance-api:
     needs:
@@ -120,9 +126,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v2
@@ -157,12 +161,18 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
         run: |
-          make acceptance-cluster-delete
           make acceptance-cluster-setup
           export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
           make prepare_environment_k3d
           make test-acceptance-api
-          make acceptance-cluster-delete
+
+      - name: Cleanup k3d cluster
+        if: always()
+        run: make acceptance-cluster-delete
+
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1
 
   acceptance-apps:
     needs:
@@ -174,9 +184,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v2
@@ -211,7 +219,6 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           EPINIO_TIMEOUT_MULTIPLIER: 5
         run: |
-          make acceptance-cluster-delete
           make acceptance-cluster-setup
           export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
           make prepare_environment_k3d
@@ -237,4 +244,9 @@ jobs:
           retention-days: 2
 
       - name: Cleanup k3d cluster
+        if: always()
         run: make acceptance-cluster-delete
+
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1

--- a/.github/workflows/outside-pr.yml
+++ b/.github/workflows/outside-pr.yml
@@ -8,6 +8,10 @@ on:
     - 'docs/**'
     - 'README.md'
 
+env:
+  SETUP_GO_VERSION: '^1.17.2'
+  GINKGO_NODES: 8
+
 jobs:
   build:
     runs-on: self-hosted
@@ -18,35 +22,57 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Get all git tags
-        run: git fetch --prune --unshallow --tags
-      - name: Setup Go for Building
+          fetch-depth: 0
+
+      - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.2'
+          go-version: ${{ env.SETUP_GO_VERSION }}
+
       - name: Setup Ginkgo Test Framework
-        run: go get -u github.com/onsi/ginkgo/v2/ginkgo
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+
       - name: Cache Tools
         uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Install Tools
         run: make tools-install
+
       - name: Add Tools to PATH
         run: |
           echo "`pwd`/output/bin" >> $GITHUB_PATH
-      - name: lint Epinio
+
+      - name: Lint Epinio
         run: make lint
+
       - name: Run unit tests
         run: make test
+
       - name: Acceptance tests
         env:
           REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          EPINIO_TIMEOUT_MULTIPLIER: 5
         run: |
-          export GINKGO_NODES=8
-          make acceptance-cluster-delete
           make acceptance-cluster-setup
           export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+          make prepare_environment_k3d
+          # Run *ALL* test-acceptance-* tests
           make test-acceptance
+
+      - name: Cleanup k3d cluster
+        if: always()
+        run: make acceptance-cluster-delete
+
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1

--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -32,9 +32,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -56,6 +53,10 @@ jobs:
       - name: Lint Epinio
         run: make lint
 
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1
+
   acceptance-scenario3:
     needs:
       - linter
@@ -66,9 +67,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-
-      - name: Get All Git Tags
-        run: git fetch --force --prune --unshallow --tags
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v2
@@ -127,3 +126,8 @@ jobs:
         if: ${{ always() && !github.event.inputs.keep_cluster }}
         run: |
           sudo sh /usr/local/bin/rke2-uninstall.sh
+
+      # Only on RKE, as it uses a self-hosted runner
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ acceptance-cluster-setup-kind:
 	@./scripts/acceptance-cluster-setup-kind.sh
 
 test-acceptance: showfocus
-	ginkgo -nodes ${GINKGO_NODES} --slow-spec-threshold ${GINKGO_SLOW_TRESHOLD}s -randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending acceptance/. acceptance/api/v1/. acceptance/apps/.
+	ginkgo -nodes ${GINKGO_NODES} -slow-spec-threshold ${GINKGO_SLOW_TRESHOLD}s -randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending acceptance/. acceptance/api/v1/. acceptance/apps/.
 
 test-acceptance-api: showfocus
 	ginkgo -nodes ${GINKGO_NODES} -slow-spec-threshold ${GINKGO_SLOW_TRESHOLD}s -randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending acceptance/api/v1/.

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ compress:
 	upx --brute -1 ./dist/epinio-darwin-arm64
 
 test:
-	ginkgo -nodes ${GINKGO_NODES} -r -p -race --fail-on-pending helpers internal
+	ginkgo --nodes ${GINKGO_NODES} -r -p -race --fail-on-pending helpers internal
 
 tag:
 	@git describe --tags --abbrev=0
@@ -96,20 +96,20 @@ acceptance-cluster-setup-kind:
 	@./scripts/acceptance-cluster-setup-kind.sh
 
 test-acceptance: showfocus
-	ginkgo -nodes ${GINKGO_NODES} -slow-spec-threshold ${GINKGO_SLOW_TRESHOLD}s -randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending acceptance/. acceptance/api/v1/. acceptance/apps/.
+	ginkgo --nodes ${GINKGO_NODES} --slow-spec-threshold ${GINKGO_SLOW_TRESHOLD}s --randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending acceptance/. acceptance/api/v1/. acceptance/apps/.
 
 test-acceptance-api: showfocus
-	ginkgo -nodes ${GINKGO_NODES} -slow-spec-threshold ${GINKGO_SLOW_TRESHOLD}s -randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending acceptance/api/v1/.
+	ginkgo --nodes ${GINKGO_NODES} --slow-spec-threshold ${GINKGO_SLOW_TRESHOLD}s --randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending acceptance/api/v1/.
 
 test-acceptance-apps: showfocus
-	ginkgo -nodes ${GINKGO_NODES} -slow-spec-threshold ${GINKGO_SLOW_TRESHOLD}s -randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending acceptance/apps/.
+	ginkgo --nodes ${GINKGO_NODES} --slow-spec-threshold ${GINKGO_SLOW_TRESHOLD}s --randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending acceptance/apps/.
 
 test-acceptance-cli: showfocus
-	ginkgo -nodes ${GINKGO_NODES} -slow-spec-threshold ${GINKGO_SLOW_TRESHOLD}s -randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending acceptance/.
+	ginkgo --nodes ${GINKGO_NODES} --slow-spec-threshold ${GINKGO_SLOW_TRESHOLD}s --randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending acceptance/.
 
 test-acceptance-install: showfocus
 	# TODO support for labels is coming in ginkgo v2
-	ginkgo -nodes ${GINKGO_NODES} -focus "${REGEX}" -randomize-all --flake-attempts=${FLAKE_ATTEMPTS} acceptance/install/.
+	ginkgo --nodes ${GINKGO_NODES} --focus "${REGEX}" --randomize-all --flake-attempts=${FLAKE_ATTEMPTS} acceptance/install/.
 
 showfocus:
 	@if test `cat acceptance/*.go acceptance/apps/*.go acceptance/api/v1/*.go | grep -c 'FIt\|FWhen\|FDescribe\|FContext'` -gt 0 ; then echo ; echo 'Focus:' ; grep 'FIt\|FWhen\|FDescribe\|FContext' acceptance/*.go acceptance/apps/*.go acceptance/api/v1/*.go ; echo ; fi


### PR DESCRIPTION
- Use `fetch-depth` to get the whole repo
- Properly clean all at the end of the tests on self-hosted runners
- Make sure that k3d cluster is *really* deleted at the end of the tests
- Make `outside-pr` workflow working again