### PR TITLE
[Login command] Use default port only if not specified

### DIFF
--- a/acceptance/login_test.go
+++ b/acceptance/login_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Login", func() {
 		)
 	})
 
-	It("fails while checking the certificate on the wrong port", func() {
+	It("respects the port when one is present [fixed bug]", func() {
 		randomPort := fmt.Sprintf(`:%d`, rand.Intn(65536))
 		serverURLWithPort := serverURL + randomPort
 

--- a/internal/cli/usercmd/login.go
+++ b/internal/cli/usercmd/login.go
@@ -150,8 +150,13 @@ func checkCA(address string) (*x509.Certificate, error) {
 		return nil, errors.New("error parsing the address")
 	}
 
+	port := parsedURL.Port()
+	if port == "" {
+		port = "443"
+	}
+
 	tlsConfig := &tls.Config{InsecureSkipVerify: true} // nolint:gosec // We need to check the validity
-	conn, err := tls.Dial("tcp", parsedURL.Hostname()+":443", tlsConfig)
+	conn, err := tls.Dial("tcp", parsedURL.Hostname()+":"+port, tlsConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "error while dialing the server")
 	}


### PR DESCRIPTION
Ref:
 - https://github.com/epinio/epinio/issues/1615
 ---

The `login` command should use the port `443` only if no port is specified.

Fixes #1615 