### PR TITLE
Fail fast targeting unauthorized namespaces

### DIFF
--- a/acceptance/api/v1/configurations_mutation_test.go
+++ b/acceptance/api/v1/configurations_mutation_test.go
@@ -240,8 +240,8 @@ var _ = Describe("Configurations API Application Endpoints, Mutations", func() {
 
 		It("returns a 'not found' when the namespace does not exist", func() {
 			endpoint := fmt.Sprintf(
-				"%s%s/namespaces/%s/configurations/%s",
-				serverURL, api.Root, namespace, configuration,
+				"%s%s/namespaces/idontexist/configurations/%s",
+				serverURL, api.Root, configuration,
 			)
 			response, err := env.Curl("DELETE", endpoint, strings.NewReader(`{ "unbind": false }`))
 			Expect(err).ToNot(HaveOccurred())

--- a/acceptance/api/v1/configurations_mutation_test.go
+++ b/acceptance/api/v1/configurations_mutation_test.go
@@ -197,27 +197,31 @@ var _ = Describe("Configurations API Application Endpoints, Mutations", func() {
 		})
 
 		It("returns a 'bad request' for a non JSON body", func() {
-			response, err := env.Curl("DELETE",
-				fmt.Sprintf("%s%s/namespaces/idontexist/configurations/%s",
-					serverURL, api.Root, configuration),
-				strings.NewReader(""))
+			endpoint := fmt.Sprintf(
+				"%s%s/namespaces/%s/configurations/%s",
+				serverURL, api.Root, namespace, configuration,
+			)
+			response, err := env.Curl("DELETE", endpoint, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 
 			defer response.Body.Close()
+
 			bodyBytes, err := ioutil.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.StatusCode).To(Equal(http.StatusBadRequest), string(bodyBytes))
+
 			var responseBody map[string][]errors.APIError
 			json.Unmarshal(bodyBytes, &responseBody)
 			Expect(responseBody["errors"][0].Title).To(Equal("EOF"))
 		})
 
 		It("returns a 'bad request' for a non-object JSON body", func() {
-			response, err := env.Curl("DELETE",
-				fmt.Sprintf("%s%s/namespaces/idontexist/configurations/%s",
-					serverURL, api.Root, configuration),
-				strings.NewReader(`[]`))
+			endpoint := fmt.Sprintf(
+				"%s%s/namespaces/%s/configurations/%s",
+				serverURL, api.Root, namespace, configuration,
+			)
+			response, err := env.Curl("DELETE", endpoint, strings.NewReader(`[]`))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 
@@ -225,17 +229,21 @@ var _ = Describe("Configurations API Application Endpoints, Mutations", func() {
 			bodyBytes, err := ioutil.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.StatusCode).To(Equal(http.StatusBadRequest), string(bodyBytes))
+
 			var responseBody map[string][]errors.APIError
-			json.Unmarshal(bodyBytes, &responseBody)
-			Expect(responseBody["errors"][0].Title).To(
-				Equal("json: cannot unmarshal array into Go value of type models.ConfigurationDeleteRequest"))
+			err = json.Unmarshal(bodyBytes, &responseBody)
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedErrorMsg := "json: cannot unmarshal array into Go value of type models.ConfigurationDeleteRequest"
+			Expect(responseBody["errors"][0].Title).To(Equal(expectedErrorMsg))
 		})
 
 		It("returns a 'not found' when the namespace does not exist", func() {
-			response, err := env.Curl("DELETE",
-				fmt.Sprintf("%s%s/namespaces/idontexist/configurations/%s",
-					serverURL, api.Root, configuration),
-				strings.NewReader(`{ "unbind": false }`))
+			endpoint := fmt.Sprintf(
+				"%s%s/namespaces/%s/configurations/%s",
+				serverURL, api.Root, namespace, configuration,
+			)
+			response, err := env.Curl("DELETE", endpoint, strings.NewReader(`{ "unbind": false }`))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 
@@ -243,10 +251,13 @@ var _ = Describe("Configurations API Application Endpoints, Mutations", func() {
 			bodyBytes, err := ioutil.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response.StatusCode).To(Equal(http.StatusNotFound), string(bodyBytes))
+
 			var responseBody map[string][]errors.APIError
-			json.Unmarshal(bodyBytes, &responseBody)
-			Expect(responseBody["errors"][0].Title).To(
-				Equal("Targeted namespace 'idontexist' does not exist"))
+			err = json.Unmarshal(bodyBytes, &responseBody)
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedErrorMsg := "Targeted namespace 'idontexist' does not exist"
+			Expect(responseBody["errors"][0].Title).To(Equal(expectedErrorMsg))
 		})
 
 		It("returns a 'not found' when the configuration does not exist", func() {

--- a/acceptance/api/v1/namespace_auth_test.go
+++ b/acceptance/api/v1/namespace_auth_test.go
@@ -86,13 +86,13 @@ var _ = Describe("Users Namespace", func() {
 
 				It("doesn't show the other user's namespace", func() {
 					response := showNamespace(user1, passwordUser1, namespaceUser2)
-					Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
 					response.Body.Close()
 				})
 
 				It("doesn't show the admin's namespace", func() {
 					response := showNamespace(user1, passwordUser1, namespaceAdmin)
-					Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
 					response.Body.Close()
 				})
 			})
@@ -131,7 +131,7 @@ var _ = Describe("Users Namespace", func() {
 
 				It("doesn't show the other user's namespace", func() {
 					response := showNamespace(user1, passwordUser1, commonNamespace)
-					Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
 					response.Body.Close()
 				})
 			})

--- a/acceptance/api/v1/service_create_test.go
+++ b/acceptance/api/v1/service_create_test.go
@@ -24,8 +24,7 @@ var _ = Describe("ServiceCreate Endpoint", func() {
 			endpoint := fmt.Sprintf("%s%s/namespaces/doesntexist/services", serverURL, v1.Root)
 			response, err := env.Curl("POST", endpoint, strings.NewReader(""))
 			Expect(err).ToNot(HaveOccurred())
-
-			Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+			Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 		})
 	})
 

--- a/acceptance/helpers/machine/curl.go
+++ b/acceptance/helpers/machine/curl.go
@@ -2,12 +2,12 @@ package machine
 
 import (
 	"crypto/tls"
+	"io"
 	"net/http"
-	"strings"
 )
 
 // Curl is used to make requests against a server
-func (m *Machine) Curl(method, uri string, requestBody *strings.Reader) (*http.Response, error) {
+func (m *Machine) Curl(method, uri string, requestBody io.Reader) (*http.Response, error) {
 	request, err := http.NewRequest(method, uri, requestBody)
 	if err != nil {
 		return nil, err

--- a/acceptance/helpers/machine/machine.go
+++ b/acceptance/helpers/machine/machine.go
@@ -57,7 +57,7 @@ func (m *Machine) EpinioPush(dir string, name string, arg ...string) (string, er
 	return out, err
 }
 
-func (m *Machine) SetupAndTargetNamespace(namespace string) {
+func (m *Machine) SetupNamespace(namespace string) {
 	By(fmt.Sprintf("creating a namespace: %s", namespace))
 
 	out, err := m.Epinio("", "namespace", "create", namespace)
@@ -66,8 +66,6 @@ func (m *Machine) SetupAndTargetNamespace(namespace string) {
 	out, err = m.Epinio("", "namespace", "show", namespace)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	ExpectWithOffset(1, out).To(MatchRegexp("Name.*|.*" + namespace))
-
-	m.TargetNamespace(namespace)
 }
 
 func (m *Machine) TargetNamespace(namespace string) {
@@ -79,6 +77,11 @@ func (m *Machine) TargetNamespace(namespace string) {
 	out, err = m.Epinio(m.nodeTmpDir, "target")
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)
 	ExpectWithOffset(1, out).To(MatchRegexp("Currently targeted namespace: " + namespace))
+}
+
+func (m *Machine) SetupAndTargetNamespace(namespace string) {
+	m.SetupNamespace(namespace)
+	m.TargetNamespace(namespace)
 }
 
 func (m *Machine) DeleteNamespace(namespace string) {

--- a/acceptance/namespaces_test.go
+++ b/acceptance/namespaces_test.go
@@ -127,4 +127,32 @@ var _ = Describe("Namespaces", func() {
 			Expect(err).ToNot(HaveOccurred(), out)
 		})
 	})
+
+	Describe("namespace target", func() {
+		It("rejects targeting an unknown namespace", func() {
+			out, err := env.Epinio("", "target", "missing-namespace")
+			Expect(err).To(HaveOccurred(), out)
+			Expect(out).To(MatchRegexp("namespace 'missing-namespace' does not exist"))
+		})
+
+		Context("existing namespace", func() {
+			var namespaceName string
+
+			BeforeEach(func() {
+				namespaceName = catalog.NewNamespaceName()
+				env.SetupAndTargetNamespace(namespaceName)
+			})
+
+			AfterEach(func() {
+				env.DeleteNamespace(namespaceName)
+			})
+
+			It("shows a namespace", func() {
+				out, err := env.Epinio("", "target", namespaceName)
+				Expect(err).ToNot(HaveOccurred(), out)
+				Expect(out).To(MatchRegexp(`Name: %s`, namespaceName))
+				Expect(out).To(ContainSubstring(`Namespace targeted.`))
+			})
+		})
+	})
 })

--- a/acceptance/users_test.go
+++ b/acceptance/users_test.go
@@ -154,7 +154,7 @@ var _ = Describe("Users", func() {
 			resp, err := env.Client().Do(request)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 		})
 	})
 

--- a/acceptance/users_test.go
+++ b/acceptance/users_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/epinio/epinio/acceptance/helpers/catalog"
 	v1 "github.com/epinio/epinio/internal/api/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -119,13 +120,17 @@ var _ = Describe("Users", func() {
 
 	Describe("a regular user", func() {
 		var user, password string
+		var namespace string
 
 		BeforeEach(func() {
+			namespace = catalog.NewNamespaceName()
+			env.SetupNamespace(namespace)
 			user, password = env.CreateEpinioUser("user", []string{"workspace", "workspace2"})
 		})
 
 		AfterEach(func() {
 			env.DeleteEpinioUser(user)
+			env.DeleteNamespace(namespace)
 		})
 
 		Specify("can describe its namespace", func() {
@@ -141,7 +146,7 @@ var _ = Describe("Users", func() {
 		})
 
 		Specify("cannot describe another namespace", func() {
-			uri := fmt.Sprintf("%s%s/namespaces/another", serverURL, v1.Root)
+			uri := fmt.Sprintf("%s%s/namespaces/%s", serverURL, v1.Root, namespace)
 			request, err := http.NewRequest("GET", uri, nil)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/internal/api/v1/application/controller.go
+++ b/internal/api/v1/application/controller.go
@@ -1,28 +1,6 @@
 // Application contains the API handlers to manage applications. Except for app environment.
 package application
 
-import (
-	"context"
-
-	"github.com/epinio/epinio/helpers/kubernetes"
-	"github.com/epinio/epinio/internal/namespaces"
-	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
-)
-
 // Controller represents all functionality of the API related to applications
 type Controller struct {
-}
-
-func (c Controller) validateNamespace(ctx context.Context, cluster *kubernetes.Cluster, namespace string) apierror.APIErrors {
-	exists, err := namespaces.Exists(ctx, cluster, namespace)
-
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespace)
-	}
-
-	return nil
 }

--- a/internal/api/v1/application/create.go
+++ b/internal/api/v1/application/create.go
@@ -26,10 +26,6 @@ func (hc Controller) Create(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	if err := hc.validateNamespace(ctx, cluster, namespace); err != nil {
-		return err
-	}
-
 	var createRequest models.ApplicationCreateRequest
 	err = c.BindJSON(&createRequest)
 	if err != nil {

--- a/internal/api/v1/application/delete.go
+++ b/internal/api/v1/application/delete.go
@@ -21,10 +21,6 @@ func (hc Controller) Delete(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	if err := hc.validateNamespace(ctx, cluster, namespace); err != nil {
-		return err
-	}
-
 	app := models.NewAppRef(appName, namespace)
 
 	found, err := application.Exists(ctx, cluster, app)

--- a/internal/api/v1/application/exec.go
+++ b/internal/api/v1/application/exec.go
@@ -31,10 +31,6 @@ func (hc Controller) Exec(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	if err := hc.validateNamespace(ctx, cluster, namespace); err != nil {
-		return err
-	}
-
 	app, err := application.Lookup(ctx, cluster, namespace, appName)
 	if err != nil {
 		return apierror.InternalError(err)

--- a/internal/api/v1/application/index.go
+++ b/internal/api/v1/application/index.go
@@ -19,10 +19,6 @@ func (hc Controller) Index(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	if err := hc.validateNamespace(ctx, cluster, namespace); err != nil {
-		return err
-	}
-
 	apps, err := application.List(ctx, cluster, namespace)
 	if err != nil {
 		return apierror.InternalError(err)

--- a/internal/api/v1/application/logs.go
+++ b/internal/api/v1/application/logs.go
@@ -41,12 +41,6 @@ func (hc Controller) Logs(c *gin.Context) {
 		return
 	}
 
-	log.Info("validate namespace", "name", namespace)
-	if err := hc.validateNamespace(ctx, cluster, namespace); err != nil {
-		response.Error(c, err)
-		return
-	}
-
 	if appName != "" {
 		log.Info("retrieve application", "name", appName, "namespace", namespace)
 

--- a/internal/api/v1/application/part.go
+++ b/internal/api/v1/application/part.go
@@ -44,10 +44,6 @@ func (hc Controller) GetPart(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	if err := hc.validateNamespace(ctx, cluster, namespace); err != nil {
-		return err
-	}
-
 	app, err := application.Lookup(ctx, cluster, namespace, appName)
 	if err != nil {
 		return apierror.InternalError(err)

--- a/internal/api/v1/application/portforward.go
+++ b/internal/api/v1/application/portforward.go
@@ -24,10 +24,6 @@ func (hc Controller) PortForward(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	if err := hc.validateNamespace(ctx, cluster, namespace); err != nil {
-		return err
-	}
-
 	app, err := application.Lookup(ctx, cluster, namespace, appName)
 	if err != nil {
 		return apierror.InternalError(err)

--- a/internal/api/v1/application/restart.go
+++ b/internal/api/v1/application/restart.go
@@ -25,10 +25,6 @@ func (hc Controller) Restart(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	if err := hc.validateNamespace(ctx, cluster, namespace); err != nil {
-		return err
-	}
-
 	app, err := application.Lookup(ctx, cluster, namespace, appName)
 	if err != nil {
 		return apierror.InternalError(err)

--- a/internal/api/v1/application/running.go
+++ b/internal/api/v1/application/running.go
@@ -25,10 +25,6 @@ func (hc Controller) Running(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	if err := hc.validateNamespace(ctx, cluster, namespace); err != nil {
-		return err
-	}
-
 	app, err := application.Lookup(ctx, cluster, namespace, appName)
 	if err != nil {
 		return apierror.InternalError(err)

--- a/internal/api/v1/application/show.go
+++ b/internal/api/v1/application/show.go
@@ -20,10 +20,6 @@ func (hc Controller) Show(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	if err := hc.validateNamespace(ctx, cluster, namespace); err != nil {
-		return err
-	}
-
 	app, err := application.Lookup(ctx, cluster, namespace, appName)
 	if err != nil {
 		return apierror.InternalError(err)

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -270,10 +270,6 @@ func (hc Controller) Staged(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	if err := hc.validateNamespace(ctx, cluster, namespace); err != nil {
-		return err
-	}
-
 	// Wait for the staging to be done, then check if it ended in failure.
 	// Select the job for this stage `id`.
 	selector := fmt.Sprintf("app.kubernetes.io/component=staging,app.kubernetes.io/part-of=%s,epinio.suse.org/stage-id=%s",

--- a/internal/api/v1/application/update.go
+++ b/internal/api/v1/application/update.go
@@ -30,10 +30,6 @@ func (hc Controller) Update(c *gin.Context) apierror.APIErrors { // nolint:gocyc
 		return apierror.InternalError(err)
 	}
 
-	if err := hc.validateNamespace(ctx, cluster, namespace); err != nil {
-		return err
-	}
-
 	appRef := models.NewAppRef(appName, namespace)
 	exists, err := application.Exists(ctx, cluster, appRef)
 	if err != nil {

--- a/internal/api/v1/auth.go
+++ b/internal/api/v1/auth.go
@@ -34,7 +34,7 @@ func AuthorizationMiddleware(c *gin.Context) {
 	logger.Info(fmt.Sprintf("user [%s] with role [%s] authorized [%t] for namespace [%s]", user.Username, user.Role, authorized, namespace))
 
 	if !authorized {
-		response.Error(c, apierrors.NewAPIError("user unauthorized", "", http.StatusUnauthorized))
+		response.Error(c, apierrors.NewAPIError("user unauthorized", "", http.StatusForbidden))
 		c.Abort()
 	}
 

--- a/internal/api/v1/auth_test.go
+++ b/internal/api/v1/auth_test.go
@@ -58,18 +58,18 @@ var _ = Describe("Authorization Middleware", func() {
 				url = "http://url.com/restricted"
 			})
 
-			It("returns status code 401", func() {
+			It("returns status code 403", func() {
 				v1.AuthorizationMiddleware(c)
-				Expect(w.Code).To(Equal(http.StatusUnauthorized))
+				Expect(w.Code).To(Equal(http.StatusForbidden))
 			})
 		})
 
 		When("url is namespaced", func() {
-			It("returns status code 401 for another namespace", func() {
+			It("returns status code 403 for another namespace", func() {
 				c.Params = []gin.Param{{Key: "namespace", Value: "another-workspace"}}
 
 				v1.AuthorizationMiddleware(c)
-				Expect(w.Code).To(Equal(http.StatusUnauthorized))
+				Expect(w.Code).To(Equal(http.StatusForbidden))
 			})
 
 			It("returns status code 200 for its namespace", func() {

--- a/internal/api/v1/configuration/configurationapps.go
+++ b/internal/api/v1/configuration/configurationapps.go
@@ -4,7 +4,6 @@ import (
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/gin-gonic/gin"
 )
@@ -19,15 +18,6 @@ func (hc Controller) ConfigurationApps(c *gin.Context) apierror.APIErrors {
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
-	}
-
-	exists, err := namespaces.Exists(ctx, cluster, namespace)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespace)
 	}
 
 	appsOf, err := application.BoundApps(ctx, cluster, namespace)

--- a/internal/api/v1/configuration/create.go
+++ b/internal/api/v1/configuration/create.go
@@ -5,7 +5,6 @@ import (
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/configurations"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/gin-gonic/gin"
@@ -35,14 +34,6 @@ func (sc Controller) Create(c *gin.Context) apierror.APIErrors {
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
-	}
-
-	exists, err := namespaces.Exists(ctx, cluster, namespace)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespace)
 	}
 
 	// Verify that the requested name is not yet used by a different configuration.

--- a/internal/api/v1/configuration/delete.go
+++ b/internal/api/v1/configuration/delete.go
@@ -9,7 +9,6 @@ import (
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/configurations"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/gin-gonic/gin"
@@ -32,14 +31,6 @@ func (sc Controller) Delete(c *gin.Context) apierror.APIErrors {
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
-	}
-
-	exists, err := namespaces.Exists(ctx, cluster, namespace)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespace)
 	}
 
 	configuration, err := configurations.Lookup(ctx, cluster, namespace, configurationName)

--- a/internal/api/v1/configuration/index.go
+++ b/internal/api/v1/configuration/index.go
@@ -7,7 +7,6 @@ import (
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/configurations"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/gin-gonic/gin"
@@ -23,14 +22,6 @@ func (sc Controller) Index(c *gin.Context) apierror.APIErrors {
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
-	}
-
-	exists, err := namespaces.Exists(ctx, cluster, namespace)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespace)
 	}
 
 	namespaceConfigurations, err := configurations.List(ctx, cluster, namespace)

--- a/internal/api/v1/configuration/replace.go
+++ b/internal/api/v1/configuration/replace.go
@@ -9,7 +9,6 @@ import (
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/configurations"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/gin-gonic/gin"
@@ -25,15 +24,6 @@ func (sc Controller) Replace(c *gin.Context) apierror.APIErrors { // nolint:gocy
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
-	}
-
-	exists, err := namespaces.Exists(ctx, cluster, namespace)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespace)
 	}
 
 	configuration, err := configurations.Lookup(ctx, cluster, namespace, configurationName)

--- a/internal/api/v1/configuration/show.go
+++ b/internal/api/v1/configuration/show.go
@@ -5,7 +5,6 @@ import (
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/configurations"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/gin-gonic/gin"
@@ -21,14 +20,6 @@ func (sc Controller) Show(c *gin.Context) apierror.APIErrors {
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
-	}
-
-	exists, err := namespaces.Exists(ctx, cluster, namespace)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespace)
 	}
 
 	configuration, err := configurations.Lookup(ctx, cluster, namespace, configurationName)

--- a/internal/api/v1/configuration/update.go
+++ b/internal/api/v1/configuration/update.go
@@ -9,7 +9,6 @@ import (
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/configurations"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/gin-gonic/gin"
@@ -25,15 +24,6 @@ func (sc Controller) Update(c *gin.Context) apierror.APIErrors { // nolint:gocyc
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
-	}
-
-	exists, err := namespaces.Exists(ctx, cluster, namespace)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespace)
 	}
 
 	configuration, err := configurations.Lookup(ctx, cluster, namespace, configurationName)

--- a/internal/api/v1/configurationbinding/create.go
+++ b/internal/api/v1/configurationbinding/create.go
@@ -10,7 +10,6 @@ import (
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/configurations"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/gin-gonic/gin"
@@ -51,14 +50,6 @@ func (hc Controller) Create(c *gin.Context) apierror.APIErrors {
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
-	}
-
-	exists, err := namespaces.Exists(ctx, cluster, namespace)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespace)
 	}
 
 	app, err := application.Lookup(ctx, cluster, namespace, appName)

--- a/internal/api/v1/configurationbinding/delete.go
+++ b/internal/api/v1/configurationbinding/delete.go
@@ -4,7 +4,6 @@ import (
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/gin-gonic/gin"
 )
@@ -21,14 +20,6 @@ func (hc Controller) Delete(c *gin.Context) apierror.APIErrors {
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
-	}
-
-	exists, err := namespaces.Exists(ctx, cluster, namespace)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespace)
 	}
 
 	apiErr := DeleteBinding(ctx, cluster, namespace, appName, configurationName, username)

--- a/internal/api/v1/env/index.go
+++ b/internal/api/v1/env/index.go
@@ -5,7 +5,6 @@ import (
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 
@@ -29,18 +28,9 @@ func (hc Controller) Index(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	exists, err := namespaces.Exists(ctx, cluster, namespaceName)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespaceName)
-	}
-
 	app := models.NewAppRef(appName, namespaceName)
 
-	exists, err = application.Exists(ctx, cluster, app)
+	exists, err := application.Exists(ctx, cluster, app)
 	if err != nil {
 		return apierror.InternalError(err)
 	}

--- a/internal/api/v1/env/match.go
+++ b/internal/api/v1/env/match.go
@@ -8,7 +8,6 @@ import (
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 
@@ -35,18 +34,9 @@ func (hc Controller) Match(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	exists, err := namespaces.Exists(ctx, cluster, namespaceName)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespaceName)
-	}
-
 	app := models.NewAppRef(appName, namespaceName)
 
-	exists, err = application.Exists(ctx, cluster, app)
+	exists, err := application.Exists(ctx, cluster, app)
 	if err != nil {
 		return apierror.InternalError(err)
 	}

--- a/internal/api/v1/env/set.go
+++ b/internal/api/v1/env/set.go
@@ -6,7 +6,6 @@ import (
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/gin-gonic/gin"
@@ -29,15 +28,6 @@ func (hc Controller) Set(c *gin.Context) apierror.APIErrors {
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
-	}
-
-	exists, err := namespaces.Exists(ctx, cluster, namespaceName)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespaceName)
 	}
 
 	app, err := application.Lookup(ctx, cluster, namespaceName, appName)

--- a/internal/api/v1/env/show.go
+++ b/internal/api/v1/env/show.go
@@ -5,7 +5,6 @@ import (
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 
@@ -31,18 +30,9 @@ func (hc Controller) Show(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	exists, err := namespaces.Exists(ctx, cluster, namespaceName)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespaceName)
-	}
-
 	app := models.NewAppRef(appName, namespaceName)
 
-	exists, err = application.Exists(ctx, cluster, app)
+	exists, err := application.Exists(ctx, cluster, app)
 	if err != nil {
 		return apierror.InternalError(err)
 	}

--- a/internal/api/v1/env/unset.go
+++ b/internal/api/v1/env/unset.go
@@ -6,7 +6,6 @@ import (
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/gin-gonic/gin"
 )
@@ -29,15 +28,6 @@ func (hc Controller) Unset(c *gin.Context) apierror.APIErrors {
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
-	}
-
-	exists, err := namespaces.Exists(ctx, cluster, namespaceName)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespaceName)
 	}
 
 	app, err := application.Lookup(ctx, cluster, namespaceName, appName)

--- a/internal/api/v1/namespace.go
+++ b/internal/api/v1/namespace.go
@@ -9,6 +9,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// NamespaceMiddleware is a gin middleware used to check if a namespaced route is valid.
+// It checks the validity of the requested namespace, returning a 404 if it doesn't exists
 func NamespaceMiddleware(c *gin.Context) {
 	_ = requestctx.Logger(c.Request.Context()).WithName("NamespaceMiddleware")
 	ctx := c.Request.Context()

--- a/internal/api/v1/namespace.go
+++ b/internal/api/v1/namespace.go
@@ -1,0 +1,39 @@
+package v1
+
+import (
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
+	"github.com/epinio/epinio/internal/namespaces"
+	apierrors "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/gin-gonic/gin"
+)
+
+func NamespaceMiddleware(c *gin.Context) {
+	_ = requestctx.Logger(c.Request.Context()).WithName("NamespaceMiddleware")
+	ctx := c.Request.Context()
+
+	namespace := c.Param("namespace")
+	if namespace == "" {
+		return
+	}
+
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		response.Error(c, apierrors.InternalError(err))
+		c.Abort()
+		return
+	}
+
+	exists, err := namespaces.Exists(ctx, cluster, namespace)
+	if err != nil {
+		response.Error(c, apierrors.InternalError(err))
+		c.Abort()
+		return
+	}
+
+	if !exists {
+		response.Error(c, apierrors.NamespaceIsNotKnown(namespace))
+		c.Abort()
+	}
+}

--- a/internal/api/v1/namespace/delete.go
+++ b/internal/api/v1/namespace/delete.go
@@ -35,14 +35,6 @@ func (oc Controller) Delete(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	exists, err := namespaces.Exists(ctx, cluster, namespace)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespace)
-	}
-
 	err = deleteApps(ctx, cluster, namespace)
 	if err != nil {
 		return apierror.InternalError(err)

--- a/internal/api/v1/namespace/show.go
+++ b/internal/api/v1/namespace/show.go
@@ -21,15 +21,6 @@ func (hc Controller) Show(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	exists, err := namespaces.Exists(ctx, cluster, namespace)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespace)
-	}
-
 	appNames, err := namespaceApps(ctx, cluster, namespace)
 	if err != nil {
 		return apierror.InternalError(err)

--- a/internal/api/v1/service/controller.go
+++ b/internal/api/v1/service/controller.go
@@ -1,26 +1,4 @@
 package service
 
-import (
-	"context"
-
-	"github.com/epinio/epinio/helpers/kubernetes"
-	"github.com/epinio/epinio/internal/namespaces"
-	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
-)
-
 // Controller represents all functionality of the API related to services
 type Controller struct{}
-
-func (c Controller) validateNamespace(ctx context.Context, cluster *kubernetes.Cluster, namespace string) apierror.APIErrors {
-	exists, err := namespaces.Exists(ctx, cluster, namespace)
-
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespace)
-	}
-
-	return nil
-}

--- a/internal/api/v1/service/delete.go
+++ b/internal/api/v1/service/delete.go
@@ -38,10 +38,6 @@ func (ctr Controller) Delete(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	if err := ctr.validateNamespace(ctx, cluster, namespace); err != nil {
-		return err
-	}
-
 	apiErr := ValidateService(ctx, cluster, logger, namespace, serviceName)
 	if apiErr != nil {
 		return apiErr

--- a/internal/api/v1/service/list.go
+++ b/internal/api/v1/service/list.go
@@ -19,10 +19,6 @@ func (ctr Controller) List(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	if err := ctr.validateNamespace(ctx, cluster, namespace); err != nil {
-		return err
-	}
-
 	kubeServiceClient, err := services.NewKubernetesServiceClient(cluster)
 	if err != nil {
 		return apierror.InternalError(err)

--- a/internal/api/v1/service/serviceapps.go
+++ b/internal/api/v1/service/serviceapps.go
@@ -4,7 +4,6 @@ import (
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/gin-gonic/gin"
 )
@@ -19,15 +18,6 @@ func (hc Controller) ServiceApps(c *gin.Context) apierror.APIErrors {
 	cluster, err := kubernetes.GetCluster(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
-	}
-
-	exists, err := namespaces.Exists(ctx, cluster, namespace)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	if !exists {
-		return apierror.NamespaceIsNotKnown(namespace)
 	}
 
 	appsOf, err := application.ServicesBoundApps(ctx, cluster, namespace)

--- a/internal/api/v1/service/show.go
+++ b/internal/api/v1/service/show.go
@@ -19,10 +19,6 @@ func (ctr Controller) Show(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	if err := ctr.validateNamespace(ctx, cluster, namespace); err != nil {
-		return err
-	}
-
 	kubeServiceClient, err := services.NewKubernetesServiceClient(cluster)
 	if err != nil {
 		return apierror.InternalError(err)

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -97,13 +97,22 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 
 	// Register api routes
 	{
-		apiRoutesGroup := router.Group(apiv1.Root, authMiddleware, sessionMiddleware, apiv1.AuthorizationMiddleware)
+		apiRoutesGroup := router.Group(apiv1.Root,
+			apiv1.NamespaceMiddleware,
+			authMiddleware,
+			sessionMiddleware,
+			apiv1.AuthorizationMiddleware,
+		)
 		apiv1.Lemon(apiRoutesGroup)
 	}
 
 	// Register web socket routes
 	{
-		wapiRoutesGroup := router.Group(apiv1.WsRoot, tokenAuthMiddleware, apiv1.AuthorizationMiddleware)
+		wapiRoutesGroup := router.Group(apiv1.WsRoot,
+			apiv1.NamespaceMiddleware,
+			tokenAuthMiddleware,
+			apiv1.AuthorizationMiddleware,
+		)
 		apiv1.Spice(wapiRoutesGroup)
 	}
 

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -98,9 +98,9 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 	// Register api routes
 	{
 		apiRoutesGroup := router.Group(apiv1.Root,
-			apiv1.NamespaceMiddleware,
 			authMiddleware,
 			sessionMiddleware,
+			apiv1.NamespaceMiddleware,
 			apiv1.AuthorizationMiddleware,
 		)
 		apiv1.Lemon(apiRoutesGroup)
@@ -109,8 +109,8 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 	// Register web socket routes
 	{
 		wapiRoutesGroup := router.Group(apiv1.WsRoot,
-			apiv1.NamespaceMiddleware,
 			tokenAuthMiddleware,
+			apiv1.NamespaceMiddleware,
 			apiv1.AuthorizationMiddleware,
 		)
 		apiv1.Spice(wapiRoutesGroup)

--- a/internal/cli/usercmd/namespace.go
+++ b/internal/cli/usercmd/namespace.go
@@ -107,9 +107,15 @@ func (c *EpinioClient) Target(namespace string) error {
 		WithStringValue("Name", namespace).
 		Msg("Targeting namespace...")
 
+	// we don't need anything, just checking if the namespace exist and we have permissions
+	_, err := c.API.NamespaceShow(namespace)
+	if err != nil {
+		return errors.Wrap(err, "error targeting namespace")
+	}
+
 	details.Info("set settings")
 	c.Settings.Namespace = namespace
-	err := c.Settings.Save()
+	err = c.Settings.Save()
 	if err != nil {
 		return errors.Wrap(err, "failed to save settings")
 	}


### PR DESCRIPTION
Ref:
- https://github.com/epinio/epinio/issues/1375
---

Last point for the authorization layer.

This PR adds the check for the existence of a namespace, to fail-fast with a 404 in case of a missing one, and a 401 in case of an unauthorized.
As for the comments in the issue we had the authorization middleware before the business logic that was checking the validity of the namespace, and this check was repeated among all the controllers and methods that needed to do this validation.

Adding a `NamespaceMiddleware` before the auth layer simplified and moved all the logic just before entering the controller.

- [x] implementation
- [x] tests
- [x] ~~cli documentation~~
- [x] ~~documentation~~
- [x] ~~swagger documentation~~
