### PR TITLE
Disable container registry to test ext registry

### DIFF
--- a/acceptance/install/scenario3_test.go
+++ b/acceptance/install/scenario3_test.go
@@ -54,10 +54,11 @@ var _ = Describe("<Scenario3> RKE, Private CA, Service, on External Registry", f
 		flags = []string{
 			"--set", "global.domain=" + domain,
 			"--set", "global.tlsIssuer=private-ca",
-			"--set", "registry.url=registry.hub.docker.com",
-			"--set", "registry.username=" + registryUsername,
-			"--set", "registry.password=" + registryPassword,
-			"--set", "registry.namespace=splatform",
+			"--set", "containerregistry.enabled=false",
+			"--set", "global.registryURL=registry.hub.docker.com",
+			"--set", "global.registryUsername=" + registryUsername,
+			"--set", "global.registryPassword=" + registryPassword,
+			"--set", "global.registryNamespace=splatform",
 		}
 
 	})


### PR DESCRIPTION
By default, container registry is enabled, so we need do disable it to test external registry.
Without this fix, we configure external registry but at the end, the application is pushed locally, it doesn't use the configured external registry.

I see it because this image was not update since 1 week:
https://hub.docker.com/r/splatform/workspace-externalregtest

However, I'm not sure about the Helm values we are using to configure external registry. Documentation is [outdated](https://github.com/epinio/helm-charts/tree/main/chart/epinio#container-registry), it points to [an obsolete version of the values.yaml file](https://github.com/epinio/helm-charts/blob/7ce84a4b391105551ba52f9ab8ea7213b5358977/chart/epinio/values.yaml#L57-L76).

Failed test: https://github.com/epinio/epinio/runs/5404016286?check_suite_focus=true