### PR TITLE
[Swagger] Fixed host and missing path, and new UI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 acceptance/
 docs/
+!/docs/references/api/swagger.json
 images/
 output/
 helm-charts/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,7 +95,8 @@ dockers:
     # GoReleaser is being run (usually the repository root folder).
     # This field does not support wildcards, you can add an entire folder here
     # and use wildcards when you `COPY`/`ADD` in your Dockerfile.
-    extra_files: []
+    extra_files: [ "docs/references/api/swagger.json" ]
+
   -
     use: buildx
     goos: linux
@@ -114,6 +115,9 @@ dockers:
     - "--label=org.opencontainers.image.source=https://github.com/epinio/epinio"
     - "--build-arg=DIST_BINARY=epinio"
     - "--platform=linux/arm64/v8"
+
+    extra_files: [ "docs/references/api/swagger.json" ]
+
   -
     use: buildx
     goos: linux
@@ -133,6 +137,9 @@ dockers:
     - "--label=org.opencontainers.image.source=https://github.com/epinio/epinio"
     - "--build-arg=DIST_BINARY=epinio"
     - "--platform=linux/arm/v7"
+
+    extra_files: [ "docs/references/api/swagger.json" ]
+
   -
     use: buildx
     goos: linux
@@ -151,6 +158,9 @@ dockers:
     - "--label=org.opencontainers.image.source=https://github.com/epinio/epinio"
     - "--build-arg=DIST_BINARY=epinio"
     - "--platform=linux/s390x"
+
+    extra_files: [ "docs/references/api/swagger.json" ]
+
 docker_manifests:
   # https://goreleaser.com/customization/docker_manifest/
   -

--- a/Makefile
+++ b/Makefile
@@ -148,11 +148,10 @@ getswagger:
 
 swagger: getswagger
 	swagger generate spec > docs/references/api/swagger.json
-	sed -i 's/^{/{ "info": {"title": "Epinio", "version":"1"},/' docs/references/api/swagger.json
 	swagger validate        docs/references/api/swagger.json
 
-swagger-serve: getswagger
-	swagger serve docs/references/api/swagger.json
+swagger-serve:
+	@./scripts/swagger-serve.sh
 
 ########################################################################
 # Support

--- a/docs/howtos/swagger.md
+++ b/docs/howtos/swagger.md
@@ -1,0 +1,35 @@
+# Swagger
+
+A Swagger endpoint is available on `/api/swagger.json`. This will expose the OpenAPI spec for the Epinio API.
+
+## Generate the `swagger.json` file
+
+To generate the `swagger.json` file you need `github.com/go-swagger/go-swagger`.
+
+You can just run the `make swagger` command and it will install the tool if needed, and generate the `swagger.json` file.
+
+
+## Serve the documentation
+
+### Development mode
+
+To see the documentation of a local deployment you can run the `make swagger-serve` command.
+It will query your running Epinio for its swagger file and you will be able to try out the APis.
+
+### External Epinio instance
+
+If you want run the documentation on a running Epinio deployment you just need to specify the URL:
+
+```
+docker run -p 8080:8080 -e SWAGGER_JSON_URL=https://epinio.<EPINIO_SYSTEM_DOMAIN>/api/swagger.json swaggerapi/swagger-ui
+```
+but remember that since you are running the documentatio locally then you would need to enable CORS on your deployment.
+You can do it specifying the `server.accessControlAllowOrigin: "*"` value in the Helm values.
+
+### Locally
+
+If you just want to see the documentation without a running instance of Epinio you can do it with:
+
+```
+docker run -p 8080:8080 -e SWAGGER_JSON=/docs/swagger.json -v $(pwd)/docs/references/api:/docs swaggerapi/swagger-ui
+```

--- a/docs/howtos/swagger.md
+++ b/docs/howtos/swagger.md
@@ -23,7 +23,7 @@ If you want run the documentation on a running Epinio deployment you just need t
 ```
 docker run -p 8080:8080 -e SWAGGER_JSON_URL=https://epinio.<EPINIO_SYSTEM_DOMAIN>/api/swagger.json swaggerapi/swagger-ui
 ```
-but remember that since you are running the documentatio locally then you would need to enable CORS on your deployment.
+but remember that since you are running the documentation locally then you would need to enable CORS on your deployment.
 You can do it specifying the `server.accessControlAllowOrigin: "*"` value in the Helm values.
 
 ### Locally

