### PR TITLE
Trim surrounding whitespace when reading user input

### DIFF
--- a/internal/cli/namespaces.go
+++ b/internal/cli/namespaces.go
@@ -151,8 +151,7 @@ func askConfirmation(cmd *cobra.Command) bool {
 	reader := bufio.NewReader(os.Stdin)
 	for {
 		s, _ := reader.ReadString('\n')
-		s = strings.TrimSuffix(s, "\n")
-		s = strings.ToLower(s)
+		s = strings.TrimSpace(strings.ToLower(s))
 		if strings.Compare(s, "n") == 0 {
 			return false
 		} else if strings.Compare(s, "y") == 0 {

--- a/internal/cli/usercmd/login.go
+++ b/internal/cli/usercmd/login.go
@@ -195,7 +195,7 @@ func askTrustCA(ui *termui.UI, cert *x509.Certificate) (bool, error) {
 			return false, err
 		}
 
-		switch strings.ToLower(input) {
+		switch strings.TrimSpace(strings.ToLower(input)) {
 		case "y", "yes":
 			return true, nil
 		case "n", "no":


### PR DESCRIPTION
because it breaks on windows (some \r character maybe?)

Fixes #1577 