### PR TITLE
Hide password from show command

### DIFF
--- a/acceptance/settings_test.go
+++ b/acceptance/settings_test.go
@@ -74,6 +74,23 @@ var _ = Describe("Settings", func() {
 					WithRow("Current Namespace", ".*"),
 					WithRow("Certificates", "Present"),
 					WithRow("API User Name", env.EpinioUser),
+					WithRow("API Password", "[*]+"),
+					WithRow("API Url", "https://epinio.*"),
+					WithRow("WSS Url", "wss://epinio.*"),
+				),
+			)
+		})
+
+		It("shows the settings with the password in plaintext", func() {
+			settings, err := env.Epinio("", "settings", "show", "--show-password")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(settings).To(
+				HaveATable(
+					WithHeaders("KEY", "VALUE"),
+					WithRow("Colorized Output", "true|false"),
+					WithRow("Current Namespace", ".*"),
+					WithRow("Certificates", "Present"),
+					WithRow("API User Name", env.EpinioUser),
 					WithRow("API Password", env.EpinioPassword),
 					WithRow("API Url", "https://epinio.*"),
 					WithRow("WSS Url", "wss://epinio.*"),

--- a/internal/cli/settings.go
+++ b/internal/cli/settings.go
@@ -37,6 +37,9 @@ func init() {
 	viper.BindPFlag("namespace", flags.Lookup("namespace"))
 	viper.BindEnv("namespace", "NAMESPACE")
 
+	CmdSettingsShow.Flags().Bool("show-password", false, "Show hidden password")
+	viper.BindPFlag("show-password", CmdSettingsShow.Flags().Lookup("show-password"))
+
 	CmdSettings.AddCommand(CmdSettingsUpdate)
 	CmdSettings.AddCommand(CmdSettingsShow)
 	CmdSettings.AddCommand(CmdSettingsColors)
@@ -107,13 +110,18 @@ var CmdSettingsShow = &cobra.Command{
 			certInfo = color.BlueString("Present")
 		}
 
+		password := "***********"
+		if viper.GetBool("show-password") {
+			password = theSettings.Password
+		}
+
 		ui.Success().
 			WithTable("Key", "Value").
 			WithTableRow("Colorized Output", color.MagentaString("%t", theSettings.Colors)).
 			WithTableRow("Current Namespace", color.CyanString(theSettings.Namespace)).
 			WithTableRow("Default App Chart", color.CyanString(theSettings.AppChart)).
 			WithTableRow("API User Name", color.BlueString(theSettings.User)).
-			WithTableRow("API Password", color.BlueString(theSettings.Password)).
+			WithTableRow("API Password", color.BlueString(password)).
 			WithTableRow("API Url", color.BlueString(theSettings.API)).
 			WithTableRow("WSS Url", color.BlueString(theSettings.WSS)).
 			WithTableRow("Certificates", certInfo).


### PR DESCRIPTION
Ref:
- #1361 
---

This PR will hide the password from the `epinio settings show` command.

It can be shown specifying the `--show-password` flag.