### PR TITLE
Fix Github permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 
       - name: Get current tag
         id: get_tag

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -177,6 +177,7 @@ brews:
     tap:
       owner: epinio
       name: homebrew-tap
+      token: "{{ .Env.COMMITTER_TOKEN }}"
 
     folder: Formula
     url_template: "https://github.com/epinio/epinio/releases/download/{{ .Tag }}/{{ .ArtifactName }}"


### PR DESCRIPTION
The Github token doesn't have enough permissions to commit/push to other repo, so we're using a PAT to do this (the same that we are usingo for the `homebrew-core`).