### PR TITLE
Bump actions and golangci-lint (go1.18)

### DIFF
--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -53,7 +53,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.1
+        uses: actions/cache@v3.0.2
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools

--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -48,7 +48,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
@@ -85,7 +85,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -53,7 +53,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.1
+        uses: actions/cache@v3.0.2
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -48,7 +48,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
@@ -85,7 +85,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
         submodules: recursive
 
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ env.SETUP_GO_VERSION }}
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,14 +47,14 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       # Override language selection by uncommenting this and choosing your languages
       with:
         languages: go
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -57,7 +57,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.1
+        uses: actions/cache@v3.0.2
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -52,7 +52,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
@@ -89,7 +89,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 

--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -44,7 +44,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.1
+        uses: actions/cache@v3.0.2
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools

--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -39,7 +39,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
@@ -76,7 +76,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -44,7 +44,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.1
+        uses: actions/cache@v3.0.2
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -39,7 +39,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
@@ -76,7 +76,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,7 +1,7 @@
 name: golangci-lint
 
 env:
-  SETUP_GO_VERSION: '^1.17.2'
+  SETUP_GO_VERSION: '^1.18.2'
 
 on:
   schedule:
@@ -22,7 +22,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
@@ -43,7 +43,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.1.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.45
+          version: v1.46
 
           args: --timeout=10m --config=${{ steps.configfile.outputs.file }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.1
+        uses: actions/cache@v3.0.2
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
@@ -61,7 +61,7 @@ jobs:
         run: make test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverprofile.out
           flags: unittests
@@ -96,7 +96,7 @@ jobs:
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.1
+        uses: actions/cache@v3.0.2
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
@@ -122,7 +122,7 @@ jobs:
           scripts/collect-coverage.sh
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverprofile.out
           flags: acceptance-cli
@@ -161,7 +161,7 @@ jobs:
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.1
+        uses: actions/cache@v3.0.2
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
@@ -187,7 +187,7 @@ jobs:
           scripts/collect-coverage.sh
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverprofile.out
           flags: acceptance-api
@@ -226,7 +226,7 @@ jobs:
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.1
+        uses: actions/cache@v3.0.2
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
@@ -252,7 +252,7 @@ jobs:
           scripts/collect-coverage.sh
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverprofile.out
           flags: acceptance-apps
@@ -269,7 +269,7 @@ jobs:
           docker exec k3d-epinio-acceptance-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers.log
 
       - name: Upload Logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: acceptance-logs-${{ github.sha }}-${{ github.run_id }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
@@ -88,7 +88,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
@@ -153,7 +153,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
@@ -218,7 +218,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 

--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '1.18'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '1.18'
 

--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -38,7 +38,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.1
+        uses: actions/cache@v3.0.2
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
@@ -78,7 +78,7 @@ jobs:
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.1
+        uses: actions/cache@v3.0.2
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools

--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -33,7 +33,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
@@ -70,7 +70,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  go: 1.17
+  go: "1.18"
   deadline: 20s
 
   # don't report issues from these dirs

--- a/acceptance/install/scenario4_test.go
+++ b/acceptance/install/scenario4_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/epinio/epinio/acceptance/helpers/proc"
 	"github.com/epinio/epinio/acceptance/helpers/route53"
 	"github.com/epinio/epinio/acceptance/testenv"
+	"github.com/epinio/epinio/internal/names"
 )
 
 // This test uses AWS route53 to update the system domain's records
@@ -151,11 +152,14 @@ var _ = Describe("<Scenario4> EKS, epinio-ca, on S3 storage", func() {
 		By("Bind the database to the app", func() {
 			out, err := epinioHelper.Run("service", "bind", serviceName, appName)
 			Expect(err).ToNot(HaveOccurred(), out)
+
+			chart := names.ServiceHelmChartName(serviceName, testenv.DefaultWorkspace)
+
 			Eventually(func() string {
 				out, err := epinioHelper.Run("app", "show", appName)
 				Expect(err).ToNot(HaveOccurred(), out)
 				return out
-			}, "2m", "5s").Should(MatchRegexp("Bound Configurations.*\\|.*%s-%s-mysql", testenv.DefaultWorkspace, serviceName))
+			}, "2m", "5s").Should(MatchRegexp("Bound Configurations.*\\|.*%s", chart))
 		})
 
 		By("Pushing an app with Env vars", func() {


### PR DESCRIPTION
This PR bumps the version of some actions, and enable the `golangci-lint` to support **Go 1.18**.

At the moment just a couple of linters are not available, but as soon they will be available they should be included automatically:
```
structcheck is disabled because of go1.18
unparam is disabled because of go1.18

You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
```

