### PR TITLE
Error refinement [NotFound and Conflict]

### DIFF
--- a/internal/api/v1/application/exec.go
+++ b/internal/api/v1/application/exec.go
@@ -42,8 +42,7 @@ func (hc Controller) Exec(c *gin.Context) apierror.APIErrors {
 
 	// app exists but has no workload to connect to
 	if app.Workload == nil {
-		return apierror.NewAPIError("Cannot connect to application without workload",
-			"", http.StatusBadRequest)
+		return apierror.NewAPIError("Cannot connect to application without workload", http.StatusBadRequest)
 	}
 
 	workload := application.NewWorkload(cluster, app.Meta)
@@ -53,8 +52,7 @@ func (hc Controller) Exec(c *gin.Context) apierror.APIErrors {
 	}
 
 	if len(podNames) < 1 {
-		return apierror.NewAPIError("couldn't find any Instances to connect to",
-			"", http.StatusBadRequest)
+		return apierror.NewAPIError("couldn't find any Instances to connect to", http.StatusBadRequest)
 	}
 
 	podToConnect := ""
@@ -67,8 +65,7 @@ func (hc Controller) Exec(c *gin.Context) apierror.APIErrors {
 		}
 
 		if podToConnect == "" {
-			return apierror.NewAPIError("specified instance doesn't exist",
-				"", http.StatusBadRequest)
+			return apierror.NewAPIError("specified instance doesn't exist", http.StatusBadRequest)
 		}
 	} else {
 		podToConnect = podNames[0]

--- a/internal/api/v1/application/logs.go
+++ b/internal/api/v1/application/logs.go
@@ -57,7 +57,7 @@ func (hc Controller) Logs(c *gin.Context) {
 
 		if app.Workload == nil {
 			// While the app exists it has no workload, therefore no logs
-			response.Error(c, apierror.NewAPIError("No logs available for application without workload", "", http.StatusBadRequest))
+			response.Error(c, apierror.NewAPIError("No logs available for application without workload", http.StatusBadRequest))
 			return
 		}
 	}

--- a/internal/api/v1/application/portforward.go
+++ b/internal/api/v1/application/portforward.go
@@ -35,8 +35,7 @@ func (hc Controller) PortForward(c *gin.Context) apierror.APIErrors {
 
 	// app exists but has no workload to connect to
 	if app.Workload == nil {
-		return apierror.NewAPIError("Cannot connect to application without workload",
-			"", http.StatusBadRequest)
+		return apierror.NewAPIError("Cannot connect to application without workload", http.StatusBadRequest)
 	}
 
 	// TODO: Find podName from application and params (e.g. instance number etc).
@@ -46,8 +45,7 @@ func (hc Controller) PortForward(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 	if len(podNames) == 0 {
-		return apierror.NewAPIError("couldn't find any Pods to connect to",
-			"", http.StatusBadRequest)
+		return apierror.NewAPIError("couldn't find any Pods to connect to", http.StatusBadRequest)
 	}
 
 	podToConnect := ""
@@ -60,8 +58,7 @@ func (hc Controller) PortForward(c *gin.Context) apierror.APIErrors {
 		}
 
 		if podToConnect == "" {
-			return apierror.NewAPIError("specified instance doesn't exist",
-				"", http.StatusBadRequest)
+			return apierror.NewAPIError("specified instance doesn't exist", http.StatusBadRequest)
 		}
 	} else {
 		podToConnect = podNames[0]

--- a/internal/api/v1/application/restart.go
+++ b/internal/api/v1/application/restart.go
@@ -35,8 +35,7 @@ func (hc Controller) Restart(c *gin.Context) apierror.APIErrors {
 	}
 
 	if app.Workload == nil {
-		return apierror.NewAPIError("No restart possible for an application without workload",
-			"", http.StatusBadRequest)
+		return apierror.NewAPIError("No restart possible for an application without workload", http.StatusBadRequest)
 	}
 
 	nano := time.Now().UnixNano()

--- a/internal/api/v1/auth.go
+++ b/internal/api/v1/auth.go
@@ -34,7 +34,7 @@ func AuthorizationMiddleware(c *gin.Context) {
 	logger.Info(fmt.Sprintf("user [%s] with role [%s] authorized [%t] for namespace [%s]", user.Username, user.Role, authorized, namespace))
 
 	if !authorized {
-		response.Error(c, apierrors.NewAPIError("user unauthorized", "", http.StatusForbidden))
+		response.Error(c, apierrors.NewAPIError("user unauthorized", http.StatusForbidden))
 		c.Abort()
 	}
 

--- a/internal/api/v1/service/catalog.go
+++ b/internal/api/v1/service/catalog.go
@@ -5,6 +5,7 @@ import (
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/services"
 	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
 
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -49,7 +50,7 @@ func (ctr Controller) CatalogShow(c *gin.Context) apierror.APIErrors {
 	service, err := kubeServiceClient.GetCatalogService(ctx, serviceName)
 	if err != nil {
 		if k8sapierrors.IsNotFound(err) {
-			return apierror.NewNotFoundError("service instance doesn't exist")
+			return apierror.NewNotFoundError(errors.Wrap(err, "service instance doesn't exist"))
 		}
 
 		return apierror.InternalError(err)

--- a/internal/api/v1/service/catalog.go
+++ b/internal/api/v1/service/catalog.go
@@ -5,7 +5,6 @@ import (
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/services"
 	"github.com/gin-gonic/gin"
-	"github.com/pkg/errors"
 
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -50,7 +49,7 @@ func (ctr Controller) CatalogShow(c *gin.Context) apierror.APIErrors {
 	service, err := kubeServiceClient.GetCatalogService(ctx, serviceName)
 	if err != nil {
 		if k8sapierrors.IsNotFound(err) {
-			return apierror.NewNotFoundError(errors.Wrap(err, "service instance doesn't exist"))
+			return apierror.NewNotFoundError(err.Error()).WithDetailsf("service instance '%s' doesn't exist", serviceName)
 		}
 
 		return apierror.InternalError(err)

--- a/internal/api/v1/service/delete.go
+++ b/internal/api/v1/service/delete.go
@@ -14,6 +14,7 @@ import (
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -99,7 +100,7 @@ func (ctr Controller) Delete(c *gin.Context) apierror.APIErrors {
 	err = kubeServiceClient.Delete(ctx, namespace, serviceName)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return apierror.NewNotFoundError("service not found")
+			return apierror.NewNotFoundError(errors.Wrap(err, "service not found"))
 		}
 
 		return apierror.InternalError(err)

--- a/internal/api/v1/service/delete.go
+++ b/internal/api/v1/service/delete.go
@@ -14,7 +14,6 @@ import (
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/gin-gonic/gin"
-	"github.com/pkg/errors"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -100,7 +99,7 @@ func (ctr Controller) Delete(c *gin.Context) apierror.APIErrors {
 	err = kubeServiceClient.Delete(ctx, namespace, serviceName)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return apierror.NewNotFoundError(errors.Wrap(err, "service not found"))
+			return apierror.NewNotFoundError(err.Error()).WithDetailsf("service '%s' not found", serviceName)
 		}
 
 		return apierror.InternalError(err)

--- a/internal/api/v1/service/validate.go
+++ b/internal/api/v1/service/validate.go
@@ -37,14 +37,14 @@ func ValidateService(
 	theService, err := kubeServiceClient.Get(ctx, namespace, service)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return apierror.NewNotFoundError(errors.Wrap(err, "service not found"))
+			return apierror.NewNotFoundError(err.Error()).WithDetailsf("service '%s' not found", service)
 		}
 
 		return apierror.InternalError(err)
 	}
 	// See internal/services/instances.go - not found => no error, nil structure
 	if theService == nil {
-		return apierror.NewNotFoundError(errors.New("service not found"))
+		return apierror.NewNotFoundError("service not found")
 	}
 
 	logger.Info("getting helm client")
@@ -60,7 +60,7 @@ func ValidateService(
 	srv, err := client.GetRelease(releaseName)
 	if err != nil {
 		if errors.Is(err, helmdriver.ErrReleaseNotFound) {
-			return apierror.NewNotFoundError(errors.Wrapf(err, "release %s not found", releaseName))
+			return apierror.NewNotFoundError(err.Error()).WithDetailsf("release %s not found", releaseName)
 		}
 		return apierror.InternalError(err)
 	}

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -52,7 +52,7 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 		response.Error(ctx, apierrors.NewAPIError("Method not allowed", "", http.StatusMethodNotAllowed))
 	})
 	router.NoRoute(func(ctx *gin.Context) {
-		response.Error(ctx, apierrors.NewNotFoundError("Route not found"))
+		response.Error(ctx, apierrors.NewNotFoundError(errors.New("Route not found")))
 	})
 	router.Use(gin.Recovery())
 

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -49,10 +49,10 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 	router := gin.New()
 	router.HandleMethodNotAllowed = true
 	router.NoMethod(func(ctx *gin.Context) {
-		response.Error(ctx, apierrors.NewAPIError("Method not allowed", "", http.StatusMethodNotAllowed))
+		response.Error(ctx, apierrors.NewAPIError("Method not allowed", http.StatusMethodNotAllowed))
 	})
 	router.NoRoute(func(ctx *gin.Context) {
-		response.Error(ctx, apierrors.NewNotFoundError(errors.New("Route not found")))
+		response.Error(ctx, apierrors.NewNotFoundError("Route not found"))
 	})
 	router.Use(gin.Recovery())
 
@@ -187,7 +187,7 @@ func authMiddleware(ctx *gin.Context) {
 	}
 
 	if len(userMap) == 0 {
-		response.Error(ctx, apierrors.NewAPIError("no user found", "", http.StatusUnauthorized))
+		response.Error(ctx, apierrors.NewAPIError("no user found", http.StatusUnauthorized))
 		ctx.Abort()
 		return
 	}
@@ -221,7 +221,7 @@ func authMiddleware(ctx *gin.Context) {
 				return
 			}
 
-			response.Error(ctx, apierrors.NewAPIError("User no longer exists. Session expired.", "", http.StatusUnauthorized))
+			response.Error(ctx, apierrors.NewAPIError("User no longer exists. Session expired.", http.StatusUnauthorized))
 			ctx.Abort()
 			return
 		}
@@ -235,7 +235,7 @@ func authMiddleware(ctx *gin.Context) {
 		// we need this check to return a 401 instead of an error
 		auth := ctx.Request.Header.Get("Authorization")
 		if auth == "" {
-			response.Error(ctx, apierrors.NewAPIError("missing credentials", "", http.StatusUnauthorized))
+			response.Error(ctx, apierrors.NewAPIError("missing credentials", http.StatusUnauthorized))
 			ctx.Abort()
 			return
 		}
@@ -249,7 +249,7 @@ func authMiddleware(ctx *gin.Context) {
 
 		err = bcrypt.CompareHashAndPassword([]byte(userMap[username].Password), []byte(password))
 		if err != nil {
-			response.Error(ctx, apierrors.NewAPIError("wrong password", "", http.StatusUnauthorized))
+			response.Error(ctx, apierrors.NewAPIError("wrong password", http.StatusUnauthorized))
 			ctx.Abort()
 			return
 		}
@@ -327,7 +327,7 @@ func tokenAuthMiddleware(ctx *gin.Context) {
 	token := ctx.Query("authtoken")
 	claims, err := authtoken.Validate(token)
 	if err != nil {
-		apiErr := apierrors.NewAPIError("unknown token validation error", "", http.StatusUnauthorized)
+		apiErr := apierrors.NewAPIError("unknown token validation error", http.StatusUnauthorized)
 		if ve, ok := err.(*jwt.ValidationError); ok {
 			if ve.Errors&jwt.ValidationErrorMalformed != 0 {
 				apiErr.Title = "malformed token format"

--- a/pkg/api/core/v1/errors/errors.go
+++ b/pkg/api/core/v1/errors/errors.go
@@ -104,8 +104,24 @@ func NewBadRequest(msg string, details ...string) APIError {
 }
 
 // NewNotFoundError constructs a general API error for when something desired does not exist
-func NewNotFoundError(msg string, details ...string) APIError {
-	return NewAPIError(msg, strings.Join(details, ", "), http.StatusNotFound)
+func NewNotFoundError(err error, details ...string) APIError {
+	return NewAPIError(err.Error(), strings.Join(details, ", "), http.StatusNotFound)
+}
+
+// NewConflictError constructs a general API error for when something conflicts
+func NewConflictError(err error, details ...string) APIError {
+	return NewAPIError(err.Error(), strings.Join(details, ", "), http.StatusConflict)
+}
+
+////////////////////////////////////////////
+//
+// Helpers to build common "domain" errors
+//
+////////////////////////////////////////////
+
+// NamespaceIsNotKnown constructs an API error for when the desired namespace does not exist
+func NamespaceIsNotKnown(namespace string) APIError {
+	return NewNotFoundError(fmt.Errorf("Targeted namespace '%s' does not exist", namespace))
 }
 
 // UserNotFound constructs an API error for when the user name is not found in the header
@@ -116,68 +132,39 @@ func UserNotFound() APIError {
 		http.StatusBadRequest)
 }
 
-// NamespaceIsNotKnown constructs an API error for when the desired namespace does not exist
-func NamespaceIsNotKnown(namespace string) APIError {
-	return NewAPIError(
-		fmt.Sprintf("Targeted namespace '%s' does not exist", namespace),
-		"",
-		http.StatusNotFound)
-}
-
 // AppAlreadyKnown constructs an API error for when we have a conflict with an existing app
 func AppAlreadyKnown(app string) APIError {
-	return NewAPIError(
-		fmt.Sprintf("Application '%s' already exists", app),
-		"",
-		http.StatusConflict)
+	return NewConflictError(fmt.Errorf("Application '%s' already exists", app))
 }
 
 // AppIsNotKnown constructs an API error for when the desired app does not exist
 func AppIsNotKnown(app string) APIError {
-	return NewAPIError(
-		fmt.Sprintf("Application '%s' does not exist", app),
-		"",
-		http.StatusNotFound)
+	return NewNotFoundError(fmt.Errorf("Application '%s' does not exist", app))
 }
 
 // ServiceIsNotKnown constructs an API error for when the desired service does not exist
 func ServiceIsNotKnown(service string) APIError {
-	return NewAPIError(
-		fmt.Sprintf("Service '%s' does not exist", service),
-		"",
-		http.StatusNotFound)
+	return NewNotFoundError(fmt.Errorf("Service '%s' does not exist", service))
 }
 
 // ConfigurationIsNotKnown constructs an API error for when the desired configuration instance does not exist
 func ConfigurationIsNotKnown(configuration string) APIError {
-	return NewAPIError(
-		fmt.Sprintf("Configuration '%s' does not exist", configuration),
-		"",
-		http.StatusNotFound)
+	return NewNotFoundError(fmt.Errorf("Configuration '%s' does not exist", configuration))
 }
 
 // NamespaceAlreadyKnown constructs an API error for when we have a conflict with an existing namespace
 func NamespaceAlreadyKnown(namespace string) APIError {
-	return NewAPIError(
-		fmt.Sprintf("Namespace '%s' already exists", namespace),
-		"",
-		http.StatusConflict)
+	return NewConflictError(fmt.Errorf("Namespace '%s' already exists", namespace))
 }
 
 // ConfigurationAlreadyKnown constructs an API error for when we have a conflict with an existing configuration instance
 func ConfigurationAlreadyKnown(configuration string) APIError {
-	return NewAPIError(
-		fmt.Sprintf("Configuration '%s' already exists", configuration),
-		"",
-		http.StatusConflict)
+	return NewConflictError(fmt.Errorf("Configuration '%s' already exists", configuration))
 }
 
 // ConfigurationAlreadyBound constructs an API error for when the configuration to bind is already bound to the app
 func ConfigurationAlreadyBound(configuration string) APIError {
-	return NewAPIError(
-		fmt.Sprintf("Configuration '%s' already bound", configuration),
-		"",
-		http.StatusConflict)
+	return NewConflictError(fmt.Errorf("Configuration '%s' already bound", configuration))
 }
 
 // ConfigurationIsNotBound constructs an API error for when the configuration to unbind is actually not bound to the app
@@ -190,16 +177,10 @@ func ConfigurationIsNotBound(configuration string) APIError {
 
 // AppChartAlreadyKnown constructs an API error for when we have a conflict with an existing app chart
 func AppChartAlreadyKnown(app string) APIError {
-	return NewAPIError(
-		fmt.Sprintf("Application Chart '%s' already exists", app),
-		"",
-		http.StatusConflict)
+	return NewConflictError(fmt.Errorf("Application Chart '%s' already exists", app))
 }
 
 // AppChartIsNotKnown constructs an API error for when the desired app chart does not exist
 func AppChartIsNotKnown(app string) APIError {
-	return NewAPIError(
-		fmt.Sprintf("Application Chart '%s' does not exist", app),
-		"",
-		http.StatusNotFound)
+	return NewNotFoundError(fmt.Errorf("Application Chart '%s' does not exist", app))
 }

--- a/pkg/api/core/v1/errors/errors.go
+++ b/pkg/api/core/v1/errors/errors.go
@@ -43,12 +43,23 @@ func (a APIError) FirstStatus() int {
 }
 
 // NewAPIError constructs an APIerror from basics
-func NewAPIError(title string, details string, status int) APIError {
+func NewAPIError(title string, status int) APIError {
 	return APIError{
-		Title:   title,
-		Details: details,
-		Status:  status,
+		Title:  title,
+		Status: status,
 	}
+}
+
+// WithDetails returns a new error with the provided details
+func (a APIError) WithDetails(details string) APIError {
+	a.Details = details
+	return a
+}
+
+// WithDetailsf returns a new error with the provided details formatted as specified
+func (a APIError) WithDetailsf(format string, values ...any) APIError {
+	a.Details = fmt.Sprintf(format, values...)
+	return a
 }
 
 // MultiError fulfills the APIErrors interface. It contains multiple errors.
@@ -81,36 +92,36 @@ func NewMultiError(errs []APIError) MultiError {
 
 // InternalError constructs an API error for server internal issues, from a lower-level error
 func InternalError(err error, details ...string) APIError {
+	joinedDetails := strings.Join(details, ", ")
 	return NewAPIError(
 		err.Error(),
-		strings.Join(details, ", ")+fmt.Sprintf("\nServer Backtrace: %+v", err),
 		http.StatusInternalServerError,
-	)
+	).WithDetailsf("%s\nServer Backtrace: %+v", joinedDetails, err)
 }
 
 // NewInternalError constructs an API error for server internal issues, from a message
 func NewInternalError(msg string, details ...string) APIError {
-	return NewAPIError(msg, strings.Join(details, ", "), http.StatusInternalServerError)
+	return NewAPIError(msg, http.StatusInternalServerError).WithDetails(strings.Join(details, ", "))
 }
 
 // BadRequest constructs an API error for general issues with a request, from a lower-level error
 func BadRequest(err error, details ...string) APIError {
-	return NewAPIError(err.Error(), strings.Join(details, ", "), http.StatusBadRequest)
+	return NewAPIError(err.Error(), http.StatusBadRequest).WithDetails(strings.Join(details, ", "))
 }
 
 // NewBadRequest constructs an API error for general issues with a request, from a message
 func NewBadRequest(msg string, details ...string) APIError {
-	return NewAPIError(msg, strings.Join(details, ", "), http.StatusBadRequest)
+	return NewAPIError(msg, http.StatusBadRequest).WithDetails(strings.Join(details, ", "))
 }
 
 // NewNotFoundError constructs a general API error for when something desired does not exist
-func NewNotFoundError(err error, details ...string) APIError {
-	return NewAPIError(err.Error(), strings.Join(details, ", "), http.StatusNotFound)
+func NewNotFoundError(msg string) APIError {
+	return NewAPIError(msg, http.StatusNotFound)
 }
 
 // NewConflictError constructs a general API error for when something conflicts
-func NewConflictError(err error, details ...string) APIError {
-	return NewAPIError(err.Error(), strings.Join(details, ", "), http.StatusConflict)
+func NewConflictError(msg string) APIError {
+	return NewAPIError(msg, http.StatusConflict)
 }
 
 ////////////////////////////////////////////
@@ -121,66 +132,62 @@ func NewConflictError(err error, details ...string) APIError {
 
 // NamespaceIsNotKnown constructs an API error for when the desired namespace does not exist
 func NamespaceIsNotKnown(namespace string) APIError {
-	return NewNotFoundError(fmt.Errorf("Targeted namespace '%s' does not exist", namespace))
+	return NewNotFoundError(fmt.Sprintf("Targeted namespace '%s' does not exist", namespace))
 }
 
 // UserNotFound constructs an API error for when the user name is not found in the header
 func UserNotFound() APIError {
-	return NewAPIError(
-		"User not found in the request header",
-		"",
-		http.StatusBadRequest)
+	return NewAPIError("User not found in the request header", http.StatusBadRequest)
 }
 
 // AppAlreadyKnown constructs an API error for when we have a conflict with an existing app
 func AppAlreadyKnown(app string) APIError {
-	return NewConflictError(fmt.Errorf("Application '%s' already exists", app))
+	return NewConflictError(fmt.Sprintf("application '%s' already exists", app))
 }
 
 // AppIsNotKnown constructs an API error for when the desired app does not exist
 func AppIsNotKnown(app string) APIError {
-	return NewNotFoundError(fmt.Errorf("Application '%s' does not exist", app))
+	return NewNotFoundError(fmt.Sprintf("application '%s' does not exist", app))
 }
 
 // ServiceIsNotKnown constructs an API error for when the desired service does not exist
 func ServiceIsNotKnown(service string) APIError {
-	return NewNotFoundError(fmt.Errorf("Service '%s' does not exist", service))
+	return NewNotFoundError(fmt.Sprintf("Service '%s' does not exist", service))
 }
 
 // ConfigurationIsNotKnown constructs an API error for when the desired configuration instance does not exist
 func ConfigurationIsNotKnown(configuration string) APIError {
-	return NewNotFoundError(fmt.Errorf("Configuration '%s' does not exist", configuration))
+	return NewNotFoundError(fmt.Sprintf("Configuration '%s' does not exist", configuration))
 }
 
 // NamespaceAlreadyKnown constructs an API error for when we have a conflict with an existing namespace
 func NamespaceAlreadyKnown(namespace string) APIError {
-	return NewConflictError(fmt.Errorf("Namespace '%s' already exists", namespace))
+	return NewConflictError(fmt.Sprintf("Namespace '%s' already exists", namespace))
 }
 
 // ConfigurationAlreadyKnown constructs an API error for when we have a conflict with an existing configuration instance
 func ConfigurationAlreadyKnown(configuration string) APIError {
-	return NewConflictError(fmt.Errorf("Configuration '%s' already exists", configuration))
+	return NewConflictError(fmt.Sprintf("Configuration '%s' already exists", configuration))
 }
 
 // ConfigurationAlreadyBound constructs an API error for when the configuration to bind is already bound to the app
 func ConfigurationAlreadyBound(configuration string) APIError {
-	return NewConflictError(fmt.Errorf("Configuration '%s' already bound", configuration))
+	return NewConflictError(fmt.Sprintf("Configuration '%s' already bound", configuration))
 }
 
 // ConfigurationIsNotBound constructs an API error for when the configuration to unbind is actually not bound to the app
 func ConfigurationIsNotBound(configuration string) APIError {
 	return NewAPIError(
 		fmt.Sprintf("Configuration '%s' is not bound", configuration),
-		"",
 		http.StatusBadRequest)
 }
 
 // AppChartAlreadyKnown constructs an API error for when we have a conflict with an existing app chart
 func AppChartAlreadyKnown(app string) APIError {
-	return NewConflictError(fmt.Errorf("Application Chart '%s' already exists", app))
+	return NewConflictError(fmt.Sprintf("Application Chart '%s' already exists", app))
 }
 
 // AppChartIsNotKnown constructs an API error for when the desired app chart does not exist
 func AppChartIsNotKnown(app string) APIError {
-	return NewNotFoundError(fmt.Errorf("Application Chart '%s' does not exist", app))
+	return NewNotFoundError(fmt.Sprintf("Application Chart '%s' does not exist", app))
 }


### PR DESCRIPTION
I was having a look at the `errors` package of the APIs and it's probably a bit "over complicated", or maybe just verbose.

I wanted to simplify it a bit, and I've started just doing a small couple of things for the NotFound and Conflict errors.

I've changed the `NewNotFoundError` signature to accept an `error` instead of just a message. In my opinion it makes sense to create an API error from another error, that has more context about what happened and where. So I just needed to modify the callers adding a Wrap or using a simple errors.New.

I've also added a `NewConflictError`, and used it (along with the `NewNotFoundError`) to construct the other "domain" errors.