### PR TITLE
Use Bcrypt for authentication

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -191,6 +191,6 @@ brews:
       output = shell_output("#{bin}/epinio version 2>&1")
       assert_match "Epinio Version: #{version}", output
 
-      output = shell_output("#{bin}/epinio settings update 2>&1")
+      output = shell_output("#{bin}/epinio settings update-ca 2>&1")
       assert_match "failed to get kube config", output
       assert_match "no configuration has been provided", output

--- a/acceptance/helpers/machine/users.go
+++ b/acceptance/helpers/machine/users.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	. "github.com/onsi/gomega"
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/epinio/epinio/acceptance/helpers/catalog"
 	"github.com/epinio/epinio/acceptance/helpers/proc"
@@ -17,6 +18,8 @@ import (
 // CreateEpinioUser creates a new "user" BasicAuth Secret labeled as an Epinio User.
 func (m *Machine) CreateEpinioUser(role string, namespaces []string) (string, string) {
 	user, password := catalog.NewUserCredentials()
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	Expect(err).ToNot(HaveOccurred())
 
 	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -34,7 +37,7 @@ func (m *Machine) CreateEpinioUser(role string, namespaces []string) (string, st
 		},
 		StringData: map[string]string{
 			"username":   user,
-			"password":   password,
+			"password":   string(hashedPassword),
 			"namespaces": strings.Join(namespaces, "\n"),
 		},
 	}

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Services", func() {
 
 			// create temp settings that we can use to switch users
 			tmpSettingsPath = catalog.NewTmpName("tmpEpinio") + `.yaml`
-			out, err := env.Epinio("", "settings", "update", "--settings-file", tmpSettingsPath)
+			out, err := env.Epinio("", "settings", "update-ca", "--settings-file", tmpSettingsPath)
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			// create users with permissions in different namespaces

--- a/acceptance/settings_test.go
+++ b/acceptance/settings_test.go
@@ -122,16 +122,16 @@ var _ = Describe("Settings", func() {
 		})
 	})
 
