### PR TITLE
Remove non-existent DEBUG option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,11 +38,10 @@ If you paste long logs, you could also add them into a collapsed block:
   \```
 &lt;details&gt;
 
-You can increase Epinio's logging by exporting these variables:
+You can increase Epinio's logging by exporting this variable:
 
 ```
 export TRACE_LEVEL=255
-export DEBUG=true
 ```
 
 To follow the server logs you can use:


### PR DESCRIPTION
DEBUG option does not exist in epinio-server, let's remove it form the issue template.
Fix #1580