### PR TITLE
Add Multi-Arch Image for Epinio Server

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,11 +6,13 @@ on:
     paths-ignore:
     - 'docs/**'
     - 'README.md'
+    - '.goreleaser.yml'
   pull_request:
     branches: [ main ]
     paths-ignore:
     - 'docs/**'
     - 'README.md'
+    - '.goreleaser.yml'
   # nightly
   schedule:
     - cron:  '0 0 * * *'

--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           go-version: '1.17'
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           go-version: '1.17'
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,21 +22,24 @@ builds:
       - -w -s
       - -X "github.com/epinio/epinio/internal/version.Version={{ .Tag }}"
     goos:
-      - linux
       - darwin
+      - linux
       - windows
     goarch:
       - amd64
       - arm64
       - arm
+      - s390x
     goarm:
       - "7"
-    ignore:
-    - goos: windows
-      goarch: arm
-      goarm: "7"
-    - goos: windows
-      goarch: arm64
+    targets:
+    - darwin_amd64
+    - darwin_arm64
+    - linux_amd64
+    - linux_arm64
+    - linux_arm_7
+    - linux_s390x
+    - windows_amd64
 
 changelog:
   ## Delegate Changelog to release-drafter
@@ -130,6 +133,24 @@ dockers:
     - "--label=org.opencontainers.image.source=https://github.com/epinio/epinio"
     - "--build-arg=DIST_BINARY=epinio"
     - "--platform=linux/arm/v7"
+  -
+    use: buildx
+    goos: linux
+    goarch: s390x
+    ids:
+    - epinio
+    image_templates:
+    - "ghcr.io/epinio/epinio-server:{{ .Tag }}-s390x"
+    dockerfile: images/Dockerfile
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/epinio/epinio"
+    - "--build-arg=DIST_BINARY=epinio"
+    - "--platform=linux/s390x"
 docker_manifests:
   # https://goreleaser.com/customization/docker_manifest/
   -
@@ -138,12 +159,14 @@ docker_manifests:
     - "ghcr.io/epinio/epinio-server:{{ .Tag }}-amd64"
     - "ghcr.io/epinio/epinio-server:{{ .Tag }}-arm64v8"
     - "ghcr.io/epinio/epinio-server:{{ .Tag }}-armv7"
+    - "ghcr.io/epinio/epinio-server:{{ .Tag }}-s390x"
   -
     name_template: "ghcr.io/epinio/epinio-server:latest"
     image_templates:
     - "ghcr.io/epinio/epinio-server:{{ .Tag }}-amd64"
     - "ghcr.io/epinio/epinio-server:{{ .Tag }}-arm64v8"
     - "ghcr.io/epinio/epinio-server:{{ .Tag }}-armv7"
+    - "ghcr.io/epinio/epinio-server:{{ .Tag }}-s390x"
 
 brews:
   - name: epinio

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,15 @@ builds:
     goarch:
       - amd64
       - arm64
-      # - arm
+      - arm
+    goarm:
+      - "7"
+    ignore:
+    - goos: windows
+      goarch: arm
+      goarm: "7"
+    - goos: windows
+      goarch: arm64
 
 changelog:
   ## Delegate Changelog to release-drafter
@@ -42,8 +50,7 @@ snapshot:
 
 dockers:
   -
-    # ID of the image, needed if you want to filter by it later on (e.g. on custom publishers).
-    id: epinio
+    use: buildx
 
     # GOOS of the built binaries/packages that should be used.
     goos: linux
@@ -57,16 +64,13 @@ dockers:
 
     # Templates of the Docker image names.
     image_templates:
-    - "ghcr.io/epinio/epinio-server:{{ .Tag }}"
-    - "ghcr.io/epinio/epinio-server:latest"
+    - "ghcr.io/epinio/epinio-server:{{ .Tag }}-amd64"
 
     # Skips the docker push.
     #skip_push: "true"
 
     # Path to the Dockerfile (from the project root).
     dockerfile: images/Dockerfile
-
-    use: docker
 
     # Template of the docker build flags.
     build_flag_templates:
@@ -89,6 +93,57 @@ dockers:
     # This field does not support wildcards, you can add an entire folder here
     # and use wildcards when you `COPY`/`ADD` in your Dockerfile.
     extra_files: []
+  -
+    use: buildx
+    goos: linux
+    goarch: arm64
+    ids:
+    - epinio
+    image_templates:
+    - "ghcr.io/epinio/epinio-server:{{ .Tag }}-arm64v8"
+    dockerfile: images/Dockerfile
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/epinio/epinio"
+    - "--build-arg=DIST_BINARY=epinio"
+    - "--platform=linux/arm64/v8"
+  -
+    use: buildx
+    goos: linux
+    goarch: arm
+    goarm: "7"
+    ids:
+    - epinio
+    image_templates:
+    - "ghcr.io/epinio/epinio-server:{{ .Tag }}-armv7"
+    dockerfile: images/Dockerfile
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/epinio/epinio"
+    - "--build-arg=DIST_BINARY=epinio"
+    - "--platform=linux/arm/v7"
+docker_manifests:
+  # https://goreleaser.com/customization/docker_manifest/
+  -
+    name_template: "ghcr.io/epinio/epinio-server:{{ .Tag }}"
+    image_templates:
+    - "ghcr.io/epinio/epinio-server:{{ .Tag }}-amd64"
+    - "ghcr.io/epinio/epinio-server:{{ .Tag }}-arm64v8"
+    - "ghcr.io/epinio/epinio-server:{{ .Tag }}-armv7"
+  -
+    name_template: "ghcr.io/epinio/epinio-server:latest"
+    image_templates:
+    - "ghcr.io/epinio/epinio-server:{{ .Tag }}-amd64"
+    - "ghcr.io/epinio/epinio-server:{{ .Tag }}-arm64v8"
+    - "ghcr.io/epinio/epinio-server:{{ .Tag }}-armv7"
 
 brews:
   - name: epinio


### PR DESCRIPTION
fixes #1307 

Tested with `goreleaser --rm-dist --skip-validate --skip-publish`. 

Unclear if it builds the manifest:       `• pipe skipped              error=publishing is disabled`.
Probably need a release to test this.