### PR TITLE
Store the user's password in base64 encoding to prevent shoulder surfing

### DIFF
--- a/acceptance/settings_test.go
+++ b/acceptance/settings_test.go
@@ -1,6 +1,10 @@
 package acceptance_test
 
 import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+
 	"github.com/epinio/epinio/acceptance/helpers/catalog"
 	"github.com/epinio/epinio/acceptance/helpers/proc"
 	"github.com/epinio/epinio/acceptance/testenv"
@@ -140,6 +144,20 @@ var _ = Describe("Settings", func() {
 			Expect(newSettings.API).To(Equal(oldSettings.API))
 			Expect(newSettings.WSS).To(Equal(oldSettings.WSS))
 			Expect(newSettings.Certs).To(Equal(oldSettings.Certs))
+		})
+
+		It("stores the password in base64", func() {
+			out, err := env.Epinio("", "settings", "update", "--settings-file", tmpSettingsPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring(`Updating the stored credentials`))
+
+			settings, err := env.GetSettingsFrom(oldSettingsPath)
+			Expect(err).ToNot(HaveOccurred())
+
+			fileContents, err := ioutil.ReadFile(oldSettingsPath)
+			Expect(err).ToNot(HaveOccurred())
+			encodedPass := base64.StdEncoding.EncodeToString([]byte(settings.Password))
+			Expect(string(fileContents)).To(MatchRegexp(fmt.Sprintf("pass: %s", encodedPass)))
 		})
 	})
 })

--- a/internal/cli/settings/settings.go
+++ b/internal/cli/settings/settings.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"os"
@@ -123,6 +124,13 @@ func LoadFrom(file string) (*Settings, error) {
 		color.NoColor = true
 	}
 
+	// Decode base64 password
+	decodedPassword, err := base64.StdEncoding.DecodeString(cfg.Password)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.Password = string(decodedPassword)
+
 	cfg.log = log
 	log.Info("Loaded", "value", cfg.String())
 	return cfg, nil
@@ -140,7 +148,7 @@ func (c *Settings) Save() error {
 	c.v.Set("namespace", c.Namespace)
 	c.v.Set("appchart", c.AppChart)
 	c.v.Set("user", c.User)
-	c.v.Set("pass", c.Password)
+	c.v.Set("pass", base64.StdEncoding.EncodeToString([]byte(c.Password)))
 	c.v.Set("api", c.API)
 	c.v.Set("wss", c.WSS)
 	c.v.Set("certs", c.Certs)


### PR DESCRIPTION
Part of #1361

Docs update: https://github.com/epinio/docs/pull/126