### PR TITLE
Support service versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/alron/ginlogr v0.0.4
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/briandowns/spinner v1.18.1
-	github.com/epinio/application v0.0.0-20220421063308-fc0e65e23045
+	github.com/epinio/application v0.0.0-20220511081359-68934c440430
 	github.com/fatih/color v1.13.0
 	github.com/gin-contrib/sessions v0.0.4
 	github.com/gin-gonic/gin v1.7.7

--- a/go.sum
+++ b/go.sum
@@ -357,8 +357,8 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
-github.com/epinio/application v0.0.0-20220421063308-fc0e65e23045 h1:xEcz7dnJiuQonfZb1Grxtug0ymwfj0Q0JxvhyK31eKk=
-github.com/epinio/application v0.0.0-20220421063308-fc0e65e23045/go.mod h1:TsOLExnVfT4RDqLnOv6UHQ6ri26dDNG8RkQTyVqCU14=
+github.com/epinio/application v0.0.0-20220511081359-68934c440430 h1:cTRz1+Zk9LnBGpiBrCwtJS45QEkFFf5QD+7J5irA6KI=
+github.com/epinio/application v0.0.0-20220511081359-68934c440430/go.mod h1:TsOLExnVfT4RDqLnOv6UHQ6ri26dDNG8RkQTyVqCU14=
 github.com/evanphx/json-patch v0.0.0-20200808040245-162e5629780b/go.mod h1:NAJj0yf/KaRKURN6nyi7A9IZydMivZEm9oQLWNjfKDc=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -18,12 +18,14 @@ func (c *EpinioClient) ServiceCatalog() error {
 		return errors.Wrap(err, "service catalog failed")
 	}
 
-	msg := c.ui.Success().WithTable("Name", "Description")
+	msg := c.ui.Success().WithTable("Name", "Repo", "Chart", "Description")
 
