### PR TITLE
Pin goreleaser to 1.8.2 and fix #1365

### DIFF
--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -36,6 +36,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           distribution: goreleaser
-          version: 1.7.0
+          version: 1.8.2
           args: release --rm-dist --skip-publish --snapshot
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           distribution: goreleaser
-          version: 1.7.0
+          version: 1.8.2
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,7 +35,7 @@ builds:
     targets:
     - darwin_amd64
     - darwin_arm64
-    - linux_amd64
+    - linux_amd64_v1
     - linux_arm64
     - linux_arm_7
     - linux_s390x


### PR DESCRIPTION
Goreleaser wasn't able to copy the binary into the Dockerfile:

```
   ⨯ release failed after 5.22s error=failed to build ghcr.io/epinio/epinio-server:v0.7.0-amd64: exit status 1: #1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 328B done
#1 DONE 0.0s

#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/alpine:latest
#3 DONE 1.1s

#4 [certs 1/2] FROM docker.io/library/alpine@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454
#4 DONE 0.0s

#5 [internal] load build context
#5 transferring context: 2B done
#5 DONE 0.0s

#6 [certs 2/2] RUN apk --update --no-cache add ca-certificates
#6 CACHED

#7 [stage-1 1/2] COPY --from=certs /etc/ssl/certs /etc/ssl/certs
#7 CACHED

#8 [stage-1 2/2] COPY epinio /
#8 ERROR: "/epinio" not found: not found
------
 > [stage-1 2/2] COPY epinio /:
------
error: failed to solve: failed to compute cache key: "/epinio" not found: not found
```


However the file is there:

```
dist
├── config.yaml
├── epinio-windows-x86_64.zip
├── epinio.rb
├── epinio_darwin_amd64
│   └── epinio
├── epinio_darwin_arm64
│   └── epinio
├── epinio_linux_amd64
│   └── epinio
├── epinio_linux_arm64
│   └── epinio
├── epinio_linux_arm_7
│   └── epinio
├── epinio_linux_s390x
│   └── epinio
├── epinio_v0.7.1-next_checksums.txt
├── epinio_windows_amd64
│   └── epinio.exe
├── goreleaserdocker1623437802
│   └── Dockerfile
├── goreleaserdocker2966840997
│   ├── Dockerfile
│   └── epinio
├── goreleaserdocker523845127
│   ├── Dockerfile
│   └── epinio
└── goreleaserdocker756305209
    ├── Dockerfile
    └── epinio
```

This fixes #1365 