### PR TITLE
Restage cli

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -215,6 +215,57 @@ configuration:
 		})
 	})
 
+	Describe("restage", func() {
+		When("restaging an app from git", func() {
+			It("will be staged again", func() {
+				wordpress := "https://github.com/epinio/example-wordpress"
+				pushLog, err := env.EpinioPush("",
+					appName,
+					"--name", appName,
+					"--git", wordpress+",main")
+				Expect(err).ToNot(HaveOccurred(), pushLog)
+
+				Eventually(func() string {
+					out, err := env.Epinio("", "app", "list")
+					Expect(err).ToNot(HaveOccurred(), out)
+					return out
+				}, "5m").Should(MatchRegexp(fmt.Sprintf(`%s.*\|.*1\/1.*\|.*`, appName)))
+
+				restageLogs, err := env.Epinio("", "app", "restage", appName)
+				Expect(err).ToNot(HaveOccurred(), restageLogs)
+
+				By("deleting the app")
+				env.DeleteApp(appName)
+			})
+
+		})
+
+		When("restaging a container based app", func() {
+			It("won't be staged", func() {
+				pushLog, err := env.EpinioPush("",
+					appName,
+					"--name", appName,
+					"--container-image-url", containerImageURL)
+				Expect(err).ToNot(HaveOccurred(), pushLog)
+
+				Eventually(func() string {
+					out, err := env.Epinio("", "app", "list")
+					Expect(err).ToNot(HaveOccurred(), out)
+					return out
+				}, "5m").Should(MatchRegexp(fmt.Sprintf(`%s.*\|.*1\/1.*\|.*`, appName)))
+
+				restageLogs, err := env.Epinio("", "app", "restage", appName)
+				Expect(err).ToNot(HaveOccurred(), pushLog)
+				Expect(restageLogs).Should(MatchRegexp("Unable to restage container-based application"))
+
+				By("deleting the app")
+				env.DeleteApp(appName)
+			})
+
+		})
+
+	})
+
 	When("pushing with custom route flag", func() {
 		AfterEach(func() {
 			env.DeleteApp(appName)

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -48,6 +48,7 @@ func init() {
 	CmdApp.AddCommand(CmdAppDelete)
 	CmdApp.AddCommand(CmdAppPush) // See push.go for implementation
 	CmdApp.AddCommand(CmdAppRestart)
+	CmdApp.AddCommand(CmdAppRestage)
 }
 
 // CmdAppList implements the command: epinio app list
@@ -274,8 +275,9 @@ var CmdAppManifest = &cobra.Command{
 
 // CmdAppRestart implements the command: epinio app restart
 var CmdAppRestart = &cobra.Command{
-	Use:               "restart NAME",
-	Short:             "Restart the application",
+	Use:   "restart NAME",
+	Short: "Restart the application",
+
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -287,6 +289,26 @@ var CmdAppRestart = &cobra.Command{
 		}
 
 		err = client.AppRestart(args[0])
+		// Note: errors.Wrap (nil, "...") == nil
+		return errors.Wrap(err, "error restarting app")
+	},
+}
+
+// CmdAppRestage implements the command: epinio app restage
+var CmdAppRestage = &cobra.Command{
+	Use:               "restage NAME",
+	Short:             "Restage the application",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: matchingAppsFinder,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		client, err := usercmd.New()
+		if err != nil {
+			return errors.Wrap(err, "error initializing cli")
+		}
+
+		err = client.AppRestage(args[0])
 		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error restarting app")
 	},

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -275,9 +275,8 @@ var CmdAppManifest = &cobra.Command{
 
 // CmdAppRestart implements the command: epinio app restart
 var CmdAppRestart = &cobra.Command{
-	Use:   "restart NAME",
-	Short: "Restart the application",
-
+	Use:               "restart NAME",
+	Short:             "Restart the application",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -310,6 +310,6 @@ var CmdAppRestage = &cobra.Command{
 
 		err = client.AppRestage(args[0])
 		// Note: errors.Wrap (nil, "...") == nil
-		return errors.Wrap(err, "error restarting app")
+		return errors.Wrap(err, "error restaging app")
 	},
 }

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -550,6 +550,7 @@ func (c *EpinioClient) AppRestage(appName string) error {
 	}
 
 	if app.Origin.Kind == models.OriginContainer {
+		c.ui.Note().Msg("Unable to restage container-based application")
 		return nil
 	}
 

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -529,12 +529,12 @@ func (c *EpinioClient) printReplicaDetails(app models.App) error {
 
 // AppRestage restage an application
 func (c *EpinioClient) AppRestage(appName string) error {
-	log := c.Log.WithName("AppRestage").WithValues("Namespace", c.Config.Namespace, "Application", appName)
+	log := c.Log.WithName("AppRestage").WithValues("Namespace", c.Settings.Namespace, "Application", appName)
 	log.Info("start")
 	defer log.Info("return")
 
 	c.ui.Note().
-		WithStringValue("Namespace", c.Config.Namespace).
+		WithStringValue("Namespace", c.Settings.Namespace).
 		WithStringValue("Application", appName).
 		Msg("Restaging application")
 
@@ -544,7 +544,7 @@ func (c *EpinioClient) AppRestage(appName string) error {
 
 	log.V(1).Info("restaging application")
 
-	app, err := c.API.AppShow(c.Config.Namespace, appName)
+	app, err := c.API.AppShow(c.Settings.Namespace, appName)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -554,8 +554,6 @@ func (c *EpinioClient) AppRestage(appName string) error {
 		return nil
 	}
 
-	c.ui.Normal().Msg("Restaging application...")
-
 	req := models.StageRequest{App: app.Meta}
 	stageResponse, err := c.API.AppStage(req)
 	if err != nil {

--- a/internal/cli/usercmd/app_test.go
+++ b/internal/cli/usercmd/app_test.go
@@ -1,0 +1,232 @@
+package usercmd_test
+
+import (
+	"context"
+
+	"github.com/epinio/epinio/internal/cli/settings"
+	"github.com/epinio/epinio/internal/cli/usercmd"
+	epinioapi "github.com/epinio/epinio/pkg/api/core/v1/client"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	kubectlterm "k8s.io/kubectl/pkg/util/term"
+)
+
+var _ = Describe("Client Apps unit tests", Label("wip"), func() {
+
+	Describe("AppRestage", func() {
+
+		When("restaging an existing app", func() {
+			var mockClient *mockAPIClient
+
+			BeforeEach(func() {
+				mockClient = &mockAPIClient{}
+
+				mockClient.mockAppShow = func(namespace, appName string) (models.App, error) {
+					return *models.NewApp(appName, namespace), nil
+				}
+
+				mockClient.mockAppStage = func(req models.StageRequest) (*models.StageResponse, error) {
+					return &models.StageResponse{Stage: models.NewStage("ID")}, nil
+				}
+
+				mockClient.mockAppLogs = func(ctx context.Context, namespace, appName, stageID string, follow bool) (chan []byte, error) {
+					return make(chan []byte), nil
+				}
+
+				mockClient.mockStagingComplete = func(namespace, id string) (models.Response, error) {
+					return models.Response{Status: "ok"}, nil
+				}
+			})
+
+			It("returns no error", func() {
+				epinioClient, err := usercmd.NewEpinioClient(&settings.Settings{Namespace: "workspace"}, mockClient)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = epinioClient.AppRestage("appname")
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		When("restaging an app of kind container", func() {
+			var mockClient *mockAPIClient
+
+			BeforeEach(func() {
+				mockClient = &mockAPIClient{}
+
+				mockClient.mockAppShow = func(namespace, appName string) (models.App, error) {
+					newApp := models.NewApp(appName, namespace)
+					newApp.Origin = models.ApplicationOrigin{Kind: models.OriginContainer}
+					return *newApp, nil
+				}
+
+				mockClient.mockAppStage = func(req models.StageRequest) (*models.StageResponse, error) {
+					panic("called AppStage!")
+				}
+			})
+
+			It("returns no error and it won't stage", func() {
+				epinioClient, err := usercmd.NewEpinioClient(&settings.Settings{Namespace: "workspace"}, mockClient)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = epinioClient.AppRestage("appname")
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+})
+
+type mockAPIClient struct {
+	mockAppShow         func(namespace string, appName string) (models.App, error)
+	mockAppStage        func(req models.StageRequest) (*models.StageResponse, error)
+	mockAppLogs         func(ctx context.Context, namespace, appName, stageID string, follow bool) (chan []byte, error)
+	mockStagingComplete func(namespace string, id string) (models.Response, error)
+}
+
+func (m *mockAPIClient) AuthToken() (string, error) {
+	return "", nil
+}
+
+func (m *mockAPIClient) AppCreate(req models.ApplicationCreateRequest, namespace string) (models.Response, error) {
+	return models.Response{}, nil
+}
+
+func (m *mockAPIClient) Apps(namespace string) (models.AppList, error) {
+	return models.AppList{}, nil
+}
+
+func (m *mockAPIClient) AllApps() (models.AppList, error) {
+	return models.AppList{}, nil
+}
+
+func (m *mockAPIClient) AppShow(namespace string, appName string) (models.App, error) {
+	return m.mockAppShow(namespace, appName)
+}
+
+func (m *mockAPIClient) AppUpdate(req models.ApplicationUpdateRequest, namespace string, appName string) (models.Response, error) {
+	return models.Response{}, nil
+}
+
+func (m *mockAPIClient) AppDelete(namespace string, name string) (models.ApplicationDeleteResponse, error) {
+	return models.ApplicationDeleteResponse{}, nil
+}
+
+func (m *mockAPIClient) AppUpload(namespace string, name string, tarball string) (models.UploadResponse, error) {
+	return models.UploadResponse{}, nil
+}
+
+func (m *mockAPIClient) AppImportGit(app models.AppRef, gitRef models.GitRef) (*models.ImportGitResponse, error) {
+	return nil, nil
+}
+
+func (m *mockAPIClient) AppStage(req models.StageRequest) (*models.StageResponse, error) {
+	return m.mockAppStage(req)
+}
+
+func (m *mockAPIClient) AppDeploy(req models.DeployRequest) (*models.DeployResponse, error) {
+	return nil, nil
+}
+
+func (m *mockAPIClient) AppLogs(ctx context.Context, namespace, appName, stageID string, follow bool) (chan []byte, error) {
+	return m.mockAppLogs(ctx, namespace, appName, stageID, follow)
+}
+
+func (m *mockAPIClient) StagingComplete(namespace string, id string) (models.Response, error) {
+	return m.mockStagingComplete(namespace, id)
+}
+
+func (m *mockAPIClient) AppRunning(app models.AppRef) (models.Response, error) {
+	return models.Response{}, nil
+}
+
+func (m *mockAPIClient) AppExec(namespace string, appName, instance string, tty kubectlterm.TTY) error {
+	return nil
+}
+
+func (m *mockAPIClient) AppPortForward(namespace string, appName, instance string, opts *epinioapi.PortForwardOpts) error {
+	return nil
+}
+
+func (m *mockAPIClient) AppRestart(namespace string, appName string) error {
+	return nil
+}
+
+func (m *mockAPIClient) EnvList(namespace string, appName string) (models.EnvVariableMap, error) {
+	return models.EnvVariableMap{}, nil
+}
+
+func (m *mockAPIClient) EnvSet(req models.EnvVariableMap, namespace string, appName string) (models.Response, error) {
+	return models.Response{}, nil
+}
+
+func (m *mockAPIClient) EnvShow(namespace string, appName string, envName string) (models.EnvVariable, error) {
+	return models.EnvVariable{}, nil
+}
+
+func (m *mockAPIClient) EnvUnset(namespace string, appName string, envName string) (models.Response, error) {
+	return models.Response{}, nil
+}
+
+func (m *mockAPIClient) EnvMatch(namespace string, appName string, prefix string) (models.EnvMatchResponse, error) {
+	return models.EnvMatchResponse{}, nil
+}
+
+func (m *mockAPIClient) Info() (models.InfoResponse, error) {
+	return models.InfoResponse{}, nil
+}
+
+func (m *mockAPIClient) NamespaceCreate(req models.NamespaceCreateRequest) (models.Response, error) {
+	return models.Response{}, nil
+}
+
+func (m *mockAPIClient) NamespaceDelete(namespace string) (models.Response, error) {
+	return models.Response{}, nil
+}
+
+func (m *mockAPIClient) NamespaceShow(namespace string) (models.Namespace, error) {
+	return models.Namespace{}, nil
+}
+
+func (m *mockAPIClient) NamespacesMatch(prefix string) (models.NamespacesMatchResponse, error) {
+	return models.NamespacesMatchResponse{}, nil
+}
+
+func (m *mockAPIClient) Namespaces() (models.NamespaceList, error) {
+	return models.NamespaceList{}, nil
+}
+
+func (m *mockAPIClient) Configurations(namespace string) (models.ConfigurationResponseList, error) {
+	return models.ConfigurationResponseList{}, nil
+}
+
+func (m *mockAPIClient) AllConfigurations() (models.ConfigurationResponseList, error) {
+	return models.ConfigurationResponseList{}, nil
+}
+
+func (m *mockAPIClient) ConfigurationBindingCreate(req models.BindRequest, namespace string, appName string) (models.BindResponse, error) {
+	return models.BindResponse{}, nil
+}
+
+func (m *mockAPIClient) ConfigurationBindingDelete(namespace string, appName string, serviceName string) (models.Response, error) {
+	return models.Response{}, nil
+}
+
+func (m *mockAPIClient) ConfigurationDelete(req models.ConfigurationDeleteRequest, namespace string, name string, f epinioapi.ErrorFunc) (models.ConfigurationDeleteResponse, error) {
+	return models.ConfigurationDeleteResponse{}, nil
+}
+
+func (m *mockAPIClient) ConfigurationCreate(req models.ConfigurationCreateRequest, namespace string) (models.Response, error) {
+	return models.Response{}, nil
+}
+
+func (m *mockAPIClient) ConfigurationUpdate(req models.ConfigurationUpdateRequest, namespace, name string) (models.Response, error) {
+	return models.Response{}, nil
+}
+
+func (m *mockAPIClient) ConfigurationShow(namespace string, name string) (models.ConfigurationResponse, error) {
+	return models.ConfigurationResponse{}, nil
+}
+
+func (m *mockAPIClient) ConfigurationApps(namespace string) (models.ConfigurationAppsResponse, error) {
+	return models.ConfigurationAppsResponse{}, nil
+}

--- a/internal/cli/usercmd/app_test.go
+++ b/internal/cli/usercmd/app_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Client Apps unit tests", Label("wip"), func() {
 			})
 		})
 
-		When("restaging an app of kind container", func() {
+		When("restaging a container-based app", func() {
 			var mockClient *mockAPIClient
 
 			BeforeEach(func() {

--- a/internal/cli/usercmd/suite_test.go
+++ b/internal/cli/usercmd/suite_test.go
@@ -1,0 +1,13 @@
+package usercmd_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEpinio(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CLI usercmd unit test suite")
+}


### PR DESCRIPTION
This PR adds the `restage` command to the cli.

While trying to add some tests I've encountered some difficulties, so I'm going to open a couple of smaller PRs to make it easier to understand.

Adding ApiClient interface:
 * https://github.com/epinio/epinio/pull/1289

Moving AppLogs from EpinioClient to the ApiClient
* https://github.com/epinio/epinio/pull/1291