### PR TITLE
Improve error output in CLI

### DIFF
--- a/helpers/termui/ui.go
+++ b/helpers/termui/ui.go
@@ -179,18 +179,18 @@ func (u *Message) Msg(message string) {
 	switch u.msgType {
 	case normal:
 	case exclamation:
-		message = emoji.Sprintf(":warning: %s", message)
+		message = emoji.Sprintf(":warning:%s", message)
 		message = color.YellowString(message)
 	case note:
 		message = emoji.Sprintf(":ship:%s", message)
 		message = color.BlueString(message)
 	case success:
-		message = emoji.Sprintf(":heavy_check_mark: %s", message)
+		message = emoji.Sprintf(":heavy_check_mark:%s", message)
 		message = color.GreenString(message)
 	case progress:
-		message = emoji.Sprintf(":three-thirty: %s", message)
+		message = emoji.Sprintf(":three-thirty:%s", message)
 	case problem:
-		message = emoji.Sprintf(":forbidden:%s", message)
+		message = emoji.Sprintf(":cross_mark:%s", message)
 		message = color.RedString(message)
 	}
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/epinio/epinio/helpers/kubernetes/config"
+	"github.com/epinio/epinio/helpers/termui"
 	"github.com/epinio/epinio/helpers/tracelog"
 	settings "github.com/epinio/epinio/internal/cli/settings"
 	"github.com/epinio/epinio/internal/duration"
@@ -37,7 +38,7 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		termui.NewUI().Problem().Msg(err.Error())
 		os.Exit(-1)
 	}
 }

--- a/pkg/api/core/v1/client/http.go
+++ b/pkg/api/core/v1/client/http.go
@@ -158,7 +158,7 @@ func (c *Client) do(endpoint, method, requestBody string) ([]byte, error) {
 		if respLog.V(5).Enabled() {
 			respLog = respLog.WithValues("body", string(bodyBytes))
 		}
-		respLog.V(1).Error(err, "response is not StatusOK")
+		respLog.V(1).Info("response is not StatusOK: " + err.Error())
 
 		return bodyBytes, wrapResponseError(err, response.StatusCode)
 	}
@@ -219,7 +219,7 @@ func (c *Client) doWithCustomErrorHandling(endpoint, method, requestBody string,
 			if respLog.V(5).Enabled() {
 				respLog = respLog.WithValues("body", string(bodyBytes))
 			}
-			respLog.V(1).Error(err, "response is not StatusOK after custom error handling")
+			respLog.V(1).Info("response is not StatusOK after custom error handling: " + err.Error())
 
 			return bodyBytes, wrapResponseError(err, response.StatusCode)
 		}


### PR DESCRIPTION
At the moment when an error occurs the output from the CLI is something like this

![image](https://user-images.githubusercontent.com/1763949/162478939-c4418118-d2f7-4e66-bcbb-04ef6036abb0.png)

This is because the log is always printing the log `Error` messages, despite the level enabled. This is not really nice for the CLI.
Also we were not really using the `Problem()` message from `termui` because the `:forbidden:` emoji doesn't exists at all. See https://github.com/kyokomi/emoji/blob/master/emoji_codemap.go for the existing ones.

This PR change that in order to use the `:cross_mark:` ❌, "suppress" the Error with an Info (that can be seen just with an higher `TRACE_LOG`), and output the error if any at the root level.

![image](https://user-images.githubusercontent.com/1763949/162479672-f7653a1b-b7f3-446b-89ed-5ae532a1871a.png)

