### PR TITLE
Ignore services that were deleted in the middle of an "index" request

### DIFF
--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -244,9 +244,6 @@ func (s *Service) Delete(ctx context.Context) error {
 func (s *Service) Details(ctx context.Context) (map[string]string, error) {
 	serviceSecret, err := s.kubeClient.GetSecret(ctx, s.NamespaceName, s.SecretName)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, errors.New("service does not exist")
-		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes #1235 

E.g. This happens in tests when a ginkgo node is listing all services
from all namespaces while some other ginkgo node is deleting a service
in that list. Our "index" code, first fetchese the list of services and
then finds details for each one of them. If a service is gone between
listing and fetching the details, the old version would make the whole
request fails. Now the service is simply ignored.