### PR TITLE
Allow streaming of staging logs after staging is done

### DIFF
--- a/helpers/kubernetes/tailer/setup.go
+++ b/helpers/kubernetes/tailer/setup.go
@@ -156,7 +156,6 @@ func StreamLogs(ctx context.Context, logChan chan ContainerLogLine, wg *sync.Wai
 		"pods", config.PodQuery.String(),
 		"containers", config.ContainerQuery.String(),
 		"excluded", config.ExcludeContainerQuery.String(),
-		"state", config.ContainerState,
 		"selector", config.LabelSelector.String())
 	added, removed, err := Watch(ctx, cluster.Kubectl.CoreV1().Pods(namespace),
 		config.PodQuery, config.ContainerQuery, config.ExcludeContainerQuery, config.ContainerState, config.LabelSelector)

--- a/helpers/kubernetes/tailer/setup.go
+++ b/helpers/kubernetes/tailer/setup.go
@@ -176,7 +176,7 @@ func StreamLogs(ctx context.Context, logChan chan ContainerLogLine, wg *sync.Wai
 		case p := <-added:
 			id := p.GetID()
 			if tails[id] != nil {
-				break
+				continue
 			}
 
 			logger.Info("tailer add", "id", id)
@@ -207,7 +207,7 @@ func StreamLogs(ctx context.Context, logChan chan ContainerLogLine, wg *sync.Wai
 		case p := <-removed:
 			id := p.GetID()
 			if tails[id] == nil {
-				break
+				continue
 			}
 
 			logger.Info("tailer remove", "id", id)

--- a/helpers/kubernetes/tailer/watcher.go
+++ b/helpers/kubernetes/tailer/watcher.go
@@ -92,16 +92,12 @@ func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp,
 							continue
 						}
 
-						if containerState.Match(c.State) {
-							logger.Info("report added", "container", c.Name, "pod", pod.Name, "namespace", pod.Namespace)
-							added <- &Target{
-								Namespace: pod.Namespace,
-								Pod:       pod.Name,
-								Container: c.Name,
-							}
+						logger.Info("report added", "container", c.Name, "pod", pod.Name, "namespace", pod.Namespace)
+						added <- &Target{
+							Namespace: pod.Namespace,
+							Pod:       pod.Name,
+							Container: c.Name,
 						}
-
-						logger.Info("state mismatch", "container", c.Name, "pod", pod.Name, "namespace", pod.Namespace, "actual", c.State, "desired", containerState)
 					}
 				case watch.Deleted:
 					logger.Info("pod deleted", "name", pod.Name)

--- a/helpers/kubernetes/tailer/watcher.go
+++ b/helpers/kubernetes/tailer/watcher.go
@@ -92,11 +92,13 @@ func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp,
 							continue
 						}
 
-						logger.Info("report added", "container", c.Name, "pod", pod.Name, "namespace", pod.Namespace)
-						added <- &Target{
-							Namespace: pod.Namespace,
-							Pod:       pod.Name,
-							Container: c.Name,
+						if c.State.Running != nil || c.State.Terminated != nil { // There are logs to read
+							logger.Info("report added", "container", c.Name, "pod", pod.Name, "namespace", pod.Namespace)
+							added <- &Target{
+								Namespace: pod.Namespace,
+								Pod:       pod.Name,
+								Container: c.Name,
+							}
 						}
 					}
 				case watch.Deleted:

