### PR TITLE
ApiClient interface

### DIFF
--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -384,7 +384,7 @@ func (c *EpinioClient) AppLogs(appName, stageID string, follow bool, interrupt c
 		endpoint = api.WsRoutes.Path("StagingLogs", c.Settings.Namespace, stageID)
 	}
 	webSocketConn, resp, err := websocket.DefaultDialer.Dial(
-		fmt.Sprintf("%s%s/%s?%s", c.API.WsURL, api.WsRoot, endpoint, strings.Join(urlArgs, "&")), http.Header{})
+		fmt.Sprintf("%s%s/%s?%s", c.Settings.WSS, api.WsRoot, endpoint, strings.Join(urlArgs, "&")), http.Header{})
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Failed to connect to websockets endpoint. Response was = %+v\nThe error is", resp))
 	}

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -19,10 +19,10 @@ type EpinioClient struct {
 	Settings *settings.Settings
 	Log      logr.Logger
 	ui       *termui.UI
-	API      ApiClient
+	API      APIClient
 }
 
-type ApiClient interface {
+type APIClient interface {
 	AuthToken() (string, error)
 	// app
 	AppCreate(req models.ApplicationCreateRequest, namespace string) (models.Response, error)
@@ -77,7 +77,7 @@ func New() (*EpinioClient, error) {
 	return NewEpinioClient(cfg, apiClient)
 }
 
-func NewEpinioClient(cfg *settings.Settings, apiClient ApiClient) (*EpinioClient, error) {
+func NewEpinioClient(cfg *settings.Settings, apiClient APIClient) (*EpinioClient, error) {
 	logger := tracelog.NewLogger().WithName("EpinioClient").V(3)
 
 	log := logger.WithName("NewEpinioClient")

--- a/pkg/api/core/v1/client/apps_test.go
+++ b/pkg/api/core/v1/client/apps_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/pkg/api/core/v1/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -22,7 +21,7 @@ var _ = Describe("Client Apps unit tests", func() {
 			fmt.Fprint(w, responseBody)
 		}))
 
-		epinioClient = client.New(tracelog.NewLogger(), srv.URL, "", "", "")
+		epinioClient = client.New(srv.URL, "", "", "")
 	})
 
 	Describe("AppRestart", func() {

--- a/pkg/api/core/v1/client/client.go
+++ b/pkg/api/core/v1/client/client.go
@@ -2,6 +2,7 @@
 package client
 
 import (
+	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/go-logr/logr"
 )
 
@@ -16,6 +17,14 @@ type Client struct {
 }
 
 // New returns a new Epinio API client
-func New(log logr.Logger, url string, wsURL string, user string, password string) *Client {
-	return &Client{log: log, URL: url, WsURL: wsURL, user: user, password: password}
+func New(url string, wsURL string, user string, password string) *Client {
+	log := tracelog.NewLogger().WithName("EpinioApiClient").V(3)
+
+	return &Client{
+		log:      log,
+		URL:      url,
+		WsURL:    wsURL,
+		user:     user,
+		password: password,
+	}
 }

--- a/pkg/api/core/v1/client/http.go
+++ b/pkg/api/core/v1/client/http.go
@@ -167,16 +167,16 @@ func (c *Client) do(endpoint, method, requestBody string) ([]byte, error) {
 	return bodyBytes, nil
 }
 
-type errorFunc = func(response *http.Response, bodyBytes []byte, err error) error
+type ErrorFunc = func(response *http.Response, bodyBytes []byte, err error) error
 
 // doWithCustomErrorHandling has a special handler for "response type" errors.
 // These are errors where the server send a valid http response, but the status
 // code is not 200.
-// The errorFunc allows us to inspect the response, even unmarshal it into an
+// The ErrorFunc allows us to inspect the response, even unmarshal it into an
 // api.ErrorResponse and change the returned error.
 // Note: it's only used by ServiceDelete and that could be changed to transmit
 // it's data in a normal Response, instead of an error?
-func (c *Client) doWithCustomErrorHandling(endpoint, method, requestBody string, f errorFunc) ([]byte, error) {
+func (c *Client) doWithCustomErrorHandling(endpoint, method, requestBody string, f ErrorFunc) ([]byte, error) {
 
 	uri := fmt.Sprintf("%s%s/%s", c.URL, api.Root, endpoint)
 	c.log.Info(fmt.Sprintf("%s %s", method, uri))

--- a/pkg/api/core/v1/client/services.go
+++ b/pkg/api/core/v1/client/services.go
@@ -87,7 +87,7 @@ func (c *Client) ServiceBindingDelete(namespace string, appName string, serviceN
 }
 
 // ServiceDelete deletes a service
-func (c *Client) ServiceDelete(req models.ServiceDeleteRequest, namespace string, name string, f errorFunc) (models.ServiceDeleteResponse, error) {
+func (c *Client) ServiceDelete(req models.ServiceDeleteRequest, namespace string, name string, f ErrorFunc) (models.ServiceDeleteResponse, error) {
 	resp := models.ServiceDeleteResponse{}
 
 	b, err := json.Marshal(req)


### PR DESCRIPTION
This PR abstract the ApiClient as an interface, so it can be mocked during the tests, without having to mock the http requests.

It also refactor a bit the EpinioClient constructor, removing the (unused? useless?) memoization of the ApiClient.