### PR TITLE
Bring docker login action back

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,6 +101,12 @@ jobs:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Install Tools
         run: make tools-install
 
@@ -167,6 +173,12 @@ jobs:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Install Tools
         run: make tools-install
 
@@ -232,6 +244,12 @@ jobs:
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Install Tools
         run: make tools-install

--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -83,6 +83,12 @@ jobs:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          
       - name: Install Tools
         run: make tools-install
 


### PR DESCRIPTION
Our tests are failing due to rate limiting on the docker hub side.
We need to rollback this PR https://github.com/epinio/epinio/pull/1230

The recommendation from docker is to always make authenticated requests