### PR TITLE
Add upgrade test for Epinio

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,0 +1,88 @@
+# Upgrade epinio from latest released version to the main branch version
+# using the latest helm chart submodule
+name: Upgrade test
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+    - 'docs/**'
+    - 'README.md'
+    - '.goreleaser.yml'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+    - 'docs/**'
+    - 'README.md'
+    - '.goreleaser.yml'
+  workflow_dispatch:
+  # nightly
+  schedule:
+    - cron:  '0 0 * * *'
+
+env:
+  EPINIO_RELEASED: true
+  SETUP_GO_VERSION: '^1.18'
+  GINKGO_NODES: 2
+  INGRESS_CONTROLLER: traefik
+
+jobs:
+  upgrade-test:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+
+      - name: Setup Ginkgo Test Framework
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+
+      - name: Cache Tools
+        uses: actions/cache@v3.0.4
+        with:
+          path: ${{ github.workspace }}/tools
+          key: ${{ runner.os }}-tools
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Install Tools
+        run: make tools-install
+
+      - name: Add Tools to PATH
+        run: |
+          echo "`pwd`/output/bin" >> $GITHUB_PATH    
+
+      - name: Deploy k3d cluster with latest release of Epinio
+        run: |
+          make acceptance-cluster-setup
+          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+          make install-cert-manager
+          make prepare_environment_k3d
+
+      - name: Upgrade Epinio with latest code
+        run: |
+          # We have to export the EPINIO_SYSTEM_DOMAIN
+          # before executing the ginkgo test
+          source scripts/helpers.sh
+          prepare_system_domain
+          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+          make test-acceptance-upgrade
+
+      - name: Cleanup k3d cluster
+        if: always()
+        run: make acceptance-cluster-delete
+
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ test-acceptance-apps: showfocus
 test-acceptance-cli: showfocus
 	ginkgo -v --nodes ${GINKGO_NODES} --slow-spec-threshold ${GINKGO_SLOW_TRESHOLD}s --randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending acceptance/.
 
+test-acceptance-upgrade: showfocus
+	ginkgo -v --nodes ${GINKGO_NODES} --slow-spec-threshold ${GINKGO_SLOW_TRESHOLD}s --randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending acceptance/upgrade/.
+
 test-acceptance-install: showfocus
 	# TODO support for labels is coming in ginkgo v2
 	ginkgo -v --nodes ${GINKGO_NODES} --focus "${REGEX}" --randomize-all --flake-attempts=${FLAKE_ATTEMPTS} acceptance/install/.

--- a/acceptance/upgrade/suite_test.go
+++ b/acceptance/upgrade/suite_test.go
@@ -1,0 +1,83 @@
+package upgrade_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/epinio/epinio/acceptance/helpers/proc"
+	"github.com/epinio/epinio/acceptance/testenv"
+	"github.com/epinio/epinio/internal/cli/settings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAcceptance(t *testing.T) {
+	RegisterFailHandler(FailWithReport)
+	RunSpecs(t, "Acceptance Suite for Application Tests")
+}
+
+var (
+	nodeSuffix, nodeTmpDir string
+
+	// serverURL is the URL of the epinio API server
+	serverURL, websocketURL string
+
+	env testenv.EpinioEnv
+)
+
+var _ = BeforeSuite(func() {
+	fmt.Printf("Running tests on node %d\n", GinkgoParallelProcess())
+
+	testenv.SetRoot("../..")
+	testenv.SetupEnv()
+
+	nodeSuffix = fmt.Sprintf("%d", GinkgoParallelProcess())
+	nodeTmpDir, err := ioutil.TempDir("", "epinio-"+nodeSuffix)
+	Expect(err).NotTo(HaveOccurred())
+
+	out, err := testenv.CopyEpinioSettings(nodeTmpDir)
+	Expect(err).ToNot(HaveOccurred(), out)
+	os.Setenv("EPINIO_SETTINGS", nodeTmpDir+"/epinio.yaml")
+
+	config, err := settings.LoadFrom(nodeTmpDir + "/epinio.yaml")
+	Expect(err).NotTo(HaveOccurred())
+
+	env = testenv.New(nodeTmpDir, testenv.Root(), config.User, config.Password)
+
+	out, err = proc.Run(testenv.Root(), false, "kubectl", "get", "ingress",
+		"--namespace", "epinio", "epinio",
+		"-o", "jsonpath={.spec.rules[0].host}")
+	Expect(err).ToNot(HaveOccurred(), out)
+
+	serverURL = "https://" + out
+	websocketURL = "wss://" + out
+})
+
+var _ = AfterSuite(func() {
+	if !testenv.SkipCleanup() {
+		fmt.Printf("Deleting tmpdir on node %d\n", GinkgoParallelProcess())
+		testenv.DeleteTmpDir(nodeTmpDir)
+	}
+})
+
+var _ = AfterEach(func() {
+	testenv.AfterEachSleep()
+})
+
+func FailWithReport(message string, callerSkip ...int) {
+	// NOTE: Use something like the following if you need to debug failed tests
+	// fmt.Println("\nA test failed. You may find the following information useful for debugging:")
+	// fmt.Println("The cluster pods: ")
+	// out, err := proc.Kubectl("get pods --all-namespaces")
+	// if err != nil {
+	// 	fmt.Print(err.Error())
+	// } else {
+	// 	fmt.Print(out)
+	// }
+
+	// Ensures the correct line numbers are reported
+	Fail(message, callerSkip[0]+1)
+}

