### PR TITLE
Fix for env variable.

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -74,7 +74,9 @@ var _ = Describe("Apps", func() {
 					"--bind", configurationName,
 					"--instances", "2",
 					"--env", "CREDO=up",
-					"--env", "DOGMA=no")
+					"--env", "DOGMA=no",
+					"--env", "COMPLEX=-X foo=bar",
+				)
 				Expect(err).ToNot(HaveOccurred(), out)
 				Expect(out).To(MatchRegexp("Ok"))
 
@@ -84,6 +86,7 @@ var _ = Describe("Apps", func() {
 				Expect(out).To(MatchRegexp(`Configurations\s*\|\s*` + configurationName + `\s*\|`))
 				Expect(out).To(MatchRegexp(`- CREDO\s*\|\s*up\s*\|`))
 				Expect(out).To(MatchRegexp(`- DOGMA\s*\|\s*no\s*\|`))
+				Expect(out).To(MatchRegexp(`- COMPLEX\s*\|\s*-X foo=bar\s*\|`))
 			})
 
 			Context("manifest", func() {

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -91,7 +91,7 @@ var CmdAppCreate = &cobra.Command{
 			return errors.Wrap(err, "error initializing cli")
 		}
 
-		m, err := manifest.UpdateISE(models.ApplicationManifest{}, cmd)
+		m, err := manifest.UpdateICE(models.ApplicationManifest{}, cmd)
 		if err != nil {
 			return errors.Wrap(err, "unable to get app configuration")
 		}
@@ -236,7 +236,7 @@ var CmdAppUpdate = &cobra.Command{
 			return errors.Wrap(err, "error initializing cli")
 		}
 
-		m, err := manifest.UpdateISE(models.ApplicationManifest{}, cmd)
+		m, err := manifest.UpdateICE(models.ApplicationManifest{}, cmd)
 		if err != nil {
 			return errors.Wrap(err, "unable to get app configuration")
 		}

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -62,7 +62,7 @@ var CmdAppPush = &cobra.Command{
 			return errors.Wrap(err, "Manifest error")
 		}
 
-		m, err = manifest.UpdateISE(m, cmd)
+		m, err = manifest.UpdateICE(m, cmd)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR fix a bug occuring during the parsing of the env variables

```bash
-> % epinio app create --env "BP_GO_BUILD_LDFLAGS=-X main.Version=myVersion" -- samplego
unable to get app configuration: Bad --env assignment `BP_GO_BUILD_LDFLAGS=-X main.Version=myVersion`, expected `name=value` as value
```

There was a check that an env option should be splitted in exactly two, divided by a `=` sign.
This was failing trying to set a variable like this `VAR=foo=bar`, it was not possible to set the value of `foo=bar` to `VAR`.

```golang
environment := models.EnvVariableMap{}
for _, assignment := range evAssignments {
	pieces := strings.Split(assignment, "=")
	if len(pieces) != 2 {
		return manifest, errors.New("Bad --env assignment `" + assignment + "`, expected `name=value` as value")
	}
	environment[pieces[0]] = pieces[1]
}
```

Moved the `strings.Split` to a `strings.SplitN(s, sep, 2)` so we can split at most at two values.

```golang
environment := models.EnvVariableMap{}
for _, assignment := range evAssignments {
	pieces := strings.SplitN(assignment, "=", 2)
	if len(pieces) < 2 {
		return manifest, errors.New("Bad --env assignment `" + assignment + "`, expected `name=value` as value")
	}
	environment[pieces[0]] = pieces[1]
}
```

I've also renamed the `UpdateISE` to `UpdateICE`, and refactored the `UpdateICE` and the `UpdateBSN` splitting the three logic in different functions.

### note
I don't feel that we should pass the cobra.Command, the `manifest` package should probably just perform logic on the manifest and should not be aware of where the values are coming from, but I didn't want to change too many things.

I'm available to move that logic though. :)