-	for _, name := range catalog.CatalogServices {
+	for _, service := range catalog.CatalogServices {
 		msg = msg.WithTableRow(
-			name.Name,
-			name.ShortDescription,
+			service.Name,
+			service.HelmRepo.URL,
+			service.HelmChart,
+			service.ShortDescription,
 		)
 	}
 
@@ -53,6 +55,9 @@ func (c *EpinioClient) ServiceCatalogShow(serviceName string) error {
 		WithTableRow("Name", service.Name).
 		WithTableRow("Short Description", service.ShortDescription).
 		WithTableRow("Description", service.Description).
+		WithTableRow("Helm Chart", service.HelmChart).
+		WithTableRow("Helm Repository", service.HelmRepo.URL).
+		WithTableRow("Chart Values", service.Values).
 		Msg("Epinio Service:")
 
 	return nil

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -1,8 +1,6 @@
 package usercmd
 
 import (
-	"strings"
-
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/pkg/errors"
 )
@@ -23,15 +21,9 @@ func (c *EpinioClient) ServiceCatalog() error {
 	msg := c.ui.Success().WithTable("Name", "Version", "Description")
 
 	for _, service := range catalog.CatalogServices {
-		chartVersion := "implied latest"
-		pieces := strings.SplitN(service.HelmChart, ":", 2)
-		if len(pieces) == 2 {
-			chartVersion = pieces[1]
-		}
-
 		msg = msg.WithTableRow(
 			service.Name,
-			chartVersion,
+			service.AppVersion,
 			service.ShortDescription,
 		)
 	}
@@ -58,15 +50,9 @@ func (c *EpinioClient) ServiceCatalogShow(serviceName string) error {
 
 	service := catalogShowResponse.CatalogService
 
-	chartVersion := "implied latest"
-	pieces := strings.SplitN(service.HelmChart, ":", 2)
-	if len(pieces) == 2 {
-		chartVersion = pieces[1]
-	}
-
 	c.ui.Success().WithTable("Key", "Value").
 		WithTableRow("Name", service.Name).
-		WithTableRow("Version", chartVersion).
+		WithTableRow("Version", service.AppVersion).
 		WithTableRow("Short Description", service.ShortDescription).
 		WithTableRow("Description", service.Description).
 		Msg("Epinio Service:")

--- a/internal/services/catalog.go
+++ b/internal/services/catalog.go
@@ -77,6 +77,8 @@ func convertUnstructuredIntoCatalogService(unstructured unstructured.Unstructure
 		Description:      catalogService.Spec.Description,
 		ShortDescription: catalogService.Spec.ShortDescription,
 		HelmChart:        catalogService.Spec.HelmChart,
+		ChartVersion:     catalogService.Spec.ChartVersion,
+		AppVersion:       catalogService.Spec.AppVersion,
 		HelmRepo: models.HelmRepo{
 			Name: catalogService.Spec.HelmRepo.Name,
 			URL:  catalogService.Spec.HelmRepo.URL,

--- a/internal/services/instances.go
+++ b/internal/services/instances.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/helm"
@@ -81,14 +80,6 @@ func (s *ServiceClient) Get(ctx context.Context, namespace, name string) (*model
 
 func (s *ServiceClient) Create(ctx context.Context, namespace, name string, catalogService models.CatalogService) error {
 
-	helmChartName := catalogService.HelmChart
-	helmChartVersion := ""
-	pieces := strings.SplitN(helmChartName, ":", 2)
-	if len(pieces) == 2 {
-		helmChartVersion = pieces[1]
-		helmChartName = pieces[0]
-	}
-
 	helmChart := &helmapiv1.HelmChart{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "helm.cattle.io/v1",
@@ -105,8 +96,8 @@ func (s *ServiceClient) Create(ctx context.Context, namespace, name string, cata
 		},
 		Spec: helmapiv1.HelmChartSpec{
 			TargetNamespace: namespace,
-			Chart:           helmChartName,
-			Version:         helmChartVersion,
+			Chart:           catalogService.HelmChart,
+			Version:         catalogService.ChartVersion,
 			Repo:            catalogService.HelmRepo.URL,
 			ValuesContent:   catalogService.Values,
 		},

--- a/internal/services/instances.go
+++ b/internal/services/instances.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/helm"
@@ -79,6 +80,15 @@ func (s *ServiceClient) Get(ctx context.Context, namespace, name string) (*model
 }
 
 func (s *ServiceClient) Create(ctx context.Context, namespace, name string, catalogService models.CatalogService) error {
+
+	helmChartName := catalogService.HelmChart
+	helmChartVersion := ""
+	pieces := strings.SplitN(helmChartName, ":", 2)
+	if len(pieces) == 2 {
+		helmChartVersion = pieces[1]
+		helmChartName = pieces[0]
+	}
+
 	helmChart := &helmapiv1.HelmChart{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "helm.cattle.io/v1",
@@ -95,7 +105,8 @@ func (s *ServiceClient) Create(ctx context.Context, namespace, name string, cata
 		},
 		Spec: helmapiv1.HelmChartSpec{
 			TargetNamespace: namespace,
-			Chart:           catalogService.HelmChart,
+			Chart:           helmChartName,
+			Version:         helmChartVersion,
 			Repo:            catalogService.HelmRepo.URL,
 			ValuesContent:   catalogService.Values,
 		},

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -246,18 +246,20 @@ type ServiceCatalogShowResponse struct {
 	CatalogService *CatalogService `json:"catalog_service,omitempty"`
 }
 
-// Service matches github.com/epinio/application/api/v1 ServiceSpec
-// Reason for existence: Do not expose the internal CRD struct in the API.
 type ServiceCreateRequest struct {
 	CatalogService string `json:"catalog_service,omitempty"`
 	Name           string `json:"name,omitempty"`
 }
 
+// CatalogService matches github.com/epinio/application/api/v1 ServiceSpec
+// Reason for existence: Do not expose the internal CRD struct in the API.
 type CatalogService struct {
 	Name             string   `json:"name,omitempty"`
 	Description      string   `json:"description,omitempty"`
 	ShortDescription string   `json:"short_description,omitempty"`
 	HelmChart        string   `json:"chart,omitempty"`
+	ChartVersion     string   `json:"chartVersion,omitempty"`
+	AppVersion       string   `json:"appVersion,omitempty"`
 	HelmRepo         HelmRepo `json:"helm_repo,omitempty"`
 	Values           string   `json:"values,omitempty"`
 }


### PR DESCRIPTION
Fix #1363 

~Associated chart PR https://github.com/epinio/helm-charts/pull/196~
Chart PR: https://github.com/epinio/helm-charts/pull/197
CRD PR: https://github.com/epinio/application/pull/9

Looks for version information attached to the chart name (syntax: `name:version`) and properly passes it into the helm chart CR.
Additionally extends the output of various service commands 