### PR TITLE
Namespace cleanup

### DIFF
--- a/acceptance/api/v1/application_create_test.go
+++ b/acceptance/api/v1/application_create_test.go
@@ -25,14 +25,7 @@ var _ = Describe("AppCreate Endpoint", func() {
 	})
 
 	AfterEach(func() {
-		Eventually(func() string {
-			out, err := env.Epinio("", "app", "delete", appName)
-			if err != nil {
-				return out
-			}
-			return ""
-		}, "5m").Should(BeEmpty())
-
+		env.DeleteApp(appName)
 		env.DeleteNamespace(namespace)
 	})
 

--- a/acceptance/api/v1/application_delete_test.go
+++ b/acceptance/api/v1/application_delete_test.go
@@ -24,6 +24,7 @@ var _ = Describe("AppDelete Endpoint", func() {
 		namespace = catalog.NewNamespaceName()
 		env.SetupAndTargetNamespace(namespace)
 	})
+
 	AfterEach(func() {
 		env.DeleteNamespace(namespace)
 	})

--- a/acceptance/api/v1/application_deploy_test.go
+++ b/acceptance/api/v1/application_deploy_test.go
@@ -32,6 +32,7 @@ var _ = Describe("AppDeploy Endpoint", func() {
 
 	AfterEach(func() {
 		env.DeleteApp(appName)
+		env.DeleteNamespace(namespace)
 	})
 
 	Context("with staging", func() {

--- a/acceptance/api/v1/application_importgit_test.go
+++ b/acceptance/api/v1/application_importgit_test.go
@@ -31,6 +31,7 @@ var _ = Describe("AppImportGit Endpoint", func() {
 		_, err := createApplication(appName, namespace, []string{})
 		Expect(err).ToNot(HaveOccurred())
 	})
+
 	AfterEach(func() {
 		env.DeleteNamespace(namespace)
 	})

--- a/acceptance/api/v1/application_index_all_test.go
+++ b/acceptance/api/v1/application_index_all_test.go
@@ -39,6 +39,7 @@ var _ = Describe("AllApps Endpoints", func() {
 		app2 = catalog.NewAppName()
 		env.MakeContainerImageApp(app2, 1, containerImageURL)
 	})
+
 	AfterEach(func() {
 		env.TargetNamespace(namespace2)
 		env.DeleteApp(app2)

--- a/acceptance/api/v1/application_index_test.go
+++ b/acceptance/api/v1/application_index_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Apps Endpoint", func() {
 		namespace = catalog.NewNamespaceName()
 		env.SetupAndTargetNamespace(namespace)
 	})
+
 	AfterEach(func() {
 		env.DeleteNamespace(namespace)
 	})

--- a/acceptance/api/v1/application_logs_test.go
+++ b/acceptance/api/v1/application_logs_test.go
@@ -34,6 +34,7 @@ var _ = Describe("AppLogs Endpoint", func() {
 		route = testenv.AppRouteFromOutput(out)
 		Expect(route).ToNot(BeEmpty())
 	})
+
 	AfterEach(func() {
 		env.DeleteApp(app)
 		env.DeleteNamespace(namespace)

--- a/acceptance/api/v1/application_portforward_test.go
+++ b/acceptance/api/v1/application_portforward_test.go
@@ -39,6 +39,7 @@ var _ = Describe("AppPortForward Endpoint", func() {
 	})
 
 	AfterEach(func() {
+		env.DeleteApp(appName)
 		env.DeleteNamespace(namespace)
 	})
 

--- a/acceptance/api/v1/application_restart_test.go
+++ b/acceptance/api/v1/application_restart_test.go
@@ -27,6 +27,7 @@ var _ = Describe("AppRestart Endpoint", func() {
 		app1 = catalog.NewAppName()
 		env.MakeContainerImageApp(app1, 1, containerImageURL)
 	})
+
 	AfterEach(func() {
 		env.DeleteApp(app1)
 		env.DeleteNamespace(namespace)

--- a/acceptance/api/v1/application_show_test.go
+++ b/acceptance/api/v1/application_show_test.go
@@ -26,6 +26,7 @@ var _ = Describe("AppShow Endpoint", func() {
 		namespace = catalog.NewNamespaceName()
 		env.SetupAndTargetNamespace(namespace)
 	})
+
 	AfterEach(func() {
 		env.DeleteNamespace(namespace)
 	})

--- a/acceptance/api/v1/application_stage_test.go
+++ b/acceptance/api/v1/application_stage_test.go
@@ -36,6 +36,7 @@ var _ = Describe("AppStage Endpoint", func() {
 		_, err := createApplication(appName, namespace, []string{})
 		Expect(err).ToNot(HaveOccurred())
 	})
+
 	AfterEach(func() {
 		env.DeleteNamespace(namespace)
 	})

--- a/acceptance/api/v1/application_update_test.go
+++ b/acceptance/api/v1/application_update_test.go
@@ -31,6 +31,7 @@ var _ = Describe("AppUpdate Endpoint", func() {
 		namespace = catalog.NewNamespaceName()
 		env.SetupAndTargetNamespace(namespace)
 	})
+
 	AfterEach(func() {
 		env.DeleteNamespace(namespace)
 	})

--- a/acceptance/api/v1/application_upload_test.go
+++ b/acceptance/api/v1/application_upload_test.go
@@ -26,6 +26,7 @@ var _ = Describe("AppUpload Endpoint", func() {
 		namespace = catalog.NewNamespaceName()
 		env.SetupAndTargetNamespace(namespace)
 	})
+
 	AfterEach(func() {
 		env.DeleteNamespace(namespace)
 	})

--- a/acceptance/api/v1/configurations_mutation_test.go
+++ b/acceptance/api/v1/configurations_mutation_test.go
@@ -25,6 +25,10 @@ var _ = Describe("Configurations API Application Endpoints, Mutations", func() {
 		env.SetupAndTargetNamespace(namespace)
 	})
 
+	AfterEach(func() {
+		env.DeleteNamespace(namespace)
+	})
+
 	Describe("POST /api/v1/namespaces/:namespace/configurations/", func() {
 		It("returns a 'bad request' for a non JSON body", func() {
 			response, err := env.Curl("POST",

--- a/acceptance/api/v1/configurations_test.go
+++ b/acceptance/api/v1/configurations_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Configurations API Application Endpoints", func() {
 		env.TargetNamespace(namespace)
 		env.DeleteConfiguration(svc1)
 		env.DeleteConfiguration(svc2)
+		env.DeleteNamespace(namespace)
 	})
 
 	Describe("GET /api/v1/namespaces/:namespace/configurations", func() {
@@ -111,6 +112,8 @@ var _ = Describe("Configurations API Application Endpoints", func() {
 			env.TargetNamespace(namespace1)
 			env.DeleteApp(app1)
 			env.DeleteConfiguration(configuration1)
+			env.DeleteNamespace(namespace1)
+			env.DeleteNamespace(namespace2)
 		})
 
 		It("lists all configurations belonging to all namespaces", func() {

--- a/acceptance/apps/rails_test.go
+++ b/acceptance/apps/rails_test.go
@@ -125,6 +125,7 @@ var _ = Describe("RubyOnRails", func() {
 		Expect(err).ToNot(HaveOccurred(), out)
 
 		env.DeleteApp(rails.Name)
+		env.DeleteNamespace(rails.Namespace)
 	})
 
 	It("can deploy Rails", func() {

--- a/acceptance/apps/wordpress_test.go
+++ b/acceptance/apps/wordpress_test.go
@@ -96,10 +96,11 @@ func (w *WordpressApp) AppURL() (string, error) {
 }
 
 var _ = Describe("Wordpress", func() {
+	var namespace string
 	var wordpress WordpressApp
 
 	BeforeEach(func() {
-		namespace := catalog.NewNamespaceName()
+		namespace = catalog.NewNamespaceName()
 		wordpress = WordpressApp{
 			SourceURL: "https://wordpress.org/wordpress-5.6.1.tar.gz",
 			Name:      catalog.NewAppName(),
@@ -118,6 +119,7 @@ var _ = Describe("Wordpress", func() {
 
 		err = os.RemoveAll(wordpress.Dir)
 		Expect(err).ToNot(HaveOccurred())
+		env.DeleteNamespace(namespace)
 	})
 
 	It("can deploy Wordpress", func() {

--- a/acceptance/apps_env_test.go
+++ b/acceptance/apps_env_test.go
@@ -34,6 +34,10 @@ var _ = Describe("apps env", func() {
 		appName = catalog.NewAppName()
 	})
 
+	AfterEach(func() {
+		env.DeleteNamespace(namespace)
+	})
+
 	Describe("app without workload", func() {
 		BeforeEach(func() {
 			out, err := env.Epinio("", "apps", "create", appName)

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -824,9 +824,11 @@ configuration:
 		AfterEach(func() {
 			env.TargetNamespace(namespace2)
 			env.DeleteApp(app2)
+			env.DeleteNamespace(namespace2)
 
 			env.TargetNamespace(namespace1)
 			env.DeleteApp(app1)
+			env.DeleteNamespace(namespace1)
 		})
 
 		It("lists all applications belonging to all namespaces", func() {

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -40,6 +40,10 @@ var _ = Describe("Apps", func() {
 		appName = catalog.NewAppName()
 	})
 
+	AfterEach(func() {
+		env.DeleteNamespace(namespace)
+	})
+
 	When("creating an application without a workload", func() {
 		AfterEach(func() {
 			// MakeApp... by each test (It)

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -636,7 +636,6 @@ configuration:
 			By("deleting the app")
 			out, err := env.Epinio("", "app", "delete", appName)
 			Expect(err).ToNot(HaveOccurred(), out)
-			// TODO: Fix `epinio delete` from returning before the app is deleted #131
 
 			Expect(out).To(MatchRegexp("UNBOUND CONFIGURATIONS"))
 			Expect(out).To(MatchRegexp(configurationName))

--- a/acceptance/bindings_test.go
+++ b/acceptance/bindings_test.go
@@ -15,6 +15,11 @@ var _ = Describe("Bounds between Apps & Configurations", func() {
 		namespace = catalog.NewNamespaceName()
 		env.SetupAndTargetNamespace(namespace)
 	})
+
+	AfterEach(func() {
+		env.DeleteNamespace(namespace)
+	})
+
 	Describe("Display", func() {
 		var appName string
 		var configurationName string

--- a/acceptance/configurations_test.go
+++ b/acceptance/configurations_test.go
@@ -22,6 +22,10 @@ var _ = Describe("Configurations", func() {
 		env.SetupAndTargetNamespace(namespace)
 	})
 
+	AfterEach(func() {
+		env.DeleteNamespace(namespace)
+	})
+
 	Describe("configuration list", func() {
 		BeforeEach(func() {
 			env.MakeConfiguration(configurationName1)
@@ -78,6 +82,9 @@ var _ = Describe("Configurations", func() {
 			env.TargetNamespace(namespace1)
 			env.DeleteApp(app1)
 			env.DeleteConfiguration(configuration1)
+
+			env.DeleteNamespace(namespace1)
+			env.DeleteNamespace(namespace2)
 		})
 
 		It("lists all configurations belonging to all namespaces", func() {
@@ -253,6 +260,7 @@ var _ = Describe("Configurations", func() {
 			env.TargetNamespace(namespace)
 			env.DeleteApp(appName)
 			env.CleanupConfiguration(configurationName1)
+			env.DeleteNamespace(namespace)
 		})
 	})
 })

--- a/acceptance/configurations_test.go
+++ b/acceptance/configurations_test.go
@@ -260,7 +260,6 @@ var _ = Describe("Configurations", func() {
 			env.TargetNamespace(namespace)
 			env.DeleteApp(appName)
 			env.CleanupConfiguration(configurationName1)
-			env.DeleteNamespace(namespace)
 		})
 	})
 })

--- a/acceptance/helpers/machine/apps.go
+++ b/acceptance/helpers/machine/apps.go
@@ -103,7 +103,6 @@ func (m *Machine) MakeAppWithDirSimple(appName string, deployFromCurrentDir bool
 func (m *Machine) DeleteApp(appName string) {
 	out, err := m.Epinio("", "app", "delete", appName)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)
-	// TODO: Fix `epinio delete` from returning before the app is deleted #131
 
 	EventuallyWithOffset(1, func() string {
 		out, err := m.Epinio("", "app", "list")
@@ -114,8 +113,6 @@ func (m *Machine) DeleteApp(appName string) {
 
 func (m *Machine) CleanupApp(appName string) {
 	out, err := m.Epinio("", "app", "delete", appName)
-	// TODO: Fix `epinio delete` from returning before the app is deleted #131
-
 	if err != nil {
 		fmt.Printf("deleting app failed : %s\n%s", err.Error(), out)
 	}

--- a/acceptance/namespaces_test.go
+++ b/acceptance/namespaces_test.go
@@ -17,8 +17,14 @@ var _ = Describe("Namespaces", func() {
 	})
 
 	Describe("namespace create", func() {
+		var namespaceName string
+
+		AfterEach(func() {
+			env.DeleteNamespace(namespaceName)
+		})
+
 		It("creates and targets an namespace", func() {
-			namespaceName := catalog.NewNamespaceName()
+			namespaceName = catalog.NewNamespaceName()
 			env.SetupAndTargetNamespace(namespaceName)
 
 			By("switching namespace back to default")
@@ -27,7 +33,7 @@ var _ = Describe("Namespaces", func() {
 		})
 
 		It("rejects creating an existing namespace", func() {
-			namespaceName := catalog.NewNamespaceName()
+			namespaceName = catalog.NewNamespaceName()
 			env.SetupAndTargetNamespace(namespaceName)
 
 			out, err := env.Epinio("", "namespace", "create", namespaceName)

--- a/acceptance/namespaces_test.go
+++ b/acceptance/namespaces_test.go
@@ -55,6 +55,10 @@ var _ = Describe("Namespaces", func() {
 			Expect(out).To(MatchRegexp("Ok"))
 		})
 
+		AfterEach(func() {
+			env.DeleteNamespace(namespaceName)
+		})
+
 		It("lists namespaces", func() {
 			out, err := env.Epinio("", "namespace", "list", namespaceName)
 
@@ -87,6 +91,10 @@ var _ = Describe("Namespaces", func() {
 				out, err := env.Epinio("", "app", "create", appName)
 				Expect(err).ToNot(HaveOccurred(), out)
 				Expect(out).To(MatchRegexp("Ok"))
+			})
+
+			AfterEach(func() {
+				env.DeleteNamespace(namespaceName)
 			})
 
 			It("shows a namespace", func() {

--- a/acceptance/namespaces_test.go
+++ b/acceptance/namespaces_test.go
@@ -19,12 +19,15 @@ var _ = Describe("Namespaces", func() {
 	Describe("namespace create", func() {
 		var namespaceName string
 
+		BeforeEach(func() {
+			namespaceName = catalog.NewNamespaceName()
+		})
+
 		AfterEach(func() {
 			env.DeleteNamespace(namespaceName)
 		})
 
 		It("creates and targets an namespace", func() {
-			namespaceName = catalog.NewNamespaceName()
 			env.SetupAndTargetNamespace(namespaceName)
 
 			By("switching namespace back to default")
@@ -33,7 +36,6 @@ var _ = Describe("Namespaces", func() {
 		})
 
 		It("rejects creating an existing namespace", func() {
-			namespaceName = catalog.NewNamespaceName()
 			env.SetupAndTargetNamespace(namespaceName)
 
 			out, err := env.Epinio("", "namespace", "create", namespaceName)


### PR DESCRIPTION
Running the tests more than once would leave some namespaces in the cluster (also making some tests with hardcoded namespaces failing).

Fix