### PR TITLE
Add swagger docs for `epinio service`

### DIFF
--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -1181,7 +1181,7 @@
         "tags": [
           "service"
         ],
-        "summary": "Return list of service instances in the `Namespace`.",
+        "summary": "Return list of services in the `Namespace`.",
         "operationId": "ServiceList",
         "parameters": [
           {
@@ -1201,7 +1201,7 @@
         "tags": [
           "service"
         ],
-        "summary": "Create a named instance of an Epinio Catalog Service in the `Namespace`.",
+        "summary": "Create a named service of an Epinio catalog service in the `Namespace`.",
         "operationId": "ServiceCreate",
         "parameters": [
           {
@@ -1225,47 +1225,12 @@
         }
       }
     },
-    "/namespaces/{Namespace}/services/{Servicename}/bind": {
-      "post": {
-        "tags": [
-          "service"
-        ],
-        "summary": "Bind the named `Servicename` instance in the `Namespace` to an App.",
-        "operationId": "ServiceBind",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "Namespace",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "name": "Servicename",
-            "in": "path",
-            "required": true
-          },
-          {
-            "name": "Configuration",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/ServiceBindRequest"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/ServiceBindResponse"
-          }
-        }
-      }
-    },
     "/namespaces/{Namespace}/services/{Service}": {
       "get": {
         "tags": [
           "service"
         ],
-        "summary": "Return details of the named `Service` instance in the `Namespace`.",
+        "summary": "Return details of the named `Service` in the `Namespace`.",
         "operationId": "ServiceShow",
         "parameters": [
           {
@@ -1291,7 +1256,7 @@
         "tags": [
           "service"
         ],
-        "summary": "Delete the named `Service` instance in the `Namespace`.",
+        "summary": "Delete the named `Service` in the `Namespace`.",
         "operationId": "ServiceDelete",
         "parameters": [
           {
@@ -1310,6 +1275,41 @@
         "responses": {
           "200": {
             "$ref": "#/responses/ServiceDeleteResponse"
+          }
+        }
+      }
+    },
+    "/namespaces/{Namespace}/services/{Service}/bind": {
+      "post": {
+        "tags": [
+          "service"
+        ],
+        "summary": "Bind the named `Service` in the `Namespace` to an App.",
+        "operationId": "ServiceBind",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "Namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "Service",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Configuration",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/ServiceBindRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ServiceBindResponse"
           }
         }
       }
@@ -1384,17 +1384,17 @@
         }
       }
     },
-    "/services/{Servicename}": {
+    "/services/{CatalogService}": {
       "get": {
         "tags": [
           "service"
         ],
-        "summary": "Return details of the named Epinio Catalog `Service``.",
+        "summary": "Return details of the named Epinio `CatalogService`.",
         "operationId": "ServiceCatalogShow",
         "parameters": [
           {
             "type": "string",
-            "name": "Servicename",
+            "name": "CatalogService",
             "in": "path",
             "required": true
           }

--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -1176,6 +1176,144 @@
         }
       }
     },
+    "/namespaces/{Namespace}/services": {
+      "get": {
+        "tags": [
+          "service"
+        ],
+        "summary": "Return list of service instances in the `Namespace`.",
+        "operationId": "ServiceList",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "Namespace",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ServiceListResponse"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "service"
+        ],
+        "summary": "Create a named instance of an Epinio Catalog Service in the `Namespace`.",
+        "operationId": "ServiceCreate",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "Namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Configuration",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/ServiceCreateRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ServiceCreateResponse"
+          }
+        }
+      }
+    },
+    "/namespaces/{Namespace}/services/{Servicename}/bind": {
+      "post": {
+        "tags": [
+          "service"
+        ],
+        "summary": "Bind the named `Servicename` instance in the `Namespace` to an App.",
+        "operationId": "ServiceBind",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "Namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "Servicename",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Configuration",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/ServiceBindRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ServiceBindResponse"
+          }
+        }
+      }
+    },
+    "/namespaces/{Namespace}/services/{Service}": {
+      "get": {
+        "tags": [
+          "service"
+        ],
+        "summary": "Return details of the named `Service` instance in the `Namespace`.",
+        "operationId": "ServiceShow",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "Namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "Service",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ServiceShowResponse"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "service"
+        ],
+        "summary": "Delete the named `Service` instance in the `Namespace`.",
+        "operationId": "ServiceDelete",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "Namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "Service",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ServiceDeleteResponse"
+          }
+        }
+      }
+    },
     "/namespaces/{Namespace}/staging/{StageID}/complete": {
       "get": {
         "tags": [
@@ -1231,6 +1369,42 @@
           }
         }
       }
