### PR TITLE
Test nginx ingress in EKS scenario 4

### DIFF
--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -140,6 +140,7 @@ jobs:
           AKS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.aks_domain || secrets.AKS_DOMAIN }}
           EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.aks_domain || secrets.AKS_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
+          INGRESS_CONTROLLER: traefik
         shell: bash
         run: |
           echo "System Domain: $AKS_DOMAIN"

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -140,6 +140,7 @@ jobs:
           AKS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.aks_domain || secrets.AKS_DOMAIN }}
           EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.aks_domain || secrets.AKS_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
+          INGRESS_CONTROLLER: traefik
         shell: bash
         run: |
           echo "System Domain: $AKS_DOMAIN"

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -140,7 +140,7 @@ jobs:
           AWS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.aws_domain || secrets.AWS_DOMAIN }}
           EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.aws_domain || secrets.AWS_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
-          INGRESS_CONTROLLER: NGINX
+          INGRESS_CONTROLLER: nginx
         run: |
           echo "System Domain: $AWS_DOMAIN"
           export KUBECONFIG=$PWD/${{ env.KUBECONFIG_NAME }}

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -140,6 +140,7 @@ jobs:
           AWS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.aws_domain || secrets.AWS_DOMAIN }}
           EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.aws_domain || secrets.AWS_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
+          INGRESS_CONTROLLER: NGINX
         run: |
           echo "System Domain: $AWS_DOMAIN"
           export KUBECONFIG=$PWD/${{ env.KUBECONFIG_NAME }}

--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -128,6 +128,7 @@ jobs:
           GKE_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.gke_domain || secrets.GKE_DOMAIN }}
           EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.gke_domain || secrets.GKE_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
+          INGRESS_CONTROLLER: traefik
         run: |
           echo "System Domain: $GKE_DOMAIN"
           export KUBECONFIG=$HOME/.kube/config

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -128,6 +128,7 @@ jobs:
           GKE_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.gke_domain || secrets.GKE_DOMAIN }}
           EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.gke_domain || secrets.GKE_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
+          INGRESS_CONTROLLER: traefik
         run: |
           echo "System Domain: $GKE_DOMAIN"
           export KUBECONFIG=$HOME/.kube/config

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ on:
 env:
   SETUP_GO_VERSION: '^1.18'
   GINKGO_NODES: 8
+  INGRESS_CONTROLLER: traefik
 
 jobs:
   linter:

--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -116,6 +116,7 @@ jobs:
           KUBECONFIG: /etc/rancher/rke2/rke2.yaml
           REGISTRY_USERNAME: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
+          INGRESS_CONTROLLER: traefik
         run: |
           # Get a free IP address on server's network
           export RANGE_IP="$(scripts/get-free-ip.sh)"

--- a/acceptance/install/scenario4_test.go
+++ b/acceptance/install/scenario4_test.go
@@ -61,14 +61,14 @@ var _ = Describe("<Scenario4> EKS, epinio-ca, on S3 storage", func() {
 
 	It("Installs with loadbalancer IP, custom domain and pushes an app with env vars", func() {
 		By("Checking LoadBalancer IP", func() {
-			// Ensure that Traefik LB is not in Pending state anymore, could take time
+			// Ensure that Nginx LB is not in Pending state anymore, could take time
 			Eventually(func() string {
-				out, err := proc.RunW("kubectl", "get", "svc", "-n", "traefik", "traefik", "--no-headers")
+				out, err := proc.RunW("kubectl", "get", "svc", "-n", "ingress-nginx", "ingress-nginx-controller", "--no-headers")
 				Expect(err).NotTo(HaveOccurred(), out)
 				return out
 			}, "4m", "2s").ShouldNot(ContainSubstring("<pending>"))
 
-			out, err := proc.RunW("kubectl", "get", "service", "-n", "traefik", "traefik", "-o", "json")
+			out, err := proc.RunW("kubectl", "get", "service", "-n", "ingress-nginx", "ingress-nginx-controller", "-o", "json")
 			Expect(err).NotTo(HaveOccurred(), out)
 
 			// Check that an IP address for LB is configured

--- a/acceptance/install/suite_test.go
+++ b/acceptance/install/suite_test.go
@@ -66,6 +66,8 @@ func InstallTraefik() {
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
+	ingressController := os.Getenv("INGRESS_CONTROLLER")
+
 	fmt.Printf("I'm running on runner = %s\n", os.Getenv("HOSTNAME"))
 
 	testenv.SetRoot("../..")
@@ -77,11 +79,10 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	// Install and configure the prerequisites
 	testenv.CreateRegistrySecret()
 	InstallCertManager()
-	if os.Getenv("INGRESS_CONTROLLER") == "NGINX" {
-		fmt.Printf("Installing Nginx as ingress controller")
+	fmt.Printf("Installing %s as ingress controller\n", ingressController)
+	if ingressController == "nginx" {
 		InstallNginx()
-	} else {
-		fmt.Printf("Installing Traefik as ingress controller")
+	} else if ingressController == "traefik" {
 		InstallTraefik()
 	}
 


### PR DESCRIPTION
Fix #1323 
We need to test Epinio on top of the nginx ingress controller.
This PR updates our installation test on EKS to use it instead of Traefik.
