### PR TITLE
Epinio Services (`catalog` and `create`)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alron/ginlogr v0.0.4
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/briandowns/spinner v1.18.1
-	github.com/epinio/application v0.0.0-20220308140057-3b0ed244957d
+	github.com/epinio/application v0.0.0-20220325110741-df94c040adab
 	github.com/fatih/color v1.13.0
 	github.com/gin-contrib/sessions v0.0.4
 	github.com/gin-gonic/gin v1.7.7
@@ -106,6 +106,7 @@ require (
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.0.1 // indirect
@@ -202,6 +203,7 @@ require (
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65 // indirect
 	golang.org/x/tools v0.1.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220310185008-1973136f34c6 // indirect
 	google.golang.org/grpc v1.45.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alron/ginlogr v0.0.4
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/briandowns/spinner v1.18.1
-	github.com/epinio/application v0.0.0-20220325110741-df94c040adab
+	github.com/epinio/application v0.0.0-20220328090252-fc0334eab014
 	github.com/fatih/color v1.13.0
 	github.com/gin-contrib/sessions v0.0.4
 	github.com/gin-gonic/gin v1.7.7

--- a/go.sum
+++ b/go.sum
@@ -492,6 +492,8 @@ github.com/epinio/application v0.0.0-20220223154321-90d2de33fc7e h1:mZfhH4rmhNYO
 github.com/epinio/application v0.0.0-20220223154321-90d2de33fc7e/go.mod h1:TsOLExnVfT4RDqLnOv6UHQ6ri26dDNG8RkQTyVqCU14=
 github.com/epinio/application v0.0.0-20220308140057-3b0ed244957d h1:TIyS0/NqqcggObt1vnH1FphjCC6jY0cY5qGwFa6AYfw=
 github.com/epinio/application v0.0.0-20220308140057-3b0ed244957d/go.mod h1:TsOLExnVfT4RDqLnOv6UHQ6ri26dDNG8RkQTyVqCU14=
+github.com/epinio/application v0.0.0-20220325110741-df94c040adab h1:8zKnYh5uFVE4cMEE/Ua7i9TdOtvP7vn8JQ3gESHKH1w=
+github.com/epinio/application v0.0.0-20220325110741-df94c040adab/go.mod h1:TsOLExnVfT4RDqLnOv6UHQ6ri26dDNG8RkQTyVqCU14=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -1922,6 +1924,7 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gomodules.xyz/jsonpatch/v2 v2.2.0 h1:4pT439QV83L+G9FkcCriY6EkpcK6r6bK+A5FBUMI7qY=
 gomodules.xyz/jsonpatch/v2 v2.2.0/go.mod h1:WXp+iVDkoLQqPudfQ9GBlwB2eZ5DKOnjQZCYdOS8GPY=
 google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/go.sum
+++ b/go.sum
@@ -494,6 +494,8 @@ github.com/epinio/application v0.0.0-20220308140057-3b0ed244957d h1:TIyS0/Nqqcgg
 github.com/epinio/application v0.0.0-20220308140057-3b0ed244957d/go.mod h1:TsOLExnVfT4RDqLnOv6UHQ6ri26dDNG8RkQTyVqCU14=
 github.com/epinio/application v0.0.0-20220325110741-df94c040adab h1:8zKnYh5uFVE4cMEE/Ua7i9TdOtvP7vn8JQ3gESHKH1w=
 github.com/epinio/application v0.0.0-20220325110741-df94c040adab/go.mod h1:TsOLExnVfT4RDqLnOv6UHQ6ri26dDNG8RkQTyVqCU14=
+github.com/epinio/application v0.0.0-20220328090252-fc0334eab014 h1:MO+wmwXRwfwRia/hZumHPqj7E1kIhmnGpNfNMLHs7/Q=
+github.com/epinio/application v0.0.0-20220328090252-fc0334eab014/go.mod h1:TsOLExnVfT4RDqLnOv6UHQ6ri26dDNG8RkQTyVqCU14=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/internal/api/v1/configurationbinding/create.go
+++ b/internal/api/v1/configurationbinding/create.go
@@ -91,7 +91,14 @@ func (hc Controller) Create(c *gin.Context) apierror.APIErrors {
 			continue
 		}
 
-		_, err := configurations.Lookup(ctx, cluster, namespace, configurationName)
+		// TODO we can do this in a better way?
+		err := configurations.LabelConfigurationSecrets(ctx, cluster, namespace, configurationName)
+		if err != nil {
+			theIssues = append([]apierror.APIError{apierror.InternalError(err)}, theIssues...)
+			continue
+		}
+
+		_, err = configurations.Lookup(ctx, cluster, namespace, configurationName)
 		if err != nil {
 			if err.Error() == "configuration not found" {
 				theIssues = append(theIssues, apierror.ConfigurationIsNotKnown(configurationName))

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -129,6 +129,7 @@ var Routes = routes.NamedRoutes{
 	// Services
 	"ServiceCatalog":     get("/services", errorHandler(service.Controller{}.Catalog)),
 	"ServiceCatalogShow": get("/services/:servicename", errorHandler(service.Controller{}.CatalogShow)),
+	"ServiceCreate":      post("/namespaces/:namespace/services", errorHandler(service.Controller{}.Create)),
 }
 
 var WsRoutes = routes.NamedRoutes{

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -15,6 +15,7 @@ import (
 	"github.com/epinio/epinio/internal/api/v1/env"
 	"github.com/epinio/epinio/internal/api/v1/namespace"
 	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/api/v1/service"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/pkg/api/core/v1/errors"
 )
@@ -124,6 +125,10 @@ var Routes = routes.NamedRoutes{
 	"ConfigurationDelete":  delete("/namespaces/:namespace/configurations/:configuration", errorHandler(configuration.Controller{}.Delete)),
 	"ConfigurationUpdate":  patch("/namespaces/:namespace/configurations/:configuration", errorHandler(configuration.Controller{}.Update)),
 	"ConfigurationReplace": put("/namespaces/:namespace/configurations/:configuration", errorHandler(configuration.Controller{}.Replace)),
+
+	// Services
+	"ServiceCatalog":     get("/services", errorHandler(service.Controller{}.Catalog)),
+	"ServiceCatalogShow": get("/services/:servicename", errorHandler(service.Controller{}.CatalogShow)),
 }
 
 var WsRoutes = routes.NamedRoutes{

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -130,6 +130,12 @@ var Routes = routes.NamedRoutes{
 	"ServiceCatalog":     get("/services", errorHandler(service.Controller{}.Catalog)),
 	"ServiceCatalogShow": get("/services/:servicename", errorHandler(service.Controller{}.CatalogShow)),
 	"ServiceCreate":      post("/namespaces/:namespace/services", errorHandler(service.Controller{}.Create)),
+
+	// Bind a service release to/from applications
+	"ServiceReleaseBindingCreate": post(
+		"/namespaces/:namespace/servicereleases/:servicereleasename/configurationbindings",
+		errorHandler(service.Controller{}.Bind),
+	),
 }
 
 var WsRoutes = routes.NamedRoutes{

--- a/internal/api/v1/service/catalog.go
+++ b/internal/api/v1/service/catalog.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/services"
+	"github.com/gin-gonic/gin"
+
+	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+)
+
+func (ctr Controller) Catalog(c *gin.Context) apierror.APIErrors {
+	ctx := c.Request.Context()
+
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	kubeServiceClient, err := services.NewKubernetesServiceClient(cluster)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	serviceList, err := kubeServiceClient.List(ctx)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	response.OKReturn(c, models.ServiceCatalogResponse{
+		Services: serviceList,
+	})
+	return nil
+}
+
+func (ctr Controller) CatalogShow(c *gin.Context) apierror.APIErrors {
+	ctx := c.Request.Context()
+	serviceName := c.Param("servicename")
+
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	kubeServiceClient, err := services.NewKubernetesServiceClient(cluster)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	service, err := kubeServiceClient.Get(ctx, serviceName)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	response.OKReturn(c, models.ServiceCatalogShowResponse{
+		Service: service,
+	})
+	return nil
+}

--- a/internal/api/v1/service/controller.go
+++ b/internal/api/v1/service/controller.go
@@ -1,0 +1,4 @@
+package service
+
+// Controller represents all functionality of the API related to services
+type Controller struct{}

--- a/internal/api/v1/service/releases.go
+++ b/internal/api/v1/service/releases.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/internal/api/v1/configurationbinding"
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/internal/configurations"
+	"github.com/gin-gonic/gin"
+
+	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+
+	helmrelease "helm.sh/helm/v3/pkg/release"
+)
+
+func (ctr Controller) Bind(c *gin.Context) apierror.APIErrors {
+	ctx := c.Request.Context()
+	namespace := c.Param("namespace")
+	serviceReleaseName := c.Param("servicereleasename")
+
+	var bindRequest models.ServiceReleaseBindRequest
+	err := c.BindJSON(&bindRequest)
+	if err != nil {
+		return apierror.BadRequest(err)
+	}
+
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	app, err := application.Lookup(ctx, cluster, namespace, bindRequest.AppName)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+	if app == nil {
+		return apierror.AppIsNotKnown(bindRequest.AppName)
+	}
+
+	client, err := getHelmClient(cluster.RestConfig, namespace)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	release, err := client.GetRelease(serviceReleaseName)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	if release.Info.Status != helmrelease.StatusDeployed {
+		return apierror.InternalError(err)
+	}
+
+	// label the secrets
+	configurationSecrets, err := configurations.LabelReleaseSecrets(ctx, cluster, namespace, serviceReleaseName)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	configurationNames := []string{}
+	for _, secret := range configurationSecrets {
+		configurationNames = append(configurationNames, secret.Name)
+	}
+
+	_, errors := configurationbinding.CreateConfigurationBinding(
+		ctx, cluster, namespace, *app, configurationNames,
+	)
+	if len(errors.Errors()) > 0 {
+		return apierror.NewMultiError(errors.Errors())
+	}
+
+	response.OK(c)
+	return nil
+}

--- a/internal/api/v1/service/services.go
+++ b/internal/api/v1/service/services.go
@@ -1,0 +1,105 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/duration"
+	"github.com/epinio/epinio/internal/names"
+	"github.com/epinio/epinio/internal/services"
+	"github.com/gin-gonic/gin"
+	"helm.sh/helm/v3/pkg/repo"
+	"k8s.io/client-go/rest"
+
+	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	hc "github.com/mittwald/go-helm-client"
+)
+
+func (ctr Controller) Create(c *gin.Context) apierror.APIErrors {
+	ctx := c.Request.Context()
+	namespace := c.Param("namespace")
+
+	var createRequest models.ServiceCreateRequest
+	err := c.BindJSON(&createRequest)
+	if err != nil {
+		return apierror.BadRequest(err)
+	}
+
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	kubeServiceClient, err := services.NewKubernetesServiceClient(cluster)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	service, err := kubeServiceClient.Get(ctx, createRequest.Name)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	err = helmDeployService(ctx, cluster.RestConfig, *service, namespace)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	response.OK(c)
+	return nil
+}
+
+func helmDeployService(
+	ctx context.Context,
+	restConfig *rest.Config,
+	service models.Service,
+	namespace string,
+) error {
+
+	client, err := getHelmClient(restConfig, namespace)
+	if err != nil {
+		return err
+	}
+
+	err = client.AddOrUpdateChartRepo(repo.Entry{
+		Name: service.HelmRepo.Name,
+		URL:  service.HelmRepo.URL,
+	})
+	if err != nil {
+		return err
+	}
+
+	release, err := client.InstallOrUpgradeChart(ctx, &hc.ChartSpec{
+		ReleaseName: names.ReleaseName(service.Name),
+		ChartName:   service.HelmChart,
+		Namespace:   namespace,
+		Wait:        true,
+		Atomic:      true,
+		Timeout:     duration.ToDeployment(),
+		// TODO handle values
+		ValuesYaml: `
+commonLabels:
+  "epinio.io/mylabel": "foobar"
+`,
+		ReuseValues: true,
+	})
+	fmt.Printf("%+v\n", release)
+
+	return err
+}
+
+func getHelmClient(restConfig *rest.Config, namespace string) (hc.Client, error) {
+	return hc.NewClientFromRestConf(&hc.RestConfClientOptions{
+		RestConfig: restConfig,
+		Options: &hc.Options{
+			Namespace:        namespace,
+			RepositoryCache:  "/tmp/.helmcache",
+			RepositoryConfig: "/tmp/.helmrepo",
+			Linting:          true,
+			Debug:            true,
+		},
+	})
+}

--- a/internal/api/v1/service/services.go
+++ b/internal/api/v1/service/services.go
@@ -96,20 +96,21 @@ func helmDeployService(
 		return err
 	}
 
-	_, err = client.InstallOrUpgradeChart(ctx, &hc.ChartSpec{
-		ReleaseName: names.ReleaseName(releaseName),
-		ChartName:   service.HelmChart,
-		Namespace:   namespace,
-		Wait:        true,
-		Atomic:      true,
-		Timeout:     duration.ToDeployment(),
-		// TODO handle values
-		// 		ValuesYaml: fmt.Sprintf(`
-		// commonLabels:
-		//   "%s": "true"
-		// `, configurations.ConfigurationLabelKey),
-		ReuseValues: true,
-	})
+	go func() {
+		_, err = client.InstallOrUpgradeChart(context.Background(), &hc.ChartSpec{
+			ReleaseName: names.ReleaseName(releaseName),
+			ChartName:   service.HelmChart,
+			Namespace:   namespace,
+			Atomic:      true,
+			Timeout:     duration.ToDeployment(),
+			// TODO handle values
+			// 		ValuesYaml: fmt.Sprintf(`
+			// commonLabels:
+			//   "%s": "true"
+			// `, configurations.ConfigurationLabelKey),
+			ReuseValues: true,
+		})
+	}()
 
 	return err
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -79,6 +79,7 @@ func init() {
 	rootCmd.AddCommand(CmdConfiguration)
 	rootCmd.AddCommand(CmdServer)
 	rootCmd.AddCommand(cmdVersion)
+	rootCmd.AddCommand(CmdServices) // WIP: HIDDEN
 	// Hidden command providing developer tools
 	rootCmd.AddCommand(CmdDebug)
 }

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/epinio/epinio/internal/cli/usercmd"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// CmdSettings implements the command: epinio settings
+var CmdServices = &cobra.Command{
+	Hidden:        true, // TODO remove me when ready
+	Use:           "service",
+	Short:         "Epinio service management",
+	Long:          `Manage the epinio services`,
+	SilenceErrors: false,
+	Args:          cobra.ExactArgs(1),
+}
+
+func init() {
+	CmdServices.AddCommand(CmdServiceCatalog)
+}
+
+var CmdServiceCatalog = &cobra.Command{
+	Use:   "catalog [NAME]",
+	Short: "Lists all available Epinio services, or show the details of the specified one",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		client, err := usercmd.New()
+		if err != nil {
+			return errors.Wrap(err, "error initializing cli")
+		}
+
+		if len(args) == 0 {
+			err = client.ServiceCatalog()
+			return errors.Wrap(err, "error listing Epinio services")
+		}
+
+		if len(args) == 1 {
+			serviceName := args[0]
+			err = client.ServiceCatalogShow(serviceName)
+			return errors.Wrap(err, fmt.Sprintf("error showing %s Epinio service", serviceName))
+		}
+
+		return nil
+	},
+}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -51,9 +51,9 @@ var CmdServiceCatalog = &cobra.Command{
 }
 
 var CmdServiceCreate = &cobra.Command{
-	Use:   "create NAME",
-	Short: "Create an instance of an Epinio service",
-	Args:  cobra.ExactArgs(1),
+	Use:   "create SERVICENAME RELEASENAME",
+	Short: "Create an instance RELEASENAME of an Epinio service SERVICENAME",
+	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
@@ -63,7 +63,9 @@ var CmdServiceCreate = &cobra.Command{
 		}
 
 		serviceName := args[0]
-		err = client.ServiceCreate(serviceName)
+		serviceReleaseName := args[1]
+
+		err = client.ServiceCreate(serviceName, serviceReleaseName)
 		return errors.Wrap(err, "error creating Epinio Service")
 	},
 }

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -20,6 +20,7 @@ var CmdServices = &cobra.Command{
 
 func init() {
 	CmdServices.AddCommand(CmdServiceCatalog)
+	CmdServices.AddCommand(CmdServiceCreate)
 }
 
 var CmdServiceCatalog = &cobra.Command{
@@ -46,5 +47,23 @@ var CmdServiceCatalog = &cobra.Command{
 		}
 
 		return nil
+	},
+}
+
+var CmdServiceCreate = &cobra.Command{
+	Use:   "create NAME",
+	Short: "Create an instance of an Epinio service",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		client, err := usercmd.New()
+		if err != nil {
+			return errors.Wrap(err, "error initializing cli")
+		}
+
+		serviceName := args[0]
+		err = client.ServiceCreate(serviceName)
+		return errors.Wrap(err, "error creating Epinio Service")
 	},
 }

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -21,6 +21,7 @@ var CmdServices = &cobra.Command{
 func init() {
 	CmdServices.AddCommand(CmdServiceCatalog)
 	CmdServices.AddCommand(CmdServiceCreate)
+	CmdServices.AddCommand(CmdServiceReleaseBindCreate)
 }
 
 var CmdServiceCatalog = &cobra.Command{
@@ -66,6 +67,26 @@ var CmdServiceCreate = &cobra.Command{
 		serviceReleaseName := args[1]
 
 		err = client.ServiceCreate(serviceName, serviceReleaseName)
+		return errors.Wrap(err, "error creating Epinio Service")
+	},
+}
+
+var CmdServiceReleaseBindCreate = &cobra.Command{
+	Use:   "bind RELEASENAME APPNAME",
+	Short: "Bind a service release RELEASENAME to an Epinio app APPNAME",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		client, err := usercmd.New()
+		if err != nil {
+			return errors.Wrap(err, "error initializing cli")
+		}
+
+		serviceReleaseName := args[0]
+		appName := args[1]
+
+		err = client.ServiceReleaseBind(serviceReleaseName, appName)
 		return errors.Wrap(err, "error creating Epinio Service")
 	},
 }

--- a/internal/cli/usercmd/app_test.go
+++ b/internal/cli/usercmd/app_test.go
@@ -230,3 +230,15 @@ func (m *mockAPIClient) ConfigurationShow(namespace string, name string) (models
 func (m *mockAPIClient) ConfigurationApps(namespace string) (models.ConfigurationAppsResponse, error) {
 	return models.ConfigurationAppsResponse{}, nil
 }
+
+func (m *mockAPIClient) ServiceCatalog() (*models.ServiceCatalogResponse, error) {
+	return nil, nil
+}
+
+func (m *mockAPIClient) ServiceCatalogShow(serviceName string) (*models.ServiceCatalogShowResponse, error) {
+	return nil, nil
+}
+
+func (m *mockAPIClient) ServiceCreate(req *models.ServiceCreateRequest, namespace string) error {
+	return nil
+}

--- a/internal/cli/usercmd/app_test.go
+++ b/internal/cli/usercmd/app_test.go
@@ -242,3 +242,7 @@ func (m *mockAPIClient) ServiceCatalogShow(serviceName string) (*models.ServiceC
 func (m *mockAPIClient) ServiceCreate(req *models.ServiceCreateRequest, namespace string) error {
 	return nil
 }
+
+func (m *mockAPIClient) ServiceReleaseBindingCreate(req *models.ServiceReleaseBindRequest, namespace, releaseName string) error {
+	return nil
+}

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -67,6 +67,9 @@ type APIClient interface {
 	ConfigurationUpdate(req models.ConfigurationUpdateRequest, namespace, name string) (models.Response, error)
 	ConfigurationShow(namespace string, name string) (models.ConfigurationResponse, error)
 	ConfigurationApps(namespace string) (models.ConfigurationAppsResponse, error)
+	// services
+	ServiceCatalog() (*models.ServiceCatalogResponse, error)
+	ServiceCatalogShow(serviceName string) (*models.ServiceCatalogShowResponse, error)
 }
 
 func New() (*EpinioClient, error) {

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -70,6 +70,7 @@ type APIClient interface {
 	// services
 	ServiceCatalog() (*models.ServiceCatalogResponse, error)
 	ServiceCatalogShow(serviceName string) (*models.ServiceCatalogShowResponse, error)
+	ServiceCreate(req *models.ServiceCreateRequest, namespace string) error
 }
 
 func New() (*EpinioClient, error) {

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -71,6 +71,7 @@ type APIClient interface {
 	ServiceCatalog() (*models.ServiceCatalogResponse, error)
 	ServiceCatalogShow(serviceName string) (*models.ServiceCatalogShowResponse, error)
 	ServiceCreate(req *models.ServiceCreateRequest, namespace string) error
+	ServiceReleaseBindingCreate(req *models.ServiceReleaseBindRequest, namespace, releaseName string) error
 }
 
 func New() (*EpinioClient, error) {

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -35,7 +35,9 @@ func (c *EpinioClient) ServiceCatalogShow(serviceName string) error {
 	log.Info("start")
 	defer log.Info("return")
 
-	c.ui.Note().Msg("Getting catalog...")
+	c.ui.Note().
+		WithStringValue("Service", serviceName).
+		Msg("Show service details")
 
 	catalogShowResponse, err := c.API.ServiceCatalogShow(serviceName)
 	if err != nil {
@@ -44,8 +46,10 @@ func (c *EpinioClient) ServiceCatalogShow(serviceName string) error {
 
 	service := catalogShowResponse.Service
 
-	c.ui.Success().WithTable("Name", "Description").
-		WithTableRow(service.Name, service.Description).
+	c.ui.Success().WithTable("Key", "Value").
+		WithTableRow("Name", service.Name).
+		WithTableRow("Description", service.Description).
+		WithTableRow("Long Description", service.LongDescription).
 		Msg("Epinio Service:")
 
 	return nil

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -81,3 +81,23 @@ func (c *EpinioClient) ServiceCreate(serviceName, serviceReleaseName string) err
 
 	return nil
 }
+
+// CreateNamespace creates a namespace
+func (c *EpinioClient) ServiceReleaseBind(serviceReleaseName, appName string) error {
+	log := c.Log.WithName("ServiceReleaseBind")
+	log.Info("start")
+	defer log.Info("return")
+
+	c.ui.Note().Msg("Binding Service...")
+
+	request := &models.ServiceReleaseBindRequest{
+		AppName: appName,
+	}
+
+	err := c.API.ServiceReleaseBindingCreate(request, c.Settings.Namespace, serviceReleaseName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -50,3 +50,29 @@ func (c *EpinioClient) ServiceCatalogShow(serviceName string) error {
 
 	return nil
 }
+
+// CreateNamespace creates a namespace
+func (c *EpinioClient) ServiceCreate(serviceName string) error {
+	log := c.Log.WithName("ServiceCreate")
+	log.Info("start")
+	defer log.Info("return")
+
+	c.ui.Note().Msg("Creatign Service...")
+
+	request := &models.ServiceCreateRequest{
+		Name: serviceName,
+	}
+
+	err := c.API.ServiceCreate(request, c.Settings.Namespace)
+	if err != nil {
+		return err
+	}
+
+	// service := catalogShowResponse.Service
+
+	// c.ui.Success().WithTable("Name", "Description").
+	// 	WithTableRow(service.Name, service.Description).
+	// 	Msg("Epinio Service:")
+
+	return nil
+}

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -52,15 +52,16 @@ func (c *EpinioClient) ServiceCatalogShow(serviceName string) error {
 }
 
 // CreateNamespace creates a namespace
-func (c *EpinioClient) ServiceCreate(serviceName string) error {
+func (c *EpinioClient) ServiceCreate(serviceName, serviceReleaseName string) error {
 	log := c.Log.WithName("ServiceCreate")
 	log.Info("start")
 	defer log.Info("return")
 
-	c.ui.Note().Msg("Creatign Service...")
+	c.ui.Note().Msg("Creating Service...")
 
 	request := &models.ServiceCreateRequest{
-		Name: serviceName,
+		Name:        serviceName,
+		ReleaseName: serviceReleaseName,
 	}
 
 	err := c.API.ServiceCreate(request, c.Settings.Namespace)

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -1,0 +1,52 @@
+package usercmd
+
+import "github.com/epinio/epinio/pkg/api/core/v1/models"
+
+// CreateNamespace creates a namespace
+func (c *EpinioClient) ServiceCatalog() error {
+	log := c.Log.WithName("ServiceCatalog")
+	log.Info("start")
+	defer log.Info("return")
+
+	c.ui.Note().Msg("Getting catalog...")
+
+	catalog, err := c.API.ServiceCatalog()
+	if err != nil {
+		return err
+	}
+
+	msg := c.ui.Success().WithTable("Name", "Description")
+
+	for _, name := range catalog.Services {
+		msg = msg.WithTableRow(
+			name.Name,
+			name.Description,
+		)
+	}
+
+	msg.Msg("Epinio Services:")
+
+	return nil
+}
+
+// CreateNamespace creates a namespace
+func (c *EpinioClient) ServiceCatalogShow(serviceName string) error {
+	log := c.Log.WithName("ServiceCatalog")
+	log.Info("start")
+	defer log.Info("return")
+
+	c.ui.Note().Msg("Getting catalog...")
+
+	catalogShowResponse, err := c.API.ServiceCatalogShow(serviceName)
+	if err != nil {
+		return err
+	}
+
+	service := catalogShowResponse.Service
+
+	c.ui.Success().WithTable("Name", "Description").
+		WithTableRow(service.Name, service.Description).
+		Msg("Epinio Service:")
+
+	return nil
+}

--- a/internal/services/client.go
+++ b/internal/services/client.go
@@ -1,0 +1,30 @@
+package services
+
+import (
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+type ServiceClient struct {
+	kubeClient        *kubernetes.Cluster
+	serviceKubeClient dynamic.NamespaceableResourceInterface
+}
+
+func NewKubernetesServiceClient(kubeClient *kubernetes.Cluster) (*ServiceClient, error) {
+	dynamicKubeClient, err := dynamic.NewForConfig(kubeClient.RestConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "application.epinio.io",
+		Version:  "v1",
+		Resource: "services",
+	}
+
+	return &ServiceClient{
+		kubeClient:        kubeClient,
+		serviceKubeClient: dynamicKubeClient.Resource(gvr),
+	}, nil
+}

--- a/internal/services/client.go
+++ b/internal/services/client.go
@@ -7,8 +7,9 @@ import (
 )
 
 type ServiceClient struct {
-	kubeClient        *kubernetes.Cluster
-	serviceKubeClient dynamic.NamespaceableResourceInterface
+	kubeClient               *kubernetes.Cluster
+	serviceKubeClient        dynamic.NamespaceableResourceInterface
+	serviceReleaseKubeClient dynamic.NamespaceableResourceInterface
 }
 
 func NewKubernetesServiceClient(kubeClient *kubernetes.Cluster) (*ServiceClient, error) {
@@ -17,14 +18,20 @@ func NewKubernetesServiceClient(kubeClient *kubernetes.Cluster) (*ServiceClient,
 		return nil, err
 	}
 
-	gvr := schema.GroupVersionResource{
+	serviceGroupVersion := schema.GroupVersionResource{
 		Group:    "application.epinio.io",
 		Version:  "v1",
 		Resource: "services",
 	}
+	serviceReleaseGroupVersion := schema.GroupVersionResource{
+		Group:    "application.epinio.io",
+		Version:  "v1",
+		Resource: "servicereleases",
+	}
 
 	return &ServiceClient{
-		kubeClient:        kubeClient,
-		serviceKubeClient: dynamicKubeClient.Resource(gvr),
+		kubeClient:               kubeClient,
+		serviceKubeClient:        dynamicKubeClient.Resource(serviceGroupVersion),
+		serviceReleaseKubeClient: dynamicKubeClient.Resource(serviceReleaseGroupVersion),
 	}, nil
 }

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -1,0 +1,93 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func NewServiceFromJSONMap(m map[string]interface{}) (*models.Service, error) {
+	var err error
+	service := &models.Service{}
+
+	if service.Name, _, err = unstructured.NestedString(m, "spec", "name"); err != nil {
+		return nil, errors.New("name should be string")
+	}
+
+	if service.Description, _, err = unstructured.NestedString(m, "spec", "description"); err != nil {
+		return nil, errors.New("description should be string")
+	}
+
+	if service.HelmChart, _, err = unstructured.NestedString(m, "spec", "chart"); err != nil {
+		return nil, errors.New("chart should be string")
+	}
+
+	if service.HelmRepo.Name, _, err = unstructured.NestedString(m, "spec", "helmRepo", "name"); err != nil {
+		return nil, errors.New("chart should be string")
+	}
+
+	if service.HelmRepo.URL, _, err = unstructured.NestedString(m, "spec", "helmRepo", "url"); err != nil {
+		return nil, errors.New("chart should be string")
+	}
+
+	if service.Values, _, err = unstructured.NestedString(m, "spec", "values"); err != nil {
+		return nil, errors.New("values should be string")
+	}
+
+	if service.UserValues, _, err = unstructured.NestedString(m, "spec", "userValues"); err != nil {
+		return nil, errors.New("userValues should be string")
+	}
+
+	return service, nil
+}
+
+func (s *ServiceClient) Get(ctx context.Context, serviceName string) (*models.Service, error) {
+	serviceList, err := s.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, service := range serviceList {
+		if service.Name == serviceName {
+			return service, nil
+		}
+	}
+
+	return nil, fmt.Errorf("service %s not found", serviceName)
+}
+
+// TODO fix
+// func (s *ServiceClient) Get(ctx context.Context, serviceName string) (*models.Service, error) {
+// 	result, err := s.serviceKubeClient.Get(ctx, serviceName, metav1.GetOptions{})
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	service, err := NewServiceFromJSONMap(result.UnstructuredContent())
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return service, nil
+// }
+
+func (s *ServiceClient) List(ctx context.Context) ([]*models.Service, error) {
+	listResult, err := s.serviceKubeClient.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	services := []*models.Service{}
+	for _, item := range listResult.Items {
+		service, err := NewServiceFromJSONMap(item.UnstructuredContent())
+		if err != nil {
+			return nil, err
+		}
+		services = append(services, service)
+	}
+
+	return services, nil
+}

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -24,16 +24,20 @@ func NewServiceFromJSONMap(m map[string]interface{}) (*models.Service, error) {
 		return nil, errors.New("description should be string")
 	}
 
+	if service.LongDescription, _, err = unstructured.NestedString(m, "spec", "longDescription"); err != nil {
+		return nil, errors.New("longDescription should be string")
+	}
+
 	if service.HelmChart, _, err = unstructured.NestedString(m, "spec", "chart"); err != nil {
 		return nil, errors.New("chart should be string")
 	}
 
 	if service.HelmRepo.Name, _, err = unstructured.NestedString(m, "spec", "helmRepo", "name"); err != nil {
-		return nil, errors.New("chart should be string")
+		return nil, errors.New("helmRepo.name should be string")
 	}
 
 	if service.HelmRepo.URL, _, err = unstructured.NestedString(m, "spec", "helmRepo", "url"); err != nil {
-		return nil, errors.New("chart should be string")
+		return nil, errors.New("helmRepo.url should be string")
 	}
 
 	if service.Values, _, err = unstructured.NestedString(m, "spec", "values"); err != nil {

--- a/pkg/api/core/v1/client/http.go
+++ b/pkg/api/core/v1/client/http.go
@@ -138,9 +138,8 @@ func (c *Client) do(endpoint, method, requestBody string) ([]byte, error) {
 	defer response.Body.Close()
 	reqLog.V(1).Info("request finished")
 
-	respLog := responseLogger(c.log, response)
-
 	bodyBytes, err := ioutil.ReadAll(response.Body)
+	respLog := responseLogger(c.log, response, string(bodyBytes))
 	if err != nil {
 		respLog.V(1).Error(err, "failed to read response body")
 		return []byte{}, wrapResponseError(err, response.StatusCode)
@@ -199,9 +198,8 @@ func (c *Client) doWithCustomErrorHandling(endpoint, method, requestBody string,
 	defer response.Body.Close()
 	reqLog.V(1).Info("request finished")
 
-	respLog := responseLogger(c.log, response)
-
 	bodyBytes, err := ioutil.ReadAll(response.Body)
+	respLog := responseLogger(c.log, response, string(bodyBytes))
 	if err != nil {
 		respLog.V(1).Error(err, "failed to read response body")
 		return []byte{}, wrapResponseError(err, response.StatusCode)
@@ -245,13 +243,14 @@ func requestLogger(l logr.Logger, method string, uri string, body string) logr.L
 	return log
 }
 
-func responseLogger(l logr.Logger, response *http.Response) logr.Logger {
+func responseLogger(l logr.Logger, response *http.Response, body string) logr.Logger {
 	log := l.WithValues("status", response.StatusCode)
 	if log.V(5).Enabled() {
 		log = log.WithValues("header", response.Header)
 		if response.TLS != nil {
 			log = log.WithValues("TLSServerName", response.TLS.ServerName)
 		}
+		log = log.WithValues("body", body)
 	}
 	return log
 }

--- a/pkg/api/core/v1/client/services.go
+++ b/pkg/api/core/v1/client/services.go
@@ -48,3 +48,13 @@ func (c *Client) ServiceCreate(req *models.ServiceCreateRequest, namespace strin
 	_, err = c.post(api.Routes.Path("ServiceCreate", namespace), string(b))
 	return err
 }
+
+func (c *Client) ServiceReleaseBindingCreate(req *models.ServiceReleaseBindRequest, namespace, releaseName string) error {
+	b, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.post(api.Routes.Path("ServiceReleaseBindingCreate", namespace, releaseName), string(b))
+	return err
+}

--- a/pkg/api/core/v1/client/services.go
+++ b/pkg/api/core/v1/client/services.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"encoding/json"
+
+	api "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+)
+
+func (c *Client) ServiceCatalog() (*models.ServiceCatalogResponse, error) {
+	data, err := c.get(api.Routes.Path("ServiceCatalog"))
+	if err != nil {
+		return nil, err
+	}
+
+	var resp models.ServiceCatalogResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, err
+	}
+
+	c.log.V(1).Info("response decoded", "response", resp)
+
+	return &resp, nil
+}
+
+func (c *Client) ServiceCatalogShow(serviceName string) (*models.ServiceCatalogShowResponse, error) {
+	data, err := c.get(api.Routes.Path("ServiceCatalogShow", serviceName))
+	if err != nil {
+		return nil, err
+	}
+
+	var resp models.ServiceCatalogShowResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, err
+	}
+
+	c.log.V(1).Info("response decoded", "response", resp)
+
+	return &resp, nil
+}

--- a/pkg/api/core/v1/client/services.go
+++ b/pkg/api/core/v1/client/services.go
@@ -38,3 +38,13 @@ func (c *Client) ServiceCatalogShow(serviceName string) (*models.ServiceCatalogS
 
 	return &resp, nil
 }
+
+func (c *Client) ServiceCreate(req *models.ServiceCreateRequest, namespace string) error {
+	b, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.post(api.Routes.Path("ServiceCreate", namespace), string(b))
+	return err
+}

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -242,16 +242,17 @@ type ServiceCatalogShowResponse struct {
 // TODO fix camelCase
 type ServiceCreateRequest struct {
 	Name        string `json:"name,omitempty"`
-	ReleaseName string `json:"releaseName,omitempty"`
+	ReleaseName string `json:"release_name,omitempty"`
 }
 
 type Service struct {
-	Name        string   `json:"name,omitempty"`
-	Description string   `json:"description,omitempty"`
-	HelmChart   string   `json:"chart,omitempty"`
-	HelmRepo    HelmRepo `json:"helmRepo,omitempty"`
-	Values      string   `json:"values,omitempty"`
-	UserValues  string   `json:"userValues,omitempty"`
+	Name            string   `json:"name,omitempty"`
+	Description     string   `json:"description,omitempty"`
+	LongDescription string   `json:"long_description,omitempty"`
+	HelmChart       string   `json:"chart,omitempty"`
+	HelmRepo        HelmRepo `json:"helm_repo,omitempty"`
+	Values          string   `json:"values,omitempty"`
+	UserValues      string   `json:"user_values,omitempty"`
 }
 
 type HelmRepo struct {

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -239,8 +239,10 @@ type ServiceCatalogShowResponse struct {
 	Service *Service `json:"service,omitempty"`
 }
 
+// TODO fix camelCase
 type ServiceCreateRequest struct {
-	Name string `json:"name,omitempty"`
+	Name        string `json:"name,omitempty"`
+	ReleaseName string `json:"releaseName,omitempty"`
 }
 
 type Service struct {

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -228,3 +228,27 @@ type NamespacesMatchResponse struct {
 type ConfigurationAppsResponse struct {
 	AppsOf map[string]AppList `json:"apps_of,omitempty"`
 }
+
+// ServiceCatalogResponse
+type ServiceCatalogResponse struct {
+	Services []*Service `json:"services,omitempty"`
+}
+
+// ServiceCatalogResponse
+type ServiceCatalogShowResponse struct {
+	Service *Service `json:"service,omitempty"`
+}
+
+type Service struct {
+	Name        string   `json:"name,omitempty"`
+	Description string   `json:"description,omitempty"`
+	HelmChart   string   `json:"chart,omitempty"`
+	HelmRepo    HelmRepo `json:"helmRepo,omitempty"`
+	Values      string   `json:"values,omitempty"`
+	UserValues  string   `json:"userValues,omitempty"`
+}
+
+type HelmRepo struct {
+	Name string `json:"name,omitempty"`
+	URL  string `json:"url,omitempty"`
+}

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -239,7 +239,6 @@ type ServiceCatalogShowResponse struct {
 	Service *Service `json:"service,omitempty"`
 }
 
-// TODO fix camelCase
 type ServiceCreateRequest struct {
 	Name        string `json:"name,omitempty"`
 	ReleaseName string `json:"release_name,omitempty"`
@@ -258,4 +257,8 @@ type Service struct {
 type HelmRepo struct {
 	Name string `json:"name,omitempty"`
 	URL  string `json:"url,omitempty"`
+}
+
+type ServiceReleaseBindRequest struct {
+	AppName string `json:"app_name,omitempty"`
 }

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -239,6 +239,10 @@ type ServiceCatalogShowResponse struct {
 	Service *Service `json:"service,omitempty"`
 }
 
+type ServiceCreateRequest struct {
+	Name string `json:"name,omitempty"`
+}
+
 type Service struct {
 	Name        string   `json:"name,omitempty"`
 	Description string   `json:"description,omitempty"`


### PR DESCRIPTION


This PR adds the `epinio service catalog` and `epinio service create` commands.

The `epinio service catalog [NAME]` accepts an optional NAME argument. If provided and if matches an existing Epinio Service then this will show the details of the requested Service.

It also adds the `epinio service create NAME`, to provision a Service from an Helm chart.

### TODO
- push, check and override of user and operator values
- fix for Get of specific Service
- tests

### Ref
- https://github.com/epinio/epinio/issues/1281