### PR TITLE
Update action runner setup

### DIFF
--- a/scripts/remove-github-action-runner.sh
+++ b/scripts/remove-github-action-runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script can be used to remove a Github Action Runner on an openSUSE or SLE
-# distro. It will unconfigure the configuration and unregister the runner.
+# distro. It will unconfigure the service and unregister the runner.
 # Copy the script to runner:/home/<user> and run it as <user>.
 # It requires GITHUB_REPOSITORY_URL (https) and GITHUB_RUNNER_TOKEN to be set
 # e.g. export GITHUB_REPOSITORY_URL=https://github.com/epinio/epinio
@@ -17,7 +17,7 @@ if [ -z "$GITHUB_REPOSITORY_URL" ] || [ -z "$GITHUB_RUNNER_TOKEN" ]; then
 fi
 
 REPOSITORY_NAME=$(echo "$GITHUB_REPOSITORY_URL" | cut -d '/' -f 4- | sed -e 's|/$||' -e 's|/|-|g')
-ACTIONS_RUNNER_SERVICE=actions.runner."$REPOSITORY_NAME".`hostname`.configuration
+ACTIONS_RUNNER_SERVICE=actions.runner."$REPOSITORY_NAME".`hostname`.service
 
 cd actions-runner
 sudo systemctl stop "$ACTIONS_RUNNER_SERVICE"

--- a/scripts/setup-github-action-runner.sh
+++ b/scripts/setup-github-action-runner.sh
@@ -2,7 +2,7 @@
 
 # This script can be used to create a Github Action Runner on an openSUSE or SLE
 # distro. It installs all the needed dependencies to run the acceptance tests
-# and sets up docker and the runner as a configuration itself.
+# and sets up docker and the runner as a service itself.
 # Copy the script to runner:/home/<user> and run it as <user>.
 # It requires GITHUB_REPOSITORY_URL (https) and GITHUB_RUNNER_TOKEN to be set
 # e.g. export GITHUB_REPOSITORY_URL=https://github.com/epinio/epinio
@@ -18,7 +18,7 @@ if [ -z "$GITHUB_REPOSITORY_URL" ] || [ -z "$GITHUB_RUNNER_TOKEN" ]; then
 fi
 
 REPOSITORY_NAME=$(echo "$GITHUB_REPOSITORY_URL" | cut -d '/' -f 4- | sed -e 's|/$||' -e 's|/|-|g')
-ACTIONS_RUNNER_SERVICE=actions.runner."$REPOSITORY_NAME".`hostname`.configuration
+ACTIONS_RUNNER_SERVICE=actions.runner."$REPOSITORY_NAME".`hostname`.service
 
 # Install needed packages
 rpms="make gcc docker libicu wget fping"
@@ -28,7 +28,7 @@ grep SLES /etc/os-release \
   || rpms+=" git"
 sudo ZYPP_LOCK_TIMEOUT=300 zypper --non-interactive in -y $rpms
 
-# Enable docker configuration
+# Enable docker service
 sudo systemctl enable docker
 sudo systemctl start docker
 
@@ -49,10 +49,10 @@ tar xzf ./actions-runner-linux-x64-2.278.0.tar.gz
 sed -i 's/Runner.Listener configure/Runner.Listener configure --unattended/' config.sh
 ./config.sh --url "$GITHUB_REPOSITORY_URL" --token "$GITHUB_RUNNER_TOKEN"
 
-# Configure and enable Configuration
+# Configure and enable service
 sudo ./svc.sh install
-sudo sed -i '/^\[Configuration\]/a RestartSec=5s' /etc/systemd/system/"$ACTIONS_RUNNER_SERVICE"
-sudo sed -i '/^\[Configuration\]/a Restart=always' /etc/systemd/system/"$ACTIONS_RUNNER_SERVICE"
+sudo sed -i '/^\[Service\]/a RestartSec=5s' /etc/systemd/system/"$ACTIONS_RUNNER_SERVICE"
+sudo sed -i '/^\[Service\]/a Restart=always' /etc/systemd/system/"$ACTIONS_RUNNER_SERVICE"
 sudo systemctl daemon-reload
 sudo systemctl enable "$ACTIONS_RUNNER_SERVICE"
 sudo systemctl start "$ACTIONS_RUNNER_SERVICE"

