### PR TITLE
Moved AppLogs to APIClient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ compress:
 	upx --brute -1 ./dist/epinio-darwin-arm64
 
 test:
-	ginkgo --nodes ${GINKGO_NODES} -r -p -race --fail-on-pending helpers internal pkg
+	ginkgo --nodes ${GINKGO_NODES} -r -p -race --fail-on-pending --skip-file=acceptance
 
 tag:
 	@git describe --tags --abbrev=0

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -160,7 +160,7 @@ var CmdAppLogs = &cobra.Command{
 			stageID = ""
 		}
 
-		err = client.AppLogs(args[0], stageID, follow, nil)
+		err = client.AppLogs(args[0], stageID, follow)
 		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error streaming application logs")
 	},

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -2,6 +2,8 @@
 package usercmd
 
 import (
+	"context"
+
 	"github.com/epinio/epinio/helpers/termui"
 	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/cli/settings"
@@ -35,6 +37,7 @@ type APIClient interface {
 	AppImportGit(app models.AppRef, gitRef models.GitRef) (*models.ImportGitResponse, error)
 	AppStage(req models.StageRequest) (*models.StageResponse, error)
 	AppDeploy(req models.DeployRequest) (*models.DeployResponse, error)
+	AppLogs(ctx context.Context, namespace, appName, stageID string, follow bool) (chan []byte, error)
 	StagingComplete(namespace string, id string) (models.Response, error)
 	AppRunning(app models.AppRef) (models.Response, error)
 	AppExec(namespace string, appName, instance string, tty kubectlterm.TTY) error

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -251,6 +251,11 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 }
 
 func (c *EpinioClient) stageLogs(logger logr.Logger, appRef models.AppRef, stageID string) error {
+	c.ui.Note().
+		WithStringValue("Namespace", c.Settings.Namespace).
+		WithStringValue("Application", appRef.Name).
+		Msg("Streaming application logs")
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/api/core/v1/client/app_logs_test.go
+++ b/pkg/api/core/v1/client/app_logs_test.go
@@ -1,0 +1,153 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/epinio/epinio/pkg/api/core/v1/client"
+	"github.com/gorilla/websocket"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func DescribeAppLogs() {
+
+	const logMessages int = 5
+	const logMessageDelay time.Duration = 100 * time.Millisecond
+
+	var epinioClient *client.Client
+	var statusCode int
+	var responseBody string
+
+	JustBeforeEach(func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/api/v1/authtoken", func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"token":"mytoken"}`)
+		})
+
+		mux.HandleFunc("/wapi/", func(w http.ResponseWriter, req *http.Request) {
+			upgrader := websocket.Upgrader{}
+			websocketConn, err := upgrader.Upgrade(w, req, http.Header{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// write some random logs
+			go func() {
+				defer websocketConn.Close()
+
+				followStr := req.URL.Query().Get("follow")
+				follow, err := strconv.ParseBool(followStr)
+				Expect(err).ToNot(HaveOccurred())
+
+				messagesToWrite := logMessages
+
+				// if following then write a lot of messages
+				if follow {
+					messagesToWrite = math.MaxInt
+				}
+
+				for i := 0; i < messagesToWrite; i++ {
+					logMsg := fmt.Sprintf("log message #%d", i)
+					websocketConn.WriteMessage(websocket.TextMessage, []byte(logMsg))
+					time.Sleep(logMessageDelay)
+				}
+			}()
+		})
+
+		mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+			fmt.Printf("##### %+v", req)
+
+			w.WriteHeader(statusCode)
+			fmt.Fprint(w, responseBody)
+		})
+
+		srv := httptest.NewServer(mux)
+
+		wsURL := strings.Replace(srv.URL, "http://", "ws://", 1)
+		epinioClient = client.New(srv.URL, wsURL, "", "")
+	})
+
+	When("no following the logs", func() {
+
+		It("will read all the logs if waiting more", func() {
+			totalLogTime := time.Duration(logMessages) * logMessageDelay
+			waitingTime := totalLogTime + 1*time.Second
+
+			ctx, cancel := context.WithTimeout(context.Background(), waitingTime)
+			defer cancel()
+
+			msgChan, err := epinioClient.AppLogs(ctx, "namespace-foo", "appname", "stageID", false)
+			Expect(err).ToNot(HaveOccurred())
+
+			messages := []string{}
+			for msg := range msgChan {
+				messages = append(messages, string(msg))
+			}
+
+			Expect(messages).To(HaveLen(logMessages))
+		})
+
+		It("will not read all the logs if cancelled before", func() {
+			totalLogTime := time.Duration(logMessages) * logMessageDelay
+			waitingTime := totalLogTime - 1*time.Second
+
+			ctx, cancel := context.WithTimeout(context.Background(), waitingTime)
+			defer cancel()
+
+			msgChan, err := epinioClient.AppLogs(ctx, "namespace-foo", "appname", "stageID", false)
+			Expect(err).ToNot(HaveOccurred())
+
+			messages := []string{}
+			for msg := range msgChan {
+				messages = append(messages, string(msg))
+			}
+
+			Expect(len(messages)).To(BeNumerically("<", logMessages))
+		})
+	})
+
+	When("following the logs", func() {
+
+		It("will read more logs if waiting more time", func() {
+			totalLogTime := time.Duration(logMessages) * logMessageDelay
+			waitingTime := totalLogTime + 1*time.Second
+
+			ctx, cancel := context.WithTimeout(context.Background(), waitingTime)
+			defer cancel()
+
+			msgChan, err := epinioClient.AppLogs(ctx, "namespace-foo", "appname", "stageID", true)
+			Expect(err).ToNot(HaveOccurred())
+
+			messages := []string{}
+			for msg := range msgChan {
+				messages = append(messages, string(msg))
+			}
+
+			Expect(len(messages)).To(BeNumerically(">", logMessages))
+		})
+
+		It("will read more less logs if cancelled before", func() {
+			totalLogTime := time.Duration(logMessages) * logMessageDelay
+			waitingTime := totalLogTime - 1*time.Second
+
+			ctx, cancel := context.WithTimeout(context.Background(), waitingTime)
+			defer cancel()
+
+			msgChan, err := epinioClient.AppLogs(ctx, "namespace-foo", "appname", "stageID", true)
+			Expect(err).ToNot(HaveOccurred())
+
+			messages := []string{}
+			for msg := range msgChan {
+				messages = append(messages, string(msg))
+			}
+
+			Expect(len(messages)).To(BeNumerically("<", logMessages))
+		})
+	})
+}

