### PR TITLE
Clean up labels and domain usage

### DIFF
--- a/acceptance/api/v1/application_deploy_test.go
+++ b/acceptance/api/v1/application_deploy_test.go
@@ -130,7 +130,7 @@ var _ = Describe("AppDeploy Endpoint", func() {
 				// sanity check
 				out, err := proc.Kubectl("get", "Jobs",
 					"--namespace", testenv.Namespace,
-					"-o", "jsonpath={.items[*].metadata.labels['epinio\\.suse\\.org/blob-uid']}")
+					"-o", "jsonpath={.items[*].metadata.labels['epinio\\.io/blob-uid']}")
 				Expect(err).NotTo(HaveOccurred(), out)
 				blobUIDs := strings.Split(out, " ")
 				count := 0

--- a/acceptance/api/v1/application_stage_test.go
+++ b/acceptance/api/v1/application_stage_test.go
@@ -122,8 +122,8 @@ var _ = Describe("AppStage Endpoint", func() {
 
 			stagingBlobUID, err := proc.Kubectl("get", "Jobs",
 				"--namespace", testenv.Namespace,
-				"-l", fmt.Sprintf("epinio.suse.org/stage-id=%s", stageResponse.Stage.ID),
-				"-o", "jsonpath={.items[*].metadata.labels['epinio\\.suse\\.org/blob-uid']}")
+				"-l", fmt.Sprintf("epinio.io/stage-id=%s", stageResponse.Stage.ID),
+				"-o", "jsonpath={.items[*].metadata.labels['epinio\\.io/blob-uid']}")
 			Expect(err).NotTo(HaveOccurred(), stagingBlobUID)
 			Expect(stagingBlobUID).To(Equal(oldBlob))
 
@@ -141,8 +141,8 @@ var _ = Describe("AppStage Endpoint", func() {
 
 			stagingBlobUID, err = proc.Kubectl("get", "Jobs",
 				"--namespace", testenv.Namespace,
-				"-l", fmt.Sprintf("epinio.suse.org/stage-id=%s", stageResponse.Stage.ID),
-				"-o", "jsonpath={.items[*].metadata.labels['epinio\\.suse\\.org/blob-uid']}")
+				"-l", fmt.Sprintf("epinio.io/stage-id=%s", stageResponse.Stage.ID),
+				"-o", "jsonpath={.items[*].metadata.labels['epinio\\.io/blob-uid']}")
 			Expect(err).NotTo(HaveOccurred(), stagingBlobUID)
 			Expect(stagingBlobUID).To(Equal(oldBlob))
 		})
@@ -170,7 +170,7 @@ var _ = Describe("AppStage Endpoint", func() {
 
 			stagingBuilderImage, err := proc.Kubectl("get", "Pods",
 				"--namespace", testenv.Namespace,
-				"-l", fmt.Sprintf("epinio.suse.org/stage-id=%s", stageResponse.Stage.ID),
+				"-l", fmt.Sprintf("epinio.io/stage-id=%s", stageResponse.Stage.ID),
 				"-o", "jsonpath={.items[*].spec.containers[0].image}")
 			Expect(err).NotTo(HaveOccurred(), stagingBuilderImage)
 			Expect(stagingBuilderImage).To(Equal(builderImage))
@@ -188,7 +188,7 @@ var _ = Describe("AppStage Endpoint", func() {
 
 			stagingBuilderImage, err = proc.Kubectl("get", "Pods",
 				"--namespace", testenv.Namespace,
-				"-l", fmt.Sprintf("epinio.suse.org/stage-id=%s", stageResponse.Stage.ID),
+				"-l", fmt.Sprintf("epinio.io/stage-id=%s", stageResponse.Stage.ID),
 				"-o", "jsonpath={.items[*].spec.containers[0].image}")
 			Expect(err).NotTo(HaveOccurred(), stagingBuilderImage)
 			Expect(stagingBuilderImage).To(Equal(builderImage))

--- a/acceptance/apps_env_test.go
+++ b/acceptance/apps_env_test.go
@@ -20,7 +20,7 @@ var _ = Describe("apps env", func() {
 	secret := func(ns, appname string) string {
 		n, err := proc.Kubectl("get", "secret",
 			"--namespace", ns,
-			"-l", fmt.Sprintf("app.kubernetes.io/name=%s,app.kubernetes.io/part-of=%s,epinio.suse.org/area=environment", appname, ns),
+			"-l", fmt.Sprintf("app.kubernetes.io/name=%s,app.kubernetes.io/part-of=%s,epinio.io/area=environment", appname, ns),
 			"-o", "jsonpath={.items[].metadata.name")
 		if err != nil {
 			return err.Error()

--- a/acceptance/helpers/machine/users.go
+++ b/acceptance/helpers/machine/users.go
@@ -28,8 +28,8 @@ func (m *Machine) CreateEpinioUser(role string, namespaces []string) (string, st
 			Name:      "epinio-user-" + user,
 			Namespace: "epinio",
 			Labels: map[string]string{
-				"epinio.suse.org/api-user-credentials": "true",
-				"epinio.suse.org/role":                 role,
+				"epinio.io/api-user-credentials": "true",
+				"epinio.io/role":                 role,
 			},
 		},
 		StringData: map[string]string{

--- a/helpers/kubernetes/cluster.go
+++ b/helpers/kubernetes/cluster.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	// APISGroupName is the api name used for epinio
-	APISGroupName = "epinio.suse.org"
+	APISGroupName = "epinio.io"
 )
 
 var (

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -272,7 +272,7 @@ func (hc Controller) Staged(c *gin.Context) apierror.APIErrors {
 
 	// Wait for the staging to be done, then check if it ended in failure.
 	// Select the job for this stage `id`.
-	selector := fmt.Sprintf("app.kubernetes.io/component=staging,app.kubernetes.io/part-of=%s,epinio.suse.org/stage-id=%s",
+	selector := fmt.Sprintf("app.kubernetes.io/component=staging,app.kubernetes.io/part-of=%s,epinio.io/stage-id=%s",
 		namespace, id)
 
 	jobList, err := cluster.ListJobs(ctx, helmchart.Namespace(), selector)

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 )
 
-const EpinioApplicationAreaLabel = "epinio.suse.org/area"
+const EpinioApplicationAreaLabel = "epinio.io/area"
 
 // Create generates a new kube app resource in the namespace of the
 // namespace. Note that this is the passive resource holding the

--- a/internal/application/workload.go
+++ b/internal/application/workload.go
@@ -201,7 +201,7 @@ func (a *Workload) Get(ctx context.Context) (*models.AppDeployment, error) {
 
 	status := fmt.Sprintf("%d/%d", deployment.Status.ReadyReplicas, deployment.Status.Replicas)
 
-	stageID := deployment.Spec.Template.ObjectMeta.Labels["epinio.suse.org/stage-id"]
+	stageID := deployment.Spec.Template.ObjectMeta.Labels["epinio.io/stage-id"]
 	username := deployment.Spec.Template.ObjectMeta.Labels["app.kubernetes.io/created-by"]
 
 	routes, err := ListRoutes(ctx, a.cluster, a.app)

--- a/internal/configurations/configurations.go
+++ b/internal/configurations/configurations.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	ConfigurationLabelKey       = "epinio.suse.org/configuration"
-	ConfigurationTypeLabelKey   = "epinio.suse.org/configuration-type"
-	ConfigurationOriginLabelKey = "epinio.suse.org/configuration-origin"
+	ConfigurationLabelKey       = "epinio.io/configuration"
+	ConfigurationTypeLabelKey   = "epinio.io/configuration-type"
+	ConfigurationOriginLabelKey = "epinio.io/configuration-origin"
 )
 
 type ConfigurationList []*Configuration
@@ -59,8 +59,8 @@ func Lookup(ctx context.Context, kubeClient *kubernetes.Cluster, namespace, conf
 		return nil, err
 	}
 	c.Username = s.ObjectMeta.Labels["app.kubernetes.io/created-by"]
-	c.Type = s.ObjectMeta.Labels["epinio.suse.org/configuration-type"]
-	c.Origin = s.ObjectMeta.Labels["epinio.suse.org/configuration-origin"]
+	c.Type = s.ObjectMeta.Labels["epinio.io/configuration-type"]
+	c.Origin = s.ObjectMeta.Labels["epinio.io/configuration-origin"]
 	c.CreatedAt = s.ObjectMeta.CreationTimestamp
 
 	return c, nil
@@ -99,8 +99,8 @@ func List(ctx context.Context, cluster *kubernetes.Cluster, namespace string) (C
 		name := c.Name
 		namespace := c.Namespace
 		username := c.ObjectMeta.Labels["app.kubernetes.io/created-by"]
-		ctype := c.ObjectMeta.Labels["epinio.suse.org/configuration-type"]
-		origin := c.ObjectMeta.Labels["epinio.suse.org/configuration-origin"]
+		ctype := c.ObjectMeta.Labels["epinio.io/configuration-type"]
+		origin := c.ObjectMeta.Labels["epinio.io/configuration-origin"]
 
 		result = append(result, &Configuration{
 			CreatedAt:  c.ObjectMeta.CreationTimestamp,

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	RegistrySecretNamespaceAnnotationKey = "epinio.suse.org/registry-namespace" // nolint:gosec // not credentials
+	RegistrySecretNamespaceAnnotationKey = "epinio.io/registry-namespace" // nolint:gosec // not credentials
 	CredentialsSecretName                = "registry-creds"
 )
 

--- a/pkg/api/core/v1/models/app.go
+++ b/pkg/api/core/v1/models/app.go
@@ -5,9 +5,9 @@ import (
 )
 
 const (
-	EpinioStageIDPrevious   = "epinio.suse.org/previous-stage-id"
-	EpinioStageIDLabel      = "epinio.suse.org/stage-id"
-	EpinioStageBlobUIDLabel = "epinio.suse.org/blob-uid"
+	EpinioStageIDPrevious   = "epinio.io/previous-stage-id"
+	EpinioStageIDLabel      = "epinio.io/stage-id"
+	EpinioStageBlobUIDLabel = "epinio.io/blob-uid"
 
 	ApplicationCreated = "created"
 	ApplicationStaging = "staging"


### PR DESCRIPTION
fix #1383

chore: replace `epinio.suse.org`, use `epinio.io`.
note: this changes various resource labels.
done: chart changes
note: doc changes are a separate PR