### PR TITLE
Ignore trailing slash in Origin header

### DIFF
--- a/internal/api/v1/application/logs.go
+++ b/internal/api/v1/application/logs.go
@@ -217,7 +217,8 @@ func CheckOriginFunc(allowedOrigins []string) func(r *http.Request) bool {
 
 		for _, allowedOrigin := range allowedOrigins {
 			trimmedOrigin := strings.TrimSuffix(allowedOrigin, "/")
-			if trimmedOrigin == "*" || trimmedOrigin == originHeader {
+			trimmedHeader := strings.TrimSuffix(originHeader, "/")
+			if trimmedOrigin == "*" || trimmedOrigin == trimmedHeader {
 				return true
 			}
 		}


### PR DESCRIPTION
like we do in allowed origins

I encountered this problem while debugging the logs in the UI. The origin header had a trailing `/` and the code wasn't matching the allowed header.