### PR TITLE
Authentication cleanup

### DIFF
--- a/helpers/kubernetes/cluster.go
+++ b/helpers/kubernetes/cluster.go
@@ -40,10 +40,11 @@ const (
 )
 
 var (
-	EpinioNamespaceLabelKey   = "app.kubernetes.io/component"
-	EpinioNamespaceLabelValue = "epinio-namespace"
-	EpinioAPISecretLabelKey   = fmt.Sprintf("%s/%s", APISGroupName, "api-user-credentials")
-	EpinioAPISecretLabelValue = "true"
+	EpinioNamespaceLabelKey     = "app.kubernetes.io/component"
+	EpinioNamespaceLabelValue   = "epinio-namespace"
+	EpinioAPISecretLabelKey     = fmt.Sprintf("%s/%s", APISGroupName, "api-user-credentials")
+	EpinioAPISecretLabelValue   = "true"
+	EpinioAPISecretRoleLabelKey = fmt.Sprintf("%s/%s", APISGroupName, "role")
 )
 
 // Memoization of GetCluster

--- a/internal/api/v1/application/create.go
+++ b/internal/api/v1/application/create.go
@@ -19,7 +19,7 @@ func (hc Controller) Create(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
 	namespace := c.Param("namespace")
 
-	username := requestctx.User(ctx)
+	username := requestctx.User(ctx).Username
 
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {

--- a/internal/api/v1/application/deploy.go
+++ b/internal/api/v1/application/deploy.go
@@ -25,7 +25,7 @@ func (hc Controller) Deploy(c *gin.Context) apierror.APIErrors {
 
 	namespace := c.Param("namespace")
 	name := c.Param("app")
-	username := requestctx.User(ctx)
+	username := requestctx.User(ctx).Username
 
 	req := models.DeployRequest{}
 	if err := c.BindJSON(&req); err != nil {

--- a/internal/api/v1/application/importgit.go
+++ b/internal/api/v1/application/importgit.go
@@ -79,7 +79,7 @@ func (hc Controller) ImportGit(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err, "creating an S3 manager")
 	}
 
-	username := requestctx.User(ctx)
+	username := requestctx.User(ctx).Username
 	blobUID, err := manager.Upload(ctx, tarball, map[string]string{
 		"app": name, "namespace": namespace, "username": username,
 	})

--- a/internal/api/v1/application/restart.go
+++ b/internal/api/v1/application/restart.go
@@ -18,7 +18,7 @@ func (hc Controller) Restart(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
 	namespace := c.Param("namespace")
 	appName := c.Param("app")
-	username := requestctx.User(ctx)
+	username := requestctx.User(ctx).Username
 
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -98,7 +98,7 @@ func (hc Controller) Stage(c *gin.Context) apierror.APIErrors {
 
 	namespace := c.Param("namespace")
 	name := c.Param("app")
-	username := requestctx.User(ctx)
+	username := requestctx.User(ctx).Username
 
 	req := models.StageRequest{}
 	if err := c.BindJSON(&req); err != nil {

--- a/internal/api/v1/application/update.go
+++ b/internal/api/v1/application/update.go
@@ -23,7 +23,7 @@ func (hc Controller) Update(c *gin.Context) apierror.APIErrors { // nolint:gocyc
 	ctx := c.Request.Context()
 	namespace := c.Param("namespace")
 	appName := c.Param("app")
-	username := requestctx.User(ctx)
+	username := requestctx.User(ctx).Username
 
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {

--- a/internal/api/v1/application/upload.go
+++ b/internal/api/v1/application/upload.go
@@ -45,7 +45,7 @@ func (hc Controller) Upload(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err, "creating an S3 manager")
 	}
 
-	username := requestctx.User(ctx)
+	username := requestctx.User(ctx).Username
 	blobUID, err := manager.UploadStream(ctx, file, fileheader.Size, map[string]string{
 		"app": name, "namespace": namespace, "username": username,
 	})

--- a/internal/api/v1/authtoken.go
+++ b/internal/api/v1/authtoken.go
@@ -15,7 +15,7 @@ import (
 // token for further logins
 func AuthToken(c *gin.Context) APIErrors {
 	requestContext := c.Request.Context()
-	user := requestctx.User(requestContext)
+	user := requestctx.User(requestContext).Username
 
 	response.OKReturn(c, models.AuthTokenResponse{
 		Token: authtoken.Create(user, authtoken.DefaultExpiry),

--- a/internal/api/v1/configuration/create.go
+++ b/internal/api/v1/configuration/create.go
@@ -16,7 +16,7 @@ import (
 func (sc Controller) Create(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
 	namespace := c.Param("namespace")
-	username := requestctx.User(ctx)
+	username := requestctx.User(ctx).Username
 
 	var createRequest models.ConfigurationCreateRequest
 	err := c.BindJSON(&createRequest)

--- a/internal/api/v1/configuration/delete.go
+++ b/internal/api/v1/configuration/delete.go
@@ -21,7 +21,7 @@ func (sc Controller) Delete(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
 	namespace := c.Param("namespace")
 	configurationName := c.Param("configuration")
-	username := requestctx.User(ctx)
+	username := requestctx.User(ctx).Username
 
 	var deleteRequest models.ConfigurationDeleteRequest
 	err := c.BindJSON(&deleteRequest)

--- a/internal/api/v1/configuration/replace.go
+++ b/internal/api/v1/configuration/replace.go
@@ -59,7 +59,7 @@ func (sc Controller) Replace(c *gin.Context) apierror.APIErrors { // nolint:gocy
 
 	// Perform restart on the candidates which are actually running
 	if restart {
-		username := requestctx.User(ctx)
+		username := requestctx.User(ctx).Username
 
 		// Determine bound apps, as candidates for restart.
 		appNames, err := application.BoundAppsNamesFor(ctx, cluster, namespace, configurationName)

--- a/internal/api/v1/configuration/update.go
+++ b/internal/api/v1/configuration/update.go
@@ -69,7 +69,7 @@ func (sc Controller) Update(c *gin.Context) apierror.APIErrors { // nolint:gocyc
 	}
 
 	// Perform restart on the candidates which are actually running
-	username := requestctx.User(ctx)
+	username := requestctx.User(ctx).Username
 
 	for _, appName := range appNames {
 		app, err := application.Lookup(ctx, cluster, namespace, appName)

--- a/internal/api/v1/configurationbinding/create.go
+++ b/internal/api/v1/configurationbinding/create.go
@@ -151,7 +151,7 @@ func CreateConfigurationBinding(
 
 		// Update the workload, if there is any.
 		if app.Workload != nil {
-			_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, requestctx.User(ctx), "", nil, nil)
+			_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, requestctx.User(ctx).Username, "", nil, nil)
 			if apierr != nil {
 				return nil, apierr
 			}

--- a/internal/api/v1/configurationbinding/delete.go
+++ b/internal/api/v1/configurationbinding/delete.go
@@ -16,7 +16,7 @@ func (hc Controller) Delete(c *gin.Context) apierror.APIErrors {
 	namespace := c.Param("namespace")
 	appName := c.Param("app")
 	configurationName := c.Param("configuration")
-	username := requestctx.User(ctx)
+	username := requestctx.User(ctx).Username
 
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {

--- a/internal/api/v1/env/set.go
+++ b/internal/api/v1/env/set.go
@@ -18,7 +18,7 @@ import (
 func (hc Controller) Set(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
 	log := requestctx.Logger(ctx)
-	username := requestctx.User(ctx)
+	username := requestctx.User(ctx).Username
 
 	namespaceName := c.Param("namespace")
 	appName := c.Param("app")

--- a/internal/api/v1/env/unset.go
+++ b/internal/api/v1/env/unset.go
@@ -17,7 +17,7 @@ import (
 func (hc Controller) Unset(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
 	log := requestctx.Logger(ctx)
-	username := requestctx.User(ctx)
+	username := requestctx.User(ctx).Username
 
 	namespaceName := c.Param("namespace")
 	appName := c.Param("app")

--- a/internal/api/v1/service/unbind.go
+++ b/internal/api/v1/service/unbind.go
@@ -78,7 +78,7 @@ func (ctr Controller) Unbind(c *gin.Context) apierror.APIErrors {
 
 	logger.Info(fmt.Sprintf("configurationSecrets found %+v\n", serviceConfigurations))
 
-	username := requestctx.User(ctx)
+	username := requestctx.User(ctx).Username
 	for _, secret := range serviceConfigurations {
 		// TODO: Don't `helm upgrade` after each removal. Do it once.
 		errors := configurationbinding.DeleteBinding(

--- a/internal/cli/admincmd/settings.go
+++ b/internal/cli/admincmd/settings.go
@@ -63,13 +63,14 @@ func (a *Admin) SettingsUpdate(ctx context.Context) error {
 
 	details.Info("retrieving credentials")
 
-	user, password, err := auth.GetFirstUserAccount(ctx)
-	if err != nil {
-		a.ui.Exclamation().Msg(err.Error())
+	users, err := auth.GetUsersByAge(ctx)
+	if len(users) == 0 {
+		a.ui.Exclamation().Msg("no user account found")
 		return nil
 	}
+	user := users[0]
 
-	details.Info("retrieved credentials", "user", user, "password", password)
+	details.Info("retrieved credentials", "user", user.Username, "password", user.Password)
 	details.Info("retrieving server locations")
 
 	api, wss, err := getAPI(ctx, details)
@@ -89,8 +90,8 @@ func (a *Admin) SettingsUpdate(ctx context.Context) error {
 
 	details.Info("retrieved certs", "certs", certs)
 
-	a.Settings.User = user
-	a.Settings.Password = password
+	a.Settings.User = user.Username
+	a.Settings.Password = user.Password
 	a.Settings.API = api
 	a.Settings.WSS = wss
 	a.Settings.Certs = certs

--- a/internal/cli/admincmd/settings.go
+++ b/internal/cli/admincmd/settings.go
@@ -64,6 +64,10 @@ func (a *Admin) SettingsUpdate(ctx context.Context) error {
 	details.Info("retrieving credentials")
 
 	users, err := auth.GetUsersByAge(ctx)
+	if err != nil {
+		a.ui.Exclamation().Msg(err.Error())
+		return nil
+	}
 	if len(users) == 0 {
 		a.ui.Exclamation().Msg("no user account found")
 		return nil

--- a/internal/cli/server/requestctx/context.go
+++ b/internal/cli/server/requestctx/context.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/epinio/epinio/helpers/tracelog"
+	"github.com/epinio/epinio/internal/auth"
 	"github.com/go-logr/logr"
 )
 
@@ -18,13 +19,17 @@ type UserKey struct{}
 type LoggerKey struct{}
 
 // WithUser adds the user name to the context
-func WithUser(ctx context.Context, val string) context.Context {
+func WithUser(ctx context.Context, val auth.User) context.Context {
 	return context.WithValue(ctx, UserKey{}, val)
 }
 
 // User returns the user name from the context
-func User(ctx context.Context) string {
-	return extractString(ctx, UserKey{})
+func User(ctx context.Context) auth.User {
+	user, ok := ctx.Value(UserKey{}).(auth.User)
+	if !ok {
+		return auth.User{}
+	}
+	return user
 }
 
 // WithID adds the request ID to the context

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -185,6 +185,7 @@ func authMiddleware(ctx *gin.Context) {
 			ctx.Abort()
 			return
 		}
+		username = user.Username
 
 		// Check if that user still exists. If not delete the session and block the request!
 		// This allows us to kick out users even if they keep their browser open.


### PR DESCRIPTION
## Note

This PR needs the new users from this helm-charts PR
- https://github.com/epinio/helm-charts/pull/184

It would work also without it, but I guess it's better to merge that before.

---

This is a cleanup/refactor made before the authorization spike. It should not change the behaviour of the API.

The main changes are in the `internal/auth/auth.go`.

Some unused structs and func were removed:
- PasswordAuth
- HashBcrypt()
- RandomPasswordAuth()

Then a new `auth.User` struct was added,  and all the methods were adapted accordingly. This struct will match an Epinio User (or account maybe?), and it will be the one that will be returned from the different functions and package (I don't think we should move too much around with secrets and the kubernetes internal, generally speaking). This struct will be also the one that is going to be keep around in the context and session.

```go
// User is a struct containing all the information of an Epinio User
type User struct {
	Username   string
	Password   string
	CreatedAt  time.Time
	Role       string
	Namespaces []string
}
```

So a `NewUserFromSecret` func was added, and the other `GetUserAccounts`, `GetFirstUserAccount` and `GetUserSecretsByAge` were updated accordingly.

It's probably easier to have a look at the result: https://github.com/epinio/epinio/blob/auth-cleanup/internal/auth/auth.go

Other important changes are in the `internal/cli/server/server.go`, so that now we are going to persist the `auth.User` in the session and context. I've also removed the BasicAuth header decoding, that can be done with just

```go
username, password, ok = ctx.Request.BasicAuth()
```

