### PR TITLE
Prevent `app log` panic / message channel double-close

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ build-linux-amd64: build-amd64
 build-amd64:
 	GOARCH="amd64" GOOS="linux" CGO_ENABLED=$(CGO_ENABLED) go build $(BUILD_ARGS) -ldflags '$(LDFLAGS)' -o dist/epinio-linux-amd64
 
+build-cover:
+	GOARCH="amd64" GOOS="linux" CGO_ENABLED=0 go test -c -covermode=count -coverpkg ./... -o dist/epinio-linux-amd64-coverage
+
 build-windows-amd64: build-windows
 build-windows:
 	GOARCH="amd64" GOOS="windows" CGO_ENABLED=$(CGO_ENABLED) go build $(BUILD_ARGS) -ldflags '$(LDFLAGS)' -o dist/epinio-windows-amd64.exe

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -384,7 +384,7 @@ func (c *EpinioClient) AppLogs(appName, stageID string, follow bool) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logsChan, err := c.API.AppLogs(ctx, c.Settings.Namespace, appName, stageID, follow)
+	logsChan, err := c.API.AppLogs(ctx, c.Settings.Namespace, appName, stageID, follow, false)
 	if err != nil {
 		c.ui.Problem().Msg(fmt.Sprintf("failed to tail logs: %s", err.Error()))
 		return err

--- a/internal/cli/usercmd/app_test.go
+++ b/internal/cli/usercmd/app_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Client Apps unit tests", Label("wip"), func() {
 					return &models.StageResponse{Stage: models.NewStage("ID")}, nil
 				}
 
-				mockClient.mockAppLogs = func(ctx context.Context, namespace, appName, stageID string, follow bool) (chan []byte, error) {
+				mockClient.mockAppLogs = func(ctx context.Context, namespace, appName, stageID string, follow, closer bool) (chan []byte, error) {
 					return make(chan []byte), nil
 				}
 
@@ -79,7 +79,7 @@ var _ = Describe("Client Apps unit tests", Label("wip"), func() {
 type mockAPIClient struct {
 	mockAppShow         func(namespace string, appName string) (models.App, error)
 	mockAppStage        func(req models.StageRequest) (*models.StageResponse, error)
-	mockAppLogs         func(ctx context.Context, namespace, appName, stageID string, follow bool) (chan []byte, error)
+	mockAppLogs         func(ctx context.Context, namespace, appName, stageID string, follow, closer bool) (chan []byte, error)
 	mockStagingComplete func(namespace string, id string) (models.Response, error)
 }
 
@@ -131,8 +131,8 @@ func (m *mockAPIClient) AppDeploy(req models.DeployRequest) (*models.DeployRespo
 	return nil, nil
 }
 
-func (m *mockAPIClient) AppLogs(ctx context.Context, namespace, appName, stageID string, follow bool) (chan []byte, error) {
-	return m.mockAppLogs(ctx, namespace, appName, stageID, follow)
+func (m *mockAPIClient) AppLogs(ctx context.Context, namespace, appName, stageID string, follow, closer bool) (chan []byte, error) {
+	return m.mockAppLogs(ctx, namespace, appName, stageID, follow, closer)
 }
 
 func (m *mockAPIClient) StagingComplete(namespace string, id string) (models.Response, error) {

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -37,7 +37,7 @@ type APIClient interface {
 	AppImportGit(app models.AppRef, gitRef models.GitRef) (*models.ImportGitResponse, error)
 	AppStage(req models.StageRequest) (*models.StageResponse, error)
 	AppDeploy(req models.DeployRequest) (*models.DeployResponse, error)
-	AppLogs(ctx context.Context, namespace, appName, stageID string, follow bool) (chan []byte, error)
+	AppLogs(ctx context.Context, namespace, appName, stageID string, follow, closer bool) (chan []byte, error)
 	StagingComplete(namespace string, id string) (models.Response, error)
 	AppRunning(app models.AppRef) (models.Response, error)
 	AppExec(namespace string, appName, instance string, tty kubectlterm.TTY) error

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -266,7 +266,7 @@ func (c *EpinioClient) stageLogs(logger logr.Logger, appRef models.AppRef, stage
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logsChan, err := c.API.AppLogs(ctx, c.Settings.Namespace, appRef.Name, stageID, true)
+	logsChan, err := c.API.AppLogs(ctx, c.Settings.Namespace, appRef.Name, stageID, true, true)
 	if err != nil {
 		c.ui.Problem().Msg(fmt.Sprintf("failed to tail logs: %s", err.Error()))
 	}

--- a/pkg/api/core/v1/client/app_logs_test.go
+++ b/pkg/api/core/v1/client/app_logs_test.go
@@ -82,7 +82,7 @@ func DescribeAppLogs() {
 			ctx, cancel := context.WithTimeout(context.Background(), waitingTime)
 			defer cancel()
 
-			msgChan, err := epinioClient.AppLogs(ctx, "namespace-foo", "appname", "stageID", false)
+			msgChan, err := epinioClient.AppLogs(ctx, "namespace-foo", "appname", "stageID", false, true)
 			Expect(err).ToNot(HaveOccurred())
 
 			messages := []string{}
@@ -100,7 +100,7 @@ func DescribeAppLogs() {
 			ctx, cancel := context.WithTimeout(context.Background(), waitingTime)
 			defer cancel()
 
-			msgChan, err := epinioClient.AppLogs(ctx, "namespace-foo", "appname", "stageID", false)
+			msgChan, err := epinioClient.AppLogs(ctx, "namespace-foo", "appname", "stageID", false, true)
 			Expect(err).ToNot(HaveOccurred())
 
 			messages := []string{}
@@ -121,7 +121,7 @@ func DescribeAppLogs() {
 			ctx, cancel := context.WithTimeout(context.Background(), waitingTime)
 			defer cancel()
 
-			msgChan, err := epinioClient.AppLogs(ctx, "namespace-foo", "appname", "stageID", true)
+			msgChan, err := epinioClient.AppLogs(ctx, "namespace-foo", "appname", "stageID", true, true)
 			Expect(err).ToNot(HaveOccurred())
 
 			messages := []string{}
@@ -132,14 +132,14 @@ func DescribeAppLogs() {
 			Expect(len(messages)).To(BeNumerically(">", logMessages))
 		})
 
-		It("will read more less logs if cancelled before", func() {
+		It("will read less logs if cancelled before", func() {
 			totalLogTime := time.Duration(logMessages) * logMessageDelay
 			waitingTime := totalLogTime - 1*time.Second
 
 			ctx, cancel := context.WithTimeout(context.Background(), waitingTime)
 			defer cancel()
 
-			msgChan, err := epinioClient.AppLogs(ctx, "namespace-foo", "appname", "stageID", true)
+			msgChan, err := epinioClient.AppLogs(ctx, "namespace-foo", "appname", "stageID", true, true)
 			Expect(err).ToNot(HaveOccurred())
 
 			messages := []string{}


### PR DESCRIPTION
Fix #1417 : make app logging closer goroutine on-demand and disable it for `app logs` command.

Recap: For `app logs` context cancellation is late.
Closer races against process termination
When closer wins the race a panic occurs, double close of the message channel.

However, closer is not required, because websocket is closed by server!
Closing by user would be sigterm (^C).
That kills the process and goroutines with no time for this kind of finalization.
