### PR TITLE
Fix for SSL Verify on MacOS

### DIFF
--- a/internal/cli/usercmd/login.go
+++ b/internal/cli/usercmd/login.go
@@ -119,9 +119,8 @@ func checkAndAskCA(ui *termui.UI, address string, trustCA bool) (string, error) 
 
 	cert, err := checkCA(address)
 	if err != nil {
-		_, isUnknownAuthority := err.(x509.UnknownAuthorityError)
 		// something bad happened while checking the certificates
-		if !isUnknownAuthority {
+		if cert == nil {
 			return "", errors.Wrap(err, "error while checking CA")
 		}
 


### PR DESCRIPTION
Ref:
- https://github.com/epinio/epinio/issues/1551
---

This PR fixes the bug that happens during the `Verify` and its error check with the MacOS architecture.
We actually don't need the type check, so we can probably skip it like this.
We could eventually do a check only for the `darwin/ios` arch, but it seems overkill to me.


A brief explanation.

The SSL verification in the `windows` and `darwin/ios` platforms is done with the system verifier:

https://cs.opensource.google/go/go/+/refs/tags/go1.18.3:src/crypto/x509/verify.go;l=748-761
```go
// Use platform verifiers, where available, if Roots is from SystemCertPool.
if runtime.GOOS == "windows" || runtime.GOOS == "darwin" || runtime.GOOS == "ios" {
	if opts.Roots == nil {
		return c.systemVerify(&opts)
	}
	if opts.Roots != nil && opts.Roots.systemPool {
		platformChains, err := c.systemVerify(&opts)
		// If the platform verifier succeeded, or there are no additional
		// roots, return the platform verifier result. Otherwise, continue
		// with the Go verifier.
		if err == nil || opts.Roots.len() == 0 {
			return platformChains, err
		}
	}
}
```

In the Windows implementation the `UnknownAuthorityError` error is checked and returned:

https://cs.opensource.google/go/go/+/refs/tags/go1.18.3:src/crypto/x509/root_windows.go;l=91-107

```go
// checkChainTrustStatus checks the trust status of the certificate chain, translating
// any errors it finds into Go errors in the process.
func checkChainTrustStatus(c *Certificate, chainCtx *syscall.CertChainContext) error {
	if chainCtx.TrustStatus.ErrorStatus != syscall.CERT_TRUST_NO_ERROR {
		status := chainCtx.TrustStatus.ErrorStatus
		switch status {
		case syscall.CERT_TRUST_IS_NOT_TIME_VALID:
			return CertificateInvalidError{c, Expired, ""}
		case syscall.CERT_TRUST_IS_NOT_VALID_FOR_USAGE:
			return CertificateInvalidError{c, IncompatibleUsage, ""}
		// TODO(filippo): surface more error statuses.
		default:
			return UnknownAuthorityError{c, nil, nil}
		}
	}
	return nil
}
```

but in the Darwin arch it's probably not possible and a generic `errorString` is returned:
https://cs.opensource.google/go/go/+/refs/tags/go1.18.3:src/crypto/x509/root_darwin.go
