### PR TITLE
Fix slow `epinio namespace list`

### DIFF
--- a/internal/api/v1/namespace/show.go
+++ b/internal/api/v1/namespace/show.go
@@ -1,8 +1,12 @@
 package namespace
 
 import (
+	"context"
+
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/internal/configurations"
 	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
@@ -45,4 +49,32 @@ func (hc Controller) Show(c *gin.Context) apierror.APIErrors {
 		Configurations: configurationNames,
 	})
 	return nil
+}
+
+func namespaceApps(ctx context.Context, cluster *kubernetes.Cluster, namespace string) ([]string, error) {
+	// Retrieve app references for namespace, and reduce to their names.
+	appRefs, err := application.ListAppRefs(ctx, cluster, namespace)
+	if err != nil {
+		return nil, err
+	}
+	appNames := make([]string, 0, len(appRefs))
+	for _, app := range appRefs {
+		appNames = append(appNames, app.Name)
+	}
+
+	return appNames, nil
+}
+
+func namespaceConfigurations(ctx context.Context, cluster *kubernetes.Cluster, namespace string) ([]string, error) {
+	// Retrieve configurations for namespace, and reduce to their names.
+	configurations, err := configurations.List(ctx, cluster, namespace)
+	if err != nil {
+		return nil, err
+	}
+	configurationNames := make([]string, 0, len(configurations))
+	for _, configuration := range configurations {
+		configurationNames = append(configurationNames, configuration.Name)
+	}
+
+	return configurationNames, nil
 }

--- a/internal/namespaces/namespaces.go
+++ b/internal/namespaces/namespaces.go
@@ -48,17 +48,10 @@ func List(ctx context.Context, kubeClient *kubernetes.Cluster) ([]Namespace, err
 // Exists checks if the named epinio-controlled namespace exists or
 // not, and returns an appropriate boolean flag
 func Exists(ctx context.Context, kubeClient *kubernetes.Cluster, lookupNamespace string) (bool, error) {
-	namespaces, err := List(ctx, kubeClient)
-	if err != nil {
-		return false, err
-	}
-	for _, namespace := range namespaces {
-		if namespace.Name == lookupNamespace {
-			return true, nil
-		}
-	}
+	ns, err := kubeClient.Kubectl.CoreV1().Namespaces().Get(ctx, lookupNamespace, metav1.GetOptions{})
 
-	return false, nil
+	exists := ns != nil
+	return exists, err
 }
 
 // Get returns the meta data of  the named epinio-controlled namespace

--- a/internal/namespaces/namespaces.go
+++ b/internal/namespaces/namespaces.go
@@ -49,9 +49,15 @@ func List(ctx context.Context, kubeClient *kubernetes.Cluster) ([]Namespace, err
 // not, and returns an appropriate boolean flag
 func Exists(ctx context.Context, kubeClient *kubernetes.Cluster, lookupNamespace string) (bool, error) {
 	ns, err := kubeClient.Kubectl.CoreV1().Namespaces().Get(ctx, lookupNamespace, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
 
 	exists := ns != nil
-	return exists, err
+	return exists, nil
 }
 
 // Get returns the meta data of  the named epinio-controlled namespace


### PR DESCRIPTION
Ref:
- https://github.com/epinio/epinio/issues/1353
---

This PR fixes https://github.com/epinio/epinio/issues/1353.
The `namespace list` was fetching all the apps and configurations of every namespace, one by one.
This implementation will fetch once all the AppRefs and all the Configurations, mapping them by namespace.
Then the lookup map will be used to prepare the response.

It also adds a small improvement to the `Exists` func, that will get the Secret by name, instead of getting all of them.
