### PR TITLE
Added restart comand to cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ compress:
 	upx --brute -1 ./dist/epinio-darwin-arm64
 
 test:
-	ginkgo --nodes ${GINKGO_NODES} -r -p -race --fail-on-pending helpers internal
+	ginkgo --nodes ${GINKGO_NODES} -r -p -race --fail-on-pending helpers internal pkg
 
 tag:
 	@git describe --tags --abbrev=0

--- a/internal/api/v1/application/restart.go
+++ b/internal/api/v1/application/restart.go
@@ -15,7 +15,6 @@ func (hc Controller) Restart(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
 	namespace := c.Param("namespace")
 	appName := c.Param("app")
-	//username := requestctx.User(ctx)
 
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -47,6 +47,7 @@ func init() {
 	CmdApp.AddCommand(CmdAppUpdate)
 	CmdApp.AddCommand(CmdAppDelete)
 	CmdApp.AddCommand(CmdAppPush) // See push.go for implementation
+	CmdApp.AddCommand(CmdAppRestart)
 }
 
 // CmdAppList implements the command: epinio app list
@@ -268,5 +269,25 @@ var CmdAppManifest = &cobra.Command{
 		err = client.AppManifest(args[0], args[1])
 		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error getting app manifest")
+	},
+}
+
+// CmdAppRestart implements the command: epinio app restart
+var CmdAppRestart = &cobra.Command{
+	Use:               "restart NAME",
+	Short:             "Restart the application",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: matchingAppsFinder,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		client, err := usercmd.New()
+		if err != nil {
+			return errors.Wrap(err, "error initializing cli")
+		}
+
+		err = client.AppRestart(args[0])
+		// Note: errors.Wrap (nil, "...") == nil
+		return errors.Wrap(err, "error restarting app")
 	},
 }

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -44,6 +44,12 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 
 	router := gin.New()
 	router.HandleMethodNotAllowed = true
+	router.NoMethod(func(ctx *gin.Context) {
+		response.Error(ctx, apierrors.NewAPIError("Method not allowed", "", http.StatusMethodNotAllowed))
+	})
+	router.NoRoute(func(ctx *gin.Context) {
+		response.Error(ctx, apierrors.NewNotFoundError("Route not found"))
+	})
 	router.Use(gin.Recovery())
 
 	// Do not set header if nothing is specified.

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -254,6 +254,26 @@ func (c *EpinioClient) AppManifest(appName, manifestPath string) error {
 	return nil
 }
 
+// AppRestart restarts an application
+func (c *EpinioClient) AppRestart(appName string) error {
+	log := c.Log.WithName("AppRestart").WithValues("Namespace", c.Config.Namespace, "Application", appName)
+	log.Info("start")
+	defer log.Info("return")
+
+	c.ui.Note().
+		WithStringValue("Namespace", c.Config.Namespace).
+		WithStringValue("Application", appName).
+		Msg("Restarting application")
+
+	if err := c.TargetOk(); err != nil {
+		return err
+	}
+
+	log.V(1).Info("restarting application")
+
+	return c.API.AppRestart(c.Config.Namespace, appName)
+}
+
 // AppStageID returns the last stage id of the named app, in the targeted namespace
 func (c *EpinioClient) AppStageID(appName string) (string, error) {
 	log := c.Log.WithName("Apps").WithValues("Namespace", c.Config.Namespace, "Application", appName)

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -50,12 +50,6 @@ func New() (*EpinioClient, error) {
 	return epinioClient, nil
 }
 
-// ClearMemoization clears the memo, so a new call to getEpinioAPIClient does
-// not return a cached value
-func ClearMemoization() {
-	epinioClientMemo = nil
-}
-
 func getEpinioAPIClient(logger logr.Logger) (*epinioapi.Client, error) {
 	log := logger.WithName("EpinioApiClient")
 	defer func() {

--- a/pkg/api/core/v1/client/apps.go
+++ b/pkg/api/core/v1/client/apps.go
@@ -503,3 +503,15 @@ func (c *Client) addAuthTokenToURL(url *url.URL) error {
 
 	return nil
 }
+
+// AppRestart restarts an app
+func (c *Client) AppRestart(namespace string, appName string) error {
+	endpoint := api.Routes.Path("AppRestart", namespace, appName)
+
+	if _, err := c.post(endpoint, ""); err != nil {
+		errorMsg := fmt.Sprintf("error restarting app %s in namespace %s", appName, namespace)
+		return errors.Wrap(err, errorMsg)
+	}
+
+	return nil
+}

--- a/pkg/api/core/v1/client/apps_test.go
+++ b/pkg/api/core/v1/client/apps_test.go
@@ -1,0 +1,61 @@
+package client_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/epinio/epinio/helpers/tracelog"
+	"github.com/epinio/epinio/pkg/api/core/v1/client"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Client Apps unit tests", func() {
+	var epinioClient *client.Client
+	var statusCode int
+	var responseBody string
+
+	BeforeEach(func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(statusCode)
+			fmt.Fprint(w, responseBody)
+		}))
+
+		epinioClient = client.New(tracelog.NewLogger(), srv.URL, "", "", "")
+	})
+
+	Describe("AppRestart", func() {
+		When("app restart successfully", func() {
+			BeforeEach(func() {
+				statusCode = 200
+				responseBody = `{ "status": "OK" }`
+			})
+
+			It("returns no error", func() {
+				err := epinioClient.AppRestart("namespace-foo", "appname")
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		When("something bad happened", func() {
+			BeforeEach(func() {
+				statusCode = 500
+				responseBody = `{
+					"errors": [
+						{
+							"status": 500,
+							"title": "Error title",
+							"details": "something bad happened"
+						}
+					]
+				}`
+			})
+
+			It("it returns an error", func() {
+				err := epinioClient.AppRestart("namespace-foo", "appname")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+})

--- a/pkg/api/core/v1/client/suite_test.go
+++ b/pkg/api/core/v1/client/suite_test.go
@@ -1,0 +1,13 @@
+package client_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEpinio(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Client unit test suite")
+}


### PR DESCRIPTION
Added the `epinio app restart [appName]` command to the `epinio` cli.

This PR adds also a couple of unit tests to the cli, using a mock client.

I've added also a couple of middleware that wrap the NotFound and NoMethod routes, so that we are going to receive JSON responses also in case of 404 or 405.