### PR TITLE
Get Staging Support Image References From Kube/Chart

### DIFF
--- a/helpers/kubernetes/cluster.go
+++ b/helpers/kubernetes/cluster.go
@@ -604,6 +604,11 @@ func (c *Cluster) Exec(namespace, podName, containerName string, command, stdin 
 	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
 }
 
+// GetConfigMap gets a configmap's values
+func (c *Cluster) GetConfigMap(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
+	return c.Kubectl.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
 // GetSecret gets a secret's values
 func (c *Cluster) GetSecret(ctx context.Context, namespace, name string) (*v1.Secret, error) {
 	return c.Kubectl.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	separator      = ","
-	DefaultBuilder = "paketobuildpacks/builder:full"
+	separator = ","
 )
 
 // UpdateRoutes updates the incoming manifest with information pulled from the --route option.
@@ -289,12 +288,11 @@ func Get(manifestPath string) (models.ApplicationManifest, error) {
 	}
 
 	// Base manifest, defaults
+	// Note: Builder defaults to empty string - Insertion of Default builder happens server side.
 	manifest := models.ApplicationManifest{
-		Self:   "<<Defaults>>",
-		Origin: defaultOrigin,
-		Staging: models.ApplicationStage{
-			Builder: DefaultBuilder,
-		},
+		Self:    "<<Defaults>>",
+		Origin:  defaultOrigin,
+		Staging: models.ApplicationStage{},
 	}
 
 	if !manifestExists {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -36,9 +36,7 @@ var _ = Describe("Manifest", func() {
 						Path:      workdir,
 						Container: "",
 					},
-					Staging: models.ApplicationStage{
-						Builder: manifest.DefaultBuilder,
-					},
+					Staging: models.ApplicationStage{},
 				}))
 			})
 		})


### PR DESCRIPTION
Fix #1305 

Read staging image references (paketo, awscli, bash) from kube resources.
See chart PR https://github.com/epinio/helm-charts/pull/148 for the change supplying the information to the resources.
