### PR TITLE
Pin `mc` (Minio CLI) version

### DIFF
--- a/acceptance/api/v1/helpers_test.go
+++ b/acceptance/api/v1/helpers_test.go
@@ -159,7 +159,8 @@ func createS3HelperPod() {
 	Expect(err).ToNot(HaveOccurred(), string(out))
 
 	// Start the pod
-	out, err = proc.Kubectl("run", minioHelperPod, "--image=minio/mc", "--command", "--", "/bin/bash", "-c", "trap : TERM INT; sleep infinity & wait")
+	// FIX: pinning the minio CLI while waiting for this fix https://github.com/minio/mc/issues/4024
+	out, err = proc.Kubectl("run", minioHelperPod, "--image=minio/mc:RELEASE.2022-03-13T22-34-00Z", "--command", "--", "/bin/bash", "-c", "trap : TERM INT; sleep infinity & wait")
 	Expect(err).ToNot(HaveOccurred(), out)
 
 	// Wait until the pod is ready


### PR DESCRIPTION
Some of our builds started failing:
https://github.com/epinio/epinio/runs/5584091131?check_suite_focus=true#step:9:205

It seems that the new `mc` version released today is not working with the `--insecure` flag, so this PR pins the version to the previous one, while we are waiting for some updates from this issue:
- https://github.com/minio/mc/issues/4024