### PR TITLE
Fix broken link in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -39,7 +39,7 @@ template: |
 
   # Usage
 
-  More info can be found in the [installation instructions](https://docs.epinio.io/installation).
+  More info can be found in the [installation instructions](https://docs.epinio.io/installation/install_epinio).
 
 version-resolver:
   major:


### PR DESCRIPTION
Fix #1552 

I also updated the [latest release changelog](https://github.com/epinio/epinio/releases/tag/v0.9.0) with the working link.