--- a/pkg/api/core/v1/client/app_restart_test.go
+++ b/pkg/api/core/v1/client/app_restart_test.go
@@ -1,0 +1,61 @@
+package client_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/epinio/epinio/pkg/api/core/v1/client"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func DescribeAppRestart() {
+
+	var epinioClient *client.Client
+	var statusCode int
+	var responseBody string
+
+	JustBeforeEach(func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(statusCode)
+			fmt.Fprint(w, responseBody)
+		}))
+
+		epinioClient = client.New(srv.URL, "", "", "")
+	})
+
+	When("app restart successfully", func() {
+
+		BeforeEach(func() {
+			statusCode = 200
+			responseBody = `{ "status": "OK" }`
+		})
+
+		It("returns no error", func() {
+			err := epinioClient.AppRestart("namespace-foo", "appname")
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("something bad happened", func() {
+
+		BeforeEach(func() {
+			statusCode = 500
+			responseBody = `{
+					"errors": [
+						{
+							"status": 500,
+							"title": "Error title",
+							"details": "something bad happened"
+						}
+					]
+				}`
+		})
+
+		It("it returns an error", func() {
+			err := epinioClient.AppRestart("namespace-foo", "appname")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+}

--- a/pkg/api/core/v1/client/apps_test.go
+++ b/pkg/api/core/v1/client/apps_test.go
@@ -5,6 +5,6 @@ import (
 )
 
 var _ = Describe("Client Apps unit tests", func() {
-	FDescribe("AppLogs", DescribeAppLogs)
+	Describe("AppLogs", DescribeAppLogs)
 	Describe("AppRestart", DescribeAppRestart)
 })

--- a/pkg/api/core/v1/client/apps_test.go
+++ b/pkg/api/core/v1/client/apps_test.go
@@ -1,60 +1,10 @@
 package client_test
 
 import (
-	"fmt"
-	"net/http"
-	"net/http/httptest"
-
-	"github.com/epinio/epinio/pkg/api/core/v1/client"
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Client Apps unit tests", func() {
-	var epinioClient *client.Client
-	var statusCode int
-	var responseBody string
-
-	JustBeforeEach(func() {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(statusCode)
-			fmt.Fprint(w, responseBody)
-		}))
-
-		epinioClient = client.New(srv.URL, "", "", "")
-	})
-
-	Describe("AppRestart", func() {
-		When("app restart successfully", func() {
-			BeforeEach(func() {
-				statusCode = 200
-				responseBody = `{ "status": "OK" }`
-			})
-
-			It("returns no error", func() {
-				err := epinioClient.AppRestart("namespace-foo", "appname")
-				Expect(err).ToNot(HaveOccurred())
-			})
-		})
-
-		When("something bad happened", func() {
-			BeforeEach(func() {
-				statusCode = 500
-				responseBody = `{
-					"errors": [
-						{
-							"status": 500,
-							"title": "Error title",
-							"details": "something bad happened"
-						}
-					]
-				}`
-			})
-
-			It("it returns an error", func() {
-				err := epinioClient.AppRestart("namespace-foo", "appname")
-				Expect(err).To(HaveOccurred())
-			})
-		})
-	})
+	FDescribe("AppLogs", DescribeAppLogs)
+	Describe("AppRestart", DescribeAppRestart)
 })


### PR DESCRIPTION
This PR moves the websocket connection for the AppLogs in the APIClient.

It also refactor the code to use a (hopefully) simpler approach: the function will return now a channel that can be used to read the logs from. The stop of the logging is done with the cancellation of the context.

The printing of the logs is also now in a separate func.