+    },
+    "/services": {
+      "get": {
+        "tags": [
+          "service"
+        ],
+        "summary": "Return all available Epinio Catalog services.",
+        "operationId": "ServiceCatalog",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ServiceCatalogResponse"
+          }
+        }
+      }
+    },
+    "/services/{Servicename}": {
+      "get": {
+        "tags": [
+          "service"
+        ],
+        "summary": "Return details of the named Epinio Catalog `Service``.",
+        "operationId": "ServiceCatalogShow",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "Servicename",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ServiceCatalogShowResponse"
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -1273,16 +1447,17 @@
       "description": "AppChart matches github.com/epinio/application/api/v1 AppChartSpec\nReason for existence: Do not expose the internal CRD struct in the API.",
       "type": "object",
       "properties": {
-        "chart": {
-          "type": "string",
-          "x-go-name": "HelmChart"
-        },
         "description": {
           "type": "string",
           "x-go-name": "Description"
         },
+        "helm_chart": {
+          "type": "string",
+          "x-go-name": "HelmChart"
+        },
         "helm_repo": {
-          "$ref": "#/definitions/HelmRepo"
+          "type": "string",
+          "x-go-name": "HelmRepo"
         },
         "name": {
           "type": "string",
@@ -1494,6 +1669,35 @@
       },
       "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
     },
+    "CatalogService": {
+      "type": "object",
+      "properties": {
+        "chart": {
+          "type": "string",
+          "x-go-name": "HelmChart"
+        },
+        "description": {
+          "type": "string",
+          "x-go-name": "Description"
+        },
+        "helm_repo": {
+          "$ref": "#/definitions/HelmRepo"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "short_description": {
+          "type": "string",
+          "x-go-name": "ShortDescription"
+        },
+        "values": {
+          "type": "string",
+          "x-go-name": "Values"
+        }
+      },
+      "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
+    },
     "ChartCreateRequest": {
       "description": "ChartCreateRequest represents and contains the data needed to create an application\nchart instance",
       "type": "object",
@@ -1502,21 +1706,21 @@
           "type": "string",
           "x-go-name": "Description"
         },
+        "helm_chart": {
+          "type": "string",
+          "x-go-name": "HelmChart"
+        },
+        "helm_repo": {
+          "type": "string",
+          "x-go-name": "HelmRepo"
+        },
         "name": {
           "type": "string",
           "x-go-name": "Name"
         },
-        "repository": {
-          "type": "string",
-          "x-go-name": "Repository"
-        },
-        "shortDescription": {
+        "short_description": {
           "type": "string",
           "x-go-name": "ShortDesc"
-        },
-        "url": {
-          "type": "string",
-          "x-go-name": "URL"
         }
       },
       "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
@@ -1887,6 +2091,102 @@
       },
       "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
     },
+    "Service": {
+      "type": "object",
+      "properties": {
+        "catalog_service": {
+          "type": "string",
+          "x-go-name": "CatalogService"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "namespace": {
+          "type": "string",
+          "x-go-name": "Namespace"
+        },
+        "status": {
+          "$ref": "#/definitions/ServiceStatus"
+        }
+      },
+      "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
+    },
+    "ServiceBindRequest": {
+      "type": "object",
+      "properties": {
+        "app_name": {
+          "type": "string",
+          "x-go-name": "AppName"
+        }
+      },
+      "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
+    },
+    "ServiceCatalogResponse": {
+      "description": "ServiceCatalogResponse",
+      "type": "object",
+      "properties": {
+        "catalog_services": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CatalogService"
+          },
+          "x-go-name": "CatalogServices"
+        }
+      },
+      "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
+    },
+    "ServiceCatalogShowResponse": {
+      "description": "ServiceCatalogShowResponse",
+      "type": "object",
+      "properties": {
+        "catalog_service": {
+          "$ref": "#/definitions/CatalogService"
+        }
+      },
+      "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
+    },
+    "ServiceCreateRequest": {
+      "description": "Service matches github.com/epinio/application/api/v1 ServiceSpec\nReason for existence: Do not expose the internal CRD struct in the API.",
+      "type": "object",
+      "properties": {
+        "catalog_service": {
+          "type": "string",
+          "x-go-name": "CatalogService"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
+    },
+    "ServiceListResponse": {
+      "type": "object",
+      "properties": {
+        "services": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Service"
+          },
+          "x-go-name": "Services"
+        }
+      },
+      "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
+    },
+    "ServiceShowResponse": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "$ref": "#/definitions/Service"
+        }
+      },
+      "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
+    },
+    "ServiceStatus": {
+      "type": "string",
+      "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
+    },
     "StageRef": {
       "description": "StageRef references a staging run by ID, currently randomly generated\nfor each POST to the staging endpoint",
       "type": "object",
@@ -2179,6 +2479,48 @@
       "description": "",
       "schema": {
         "$ref": "#/definitions/NamespaceList"
+      }
+    },
+    "ServiceBindResponse": {
+      "description": "",
+      "schema": {
+        "$ref": "#/definitions/Response"
+      }
+    },
+    "ServiceCatalogResponse": {
+      "description": "",
+      "schema": {
+        "$ref": "#/definitions/ServiceCatalogResponse"
+      }
+    },
+    "ServiceCatalogShowResponse": {
+      "description": "",
+      "schema": {
+        "$ref": "#/definitions/ServiceCatalogShowResponse"
+      }
+    },
+    "ServiceCreateResponse": {
+      "description": "",
+      "schema": {
+        "$ref": "#/definitions/Response"
+      }
+    },
+    "ServiceDeleteResponse": {
+      "description": "",
+      "schema": {
+        "$ref": "#/definitions/Response"
+      }
+    },
+    "ServiceListResponse": {
+      "description": "",
+      "schema": {
+        "$ref": "#/definitions/ServiceListResponse"
+      }
+    },
+    "ServiceShowResponse": {
+      "description": "",
+      "schema": {
+        "$ref": "#/definitions/ServiceShowResponse"
       }
     },
     "StagingCompleteResponse": {

--- a/internal/api/v1/docs/service.go
+++ b/internal/api/v1/docs/service.go
@@ -18,15 +18,15 @@ type ServiceCatalogResponse struct {
 	Body models.ServiceCatalogResponse
 }
 
-// swagger:route GET /services/{Servicename} service ServiceCatalogShow
-// Return details of the named Epinio Catalog `Service``.
+// swagger:route GET /services/{CatalogService} service ServiceCatalogShow
+// Return details of the named Epinio `CatalogService`.
 // responses:
 //   200: ServiceCatalogShowResponse
 
 // swagger:parameters ServiceCatalogShow
 type ServiceCatalogShowParam struct {
 	// in: path
-	Servicename string
+	CatalogService string
 }
 
 // swagger:response ServiceCatalogShowResponse
@@ -36,7 +36,7 @@ type ServiceCatalogShowResponse struct {
 }
 
 // swagger:route POST /namespaces/{Namespace}/services service ServiceCreate
-// Create a named instance of an Epinio Catalog Service in the `Namespace`.
+// Create a named service of an Epinio catalog service in the `Namespace`.
 // responses:
 //   200: ServiceCreateResponse
 
@@ -55,7 +55,7 @@ type ServiceCreateResponse struct {
 }
 
 // swagger:route GET /namespaces/{Namespace}/services service ServiceList
-// Return list of service instances in the `Namespace`.
+// Return list of services in the `Namespace`.
 // responses:
 //   200: ServiceListResponse
 
@@ -72,7 +72,7 @@ type ServiceListResponse struct {
 }
 
 // swagger:route GET /namespaces/{Namespace}/services/{Service} service ServiceShow
-// Return details of the named `Service` instance in the `Namespace`.
+// Return details of the named `Service` in the `Namespace`.
 // responses:
 //   200: ServiceShowResponse
 
@@ -91,7 +91,7 @@ type ServiceShowParam struct {
 }
 
 // swagger:route DELETE /namespaces/{Namespace}/services/{Service} service ServiceDelete
-// Delete the named `Service` instance in the `Namespace`.
+// Delete the named `Service` in the `Namespace`.
 // responses:
 //   200: ServiceDeleteResponse
 
@@ -109,8 +109,8 @@ type ServiceDeleteResponse struct {
 	Body models.Response
 }
 
-// swagger:route POST /namespaces/{Namespace}/services/{Servicename}/bind service ServiceBind
-// Bind the named `Servicename` instance in the `Namespace` to an App.
+// swagger:route POST /namespaces/{Namespace}/services/{Service}/bind service ServiceBind
+// Bind the named `Service` in the `Namespace` to an App.
 // responses:
 //   200: ServiceBindResponse
 
@@ -119,7 +119,7 @@ type ServiceBindParam struct {
 	// in: path
 	Namespace string
 	// in: path
-	Servicename string
+	Service string
 	// in: body
 	Configuration models.ServiceBindRequest
 }

--- a/internal/api/v1/docs/service.go
+++ b/internal/api/v1/docs/service.go
@@ -1,0 +1,131 @@
+package docs
+
+//go:generate swagger generate spec
+
+import "github.com/epinio/epinio/pkg/api/core/v1/models"
+
+// swagger:route GET /services service ServiceCatalog
+// Return all available Epinio Catalog services.
+// responses:
+//   200: ServiceCatalogResponse
+
+// swagger:parameters ServiceCatalog
+type ServiceCatalogParam struct{}
+
+// swagger:response ServiceCatalogResponse
+type ServiceCatalogResponse struct {
+	// in: body
+	Body models.ServiceCatalogResponse
+}
+
+// swagger:route GET /services/{Servicename} service ServiceCatalogShow
+// Return details of the named Epinio Catalog `Service``.
+// responses:
+//   200: ServiceCatalogShowResponse
+
+// swagger:parameters ServiceCatalogShow
+type ServiceCatalogShowParam struct {
+	// in: path
+	Servicename string
+}
+
+// swagger:response ServiceCatalogShowResponse
+type ServiceCatalogShowResponse struct {
+	// in: body
+	Body models.ServiceCatalogShowResponse
+}
+
+// swagger:route POST /namespaces/{Namespace}/services service ServiceCreate
+// Create a named instance of an Epinio Catalog Service in the `Namespace`.
+// responses:
+//   200: ServiceCreateResponse
+
+// swagger:parameters ServiceCreate
+type ServiceCreateParam struct {
+	// in: path
+	Namespace string
+	// in: body
+	Configuration models.ServiceCreateRequest
+}
+
+// swagger:response ServiceCreateResponse
+type ServiceCreateResponse struct {
+	// in: body
+	Body models.Response
+}
+
+// swagger:route GET /namespaces/{Namespace}/services service ServiceList
+// Return list of service instances in the `Namespace`.
+// responses:
+//   200: ServiceListResponse
+
+// swagger:parameters ServiceList
+type ServiceListParam struct {
+	// in: path
+	Namespace string
+}
+
+// swagger:response ServiceListResponse
+type ServiceListResponse struct {
+	// in: body
+	Body models.ServiceListResponse
+}
+
+// swagger:route GET /namespaces/{Namespace}/services/{Service} service ServiceShow
+// Return details of the named `Service` instance in the `Namespace`.
+// responses:
+//   200: ServiceShowResponse
+
+// swagger:response ServiceShowResponse
+type ServiceShowResponse struct {
+	// in: body
+	Body models.ServiceShowResponse
+}
+
+// swagger:parameters ServiceShow
+type ServiceShowParam struct {
+	// in: path
+	Namespace string
+	// in: path
+	Service string
+}
+
+// swagger:route DELETE /namespaces/{Namespace}/services/{Service} service ServiceDelete
+// Delete the named `Service` instance in the `Namespace`.
+// responses:
+//   200: ServiceDeleteResponse
+
+// swagger:parameters ServiceDelete
+type ServiceDeleteParam struct {
+	// in: path
+	Namespace string
+	// in: path
+	Service string
+}
+
+// swagger:response ServiceDeleteResponse
+type ServiceDeleteResponse struct {
+	// in: body
+	Body models.Response
+}
+
+// swagger:route POST /namespaces/{Namespace}/services/{Servicename}/bind service ServiceBind
+// Bind the named `Servicename` instance in the `Namespace` to an App.
+// responses:
+//   200: ServiceBindResponse
+
+// swagger:parameters ServiceBind
+type ServiceBindParam struct {
+	// in: path
+	Namespace string
+	// in: path
+	Servicename string
+	// in: body
+	Configuration models.ServiceBindRequest
+}
+
+// swagger:response ServiceBindResponse
+type ServiceBindResponse struct {
+	// in: body
+	Body models.Response
+}

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -130,7 +130,7 @@ var Routes = routes.NamedRoutes{
 
 	// Services
 	"ServiceCatalog":     get("/services", errorHandler(service.Controller{}.Catalog)),
-	"ServiceCatalogShow": get("/services/:servicename", errorHandler(service.Controller{}.CatalogShow)),
+	"ServiceCatalogShow": get("/services/:catalogservice", errorHandler(service.Controller{}.CatalogShow)),
 	"ServiceCreate":      post("/namespaces/:namespace/services", errorHandler(service.Controller{}.Create)),
 	"ServiceList":        get("/namespaces/:namespace/services", errorHandler(service.Controller{}.List)),
 	"ServiceShow":        get("/namespaces/:namespace/services/:service", errorHandler(service.Controller{}.Show)),
@@ -138,7 +138,7 @@ var Routes = routes.NamedRoutes{
 
 	// Bind a service to/from applications
 	"ServiceBind": post(
-		"/namespaces/:namespace/services/:servicename/bind",
+		"/namespaces/:namespace/services/:service/bind",
 		errorHandler(service.Controller{}.Bind),
 	),
 

--- a/internal/api/v1/service/bind.go
+++ b/internal/api/v1/service/bind.go
@@ -25,7 +25,7 @@ func (ctr Controller) Bind(c *gin.Context) apierror.APIErrors {
 	logger := requestctx.Logger(ctx).WithName("Bind")
 
 	namespace := c.Param("namespace")
-	serviceName := c.Param("servicename")
+	serviceName := c.Param("service")
 
 	var bindRequest models.ServiceBindRequest
 	err := c.BindJSON(&bindRequest)

--- a/internal/api/v1/service/catalog.go
+++ b/internal/api/v1/service/catalog.go
@@ -37,7 +37,7 @@ func (ctr Controller) Catalog(c *gin.Context) apierror.APIErrors {
 
 func (ctr Controller) CatalogShow(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
-	serviceName := c.Param("servicename")
+	serviceName := c.Param("catalogservice")
 
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -113,7 +113,7 @@ var CmdServiceDelete = &cobra.Command{
 }
 var CmdServiceBindCreate = &cobra.Command{
 	Use:   "bind SERVICENAME APPNAME",
-	Short: "Bind a service SERVICENAME to an Epinio app APPNAME",
+	Short: "Bind a service instance SERVICENAME to an Epinio app APPNAME",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -70,7 +70,7 @@ var CmdServiceCreate = &cobra.Command{
 		serviceName := args[1]
 
 		err = client.ServiceCreate(catalogServiceName, serviceName)
-		return errors.Wrap(err, "error creating Epinio catalog service")
+		return errors.Wrap(err, "error creating service")
 	},
 }
 

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -29,7 +29,7 @@ func init() {
 
 var CmdServiceCatalog = &cobra.Command{
 	Use:   "catalog [NAME]",
-	Short: "Lists all available Epinio services, or show the details of the specified one",
+	Short: "Lists all available Epinio catalog services, or show the details of the specified one",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
@@ -41,13 +41,13 @@ var CmdServiceCatalog = &cobra.Command{
 
 		if len(args) == 0 {
 			err = client.ServiceCatalog()
-			return errors.Wrap(err, "error listing Epinio services")
+			return errors.Wrap(err, "error listing Epinio catalog services")
 		}
 
 		if len(args) == 1 {
 			serviceName := args[0]
 			err = client.ServiceCatalogShow(serviceName)
-			return errors.Wrap(err, fmt.Sprintf("error showing %s Epinio service", serviceName))
+			return errors.Wrap(err, fmt.Sprintf("error showing %s Epinio catalog service", serviceName))
 		}
 
 		return nil
@@ -56,7 +56,7 @@ var CmdServiceCatalog = &cobra.Command{
 
 var CmdServiceCreate = &cobra.Command{
 	Use:   "create CATALOGSERVICENAME SERVICENAME",
-	Short: "Create an instance SERVICENAME of an Epinio service CATALOGSERVICENAME",
+	Short: "Create a service SERVICENAME of an Epinio catalog service CATALOGSERVICENAME",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
@@ -70,13 +70,13 @@ var CmdServiceCreate = &cobra.Command{
 		serviceName := args[1]
 
 		err = client.ServiceCreate(catalogServiceName, serviceName)
-		return errors.Wrap(err, "error creating Epinio Service")
+		return errors.Wrap(err, "error creating Epinio catalog service")
 	},
 }
 
 var CmdServiceShow = &cobra.Command{
 	Use:   "show SERVICENAME",
-	Short: "Show details of a service instance SERVICENAME",
+	Short: "Show details of a service SERVICENAME",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
@@ -89,13 +89,13 @@ var CmdServiceShow = &cobra.Command{
 		serviceName := args[0]
 
 		err = client.ServiceShow(serviceName)
-		return errors.Wrap(err, "error showing Service")
+		return errors.Wrap(err, "error showing service")
 	},
 }
 
 var CmdServiceDelete = &cobra.Command{
 	Use:   "delete SERVICENAME",
-	Short: "Delete service instance SERVICENAME",
+	Short: "Delete service SERVICENAME",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
@@ -108,12 +108,12 @@ var CmdServiceDelete = &cobra.Command{
 		serviceName := args[0]
 
 		err = client.ServiceDelete(serviceName)
-		return errors.Wrap(err, "error deleting Service")
+		return errors.Wrap(err, "error deleting service")
 	},
 }
 var CmdServiceBindCreate = &cobra.Command{
 	Use:   "bind SERVICENAME APPNAME",
-	Short: "Bind a service instance SERVICENAME to an Epinio app APPNAME",
+	Short: "Bind a service SERVICENAME to an Epinio app APPNAME",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
@@ -127,7 +127,7 @@ var CmdServiceBindCreate = &cobra.Command{
 		appName := args[1]
 
 		err = client.ServiceBind(serviceName, appName)
-		return errors.Wrap(err, "error binding Epinio Service")
+		return errors.Wrap(err, "error binding service")
 	},
 }
 
@@ -144,6 +144,6 @@ var CmdServiceList = &cobra.Command{
 		}
 
 		err = client.ServiceList()
-		return errors.Wrap(err, "error listing Epinio Service")
+		return errors.Wrap(err, "error listing services")
 	},
 }


### PR DESCRIPTION
There seems to be some inconsistency in the parameter naming. Sometimes we use the term `servicename` and some times just `service`. Should we align this? https://github.com/epinio/epinio/blob/main/internal/api/v1/router.go#L133

There might be also a confusion between the naming `Epinio service` for a `catalog service` and a `service instance`.
I have tried to add the term `instance` everywhere  an instance is addressed and add the term `Catalog` to `Epinio Service` to make the differentiation more clear, because even a service instance is a service managed by Epinio.
If you agree with this naming scheme we should also update the cli description of `service`.


Fixes [#91](https://github.com/epinio/docs/issues/91)