### PR TITLE
Linters refinement (dupl)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,15 +12,17 @@ run:
   - "fake_.*.go$"
 
 linters-settings:
-  dupl:
-    # duplication warning after 400 tokens, increased from 150
-    threshold: 400
   revive:
     rules:
     - name: blank-imports
       severity: warning
     - name: unexported-return
       severity: warning
+  funlen:
+    # Checks the number of lines in a function. Default: 60
+    lines: 270
+    # Checks the number of statements in a function. Default: 40
+    statements: 110
 
 issues:
   exclude-rules:
@@ -60,3 +62,4 @@ linters:
   - gosimple
   - typecheck
   - unused
+  - funlen

--- a/internal/application/env.go
+++ b/internal/application/env.go
@@ -6,7 +6,6 @@ import (
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 )
@@ -100,51 +99,5 @@ func envUpdate(ctx context.Context, cluster *kubernetes.Cluster,
 // application's environment. If necessary it creates that secret.
 func envLoad(ctx context.Context, cluster *kubernetes.Cluster, appRef models.AppRef) (*v1.Secret, error) {
 	secretName := appRef.MakeEnvSecretName()
-
-	evSecret, err := cluster.GetSecret(ctx, appRef.Namespace, secretName)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return nil, err
-		}
-
-		// Error is `Not Found`. Create the secret.
-
-		app, err := Get(ctx, cluster, appRef)
-		if err != nil {
-			// Should not happen. Application was validated to exist
-			// already somewhere by callers.
-			return nil, err
-		}
-
-		owner := metav1.OwnerReference{
-			APIVersion: app.GetAPIVersion(),
-			Kind:       app.GetKind(),
-			Name:       app.GetName(),
-			UID:        app.GetUID(),
-		}
-
-		evSecret = &v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretName,
-				Namespace: appRef.Namespace,
-				OwnerReferences: []metav1.OwnerReference{
-					owner,
-				},
-				Labels: map[string]string{
-					"app.kubernetes.io/name":       appRef.Name,
-					"app.kubernetes.io/part-of":    appRef.Namespace,
-					"app.kubernetes.io/managed-by": "epinio",
-					"app.kubernetes.io/component":  "application",
-					EpinioApplicationAreaLabel:     "environment",
-				},
-			},
-		}
-		err = cluster.CreateSecret(ctx, appRef.Namespace, *evSecret)
-
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return evSecret, nil
+	return loadOrCreateSecret(ctx, cluster, appRef, secretName, "environment")
 }

--- a/internal/application/secret.go
+++ b/internal/application/secret.go
@@ -1,0 +1,75 @@
+package application
+
+import (
+	"context"
+
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// loadOrCreateSecret locates and returns the kube secret storing the referenced
+// application's resource. If necessary it creates that secret.
+func loadOrCreateSecret(ctx context.Context, cluster *kubernetes.Cluster, appRef models.AppRef, secretName, areaLabel string) (*v1.Secret, error) {
+	secret, err := cluster.GetSecret(ctx, appRef.Namespace, secretName)
+	if err != nil {
+		// If error is `Not Found`. Create the secret.
+		if apierrors.IsNotFound(err) {
+			return createSecret(ctx, cluster, appRef, secretName, areaLabel)
+		}
+		return nil, errors.Wrapf(err, "error getting secret %s", secretName)
+	}
+	return secret, nil
+}
+
+// createSecret will create the secret in the cluster
+func createSecret(ctx context.Context, cluster *kubernetes.Cluster, appRef models.AppRef, secretName, areaLabel string) (*v1.Secret, error) {
+	app, err := Get(ctx, cluster, appRef)
+	if err != nil {
+		// Should not happen. Application was validated to exist
+		// already somewhere by callers.
+		return nil, errors.Wrapf(err, "error getting application resource")
+	}
+
+	secret := makeSecret(appRef, areaLabel)
+	secret.ObjectMeta.Name = secretName
+
+	ownerReference := makeOwnerReference(app)
+	secret.ObjectMeta.OwnerReferences = []metav1.OwnerReference{ownerReference}
+
+	err = cluster.CreateSecret(ctx, appRef.Namespace, secret)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating secret %s", secretName)
+	}
+	return &secret, nil
+}
+
+// makeOwnerReference creates an OwnerReference
+func makeOwnerReference(app *unstructured.Unstructured) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: app.GetAPIVersion(),
+		Kind:       app.GetKind(),
+		Name:       app.GetName(),
+		UID:        app.GetUID(),
+	}
+}
+
+// makeSecret create a new secret
+func makeSecret(appRef models.AppRef, areaLabel string) v1.Secret {
+	return v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: appRef.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       appRef.Name,
+				"app.kubernetes.io/part-of":    appRef.Namespace,
+				"app.kubernetes.io/managed-by": "epinio",
+				"app.kubernetes.io/component":  "application",
+				EpinioApplicationAreaLabel:     areaLabel,
+			},
+		},
+	}
+}

--- a/internal/application/services.go
+++ b/internal/application/services.go
@@ -10,7 +10,6 @@ import (
 	"github.com/epinio/epinio/internal/services"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 )
@@ -250,51 +249,5 @@ func svcUpdate(ctx context.Context, cluster *kubernetes.Cluster,
 // names. If necessary it creates that secret.
 func svcLoad(ctx context.Context, cluster *kubernetes.Cluster, appRef models.AppRef) (*v1.Secret, error) {
 	secretName := appRef.MakeServiceSecretName()
-
-	svcSecret, err := cluster.GetSecret(ctx, appRef.Namespace, secretName)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return nil, err
-		}
-
-		// Error is `Not Found`. Create the secret.
-
-		app, err := Get(ctx, cluster, appRef)
-		if err != nil {
-			// Should not happen. The application was validated to exist already somewhere
-			// by this function's callers.
-			return nil, err
-		}
-
-		owner := metav1.OwnerReference{
-			APIVersion: app.GetAPIVersion(),
-			Kind:       app.GetKind(),
-			Name:       app.GetName(),
-			UID:        app.GetUID(),
-		}
-
-		svcSecret = &v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretName,
-				Namespace: appRef.Namespace,
-				OwnerReferences: []metav1.OwnerReference{
-					owner,
-				},
-				Labels: map[string]string{
-					"app.kubernetes.io/name":       appRef.Name,
-					"app.kubernetes.io/part-of":    appRef.Namespace,
-					"app.kubernetes.io/managed-by": "epinio",
-					"app.kubernetes.io/component":  "application",
-					EpinioApplicationAreaLabel:     "service",
-				},
-			},
-		}
-		err = cluster.CreateSecret(ctx, appRef.Namespace, *svcSecret)
-
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return svcSecret, nil
+	return loadOrCreateSecret(ctx, cluster, appRef, secretName, "service")
 }


### PR DESCRIPTION
## Health of codebase

> Functions should be small. The second rule of functions is that they should be smaller than that.
> Functions should not be 100 lines long.
> Functions should hardly ever be 20 lines long.
>
> ~ Robert C. Martin (Uncle Bob)

Probably a bit too extreme, but we should avoid extremely long function. I've installed the `funlen` linter and it seems that we are over the 200 lines in some cases.
We should probably try to keep it at least under the 100 lines.

I've also removed the only duplicated code found by the `dupl` linter, so we can go back to the suggested default settings.

