### PR TITLE
Filter non accessible resources

### DIFF
--- a/acceptance/api/v1/application_index_all_test.go
+++ b/acceptance/api/v1/application_index_all_test.go
@@ -84,7 +84,7 @@ var _ = Describe("AllApps Endpoints", func() {
 			[]string{app2, namespace2}))
 	})
 
-	It("will not lists the applications belonging to other namespaces", func() {
+	It("doesn't list applications belonging to non-accessible namespaces", func() {
 		endpoint := fmt.Sprintf("%s%s/applications", serverURL, v1.Root)
 		request, err := http.NewRequest(http.MethodGet, endpoint, nil)
 		Expect(err).ToNot(HaveOccurred())

--- a/acceptance/api/v1/application_index_all_test.go
+++ b/acceptance/api/v1/application_index_all_test.go
@@ -17,11 +17,10 @@ import (
 
 var _ = Describe("AllApps Endpoints", func() {
 	var (
-		namespace1        string
-		namespace2        string
-		app1              string
-		app2              string
-		containerImageURL string
+		namespace1, namespace2 string
+		app1, app2             string
+		user, password         string
+		containerImageURL      string
 	)
 
 	BeforeEach(func() {
@@ -38,6 +37,8 @@ var _ = Describe("AllApps Endpoints", func() {
 
 		app2 = catalog.NewAppName()
 		env.MakeContainerImageApp(app2, 1, containerImageURL)
+
+		user, password = env.CreateEpinioUser("user", nil)
 	})
 
 	AfterEach(func() {
@@ -49,6 +50,8 @@ var _ = Describe("AllApps Endpoints", func() {
 
 		env.DeleteNamespace(namespace1)
 		env.DeleteNamespace(namespace2)
+
+		env.DeleteEpinioUser(user)
 	})
 
 	It("lists all applications belonging to all namespaces", func() {
@@ -79,5 +82,26 @@ var _ = Describe("AllApps Endpoints", func() {
 		Expect(appRefs).To(ContainElements(
 			[]string{app1, namespace1},
 			[]string{app2, namespace2}))
+	})
+
+	It("will not lists the applications belonging to other namespaces", func() {
+		endpoint := fmt.Sprintf("%s%s/applications", serverURL, v1.Root)
+		request, err := http.NewRequest(http.MethodGet, endpoint, nil)
+		Expect(err).ToNot(HaveOccurred())
+		request.SetBasicAuth(user, password)
+
+		response, err := env.Client().Do(request)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+
+		defer response.Body.Close()
+		bodyBytes, err := ioutil.ReadAll(response.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+		var apps models.AppList
+		err = json.Unmarshal(bodyBytes, &apps)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(apps).To(BeEmpty())
 	})
 })

--- a/acceptance/api/v1/configurations_test.go
+++ b/acceptance/api/v1/configurations_test.go
@@ -159,7 +159,7 @@ var _ = Describe("Configurations API Application Endpoints", func() {
 			))
 		})
 
-		It("will not lists all configurations belonging to other namespaces", func() {
+		It("doesn't list configurations belonging to non-accessible namespaces", func() {
 			endpoint := fmt.Sprintf("%s%s/configurations", serverURL, api.Root)
 			request, err := http.NewRequest(http.MethodGet, endpoint, nil)
 			Expect(err).ToNot(HaveOccurred())

--- a/acceptance/api/v1/configurations_test.go
+++ b/acceptance/api/v1/configurations_test.go
@@ -76,11 +76,12 @@ var _ = Describe("Configurations API Application Endpoints", func() {
 	})
 
 	Describe("GET /api/v1/configurations", func() {
-		var namespace1 string
-		var namespace2 string
-		var configuration1 string
-		var configuration2 string
-		var app1 string
+		var (
+			namespace1, namespace2         string
+			configuration1, configuration2 string
+			user, password                 string
+			app1                           string
+		)
 
 		// Setting up:
 		// namespace1 configuration1 app1
@@ -102,6 +103,8 @@ var _ = Describe("Configurations API Application Endpoints", func() {
 			env.SetupAndTargetNamespace(namespace2)
 			env.MakeConfiguration(configuration1) // separate from namespace1.configuration1
 			env.MakeConfiguration(configuration2)
+
+			user, password = env.CreateEpinioUser("user", nil)
 		})
 
 		AfterEach(func() {
@@ -114,6 +117,8 @@ var _ = Describe("Configurations API Application Endpoints", func() {
 			env.DeleteConfiguration(configuration1)
 			env.DeleteNamespace(namespace1)
 			env.DeleteNamespace(namespace2)
+
+			env.DeleteEpinioUser(user)
 		})
 
 		It("lists all configurations belonging to all namespaces", func() {
@@ -152,7 +157,27 @@ var _ = Describe("Configurations API Application Endpoints", func() {
 				[]string{configuration1, namespace2, ""},
 				[]string{configuration2, namespace2, ""},
 			))
+		})
 
+		It("will not lists all configurations belonging to other namespaces", func() {
+			endpoint := fmt.Sprintf("%s%s/configurations", serverURL, api.Root)
+			request, err := http.NewRequest(http.MethodGet, endpoint, nil)
+			Expect(err).ToNot(HaveOccurred())
+			request.SetBasicAuth(user, password)
+
+			response, err := env.Client().Do(request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+
+			defer response.Body.Close()
+			bodyBytes, err := ioutil.ReadAll(response.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+			var configurations models.ConfigurationResponseList
+			err = json.Unmarshal(bodyBytes, &configurations)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(configurations).To(BeEmpty())
 		})
 	})
 

--- a/internal/api/v1/application/fullindex.go
+++ b/internal/api/v1/application/fullindex.go
@@ -4,6 +4,8 @@ import (
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/internal/auth"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 
 	"github.com/gin-gonic/gin"
@@ -13,6 +15,7 @@ import (
 // It lists all the known applications in all namespaces, with and without workload.
 func (hc Controller) FullIndex(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
+	user := requestctx.User(ctx)
 
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {
@@ -24,6 +27,8 @@ func (hc Controller) FullIndex(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	response.OKReturn(c, allApps)
+	filteredApps := auth.FilterResources(user, allApps)
+
+	response.OKReturn(c, filteredApps)
 	return nil
 }

--- a/internal/api/v1/configuration/fullindex.go
+++ b/internal/api/v1/configuration/fullindex.go
@@ -4,6 +4,8 @@ import (
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/internal/auth"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/configurations"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 
@@ -14,6 +16,7 @@ import (
 // It lists all the known applications in all namespaces, with and without workload.
 func (hc Controller) FullIndex(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
+	user := requestctx.User(ctx)
 
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {
@@ -24,13 +27,14 @@ func (hc Controller) FullIndex(c *gin.Context) apierror.APIErrors {
 	if err != nil {
 		return apierror.InternalError(err)
 	}
+	filteredConfigurations := auth.FilterResources(user, allConfigurations)
 
 	appsOf, err := application.BoundAppsNames(ctx, cluster, "")
 	if err != nil {
 		return apierror.InternalError(err)
 	}
 
-	responseData, err := makeResponse(ctx, appsOf, allConfigurations)
+	responseData, err := makeResponse(ctx, appsOf, filteredConfigurations)
 	if err != nil {
 		return apierror.InternalError(err)
 	}

--- a/internal/api/v1/configuration/index.go
+++ b/internal/api/v1/configuration/index.go
@@ -66,7 +66,7 @@ func makeResponse(ctx context.Context, appsOf map[string][]string, configuration
 			}
 		}
 
-		key := application.ConfigurationKey(configuration.Name, configuration.Namespace)
+		key := application.ConfigurationKey(configuration.Name, configuration.Namespace())
 		appNames := appsOf[key]
 
 		response = append(response, models.ConfigurationResponse{
@@ -74,7 +74,7 @@ func makeResponse(ctx context.Context, appsOf map[string][]string, configuration
 				Meta: models.Meta{
 					CreatedAt: configuration.CreatedAt,
 					Name:      configuration.Name,
-					Namespace: configuration.Namespace,
+					Namespace: configuration.Namespace(),
 				},
 			},
 			Configuration: models.ConfigurationShowResponse{

--- a/internal/api/v1/configuration/show.go
+++ b/internal/api/v1/configuration/show.go
@@ -56,7 +56,7 @@ func (sc Controller) Show(c *gin.Context) apierror.APIErrors {
 			Meta: models.Meta{
 				CreatedAt: configuration.CreatedAt,
 				Name:      configuration.Name,
-				Namespace: configuration.Namespace,
+				Namespace: configuration.Namespace(),
 			},
 		},
 		Configuration: models.ConfigurationShowResponse{

--- a/internal/api/v1/service/fullindex.go
+++ b/internal/api/v1/service/fullindex.go
@@ -37,28 +37,10 @@ func (ctr Controller) FullIndex(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	response.OKReturn(c, extendWithBoundApps(filterServices(user, serviceList), appsOf))
+	filteredServices := auth.FilterResources(user, serviceList)
+
+	response.OKReturn(c, extendWithBoundApps(filteredServices, appsOf))
 	return nil
-}
-
-func filterServices(user auth.User, services models.ServiceList) models.ServiceList {
-	if user.Role == "admin" {
-		return services
-	}
-
-	namespacesMap := make(map[string]struct{})
-	for _, ns := range user.Namespaces {
-		namespacesMap[ns] = struct{}{}
-	}
-
-	filteredServices := models.ServiceList{}
-	for _, service := range services {
-		if _, allowed := namespacesMap[service.Meta.Namespace]; allowed {
-			filteredServices = append(filteredServices, service)
-		}
-	}
-
-	return filteredServices
 }
 
 func extendWithBoundApps(services models.ServiceList, appsOf map[string][]string) models.ServiceList {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -165,6 +165,7 @@ type NamespacedResource interface {
 	Namespace() string
 }
 
+// FilterResources returns only the NamespacedResources where the user has permissions
 func FilterResources[T NamespacedResource](user User, resources []T) []T {
 	if user.Role == "admin" {
 		return resources

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -160,3 +160,27 @@ func (s *AuthService) updateUserSecret(ctx context.Context, user User) error {
 		return err
 	}), fmt.Sprintf("error updating the user secret [%s]", user))
 }
+
+type NamespacedResource interface {
+	Namespace() string
+}
+
+func FilterResources[T NamespacedResource](user User, resources []T) []T {
+	if user.Role == "admin" {
+		return resources
+	}
+
+	namespacesMap := make(map[string]struct{})
+	for _, ns := range user.Namespaces {
+		namespacesMap[ns] = struct{}{}
+	}
+
+	filteredResources := []T{}
+	for _, resource := range resources {
+		if _, allowed := namespacesMap[resource.Namespace()]; allowed {
+			filteredResources = append(filteredResources, resource)
+		}
+	}
+
+	return filteredResources
+}

--- a/pkg/api/core/v1/models/app.go
+++ b/pkg/api/core/v1/models/app.go
@@ -76,6 +76,11 @@ func NewApp(name string, namespace string) *App {
 }
 
 // AppRef returns a reference to the app (name, namespace)
+func (a App) Namespace() string {
+	return a.Meta.Namespace
+}
+
+// AppRef returns a reference to the app (name, namespace)
 func (a *App) AppRef() AppRef {
 	return a.Meta
 }

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -317,6 +317,10 @@ type Service struct {
 	BoundApps      []string      `json:"boundapps"`
 }
 
+func (s *Service) Namespace() string {
+	return s.Meta.Namespace
+}
+
 type ServiceStatus string
 
 // ServiceList represents a collection of service instances

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -317,7 +317,7 @@ type Service struct {
 	BoundApps      []string      `json:"boundapps"`
 }
 
-func (s *Service) Namespace() string {
+func (s Service) Namespace() string {
 	return s.Meta.Namespace
 }
 


### PR DESCRIPTION
Ref:
- #1452 
---

This PR moves the filterServices func into the `auth` package, and makes use of Generics in order to be used by other resources. The `FilterResources` needs just a struct that implements the `NamespacedResource` interface, to get the `Namespace`:

```go
type NamespacedResource interface {
	Namespace() string
}

func FilterResources[T NamespacedResource](user User, resources []T) []T {
	if user.Role == "admin" {
		return resources
	}

	namespacesMap := make(map[string]struct{})
	for _, ns := range user.Namespaces {
		namespacesMap[ns] = struct{}{}
	}

	filteredResources := []T{}
	for _, resource := range resources {
		if _, allowed := namespacesMap[resource.Namespace()]; allowed {
			filteredResources = append(filteredResources, resource)
		}
	}

	return filteredResources
}
```