### PR TITLE
Recreate the helm release when pushing

### DIFF
--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -226,6 +226,9 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 		deployRequest.Stage = models.StageRef{ID: stageID}
 	}
 
+	s := c.ui.Progress("Waiting for deployment")
+	defer s.Stop()
+
 	deployResponse, err := c.API.AppDeploy(deployRequest)
 	if err != nil {
 		return err

--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	deployment          = 2 * time.Minute
+	deployment          = 3 * time.Minute
 	namespaceDeletion   = 5 * time.Minute
 	configurationSecret = 5 * time.Minute
 	appBuilt            = 10 * time.Minute

--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	deployment          = 10 * time.Minute
+	deployment          = 2 * time.Minute
 	namespaceDeletion   = 5 * time.Minute
 	configurationSecret = 5 * time.Minute
 	appBuilt            = 10 * time.Minute

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -178,6 +178,7 @@ epinio:
 		ReleaseName: names.ReleaseName(parameters.Name),
 		ChartName:   helmChart,
 		Version:     helmVersion,
+		Recreate:    true,
 		Namespace:   parameters.Namespace,
 		Wait:        true,
 		Atomic:      true,


### PR DESCRIPTION
because if helm status is `pending-install` (e.g. because the Pod is
failing with an error), then the user can no longer push the app unless
they delete it first.

There are also the "Force" and the "Replace" attributes that could possibly be
used.

Fixes #1393 