-	Describe("Update", func() {
+	Describe("UpdateCA", func() {
 		oldSettingsPath := testenv.EpinioYAML()
 
 		It("regenerates certs and credentials", func() {
 			// Get back the certs and credentials
 			// Note that `namespace`, as a purely local setting, is not restored
 
-			out, err := env.Epinio("", "settings", "update", "--settings-file", tmpSettingsPath)
+			out, err := env.Epinio("", "settings", "update-ca", "--settings-file", tmpSettingsPath)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(ContainSubstring(`Updating the stored credentials`))
+			Expect(out).To(ContainSubstring(`Updating CA in the stored credentials`))
 
 			oldSettings, err := env.GetSettingsFrom(oldSettingsPath)
 			Expect(err).ToNot(HaveOccurred())
@@ -139,17 +139,15 @@ var _ = Describe("Settings", func() {
 			newSettings, err := env.GetSettingsFrom(tmpSettingsPath)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(newSettings.User).To(Equal(oldSettings.User))
-			Expect(newSettings.Password).To(Equal(oldSettings.Password))
 			Expect(newSettings.API).To(Equal(oldSettings.API))
 			Expect(newSettings.WSS).To(Equal(oldSettings.WSS))
 			Expect(newSettings.Certs).To(Equal(oldSettings.Certs))
 		})
 
 		It("stores the password in base64", func() {
-			out, err := env.Epinio("", "settings", "update", "--settings-file", tmpSettingsPath)
+			out, err := env.Epinio("", "settings", "update-ca", "--settings-file", tmpSettingsPath)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(ContainSubstring(`Updating the stored credentials`))
+			Expect(out).To(ContainSubstring(`Updating CA in the stored credentials`))
 
 			settings, err := env.GetSettingsFrom(oldSettingsPath)
 			Expect(err).ToNot(HaveOccurred())

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,8 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.12.0
 	go.uber.org/zap v1.21.0
+	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/ini.v1 v1.66.4
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.9.0
@@ -198,13 +200,11 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	golang.org/x/tools v0.1.10 // indirect

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -7,7 +7,6 @@ package auth
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
@@ -73,17 +72,6 @@ func (s *AuthService) GetUserByUsername(ctx context.Context, username string) (U
 		}
 	}
 	return User{}, ErrUserNotFound
-}
-
-// GetUsersByAge returns the Epinio Users BasicAuth sorted from older to younger by CreationTime.
-func (s *AuthService) GetUsersByAge(ctx context.Context) ([]User, error) {
-	users, err := s.GetUsers(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "error getting users")
-	}
-	sort.Sort(ByCreationTime(users))
-
-	return users, nil
 }
 
 // AddNamespaceToUser will add to the User the specified namespace

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -70,69 +70,6 @@ var _ = Describe("Auth users", func() {
 		})
 	})
 
-	Describe("GetUsersByAge", func() {
-
-		When("kubernetes returns some user secrets", func() {
-			It("returns a list of users ordered by CreationTime", func() {
-				userSecrets := []corev1.Secret{
-					newUserSecret("user1", "password", "admin", ""),
-					newUserSecret("user2", "password", "user", "workspace\nworkspace2"),
-					newUserSecret("user3", "password", "admin", ""),
-					newUserSecret("user4", "password", "user", "workspace"),
-					newUserSecret("user5", "password", "admin", ""),
-					newUserSecret("user6", "password", "user", "workspace2"),
-				}
-
-				// shuffle secrets
-				for i := range userSecrets {
-					j := rand.Intn(i + 1)
-					userSecrets[i], userSecrets[j] = userSecrets[j], userSecrets[i]
-				}
-
-				fake.ListReturns(&corev1.SecretList{Items: userSecrets}, nil)
-
-				users, err := authService.GetUsersByAge(context.Background())
-				Expect(err).ToNot(HaveOccurred())
-
-				for i := 0; i < len(userSecrets)-1; i++ {
-					Expect(users[i].CreatedAt).To(BeTemporally("<=", users[i+1].CreatedAt))
-				}
-			})
-		})
-
-		When("kubernetes returns some user secrets created at the same time", func() {
-			now := metav1.NewTime(time.Now())
-
-			It("returns a list of users ordered by Username", func() {
-				userSecrets := []corev1.Secret{
-					newUserSecret("user1", "password", "admin", ""),
-					newUserSecret("user2", "password", "user", "workspace\nworkspace2"),
-					newUserSecret("user3", "password", "admin", ""),
-					newUserSecret("user4", "password", "user", "workspace"),
-					newUserSecret("user5", "password", "admin", ""),
-					newUserSecret("user6", "password", "user", "workspace2"),
-				}
-
-				// shuffle secrets
-				for i := range userSecrets {
-					userSecrets[i].CreationTimestamp = now
-
-					j := rand.Intn(i + 1)
-					userSecrets[i], userSecrets[j] = userSecrets[j], userSecrets[i]
-				}
-
-				fake.ListReturns(&corev1.SecretList{Items: userSecrets}, nil)
-
-				users, err := authService.GetUsersByAge(context.Background())
-				Expect(err).ToNot(HaveOccurred())
-
-				for i := 0; i < len(userSecrets)-1; i++ {
-					Expect(users[i].Username < users[i+1].Username).To(BeTrue())
-				}
-			})
-		})
-	})
-
 	Describe("AddNamespaceToUser", func() {
 
 		When("user doesn't have the namespace", func() {

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
-	"github.com/gin-gonic/gin"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -79,16 +78,6 @@ func (u *User) RemoveNamespace(namespace string) bool {
 
 	u.Namespaces = updatedNamespaces
 	return removed
-}
-
-// MakeGinAccountsFromUsers is a utility func to convert the Epinio users to gin.Accounts,
-// that can be passed to the BasicAuth middleware.
-func MakeGinAccountsFromUsers(users []User) gin.Accounts {
-	accounts := gin.Accounts{}
-	for _, user := range users {
-		accounts[user.Username] = user.Password
-	}
-	return accounts
 }
 
 // ByCreationTime can be used to sort Users by CreationTime

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -79,16 +79,3 @@ func (u *User) RemoveNamespace(namespace string) bool {
 	u.Namespaces = updatedNamespaces
 	return removed
 }
-
-// ByCreationTime can be used to sort Users by CreationTime
-type ByCreationTime []User
-
-func (c ByCreationTime) Len() int      { return len(c) }
-func (a ByCreationTime) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-
-func (c ByCreationTime) Less(i, j int) bool {
-	if c[i].CreatedAt == c[j].CreatedAt {
-		return c[i].Username < c[j].Username
-	}
-	return c[i].CreatedAt.Before(c[j].CreatedAt)
-}

--- a/internal/cli/admincmd/settings.go
+++ b/internal/cli/admincmd/settings.go
@@ -13,6 +13,7 @@ import (
 	"github.com/epinio/epinio/internal/cli/settings"
 	"github.com/epinio/epinio/internal/duration"
 	"github.com/epinio/epinio/internal/helmchart"
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -78,6 +79,13 @@ func (a *Admin) SettingsUpdate(ctx context.Context) error {
 		return nil
 	}
 	user := users[0]
+
+	// TEMP FIX! Check if the default user password is 'password' and use that
+	err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(`password`))
+	if err != nil {
+		return err
+	}
+	user.Password = "password"
 
 	details.Info("retrieved credentials", "user", user.Username, "password", user.Password)
 	details.Info("retrieving server locations")

--- a/internal/cli/admincmd/settings.go
+++ b/internal/cli/admincmd/settings.go
@@ -103,7 +103,7 @@ func (a *Admin) SettingsUpdateCA(ctx context.Context) error {
 }
 
 func getAPI(ctx context.Context, log logr.Logger) (string, string, error) {
-	// This is called only by the admin command `settings update`
+	// This is called only by the admin command `settings update-ca`
 	// which has to talk to the cluster to retrieve the
 	// information. This is allowed.
 
@@ -123,7 +123,7 @@ func getAPI(ctx context.Context, log logr.Logger) (string, string, error) {
 }
 
 func getCerts(ctx context.Context, log logr.Logger) (string, error) {
-	// This is called only by the admin command `settings update`
+	// This is called only by the admin command `settings update-ca`
 	// which has to talk to the cluster to retrieve the
 	// information. This is allowed.
 

--- a/internal/cli/settings.go
+++ b/internal/cli/settings.go
@@ -32,7 +32,7 @@ var CmdSettings = &cobra.Command{
 }
 
 func init() {
-	flags := CmdSettingsUpdate.Flags()
+	flags := CmdSettingsUpdateCA.Flags()
 	flags.StringP("namespace", "n", "epinio", "(NAMESPACE) The namespace to use")
 	viper.BindPFlag("namespace", flags.Lookup("namespace"))
 	viper.BindEnv("namespace", "NAMESPACE")
@@ -40,7 +40,7 @@ func init() {
 	CmdSettingsShow.Flags().Bool("show-password", false, "Show hidden password")
 	viper.BindPFlag("show-password", CmdSettingsShow.Flags().Lookup("show-password"))
 
-	CmdSettings.AddCommand(CmdSettingsUpdate)
+	CmdSettings.AddCommand(CmdSettingsUpdateCA)
 	CmdSettings.AddCommand(CmdSettingsShow)
 	CmdSettings.AddCommand(CmdSettingsColors)
 }
@@ -134,11 +134,11 @@ var CmdSettingsShow = &cobra.Command{
 	},
 }
 
-// CmdSettingsUpdate implements the command: epinio settings update
-var CmdSettingsUpdate = &cobra.Command{
-	Use:   "update",
-	Short: "Update the api location & stored credentials",
-	Long:  "Update the api location and stored credentials from the current cluster",
+// CmdSettingsUpdateCA implements the command: epinio settings update-ca
+var CmdSettingsUpdateCA = &cobra.Command{
+	Use:   "update-ca",
+	Short: "Update the api location and CA certificate",
+	Long:  "Update the api location and CA certificate from the current cluster",
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
@@ -149,7 +149,7 @@ var CmdSettingsUpdate = &cobra.Command{
 			return errors.Wrap(err, "error initializing cli")
 		}
 
-		err = client.SettingsUpdate(cmd.Context())
+		err = client.SettingsUpdateCA(cmd.Context())
 		if err != nil {
 			return errors.Wrap(err, "failed to update the settings")
 		}

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -33,6 +33,27 @@ function create_docker_pull_secret {
 	fi
 }
 
+function retry {
+  retry=0
+  maxRetries=$1
+  retryInterval=$2
+  local result
+  until [ ${retry} -ge ${maxRetries} ]
+  do
+    echo -n "."
+    result=$(eval "$3") && break
+    retry=$[${retry}+1]
+    sleep ${retryInterval}
+  done
+
+  if [ ${retry} -ge ${maxRetries} ]; then
+    echo "Failed to run "$3" after ${maxRetries} attempts!"
+    exit 1
+  fi
+
+  echo " ✔️"
+}
+
 # Ensure we have a value for --system-domain
 prepare_system_domain
 # Check Dependencies
@@ -69,24 +90,17 @@ if [ -n "$EPINIO_COVERAGE" ]; then
 fi
 
 # Check Epinio Installation
-# Retry 5 times because sometimes it takes a while before epinio server
-# is ready after patching.
-retry=0
-maxRetries=5
-retryInterval=1
-until [ ${retry} -ge ${maxRetries} ]
-do
-	"${EPINIO_BINARY}" login -u admin -p password --trust-ca https://epinio.$EPINIO_SYSTEM_DOMAIN && break
-	retry=$[${retry}+1]
-	echo "Retrying [${retry}/${maxRetries}] in ${retryInterval}(s) "
-	sleep ${retryInterval}
-done
+# Retry 5 times and sleep 1s because sometimes it takes a while before epinio server is ready
 
-if [ ${retry} -ge ${maxRetries} ]; then
-  echo "Failed to reach epinio endpoint after ${maxRetries} attempts!"
-  exit 1
-fi
+echo "-------------------------------------"
+echo -n "Trying to login"
+retry 5 1 "${EPINIO_BINARY} login -u admin -p password --trust-ca https://epinio.$EPINIO_SYSTEM_DOMAIN"
+echo "-------------------------------------"
+echo -n "Trying to getting info"
+retry 5 1 "${EPINIO_BINARY} info"
+echo "-------------------------------------"
 
-"${EPINIO_BINARY}" info
+${EPINIO_BINARY} info
 
+echo
 echo "Done preparing k3d environment!"

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -68,7 +68,7 @@ if [ -n "$EPINIO_COVERAGE" ]; then
     { "backend": { "service": { "name": "epinio-server", "port": { "number": 80 } } }, "path": "/exit", "pathType": "ImplementationSpecific" } }]'
 fi
 
-"${EPINIO_BINARY}" settings update
+"${EPINIO_BINARY}" login -u admin -p password --trust-ca http://epinio.$EPINIO_SYSTEM_DOMAIN
 
 # Check Epinio Installation
 # Retry 5 times because sometimes it takes a while before epinio server

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -68,8 +68,6 @@ if [ -n "$EPINIO_COVERAGE" ]; then
     { "backend": { "service": { "name": "epinio-server", "port": { "number": 80 } } }, "path": "/exit", "pathType": "ImplementationSpecific" } }]'
 fi
 
-"${EPINIO_BINARY}" login -u admin -p password --trust-ca http://epinio.$EPINIO_SYSTEM_DOMAIN
-
 # Check Epinio Installation
 # Retry 5 times because sometimes it takes a while before epinio server
 # is ready after patching.
@@ -78,7 +76,7 @@ maxRetries=5
 retryInterval=1
 until [ ${retry} -ge ${maxRetries} ]
 do
-	${EPINIO_BINARY} info && break
+	"${EPINIO_BINARY}" login -u admin -p password --trust-ca http://epinio.$EPINIO_SYSTEM_DOMAIN && break
 	retry=$[${retry}+1]
 	echo "Retrying [${retry}/${maxRetries}] in ${retryInterval}(s) "
 	sleep ${retryInterval}
@@ -88,5 +86,7 @@ if [ ${retry} -ge ${maxRetries} ]; then
   echo "Failed to reach epinio endpoint after ${maxRetries} attempts!"
   exit 1
 fi
+
+"${EPINIO_BINARY}" info
 
 echo "Done preparing k3d environment!"

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -76,7 +76,7 @@ maxRetries=5
 retryInterval=1
 until [ ${retry} -ge ${maxRetries} ]
 do
-	"${EPINIO_BINARY}" login -u admin -p password --trust-ca http://epinio.$EPINIO_SYSTEM_DOMAIN && break
+	"${EPINIO_BINARY}" login -u admin -p password --trust-ca https://epinio.$EPINIO_SYSTEM_DOMAIN && break
 	retry=$[${retry}+1]
 	echo "Retrying [${retry}/${maxRetries}] in ${retryInterval}(s) "
 	sleep ${retryInterval}


### PR DESCRIPTION
Ref:
- #1361 
---

This PR will use Bcrypt to check for password validity, instead of plaintext.

It also removes the `epinio settings update-ca` (with some unused methods) and it adds the `epinio settings update-ca` command.

**Helm charts:**
- https://github.com/epinio/helm-charts/pull/208

**Docs:**
- https://github.com/epinio/docs/pull/128