### PR TITLE
Fix GKE warning about auth plugin

### DIFF
--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -99,6 +99,9 @@ jobs:
 
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v0
+      
+      - name: Install gcloud kubectl version
+        run: gcloud components install kubectl
 
       - name: Create GKE cluster
         id: create-cluster


### PR DESCRIPTION
Fix #1434 

Installing kubectl from gcloud also brings the new auth plugin (gke-cloud-auth-plugin) and clears the warning.
<img width="414" alt="image" src="https://user-images.githubusercontent.com/6025636/168739257-30ad03ad-e5af-47d5-b50d-f851c31de9f3.png">

CI - https://github.com/epinio/epinio/runs/6460712752?check_suite_focus=true - ✅ 