### PR TITLE
ListAll Services endpoint and CatalogService rename

### DIFF
--- a/acceptance/api/v1/services_catalog_test.go
+++ b/acceptance/api/v1/services_catalog_test.go
@@ -19,7 +19,7 @@ var _ = Describe("ServiceCatalog Endpoint", func() {
 	var catalogService models.CatalogService
 
 	catalogResponse := func() models.ServiceCatalogResponse {
-		response, err := env.Curl("GET", fmt.Sprintf("%s%s/services", serverURL, v1.Root), strings.NewReader(""))
+		response, err := env.Curl("GET", fmt.Sprintf("%s%s/catalogservices", serverURL, v1.Root), strings.NewReader(""))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(response).ToNot(BeNil())
 

--- a/acceptance/helpers/regex/regex.go
+++ b/acceptance/helpers/regex/regex.go
@@ -1,0 +1,13 @@
+package regex
+
+import "fmt"
+
+// TableLine returns a regular expression that will match a line of a CLI table
+// The arguments passed should contain the expected text of the cell (or regex, i.e. you can pass '.*' to match anything)
+func TableLine(args ...string) string {
+	reg := `\|`
+	for _, arg := range args {
+		reg = fmt.Sprintf(`%s[\s]+%s[\s]+\|`, reg, arg)
+	}
+	return reg
+}

--- a/acceptance/helpers/regex/regex.go
+++ b/acceptance/helpers/regex/regex.go
@@ -2,9 +2,9 @@ package regex
 
 import "fmt"
 
-// TableLine returns a regular expression that will match a line of a CLI table
+// TableRow returns a regular expression that will match a line of a CLI table
 // The arguments passed should contain the expected text of the cell (or regex, i.e. you can pass '.*' to match anything)
-func TableLine(args ...string) string {
+func TableRow(args ...string) string {
 	reg := `\|`
 	for _, arg := range args {
 		reg = fmt.Sprintf(`%s[\s]+%s[\s]+\|`, reg, arg)

--- a/acceptance/helpers/regex/regex.go
+++ b/acceptance/helpers/regex/regex.go
@@ -1,6 +1,13 @@
 package regex
 
-import "fmt"
+import (
+	"fmt"
+)
+
+const (
+	// DateRegex will check for a date in the '2022-05-19 13:49:20 +0000' UTC format
+	DateRegex = "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [+][0-9]{4} [A-Z]{3,4}"
+)
 
 // TableRow returns a regular expression that will match a line of a CLI table
 // The arguments passed should contain the expected text of the cell (or regex, i.e. you can pass '.*' to match anything)

--- a/acceptance/helpers/regex/regex.go
+++ b/acceptance/helpers/regex/regex.go
@@ -2,6 +2,7 @@ package regex
 
 import (
 	"fmt"
+	"strings"
 )
 
 const (
@@ -12,9 +13,15 @@ const (
 // TableRow returns a regular expression that will match a line of a CLI table
 // The arguments passed should contain the expected text of the cell (or regex, i.e. you can pass '.*' to match anything)
 func TableRow(args ...string) string {
-	reg := `\|`
-	for _, arg := range args {
-		reg = fmt.Sprintf(`%s[\s]+%s[\s]+\|`, reg, arg)
+	if len(args) == 0 {
+		return ""
 	}
-	return reg
+
+	var b strings.Builder
+	for _, arg := range args {
+		fmt.Fprintf(&b, `[|][\s]+%s[\s]+`, arg)
+	}
+	b.WriteString(`[|]`)
+
+	return b.String()
 }

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -216,6 +216,11 @@ var _ = FDescribe("Services", func() {
 				return out
 			}, "2m", "5s").Should(MatchRegexp(regex.TableLine(namespace1, service1, "mysql-dev", "deployed")))
 
+			Eventually(func() string {
+				out, _ := env.Epinio("", "service", "list", "--all")
+				return out
+			}, "2m", "5s").Should(MatchRegexp(regex.TableLine(namespace2, service2, "mysql-dev", "deployed")))
+
 			By(fmt.Sprintf("%s/%s up", namespace1, service1))
 		})
 

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -123,7 +123,7 @@ var _ = FDescribe("Services", func() {
 			Expect(out).To(MatchRegexp("Listing Services"))
 			Expect(out).To(MatchRegexp("Namespace: " + namespace))
 
-			Expect(out).To(MatchRegexp(regex.TableRow(service, "mysql-dev", "not-ready")))
+			Expect(out).To(MatchRegexp(regex.TableRow(service, regex.DateRegex, "mysql-dev", "not-ready")))
 
 			By("wait for deployment")
 			Eventually(func() string {

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -123,7 +123,7 @@ var _ = FDescribe("Services", func() {
 			Expect(out).To(MatchRegexp("Listing Services"))
 			Expect(out).To(MatchRegexp("Namespace: " + namespace))
 
-			Expect(out).To(MatchRegexp(regex.TableLine(service, "mysql-dev", "not-ready")))
+			Expect(out).To(MatchRegexp(regex.TableRow(service, "mysql-dev", "not-ready")))
 
 			By("wait for deployment")
 			Eventually(func() string {
@@ -207,19 +207,19 @@ var _ = FDescribe("Services", func() {
 
 			Expect(out).To(MatchRegexp("Listing all Services"))
 
-			Expect(out).To(MatchRegexp(regex.TableLine(namespace1, service1, "mysql-dev", "not-ready")))
-			Expect(out).To(MatchRegexp(regex.TableLine(namespace2, service2, "mysql-dev", "not-ready")))
+			Expect(out).To(MatchRegexp(regex.TableRow(namespace1, service1, "mysql-dev", "not-ready")))
+			Expect(out).To(MatchRegexp(regex.TableRow(namespace2, service2, "mysql-dev", "not-ready")))
 
 			By("wait for deployment")
 			Eventually(func() string {
 				out, _ := env.Epinio("", "service", "list", "--all")
 				return out
-			}, "2m", "5s").Should(MatchRegexp(regex.TableLine(namespace1, service1, "mysql-dev", "deployed")))
+			}, "2m", "5s").Should(MatchRegexp(regex.TableRow(namespace1, service1, "mysql-dev", "deployed")))
 
 			Eventually(func() string {
 				out, _ := env.Epinio("", "service", "list", "--all")
 				return out
-			}, "2m", "5s").Should(MatchRegexp(regex.TableLine(namespace2, service2, "mysql-dev", "deployed")))
+			}, "2m", "5s").Should(MatchRegexp(regex.TableRow(namespace2, service2, "mysql-dev", "deployed")))
 
 			By(fmt.Sprintf("%s/%s up", namespace1, service1))
 		})
@@ -249,14 +249,14 @@ var _ = FDescribe("Services", func() {
 
 			Expect(out).To(MatchRegexp("Listing all Services"))
 
-			Expect(out).NotTo(MatchRegexp(regex.TableLine(namespace1, service1, "mysql-dev", "not-ready")))
-			Expect(out).To(MatchRegexp(regex.TableLine(namespace2, service2, "mysql-dev", "not-ready")))
+			Expect(out).NotTo(MatchRegexp(regex.TableRow(namespace1, service1, "mysql-dev", "not-ready")))
+			Expect(out).To(MatchRegexp(regex.TableRow(namespace2, service2, "mysql-dev", "not-ready")))
 
 			By("wait for deployment")
 			Eventually(func() string {
 				out, _ := env.Epinio("", "service", "list", "--all", "--settings-file", tmpSettingsPath)
 				return out
-			}, "2m", "5s").Should(MatchRegexp(regex.TableLine(namespace2, service2, "mysql-dev", "deployed")))
+			}, "2m", "5s").Should(MatchRegexp(regex.TableRow(namespace2, service2, "mysql-dev", "deployed")))
 
 			By(fmt.Sprintf("%s/%s up", namespace1, service1))
 		})

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = FDescribe("Services", func() {
+var _ = Describe("Services", func() {
 
 	Describe("Catalog", func() {
 		It("lists the standard catalog", func() {

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -207,21 +207,24 @@ var _ = Describe("Services", func() {
 
 			Expect(out).To(MatchRegexp("Listing all Services"))
 
-			Expect(out).To(MatchRegexp(regex.TableRow(namespace1, service1, "mysql-dev", "not-ready")))
-			Expect(out).To(MatchRegexp(regex.TableRow(namespace2, service2, "mysql-dev", "not-ready")))
+			Expect(out).To(MatchRegexp(regex.TableRow(namespace1, service1, regex.DateRegex, "mysql-dev", "not-ready")))
+			Expect(out).To(MatchRegexp(regex.TableRow(namespace2, service2, regex.DateRegex, "mysql-dev", "not-ready")))
 
-			By("wait for deployment")
+			By("wait for deployment of " + service1)
 			Eventually(func() string {
 				out, _ := env.Epinio("", "service", "list", "--all")
 				return out
-			}, "2m", "5s").Should(MatchRegexp(regex.TableRow(namespace1, service1, "mysql-dev", "deployed")))
-
-			Eventually(func() string {
-				out, _ := env.Epinio("", "service", "list", "--all")
-				return out
-			}, "2m", "5s").Should(MatchRegexp(regex.TableRow(namespace2, service2, "mysql-dev", "deployed")))
+			}, "2m", "5s").Should(MatchRegexp(regex.TableRow(namespace1, service1, regex.DateRegex, "mysql-dev", "deployed")))
 
 			By(fmt.Sprintf("%s/%s up", namespace1, service1))
+
+			By("wait for deployment of " + service2)
+			Eventually(func() string {
+				out, _ := env.Epinio("", "service", "list", "--all")
+				return out
+			}, "2m", "5s").Should(MatchRegexp(regex.TableRow(namespace2, service2, regex.DateRegex, "mysql-dev", "deployed")))
+
+			By(fmt.Sprintf("%s/%s up", namespace2, service2))
 		})
 
 		It("list only the services in the user namespace", func() {
@@ -249,16 +252,16 @@ var _ = Describe("Services", func() {
 
 			Expect(out).To(MatchRegexp("Listing all Services"))
 
-			Expect(out).NotTo(MatchRegexp(regex.TableRow(namespace1, service1, "mysql-dev", "not-ready")))
-			Expect(out).To(MatchRegexp(regex.TableRow(namespace2, service2, "mysql-dev", "not-ready")))
+			Expect(out).NotTo(MatchRegexp(regex.TableRow(namespace1, service1, regex.DateRegex, "mysql-dev", "not-ready")))
+			Expect(out).To(MatchRegexp(regex.TableRow(namespace2, service2, regex.DateRegex, "mysql-dev", "not-ready")))
 
 			By("wait for deployment")
 			Eventually(func() string {
 				out, _ := env.Epinio("", "service", "list", "--all", "--settings-file", tmpSettingsPath)
 				return out
-			}, "2m", "5s").Should(MatchRegexp(regex.TableRow(namespace2, service2, "mysql-dev", "deployed")))
+			}, "2m", "5s").Should(MatchRegexp(regex.TableRow(namespace2, service2, regex.DateRegex, "mysql-dev", "deployed")))
 
-			By(fmt.Sprintf("%s/%s up", namespace1, service1))
+			By(fmt.Sprintf("%s/%s up", namespace2, service2))
 		})
 	})
 

--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -87,6 +87,42 @@
         }
       }
     },
+    "/catalogservices": {
+      "get": {
+        "tags": [
+          "service"
+        ],
+        "summary": "Return all available Epinio Catalog services.",
+        "operationId": "ServiceCatalog",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ServiceCatalogResponse"
+          }
+        }
+      }
+    },
+    "/catalogservices/{CatalogService}": {
+      "get": {
+        "tags": [
+          "service"
+        ],
+        "summary": "Return details of the named Epinio `CatalogService`.",
+        "operationId": "ServiceCatalogShow",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "CatalogService",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ServiceCatalogShowResponse"
+          }
+        }
+      }
+    },
     "/configurations": {
       "get": {
         "tags": [
@@ -1381,33 +1417,11 @@
         "tags": [
           "service"
         ],
-        "summary": "Return all available Epinio Catalog services.",
-        "operationId": "ServiceCatalog",
+        "summary": "Return all the `Services` where the User has authorization.",
+        "operationId": "AllServices",
         "responses": {
           "200": {
-            "$ref": "#/responses/ServiceCatalogResponse"
-          }
-        }
-      }
-    },
-    "/services/{CatalogService}": {
-      "get": {
-        "tags": [
-          "service"
-        ],
-        "summary": "Return details of the named Epinio `CatalogService`.",
-        "operationId": "ServiceCatalogShow",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "CatalogService",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/ServiceCatalogShowResponse"
+            "$ref": "#/responses/ServiceListResponse"
           }
         }
       }

--- a/internal/api/v1/docs/service.go
+++ b/internal/api/v1/docs/service.go
@@ -4,7 +4,7 @@ package docs
 
 import "github.com/epinio/epinio/pkg/api/core/v1/models"
 
-// swagger:route GET /services service ServiceCatalog
+// swagger:route GET /catalogservices service ServiceCatalog
 // Return all available Epinio Catalog services.
 // responses:
 //   200: ServiceCatalogResponse
@@ -18,7 +18,7 @@ type ServiceCatalogResponse struct {
 	Body models.ServiceCatalogResponse
 }
 
-// swagger:route GET /services/{CatalogService} service ServiceCatalogShow
+// swagger:route GET /catalogservices/{CatalogService} service ServiceCatalogShow
 // Return details of the named Epinio `CatalogService`.
 // responses:
 //   200: ServiceCatalogShowResponse
@@ -34,6 +34,11 @@ type ServiceCatalogShowResponse struct {
 	// in: body
 	Body models.ServiceCatalogShowResponse
 }
+
+// swagger:route GET /services service AllServices
+// Return all the `Services` where the User has authorization.
+// responses:
+//   200: ServiceListResponse
 
 // swagger:route POST /namespaces/{Namespace}/services service ServiceCreate
 // Create a named service of an Epinio catalog service in the `Namespace`.

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -131,13 +131,16 @@ var Routes = routes.NamedRoutes{
 	"ConfigurationUpdate":  patch("/namespaces/:namespace/configurations/:configuration", errorHandler(configuration.Controller{}.Update)),
 	"ConfigurationReplace": put("/namespaces/:namespace/configurations/:configuration", errorHandler(configuration.Controller{}.Replace)),
 
+	// Service Catalog
+	"ServiceCatalog":     get("/catalogservices", errorHandler(service.Controller{}.Catalog)),
+	"ServiceCatalogShow": get("/catalogservices/:catalogservice", errorHandler(service.Controller{}.CatalogShow)),
+
 	// Services
-	"ServiceCatalog":     get("/services", errorHandler(service.Controller{}.Catalog)),
-	"ServiceCatalogShow": get("/services/:catalogservice", errorHandler(service.Controller{}.CatalogShow)),
-	"ServiceCreate":      post("/namespaces/:namespace/services", errorHandler(service.Controller{}.Create)),
-	"ServiceList":        get("/namespaces/:namespace/services", errorHandler(service.Controller{}.List)),
-	"ServiceShow":        get("/namespaces/:namespace/services/:service", errorHandler(service.Controller{}.Show)),
-	"ServiceDelete":      delete("/namespaces/:namespace/services/:service", errorHandler(service.Controller{}.Delete)),
+	"AllServices":   get("/services", errorHandler(service.Controller{}.FullIndex)),
+	"ServiceCreate": post("/namespaces/:namespace/services", errorHandler(service.Controller{}.Create)),
+	"ServiceList":   get("/namespaces/:namespace/services", errorHandler(service.Controller{}.List)),
+	"ServiceShow":   get("/namespaces/:namespace/services/:service", errorHandler(service.Controller{}.Show)),
+	"ServiceDelete": delete("/namespaces/:namespace/services/:service", errorHandler(service.Controller{}.Delete)),
 
 	// Bind a service to/from applications
 	"ServiceBind": post(

--- a/internal/api/v1/service/fullindex.go
+++ b/internal/api/v1/service/fullindex.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/auth"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
+	"github.com/epinio/epinio/internal/services"
+	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	"github.com/gin-gonic/gin"
+)
+
+func (ctr Controller) FullIndex(c *gin.Context) apierror.APIErrors {
+	ctx := c.Request.Context()
+	user := requestctx.User(ctx)
+
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	kubeServiceClient, err := services.NewKubernetesServiceClient(cluster)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	serviceList, err := kubeServiceClient.ListAll(ctx)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	resp := models.ServiceListResponse{
+		Services: filterServices(user, serviceList),
+	}
+
+	response.OKReturn(c, resp)
+	return nil
+}
+
+func filterServices(user auth.User, services []*models.Service) []*models.Service {
+	if user.Role == "admin" {
+		return services
+	}
+
+	namespacesMap := make(map[string]struct{})
+	for _, ns := range user.Namespaces {
+		namespacesMap[ns] = struct{}{}
+	}
+
+	filteredServices := []*models.Service{}
+	for _, service := range services {
+		if _, allowed := namespacesMap[service.Namespace]; allowed {
+			filteredServices = append(filteredServices, service)
+		}
+	}
+
+	return filteredServices
+}

--- a/internal/api/v1/service/fullindex.go
+++ b/internal/api/v1/service/fullindex.go
@@ -50,7 +50,7 @@ func filterServices(user auth.User, services []*models.Service) []*models.Servic
 
 	filteredServices := []*models.Service{}
 	for _, service := range services {
-		if _, allowed := namespacesMap[service.Namespace]; allowed {
+		if _, allowed := namespacesMap[service.Meta.Namespace]; allowed {
 			filteredServices = append(filteredServices, service)
 		}
 	}

--- a/internal/api/v1/service/list.go
+++ b/internal/api/v1/service/list.go
@@ -27,7 +27,7 @@ func (ctr Controller) List(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	serviceList, err := kubeServiceClient.List(ctx, namespace)
+	serviceList, err := kubeServiceClient.ListInNamespace(ctx, namespace)
 	if err != nil {
 		return apierror.InternalError(err)
 	}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -19,11 +19,12 @@ import (
 
 var _ = Describe("Auth users", func() {
 	var authService *auth.AuthService
-	var fake = &authfakes.FakeSecretInterface{}
-
-	rand.Seed(time.Now().UnixNano())
+	var fake *authfakes.FakeSecretInterface
 
 	BeforeEach(func() {
+		rand.Seed(time.Now().UnixNano())
+
+		fake = &authfakes.FakeSecretInterface{}
 		authService = &auth.AuthService{
 			SecretInterface: fake,
 		}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -27,6 +27,8 @@ func init() {
 	CmdServices.AddCommand(CmdServiceShow)
 	CmdServices.AddCommand(CmdServiceDelete)
 	CmdServices.AddCommand(CmdServiceList)
+
+	CmdServiceList.Flags().Bool("all", false, "list all services")
 }
 
 var CmdServiceCatalog = &cobra.Command{
@@ -170,7 +172,17 @@ var CmdServiceList = &cobra.Command{
 			return errors.Wrap(err, "error initializing cli")
 		}
 
-		err = client.ServiceList()
+		all, err := cmd.Flags().GetBool("all")
+		if err != nil {
+			return errors.Wrap(err, "error reading option --all")
+		}
+
+		if all {
+			err = client.ServiceListAll()
+		} else {
+			err = client.ServiceList()
+		}
+
 		return errors.Wrap(err, "error listing services")
 	},
 }

--- a/internal/cli/usercmd/app_test.go
+++ b/internal/cli/usercmd/app_test.go
@@ -242,6 +242,10 @@ func (m *mockAPIClient) ServiceCatalogShow(serviceName string) (*models.ServiceC
 	return nil, nil
 }
 
+func (m *mockAPIClient) AllServices() (*models.ServiceListResponse, error) {
+	return nil, nil
+}
+
 func (m *mockAPIClient) ServiceShow(req *models.ServiceShowRequest, namespace string) (*models.ServiceShowResponse, error) {
 	return nil, nil
 }

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -71,6 +71,7 @@ type APIClient interface {
 	ServiceCatalog() (*models.ServiceCatalogResponse, error)
 	ServiceCatalogShow(serviceName string) (*models.ServiceCatalogShowResponse, error)
 
+	AllServices() (*models.ServiceListResponse, error)
 	ServiceShow(req *models.ServiceShowRequest, namespace string) (*models.ServiceShowResponse, error)
 	ServiceCreate(req *models.ServiceCreateRequest, namespace string) error
 	ServiceBind(req *models.ServiceBindRequest, namespace, name string) error

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -228,7 +228,9 @@ func (c *EpinioClient) ServiceList() error {
 	log.Info("start")
 	defer log.Info("return")
 
-	c.ui.Note().Msg("Listing Services...")
+	c.ui.Note().
+		WithStringValue("Namespace", c.Settings.Namespace).
+		Msg("Listing Services...")
 
 	resp, err := c.API.ServiceList(c.Settings.Namespace)
 	if err != nil {
@@ -246,6 +248,33 @@ func (c *EpinioClient) ServiceList() error {
 			fmt.Sprintf("%v", service.Meta.CreatedAt),
 			service.CatalogService,
 			service.Status.String())
+	}
+	msg.Msg("Details:")
+
+	return nil
+}
+
+// ServiceListAll list of all the services instances where the user has permissions
+func (c *EpinioClient) ServiceListAll() error {
+	log := c.Log.WithName("ServiceListAll")
+	log.Info("start")
+	defer log.Info("return")
+
+	c.ui.Note().Msg("Listing all Services...")
+
+	resp, err := c.API.AllServices()
+	if err != nil {
+		return errors.Wrap(err, "service list failed")
+	}
+
+	if len(resp.Services) == 0 {
+		c.ui.Normal().Msg("No services found")
+		return nil
+	}
+
+	msg := c.ui.Success().WithTable("Namespace", "Name", "Catalog Service", "Status")
+	for _, service := range resp.Services {
+		msg = msg.WithTableRow(service.Namespace, service.Name, service.CatalogService, service.Status.String())
 	}
 	msg.Msg("Details:")
 

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -274,7 +274,7 @@ func (c *EpinioClient) ServiceListAll() error {
 
 	msg := c.ui.Success().WithTable("Namespace", "Name", "Catalog Service", "Status")
 	for _, service := range resp.Services {
-		msg = msg.WithTableRow(service.Namespace, service.Name, service.CatalogService, service.Status.String())
+		msg = msg.WithTableRow(service.Meta.Namespace, service.Meta.Name, service.CatalogService, service.Status.String())
 	}
 	msg.Msg("Details:")
 

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -244,10 +244,12 @@ func (c *EpinioClient) ServiceList() error {
 
 	msg := c.ui.Success().WithTable("Name", "Created", "Catalog Service", "Status")
 	for _, service := range resp.Services {
-		msg = msg.WithTableRow(service.Meta.Name,
-			fmt.Sprintf("%v", service.Meta.CreatedAt),
+		msg = msg.WithTableRow(
+			service.Meta.Name,
+			service.Meta.CreatedAt.String(),
 			service.CatalogService,
-			service.Status.String())
+			service.Status.String(),
+		)
 	}
 	msg.Msg("Details:")
 
@@ -272,9 +274,15 @@ func (c *EpinioClient) ServiceListAll() error {
 		return nil
 	}
 
-	msg := c.ui.Success().WithTable("Namespace", "Name", "Catalog Service", "Status")
+	msg := c.ui.Success().WithTable("Namespace", "Name", "Created", "Catalog Service", "Status")
 	for _, service := range resp.Services {
-		msg = msg.WithTableRow(service.Meta.Namespace, service.Meta.Name, service.CatalogService, service.Status.String())
+		msg = msg.WithTableRow(
+			service.Meta.Namespace,
+			service.Meta.Name,
+			service.Meta.CreatedAt.String(),
+			service.CatalogService,
+			service.Status.String(),
+		)
 	}
 	msg.Msg("Details:")
 

--- a/pkg/api/core/v1/client/services.go
+++ b/pkg/api/core/v1/client/services.go
@@ -41,6 +41,22 @@ func (c *Client) ServiceCatalogShow(serviceName string) (*models.ServiceCatalogS
 	return &resp, nil
 }
 
+func (c *Client) AllServices() (*models.ServiceListResponse, error) {
+	data, err := c.get(api.Routes.Path("AllServices"))
+	if err != nil {
+		return nil, err
+	}
+
+	var resp models.ServiceListResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, err
+	}
+
+	c.log.V(1).Info("response decoded", "response", resp)
+
+	return &resp, err
+}
+
 func (c *Client) ServiceCreate(req *models.ServiceCreateRequest, namespace string) error {
 	b, err := json.Marshal(req)
 	if err != nil {


### PR DESCRIPTION
Ref:
- https://github.com/epinio/epinio/issues/1451
- https://github.com/epinio/epinio/issues/1459
---

- [x] implementation
- [x] tests
- [x] swagger
- [x] documentation https://github.com/epinio/docs/pull/116

This PR renames the `/services` endpoint to `/catalogservices` for the CatalogServices, and adds the `/services` endpoints to list all the service instances.
When the user use the `--all` flag the instances are filtered for the namespaces where the user has the authorization.

I've also added an helper that can be used with the MatchRegexp in the tests, to check in a cleaner and more resilient way the table row from the output of the CLI:

```go
Expect(out).To(MatchRegexp(regex.TableRow(namespace1, service1, "mysql-dev", "not-ready")))
```

```go
func TableRow(args ...string) string {
	reg := `\|`
	for _, arg := range args {
		reg = fmt.Sprintf(`%s[\s]+%s[\s]+\|`, reg, arg)
	}
	return reg
}
```


Fixes also https://github.com/epinio/epinio/issues/1455