--- a/scripts/setup-github-action-runner.sh
+++ b/scripts/setup-github-action-runner.sh
@@ -42,8 +42,8 @@ sudo mv kubectl /usr/bin
 
 # Setup github worker
 mkdir -p actions-runner && cd actions-runner
-curl -o actions-runner-linux-x64-2.278.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.278.0/actions-runner-linux-x64-2.278.0.tar.gz
-tar xzf ./actions-runner-linux-x64-2.278.0.tar.gz
+curl -o actions-runner-linux-x64-2.288.1.tar.gz -L https://github.com/actions/runner/releases/download/v2.288.1/actions-runner-linux-x64-2.288.1.tar.gz
+tar xzf ./actions-runner-linux-x64-2.288.1.tar.gz
 
 # Make non-interactive
 sed -i 's/Runner.Listener configure/Runner.Listener configure --unattended/' config.sh

--- a/scripts/setup-github-action-runner.sh
+++ b/scripts/setup-github-action-runner.sh
@@ -21,7 +21,7 @@ REPOSITORY_NAME=$(echo "$GITHUB_REPOSITORY_URL" | cut -d '/' -f 4- | sed -e 's|/
 ACTIONS_RUNNER_SERVICE=actions.runner."$REPOSITORY_NAME".`hostname`.service
 
 # Install needed packages
-rpms="make gcc docker libicu wget fping"
+rpms="make gcc docker libicu wget fping unzip jq"
 sudo ZYPP_LOCK_TIMEOUT=300 zypper --gpg-auto-import-keys ref
 grep SLES /etc/os-release \
   && rpms+=" git-core"    \

--- a/scripts/setup-github-action-runner.sh
+++ b/scripts/setup-github-action-runner.sh
@@ -9,12 +9,20 @@
 # and  export GITHUB_RUNNER_TOKEN=<current token from github settings/actions/runners/new>
 # Note: You can use the same token to add or remove multiple runners,
 #       while it will expire after 1h.
+# Optional export GITHUB_RUNNER_LABELS=<label1,label2> to automatically make the
+# actions runner join/add "Labels"
 
 set -e
 
 if [ -z "$GITHUB_REPOSITORY_URL" ] || [ -z "$GITHUB_RUNNER_TOKEN" ]; then
   echo "Script requires GITHUB_REPOSITORY_URL and GITHUB_RUNNER_TOKEN to be set. Exiting"
   exit 1
+fi
+
+if [ -z "$GITHUB_RUNNER_LABELS" ]; then
+  unset GITHUB_RUNNER_LABELS
+ else
+  runner_labels="--labels $GITHUB_RUNNER_LABELS"
 fi
 
 REPOSITORY_NAME=$(echo "$GITHUB_REPOSITORY_URL" | cut -d '/' -f 4- | sed -e 's|/$||' -e 's|/|-|g')
@@ -47,7 +55,7 @@ tar xzf ./actions-runner-linux-x64-2.288.1.tar.gz
 
 # Make non-interactive
 sed -i 's/Runner.Listener configure/Runner.Listener configure --unattended/' config.sh
-./config.sh --url "$GITHUB_REPOSITORY_URL" --token "$GITHUB_RUNNER_TOKEN"
+./config.sh --url "$GITHUB_REPOSITORY_URL" --token "$GITHUB_RUNNER_TOKEN" $runner_labels
 
 # Configure and enable service
 sudo ./svc.sh install


### PR DESCRIPTION
Also reverts collateral damage from https://github.com/epinio/epinio/commit/bcc219f91253e4021846dcd25fbe8c5997f69798 (service->configuration), but just for setup-github-action-runner.sh and remove-github-action-runner.sh.