--- a/acceptance/upgrade/suite_test.go
+++ b/acceptance/upgrade/suite_test.go
@@ -21,11 +21,7 @@ func TestAcceptance(t *testing.T) {
 
 var (
 	nodeSuffix, nodeTmpDir string
-
-	// serverURL is the URL of the epinio API server
-	serverURL, websocketURL string
-
-	env testenv.EpinioEnv
+	env                    testenv.EpinioEnv
 )
 
 var _ = BeforeSuite(func() {
@@ -51,9 +47,6 @@ var _ = BeforeSuite(func() {
 		"--namespace", "epinio", "epinio",
 		"-o", "jsonpath={.spec.rules[0].host}")
 	Expect(err).ToNot(HaveOccurred(), out)
-
-	serverURL = "https://" + out
-	websocketURL = "wss://" + out
 })
 
 var _ = AfterSuite(func() {

--- a/acceptance/upgrade/upgrade_test.go
+++ b/acceptance/upgrade/upgrade_test.go
@@ -1,0 +1,79 @@
+package upgrade_test
+
+import (
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/epinio/epinio/acceptance/helpers/catalog"
+	"github.com/epinio/epinio/acceptance/helpers/proc"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Epinio upgrade with running app", func() {
+	var (
+		namespace string
+		appName   string
+		domain    string
+	)
+
+	BeforeEach(func() {
+		namespace = catalog.NewNamespaceName()
+		env.SetupAndTargetNamespace(namespace)
+		appName = catalog.NewAppName()
+		domain = os.Getenv("EPINIO_SYSTEM_DOMAIN")
+	})
+
+	AfterEach(func() {
+		env.DeleteApp(appName)
+		env.DeleteNamespace(namespace)
+	})
+
+	It("can upgrade epinio", func() {
+		// Deploy a simple application before upgrading Epinio
+		out := env.MakeGolangApp(appName, 1, true)
+		routeRegexp := regexp.MustCompile(`https:\/\/.*omg.howdoi.website`)
+		route := string(routeRegexp.Find([]byte(out)))
+
+		// Check that the app is reachable
+		Eventually(func() int {
+			resp, err := env.Curl("GET", route, strings.NewReader(""))
+			Expect(err).ToNot(HaveOccurred())
+			return resp.StatusCode
+		}, 30*time.Second, 1*time.Second).Should(Equal(http.StatusOK))
+
+		// Build image with latest epinio-server binary
+		_, err := proc.Run("../..", false, "docker", "build", "-t", "epinio/epinio-server", "-f", "images/Dockerfile", ".")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Importing the new image in k3d
+		_, err = proc.RunW("k3d", "image", "import", "-c", "epinio-acceptance", "epinio/epinio-server")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Upgrade Epinio and use the fresh image by removing the registry value
+		_, err = proc.RunW("helm", "upgrade", "epinio",
+			"-n", "epinio",
+			"../../helm-charts/chart/epinio",
+			"--set", "image.epinio.registry=",
+			"--set", "image.epinio.tag=latest",
+			"--set", "global.domain="+domain,
+			"--wait",
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check that the app is still reachable
+		Eventually(func() int {
+			resp, err := env.Curl("GET", route, strings.NewReader(""))
+			Expect(err).ToNot(HaveOccurred())
+			return resp.StatusCode
+		}, 30*time.Second, 1*time.Second).Should(Equal(http.StatusOK))
+
+		// We can think about adding more checks later like application with
+		// environment vars or configurations
+
+	})
+})


### PR DESCRIPTION
Fix #1380 

This PR adds a test to make sure we can upgrade from latest Epinio release to the latest (main branch) Epinio.
Before upgrading, the test deploys a very simple app to be sure the app will still work after the upgrade.
Later, to improve the test, we can think about a more complete application ( with env vars, configurations etc) but for now, this PR is the first step.

### Steps
- Deploy k3d cluster
- Install latest release of Epinio via the helm chart repo (https://epinio.github.io/helm-charts)
- Create a simple app and check if it's reachable via its route
- Build docker image (epinio-server) with latest epinio code and import it in k3d
- Upgrade epinio by using the helm chart from the submodule
- Test if the app is still reachable

Notes:

- `domain` has to be [set again](https://github.com/epinio/epinio/pull/1607/files#diff-a75f72a1eddf425cf3b61e8e2e01f3a2951f561f36b4f72707207db45b4b5d32R62) when we upgrade, I think that's because we deploy from the helm chart folder whereas we deploy from the official helm repo at the beginning

### Local tests: :heavy_check_mark: 
`make acceptance-cluster-setup; make install-cert-manager; make prepare_environment_k3d`

Env vars:
```
EPINIO_SYSTEM_DOMAIN=172.18.0.3.omg.howdoi.website
EPINIO_RELEASED=true
```
```
make test-acceptance-upgrade
...
Ran 1 of 1 Specs in 101.026 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```

I installed 1.0.0 and execute all the steps, then I got latest epinio deployed:
![image](https://user-images.githubusercontent.com/6025636/176483972-e8cb94fb-fb63-4289-9db5-438d981a946b.png)

### CI: :heavy_check_mark: 
https://github.com/epinio/epinio/runs/7125423165?check_suite_focus=true 
 