--- a/helpers/tracelog/logger.go
+++ b/helpers/tracelog/logger.go
@@ -43,7 +43,6 @@ func NewLogger() logr.Logger {
 
 // NewStdrLogger returns a stdr logger
 func NewStdrLogger() logr.Logger {
-	stdr.SetVerbosity(TraceLevel())
 	return stdr.New(log.New(os.Stderr, "", log.LstdFlags)).V(1) // NOTE: Increment of level, not absolute.
 }
 

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -414,7 +414,6 @@ func Logs(ctx context.Context, logChan chan tailer.ContainerLogLine, wg *sync.Wa
 	config := &tailer.Config{
 		ContainerQuery:        regexp.MustCompile(".*"),
 		ExcludeContainerQuery: regexp.MustCompile("linkerd-(proxy|init)"),
-		ContainerState:        "running",
 		Exclude:               nil,
 		Include:               nil,
 		Timestamps:            false,

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -182,14 +182,12 @@ var CmdAppLogs = &cobra.Command{
 			return errors.Wrap(err, "error reading option --staging")
 		}
 
-		stageID, err := client.AppStageID(args[0])
-		if err != nil {
-			return errors.Wrap(err, "error checking app")
-		}
+		stageID := ""
 		if staging {
-			follow = false
-		} else {
-			stageID = ""
+			stageID, err = client.AppStageID(args[0])
+			if err != nil {
+				return errors.Wrap(err, "error checking app")
+			}
 		}
 
 		err = client.AppLogs(args[0], stageID, follow)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -13,6 +13,7 @@ import (
 	settings "github.com/epinio/epinio/internal/cli/settings"
 	"github.com/epinio/epinio/internal/duration"
 	"github.com/epinio/epinio/internal/version"
+	"github.com/go-logr/stdr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -37,6 +38,7 @@ var rootCmd = &cobra.Command{
 // Execute executes the root command.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	stdr.SetVerbosity(tracelog.TraceLevel())
 	if err := rootCmd.Execute(); err != nil {
 		termui.NewUI().Problem().Msg(err.Error())
 		os.Exit(-1)

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -626,9 +626,5 @@ func (c *EpinioClient) AppRestage(appName string) error {
 	log.V(1).Info("wait for job", "StageID", stageID)
 	// blocking function that wait until the staging is done
 	_, err = c.API.StagingComplete(app.Meta.Namespace, stageID)
-	if err != nil {
-		return errors.Wrap(err, "waiting for staging failed")
-	}
-
-	return nil
+	return errors.Wrap(err, "waiting for staging failed")
 }

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -618,9 +618,17 @@ func (c *EpinioClient) AppRestage(appName string) error {
 	}
 
 	log.V(3).Info("stage response", "response", stageResponse)
-
 	stageID := stageResponse.Stage.ID
-	log.V(1).Info("start tailing logs", "StageID", stageID)
 
-	return c.stageLogs(log.V(1), app.Meta, stageID)
+	log.V(1).Info("start tailing logs", "StageID", stageID)
+	c.stageLogs(app.Meta, stageID)
+
+	log.V(1).Info("wait for job", "StageID", stageID)
+	// blocking function that wait until the staging is done
+	_, err = c.API.StagingComplete(app.Meta.Namespace, stageID)
+	if err != nil {
+		return errors.Wrap(err, "waiting for staging failed")
+	}
+
+	return nil
 }

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
 
@@ -185,6 +184,7 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 	var stageResponse *models.StageResponse
 	if params.Origin.Kind != models.OriginContainer {
 		c.ui.Normal().Msg("Staging application with code...")
+		c.ui.ProgressNote().Msg("Running staging")
 
 		req := models.StageRequest{
 			App:          appRef,
@@ -200,9 +200,16 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 		log.V(3).Info("stage response", "response", stageResponse)
 
 		details.Info("start tailing logs", "StageID", stageResponse.Stage.ID)
-		err = c.stageLogs(details, appRef, stageResponse.Stage.ID)
+		c.stageLogs(appRef, stageResponse.Stage.ID)
 		if err != nil {
 			return err
+		}
+
+		details.Info("wait for job", "StageID", stageID)
+		// blocking function that wait until the staging is done
+		_, err := c.API.StagingComplete(appRef.Namespace, stageID)
+		if err != nil {
+			return errors.Wrap(err, "waiting for staging failed")
 		}
 	}
 
@@ -256,27 +263,11 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 	return nil
 }
 
-func (c *EpinioClient) stageLogs(logger logr.Logger, appRef models.AppRef, stageID string) error {
-	c.ui.Note().
-		WithStringValue("Namespace", c.Settings.Namespace).
-		WithStringValue("Application", appRef.Name).
-		Msg("Streaming application logs")
-
+func (c *EpinioClient) stageLogs(appRef models.AppRef, stageID string) {
 	go func() {
 		err := c.AppLogs(appRef.Name, stageID, true)
 		if err != nil {
 			c.ui.Problem().Msg(fmt.Sprintf("failed to tail logs: %s", err.Error()))
 		}
 	}()
-
-	logger.Info("wait for job", "StageID", stageID)
-	c.ui.ProgressNote().Msg("Running staging")
-
-	// blocking function that wait until the staging is done
-	_, err := c.API.StagingComplete(appRef.Namespace, stageID)
-	if err != nil {
-		return errors.Wrap(err, "waiting for staging failed")
-	}
-
-	return err
 }

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -201,9 +201,6 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 
 		details.Info("start tailing logs", "StageID", stageResponse.Stage.ID)
 		c.stageLogs(appRef, stageResponse.Stage.ID)
-		if err != nil {
-			return err
-		}
 
 		details.Info("wait for job", "StageID", stageID)
 		// blocking function that wait until the staging is done

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -14,8 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/epinio/epinio/helpers"
-	"github.com/epinio/epinio/helpers/kubernetes/tailer"
-	"github.com/epinio/epinio/internal/cli/logprinter"
 	"github.com/epinio/epinio/internal/duration"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 )
@@ -265,17 +263,7 @@ func (c *EpinioClient) stageLogs(logger logr.Logger, appRef models.AppRef, stage
 		Msg("Streaming application logs")
 
 	go func() {
-		printer := logprinter.LogPrinter{Tmpl: logprinter.DefaultSingleNamespaceTemplate()}
-		callback := func(logLine tailer.ContainerLogLine) {
-			printer.Print(logprinter.Log{
-				Message:       logLine.Message,
-				Namespace:     logLine.Namespace,
-				PodName:       logLine.PodName,
-				ContainerName: logLine.ContainerName,
-			}, c.ui.ProgressNote().Compact())
-		}
-
-		err := c.API.AppLogs(c.Settings.Namespace, appRef.Name, stageID, true, callback)
+		err := c.AppLogs(appRef.Name, stageID, true)
 		if err != nil {
 			c.ui.Problem().Msg(fmt.Sprintf("failed to tail logs: %s", err.Error()))
 		}


### PR DESCRIPTION
Fixes https://github.com/epinio/ui/issues/93

- Re-use existing method for Logs
- Don't filter out containers that are not in "running" state when
  streaming logs (e.g. finished staging containers)
- Don't disable "follow" when staging logs are requested