--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -1,5 +1,15 @@
-{ "info": {"title": "Epinio", "version":"1"},
+{
+  "schemes": [
+    "http",
+    "https"
+  ],
   "swagger": "2.0",
+  "info": {
+    "description": "This is the API specification of the Epinio API",
+    "title": "Epinio API",
+    "version": "1.0.0"
+  },
+  "basePath": "/api/v1",
   "paths": {
     "/appcharts": {
       "get": {
@@ -2348,6 +2358,10 @@
           "type": "string",
           "x-go-name": "CatalogService"
         },
+        "catalog_service_version": {
+          "type": "string",
+          "x-go-name": "CatalogServiceVersion"
+        },
         "meta": {
           "$ref": "#/definitions/Meta"
         },
@@ -2820,5 +2834,17 @@
     "StagingLogsResponse": {
       "description": ""
     }
-  }
+  },
+  "securityDefinitions": {
+    "basicAuth": {
+      "type": "basic"
+    }
+  },
+  "security": [
+    {
+      "basicAuth": [
+        "[]"
+      ]
+    }
+  ]
 }

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -6,6 +6,9 @@ COPY --from=certs /etc/ssl/certs /etc/ssl/certs
 
 # default, if running outside of gorelease with a self-compiled binary
 ARG DIST_BINARY=dist/epinio-linux-amd64
+ARG SWAGGER_FILE=docs/references/api/swagger.json
 
 COPY ${DIST_BINARY} /epinio
+COPY ${SWAGGER_FILE} /swagger.json
+
 ENTRYPOINT ["/epinio"]

--- a/internal/api/v1/docs/docs.go
+++ b/internal/api/v1/docs/docs.go
@@ -1,0 +1,18 @@
+// Epinio API
+//
+// This is the API specification of the Epinio API
+//
+//     Schemes: http, https
+//     Host:
+//     BasePath: /api/v1
+//     Version: 1.0.0
+//
+//     SecurityDefinitions:
+//     basicAuth:
+//          type: basic
+//
+//     Security:
+//     - basicAuth: []
+//
+// swagger:meta
+package docs

--- a/scripts/swagger-serve.sh
+++ b/scripts/swagger-serve.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+source "${SCRIPT_DIR}/helpers.sh"
+
+# Ensure we have a value for --system-domain
+prepare_system_domain
+
+kubectl patch deployment -n epinio epinio-server \
+  --patch '{"spec": {"template": {"spec": {"containers": [{"name": "epinio-server","env": [{"name":"ACCESS_CONTROL_ALLOW_ORIGIN", "value":"*"}]}]}}}}'
+
+echo
+echo "##################################################"
+echo "#                                                #"
+echo -e "#   Serving API docs at: \e[32mhttp://localhost:8080\e[0m   #"
+echo "#                                                #"
+echo "##################################################"
+echo
+
+SWAGGER_JSON_URL=https://epinio.$EPINIO_SYSTEM_DOMAIN/api/swagger.json
+docker run -p 8080:8080 -e SWAGGER_JSON_URL=$SWAGGER_JSON_URL swaggerapi/swagger-ui


### PR DESCRIPTION
Ref:
- https://github.com/epinio/epinio/issues/1360
---

This PR fixes the missing path `/api/v1` and adds some metadata to our swagger.json file (auth, version and so on).

It also adds an handler to the epinio server on the `/api/swagger.json` path that will serve the specification.
This will be used by the new UI (https://github.com/swagger-api/swagger-ui) during the `make swagger-serve` and adds the possibility to "try out" the endpoints.

![image](https://user-images.githubusercontent.com/1763949/175279136-53044c85-94d2-48b5-accc-875a5ffebdb4.png)

![image](https://user-images.githubusercontent.com/1763949/175279968-49f9589a-9573-4c2c-99f9-7dfc0ff27850.png)

## Authentication

It's now possible to authenticate with the Basic Auth (still missing the token auth):

![image](https://user-images.githubusercontent.com/1763949/175280208-939c4802-4bba-4f8c-b4cc-cf8ef8256c80.png)

In the following screenshot an example of the output

![image](https://user-images.githubusercontent.com/1763949/175280413-ee9ad9ec-e3dc-45b7-8912-27756f0a1a58.png)

From this I've seen that we have some "mismatch" or strange things to fix.
The output of the values is the helm template, we are missing the errors declaration, and some catalog services APIs are under the "Services" section.