### PR TITLE
Goreleaser homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,15 @@ jobs:
           repository: epinio/helm-charts
           event-type: epinio-release
           client-payload: '{"ref": "${{ steps.get_tag.outputs.TAG }}"}'
+
+      - name: Bump Homebrew formula
+        uses: mislav/bump-homebrew-formula-action@v1
+        if: "!contains(github.ref, '-')" # skip prereleases
+        with:
+          download-url: https://github.com/epinio/epinio/archive/refs/tags/${{ steps.get_tag.outputs.TAG }}.tar.gz
+          commit-message: |
+            {{formulaName}} {{version}}
+
+            Created by https://github.com/mislav/bump-homebrew-formula-action
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,3 +89,29 @@ dockers:
     # This field does not support wildcards, you can add an entire folder here
     # and use wildcards when you `COPY`/`ADD` in your Dockerfile.
     extra_files: []
+
+brews:
+  - name: epinio
+    description: "CLI for Epinio, the Application Development Engine for Kubernetes"
+    homepage: "https://epinio.io/"
+    license: "Apache-2.0"
+
+    tap:
+      owner: epinio
+      name: homebrew-tap
+
+    folder: Formula
+    url_template: "https://github.com/epinio/epinio/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+
+    # If set to auto, the release will not be uploaded to the homebrew tap
+    # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
+    # Default is false.
+    skip_upload: "auto"
+
+    test: |
+      output = shell_output("#{bin}/epinio version 2>&1")
+      assert_match "Epinio Version: #{version}", output
+
+      output = shell_output("#{bin}/epinio settings update 2>&1")
+      assert_match "failed to get kube config", output
+      assert_match "no configuration has been provided", output


### PR DESCRIPTION
This PR adds the automation needed to bump the Homebrew formulas for `epinio`.

According to the [Goreleaser documentation](https://goreleaser.com/customization/homebrew/?h=homebrew) it cannot create a Formula in the official homebrew repo:

> Note that GoReleaser does not generate a valid homebrew-core formula. The generated formulas are meant to be published as [homebrew taps](https://docs.brew.sh/Taps.html), and in their current form will not be accepted in any of the official homebrew repositories.

so the release will update our new Tap repo: https://github.com/epinio/homebrew-tap

In order to install `epinio` with the latest version the users should install it using the full path

```
brew install epinio/tap/epinio
```

To update also the Formula in the https://github.com/Homebrew/homebrew-core I've added this [bump-homebrew-formula](https://github.com/marketplace/actions/bump-homebrew-formula) Github action.
It will use a `COMMITTER_TOKEN` secret to create a fork and open a PR against it.

After the merge the users will be able to fetch the latest `epinio` also from the core repo with

```
brew install epinio
```