### PR TITLE
Show better error when trying to retrieve logs of app without workload.

### DIFF
--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -389,7 +389,6 @@ func (c *EpinioClient) AppLogs(appName, stageID string, follow bool) error {
 
 	err := c.API.AppLogs(c.Settings.Namespace, appName, stageID, follow, callback)
 	if err != nil {
-		c.ui.Problem().Msg(fmt.Sprintf("failed to tail logs: %s", err.Error()))
 		return err
 	}
 

--- a/pkg/api/core/v1/client/apps.go
+++ b/pkg/api/core/v1/client/apps.go
@@ -391,6 +391,19 @@ func (c *Client) AppLogs(namespace, appName, stageID string, follow bool, printC
 	websocketURL := fmt.Sprintf("%s%s/%s?%s", c.WsURL, api.WsRoot, endpoint, queryParams.Encode())
 	webSocketConn, resp, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{})
 	if err != nil {
+		// Report detailed error found in the server response
+		if resp.StatusCode != http.StatusOK {
+			defer resp.Body.Close()
+			bodyBytes, errBody := ioutil.ReadAll(resp.Body)
+
+			if errBody != nil {
+				return errBody
+			}
+
+			return formatError(bodyBytes, resp)
+		}
+
+		// Report the dialer error if response claimed to be OK
 		return errors.Wrap(err, fmt.Sprintf("Failed to connect to websockets endpoint. Response was = %+v\nThe error is", resp))
 	}
 


### PR DESCRIPTION
fix #1458 
fix: double reporting of log error
fix: non-reporting of log error details