### PR TITLE
Add `--wait` option to Helm install/upgrade in CI

### DIFF
--- a/acceptance/helpers/epinio/epinio.go
+++ b/acceptance/helpers/epinio/epinio.go
@@ -38,6 +38,7 @@ func (e *Epinio) Install(args ...string) (string, error) {
 		"--create-namespace",
 		"epinio",
 		"helm-charts/chart/epinio",
+		"--wait",
 	}
 
 	out, err = proc.Run(testenv.Root(), false, "helm", append(opts, args...)...)

--- a/acceptance/install/scenario1_test.go
+++ b/acceptance/install/scenario1_test.go
@@ -46,19 +46,18 @@ var _ = Describe("<Scenario1> GKE, epinio-ca", func() {
 	})
 
 	It("Installs with loadbalancer IP, custom domain and pushes an app", func() {
-		By("Installing Epinio", func() {
-			out, err := epinioHelper.Install(flags...)
-			Expect(err).NotTo(HaveOccurred(), out)
-			Expect(out).To(ContainSubstring("STATUS: deployed"))
+		By("Checking LoadBalancer IP", func() {
+			// Ensure that Traefik LB is not in Pending state anymore, could take time
+			Eventually(func() string {
+				out, err := proc.RunW("kubectl", "get", "svc", "-n", "traefik", "traefik", "--no-headers")
+				Expect(err).NotTo(HaveOccurred(), out)
+				return out
+			}, "4m", "2s").ShouldNot(ContainSubstring("<pending>"))
 
-			out, err = testenv.PatchEpinio()
-			Expect(err).ToNot(HaveOccurred(), out)
-		})
-
-		By("Extracting Loadbalancer IP", func() {
 			out, err := proc.RunW("kubectl", "get", "service", "-n", "traefik", "traefik", "-o", "json")
 			Expect(err).NotTo(HaveOccurred(), out)
 
+			// Check that an IP address for LB is configured
 			status := &testenv.LoadBalancerHostname{}
 			err = json.Unmarshal([]byte(out), status)
 			Expect(err).NotTo(HaveOccurred())
@@ -95,6 +94,15 @@ var _ = Describe("<Scenario1> GKE, epinio-ca", func() {
 
 		// Workaround to (try to!) ensure that the DNS is really propagated!
 		time.Sleep(3 * time.Minute)
+
+		By("Installing Epinio", func() {
+			out, err := epinioHelper.Install(flags...)
+			Expect(err).NotTo(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("STATUS: deployed"))
+
+			out, err = testenv.PatchEpinio()
+			Expect(err).ToNot(HaveOccurred(), out)
+		})
 
 		By("Updating Epinio config", func() {
 			out, err := epinioHelper.Run("config", "update")

--- a/acceptance/install/scenario3_test.go
+++ b/acceptance/install/scenario3_test.go
@@ -77,7 +77,7 @@ var _ = Describe("<Scenario3> RKE, Private CA, Service, on External Registry", f
 			out, err = proc.RunW("helm", "repo", "add", "metallb", "https://metallb.github.io/metallb")
 			Expect(err).NotTo(HaveOccurred(), out)
 
-			out, err = proc.RunW("helm", "upgrade", "--install", "-n", "metallb",
+			out, err = proc.RunW("helm", "upgrade", "--install", "--wait", "-n", "metallb",
 				"--create-namespace", "metallb", "metallb/metallb", "-f",
 				testenv.TestAssetPath("values-metallb-rke.yml"))
 			Expect(err).NotTo(HaveOccurred(), out)

--- a/acceptance/install/scenario4_test.go
+++ b/acceptance/install/scenario4_test.go
@@ -60,19 +60,18 @@ var _ = Describe("<Scenario4> EKS, epinio-ca, on S3 storage", func() {
 	})
 
 	It("Installs with loadbalancer IP, custom domain and pushes an app with env vars", func() {
-		By("Installing Epinio", func() {
-			out, err := epinioHelper.Install(flags...)
-			Expect(err).NotTo(HaveOccurred(), out)
-			Expect(out).To(ContainSubstring("STATUS: deployed"))
+		By("Checking LoadBalancer IP", func() {
+			// Ensure that Traefik LB is not in Pending state anymore, could take time
+			Eventually(func() string {
+				out, err := proc.RunW("kubectl", "get", "svc", "-n", "traefik", "traefik", "--no-headers")
+				Expect(err).NotTo(HaveOccurred(), out)
+				return out
+			}, "4m", "2s").ShouldNot(ContainSubstring("<pending>"))
 
-			out, err = testenv.PatchEpinio()
-			Expect(err).ToNot(HaveOccurred(), out)
-		})
-
-		By("Extracting Loadbalancer Name", func() {
 			out, err := proc.RunW("kubectl", "get", "service", "-n", "traefik", "traefik", "-o", "json")
 			Expect(err).NotTo(HaveOccurred(), out)
 
+			// Check that an IP address for LB is configured
 			status := &testenv.LoadBalancerHostname{}
 			err = json.Unmarshal([]byte(out), status)
 			Expect(err).NotTo(HaveOccurred())
@@ -109,6 +108,15 @@ var _ = Describe("<Scenario4> EKS, epinio-ca, on S3 storage", func() {
 
 		// Workaround to (try to!) ensure that the DNS is really propagated!
 		time.Sleep(3 * time.Minute)
+
+		By("Installing Epinio", func() {
+			out, err := epinioHelper.Install(flags...)
+			Expect(err).NotTo(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("STATUS: deployed"))
+
+			out, err = testenv.PatchEpinio()
+			Expect(err).ToNot(HaveOccurred(), out)
+		})
 
 		By("Updating Epinio config", func() {
 			out, err := epinioHelper.Run("config", "update")

--- a/acceptance/install/scenario6_test.go
+++ b/acceptance/install/scenario6_test.go
@@ -46,25 +46,24 @@ var _ = Describe("<Scenario6> Azure, epinio-ca", func() {
 	})
 
 	It("Installs with loadbalancer IP, custom domain and pushes an app", func() {
-		By("Installing Epinio", func() {
-			out, err := epinioHelper.Install(flags...)
-			Expect(err).NotTo(HaveOccurred(), out)
-			Expect(out).To(ContainSubstring("STATUS: deployed"))
+		By("Checking LoadBalancer IP", func() {
+			// Ensure that Traefik LB is not in Pending state anymore, could take time
+			Eventually(func() string {
+				out, err := proc.RunW("kubectl", "get", "svc", "-n", "traefik", "traefik", "--no-headers")
+				Expect(err).NotTo(HaveOccurred(), out)
+				return out
+			}, "4m", "2s").ShouldNot(ContainSubstring("<pending>"))
 
-			out, err = testenv.PatchEpinio()
-			Expect(err).ToNot(HaveOccurred(), out)
-		})
-
-		By("Extracting AKS Loadbalancer IP", func() {
 			out, err := proc.RunW("kubectl", "get", "service", "-n", "traefik", "traefik", "-o", "json")
 			Expect(err).NotTo(HaveOccurred(), out)
 
+			// Check that an IP address for LB is configured
 			status := &testenv.LoadBalancerHostname{}
 			err = json.Unmarshal([]byte(out), status)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(status.Status.LoadBalancer.Ingress).To(HaveLen(1))
 			loadbalancer = status.Status.LoadBalancer.Ingress[0].IP
-			Expect(loadbalancer).ToNot(BeEmpty(), out)
+			Expect(loadbalancer).ToNot(BeEmpty())
 		})
 
 		By("Updating DNS Entries", func() {
@@ -95,6 +94,15 @@ var _ = Describe("<Scenario6> Azure, epinio-ca", func() {
 
 		// Workaround to (try to!) ensure that the DNS is really propagated!
 		time.Sleep(3 * time.Minute)
+
+		By("Installing Epinio", func() {
+			out, err := epinioHelper.Install(flags...)
+			Expect(err).NotTo(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("STATUS: deployed"))
+
+			out, err = testenv.PatchEpinio()
+			Expect(err).ToNot(HaveOccurred(), out)
+		})
 
 		By("Updating Epinio config", func() {
 			out, err := epinioHelper.Run("config", "update")

--- a/acceptance/install/suite_test.go
+++ b/acceptance/install/suite_test.go
@@ -47,7 +47,6 @@ func InstallTraefik() {
 		"--set", "ports.web.redirectTo=websecure",
 		"--set", "ingressClass.enabled=true",
 		"--set", "ingressClass.isDefaultClass=true",
-		"--wait",
 	)
 	Expect(err).NotTo(HaveOccurred(), out)
 }

--- a/acceptance/install/suite_test.go
+++ b/acceptance/install/suite_test.go
@@ -31,6 +31,7 @@ func InstallCertManager() {
 		"--create-namespace",
 		"--set", "installCRDs=true",
 		"--set", "extraArgs[0]=--enable-certificate-owner-ref=true",
+		"--wait",
 	)
 	Expect(err).NotTo(HaveOccurred(), out)
 }
@@ -46,6 +47,7 @@ func InstallTraefik() {
 		"--set", "ports.web.redirectTo=websecure",
 		"--set", "ingressClass.enabled=true",
 		"--set", "ingressClass.isDefaultClass=true",
+		"--wait",
 	)
 	Expect(err).NotTo(HaveOccurred(), out)
 }


### PR DESCRIPTION
This could help to "resolve" sporadic issues we have sometimes in Public Cloud CI. Some of them are because the helm command finish too quickly.