### PR TITLE
fix: path display across platforms.

### DIFF
--- a/helpers/string.go
+++ b/helpers/string.go
@@ -1,5 +1,18 @@
 package helpers
 
+import (
+	"fmt"
+	"path/filepath"
+)
+
+func AbsPath(path string) string {
+	absLocation, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Sprintf("<<error: %s>>", err.Error())
+	}
+	return absLocation
+}
+
 // UniqueStrings process the string slice and returns a slice where duplicate strings are
 // removed. The order of strings is not touched.  It does not assume a specific order.
 func UniqueStrings(stringSlice []string) []string {

--- a/internal/cli/admincmd/settings.go
+++ b/internal/cli/admincmd/settings.go
@@ -5,8 +5,8 @@ package admincmd
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
+	"github.com/epinio/epinio/helpers"
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/helpers/termui"
 	"github.com/epinio/epinio/helpers/tracelog"
@@ -57,14 +57,8 @@ func (a *Admin) SettingsUpdateCA(ctx context.Context) error {
 	defer log.Info("return")
 	details := log.V(1) // NOTE: Increment of level, not absolute.
 
-	location, err := filepath.Abs(a.Settings.Location)
-	if err != nil {
-		a.ui.Exclamation().Msg(err.Error())
-		return nil
-	}
-
 	a.ui.Note().
-		WithStringValue("Settings", location).
+		WithStringValue("Settings", helpers.AbsPath(a.Settings.Location)).
 		Msg("Updating CA in the stored credentials from the current cluster")
 
 	details.Info("retrieving server locations")

--- a/internal/cli/admincmd/settings.go
+++ b/internal/cli/admincmd/settings.go
@@ -5,6 +5,7 @@ package admincmd
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/helpers/termui"
@@ -56,8 +57,14 @@ func (a *Admin) SettingsUpdateCA(ctx context.Context) error {
 	defer log.Info("return")
 	details := log.V(1) // NOTE: Increment of level, not absolute.
 
+	location, err := filepath.Abs(a.Settings.Location)
+	if err != nil {
+		a.ui.Exclamation().Msg(err.Error())
+		return nil
+	}
+
 	a.ui.Note().
-		WithStringValue("Settings", a.Settings.Location).
+		WithStringValue("Settings", location).
 		Msg("Updating CA in the stored credentials from the current cluster")
 
 	details.Info("retrieving server locations")

--- a/internal/cli/settings.go
+++ b/internal/cli/settings.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/epinio/epinio/helpers"
 	"github.com/epinio/epinio/helpers/termui"
 	"github.com/epinio/epinio/internal/cli/admincmd"
 	"github.com/epinio/epinio/internal/cli/settings"
@@ -70,7 +71,9 @@ var CmdSettingsColors = &cobra.Command{
 			return errors.Wrap(err, "failed to load settings")
 		}
 
-		ui.Note().WithStringValue("Settings", theSettings.Location).Msg("Edit Colorization Flag")
+		ui.Note().
+			WithStringValue("Settings", helpers.AbsPath(theSettings.Location)).
+			Msg("Edit Colorization Flag")
 
 		colors, err := strconv.ParseBool(args[0])
 		// assert: err == nil -- see args validation
@@ -103,7 +106,9 @@ var CmdSettingsShow = &cobra.Command{
 			return errors.Wrap(err, "failed to load settings")
 		}
 
-		ui.Note().WithStringValue("Settings", theSettings.Location).Msg("Show Settings")
+		ui.Note().
+			WithStringValue("Settings", helpers.AbsPath(theSettings.Location)).
+			Msg("Show Settings")
 
 		certInfo := color.CyanString("None defined")
 		if theSettings.Certs != "" {

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -53,7 +53,7 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 	details := log.V(1) // NOTE: Increment of level, not absolute. Visible via TRACE_LEVEL=2
 
 	msg := c.ui.Note().
-		WithStringValue("Manifest", params.Self).
+		WithStringValue("Manifest", params.Self). // This path is already platform-specific
 		WithStringValue("Name", appRef.Name).
 		WithStringValue("Source Origin", source).
 		WithStringValue("AppChart", params.Configuration.AppChart).

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -10,6 +10,7 @@ package models
 import (
 	"fmt"
 
+	"github.com/epinio/epinio/helpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	helmrelease "helm.sh/helm/v3/pkg/release"
@@ -136,7 +137,7 @@ const (
 func (o *ApplicationOrigin) String() string {
 	switch o.Kind {
 	case OriginPath:
-		return o.Path
+		return helpers.AbsPath(o.Path)
 	case OriginGit:
 		if o.Git.Revision == "" {
 			return o.Git.URL
@@ -145,7 +146,7 @@ func (o *ApplicationOrigin) String() string {
 	case OriginContainer:
 		return o.Container
 	default:
-		// Nonthing
+		// Nothing
 	}
 	return "<<undefined>>"
 }


### PR DESCRIPTION
fix #1578 

Use a filepath function to ensure that the path is absolute.
And hopefully transform into the platform-specific form as well.

Should check where else we display paths for the user to see.
(`push` comes to mind, location of the app sources)