### PR TITLE
Loading extensible Domain/Secret mapping

### DIFF
--- a/acceptance/helpers/machine/machine.go
+++ b/acceptance/helpers/machine/machine.go
@@ -198,6 +198,6 @@ func (m *Machine) SaveServerLogs(destination string) {
 	Expect(err).ToNot(HaveOccurred(), log)
 
 	// And save them into the specified file
-	err = os.WriteFile(filepath.Join(m.nodeTmpDir, destination), []byte(log), 0644)
+	err = os.WriteFile(filepath.Join(m.nodeTmpDir, destination), []byte(log), 0600)
 	Expect(err).ToNot(HaveOccurred())
 }

--- a/helpers/cahash/cahash.go
+++ b/helpers/cahash/cahash.go
@@ -17,7 +17,7 @@ import (
 // -----------------------------------------------------------------------------------
 
 func GenerateHash(certRaw []byte) (string, error) {
-	cert, err := decodeOneCert(certRaw)
+	cert, err := DecodeOneCert(certRaw)
 	if err != nil {
 		return "", fmt.Errorf("failed to decode certificate\n%w", err)
 	}
@@ -36,7 +36,7 @@ func GenerateHash(certRaw []byte) (string, error) {
 
 // Iterates over pem blocks until a non-CA certificate if found or no other PEM
 // blocks exist.
-func decodeOneCert(raw []byte) (*x509.Certificate, error) {
+func DecodeOneCert(raw []byte) (*x509.Certificate, error) {
 	byteData := raw
 	for len(byteData) > 0 {
 		block, rest := pem.Decode(byteData)

--- a/internal/api/v1/application/deploy.go
+++ b/internal/api/v1/application/deploy.go
@@ -19,7 +19,8 @@ const (
 )
 
 // Deploy handles the API endpoint /namespaces/:namespace/applications/:app/deploy
-// It creates the deployment, configuration and ingress (kube) resources for the app
+// It uses an application chart to create the deployment, configuration and ingress (kube)
+// resources for the app.
 func (hc Controller) Deploy(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
 

--- a/internal/api/v1/deploy/deploy.go
+++ b/internal/api/v1/deploy/deploy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
+	"github.com/epinio/epinio/internal/domain"
 	"github.com/epinio/epinio/internal/helm"
 	"github.com/epinio/epinio/internal/helmchart"
 	"github.com/epinio/epinio/internal/registry"
@@ -41,6 +42,7 @@ func DeployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppR
 	imageURL := appObj.ImageURL
 	routes := appObj.Configuration.Routes
 	chartName := appObj.Configuration.AppChart
+	domains := domain.MatchMapLoad(ctx)
 
 	deployParams := helm.ChartParameters{
 		Context:        ctx,
@@ -54,6 +56,7 @@ func DeployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppR
 		Username:       username,
 		StageID:        stageID,
 		Routes:         routes,
+		Domains:        domains,
 		Start:          start,
 	}
 

--- a/internal/api/v1/deploy/deploy.go
+++ b/internal/api/v1/deploy/deploy.go
@@ -42,7 +42,7 @@ func DeployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppR
 	imageURL := appObj.ImageURL
 	routes := appObj.Configuration.Routes
 	chartName := appObj.Configuration.AppChart
-	domains := domain.MatchMapLoad(ctx)
+	domains := domain.MatchMapLoad(ctx, app.Namespace)
 
 	log.Info("domain map begin")
 	for k, v := range domains {

--- a/internal/api/v1/deploy/deploy.go
+++ b/internal/api/v1/deploy/deploy.go
@@ -44,11 +44,12 @@ func DeployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppR
 	chartName := appObj.Configuration.AppChart
 	domains := domain.MatchMapLoad(ctx, app.Namespace)
 
-	log.Info("domain map begin")
+	maplog := log.V(1)
+	maplog.Info("domain map begin")
 	for k, v := range domains {
-		log.Info("domain map", k, v)
+		maplog.Info("domain map", k, v)
 	}
-	log.Info("domain map end")
+	maplog.Info("domain map end")
 
 	deployParams := helm.ChartParameters{
 		Context:        ctx,

--- a/internal/api/v1/deploy/deploy.go
+++ b/internal/api/v1/deploy/deploy.go
@@ -44,6 +44,12 @@ func DeployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppR
 	chartName := appObj.Configuration.AppChart
 	domains := domain.MatchMapLoad(ctx)
 
+	log.Info("domain map begin")
+	for k, v := range domains {
+		log.Info("domain map", k, v)
+	}
+	log.Info("domain map end")
+
 	deployParams := helm.ChartParameters{
 		Context:        ctx,
 		Cluster:        cluster,

--- a/internal/domain/domain_suite_test.go
+++ b/internal/domain/domain_suite_test.go
@@ -1,0 +1,13 @@
+package domain
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAuth(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Domain Suite")
+}

--- a/internal/domain/match.go
+++ b/internal/domain/match.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/epinio/epinio/helpers/cahash"
 	"github.com/epinio/epinio/helpers/kubernetes"
-	"github.com/epinio/epinio/internal/helmchart"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -53,7 +52,7 @@ func MatchDo(domain string, domains DomainMap) (string, error) {
 // MatchMapLoad queries the cluster for TLS secrets which are marked
 // for use by epinio, via the routingSelector label. It returns a map
 // from the domains the secrets are serving, to the serving secret.
-func MatchMapLoad(ctx context.Context) DomainMap {
+func MatchMapLoad(ctx context.Context, namespace string) DomainMap {
 	listOpts := metav1.ListOptions{
 		LabelSelector: routingSelector,
 	}
@@ -63,7 +62,7 @@ func MatchMapLoad(ctx context.Context) DomainMap {
 		return nil
 	}
 
-	certSecrets, err := cluster.Kubectl.CoreV1().Secrets(helmchart.Namespace()).List(ctx, listOpts)
+	certSecrets, err := cluster.Kubectl.CoreV1().Secrets(namespace).List(ctx, listOpts)
 	if err != nil {
 		return nil
 	}

--- a/internal/domain/match.go
+++ b/internal/domain/match.go
@@ -1,0 +1,86 @@
+package domain
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/epinio/epinio/helpers/cahash"
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/internal/helmchart"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// domainMap is the internal type for the map from domain patterns to
+// the names of the secrets holding the TLS certs serving them.
+type DomainMap map[string]string
+
+const routingSelector = "epinio.io/routing"
+
+// MatchDo is the core matching function taking a domain and map and
+// returning the secret, or nothing.
+func MatchDo(domain string, domains DomainMap) (string, error) {
+	if domains == nil {
+		// No cert secrets, no matches possible.
+		return "", nil
+	}
+
+	// Check for exact match. This has priority over any wildcards.
+	if secret, ok := domains[domain]; ok {
+		return secret, nil
+	}
+
+	// Pattern match for wildcard, choose longest pattern, or random at tie
+	result := ""
+	bestlen := 0
+	for pattern, secret := range domains {
+		matched, err := filepath.Match(pattern, domain)
+		if err != nil {
+			return "", err
+		}
+		if matched && len(pattern) > bestlen {
+			bestlen = len(pattern)
+			result = secret
+		}
+	}
+
+	return result, nil
+}
+
+// MatchMapLoad queries the cluster for TLS secrets which are marked
+// for use by epinio, via the routingSelector label. It returns a map
+// from the domains the secrets are serving, to the serving secret.
+func MatchMapLoad(ctx context.Context) DomainMap {
+	listOpts := metav1.ListOptions{
+		LabelSelector: routingSelector,
+	}
+
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		return nil
+	}
+
+	certSecrets, err := cluster.Kubectl.CoreV1().Secrets(helmchart.Namespace()).List(ctx, listOpts)
+	if err != nil {
+		return nil
+	}
+
+	if len(certSecrets.Items) < 1 {
+		return nil
+	}
+
+	domains := make(DomainMap)
+
+	for _, secret := range certSecrets.Items {
+		cert, err := cahash.DecodeOneCert(secret.Data["tls.crt"])
+		if err != nil {
+			return nil
+		}
+
+		for _, dom := range cert.DNSNames {
+			domains[dom] = secret.Name
+		}
+	}
+
+	return domains
+}

--- a/internal/domain/match.go
+++ b/internal/domain/match.go
@@ -36,6 +36,9 @@ func MatchDo(domain string, domains DomainMap) (string, error) {
 	for pattern, secret := range domains {
 		matched, err := filepath.Match(pattern, domain)
 		if err != nil {
+			// Should we simply treat this as non-match ?
+			// I.e. not pass the error up, and continue ?
+			// What kind of error can filepath.Match() even generate ?
 			return "", err
 		}
 		if matched && len(pattern) > bestlen {

--- a/internal/domain/match_test.go
+++ b/internal/domain/match_test.go
@@ -1,0 +1,41 @@
+package domain
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MatchDo", func() {
+	var amap DomainMap
+
+	BeforeEach(func() {
+		amap = make(DomainMap)
+		amap["foxhouse"] = "dog"
+		amap["*house"] = "cat"
+		amap["*hou*"] = "fish"
+	})
+
+	It("returns nothing for no map", func() {
+		result, err := MatchDo("anything", nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeEmpty())
+	})
+
+	It("matches exact before wildcard", func() {
+		result, err := MatchDo("foxhouse", amap)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal("dog"))
+	})
+
+	It("matches the longest wildcard pattern", func() {
+		result, err := MatchDo("cathouse", amap)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal("cat"))
+	})
+
+	It("matches the sole wildcard pattern", func() {
+		result, err := MatchDo("houser", amap)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal("fish"))
+	})
+})

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/appchart"
+	"github.com/epinio/epinio/internal/domain"
 	"github.com/epinio/epinio/internal/duration"
 	"github.com/epinio/epinio/internal/names"
 	"github.com/epinio/epinio/internal/routes"
@@ -37,6 +38,7 @@ type ChartParameters struct {
 	Environment    models.EnvVariableMap // App Environment
 	Configurations []string              // Bound Configurations (list of names)
 	Routes         []string              // Desired application routes
+	Domains        domain.DomainMap      // Map of domains with secrets covering them
 	Start          *int64                // Nano-epoch of deployment. Optional. Used to force a restart, even when nothing else has changed.
 }
 
@@ -101,9 +103,24 @@ func Deploy(logger logr.Logger, parameters ChartParameters) error {
 		rs := []string{}
 		for _, desired := range parameters.Routes {
 			r := routes.FromString(desired)
-			rs = append(rs, fmt.Sprintf(`{"id":"%s","domain":"%s","path":"%s"}`,
-				strings.ReplaceAll(r.String(), "/", "."),
-				r.Domain, r.Path))
+			rdot := strings.ReplaceAll(r.String(), "/", ".")
+
+			domainSecret, err := domain.MatchDo(r.Domain, parameters.Domains)
+
+			// Should we treat a match error as something to stop for?
+			// The error can only come from `filepath.Match()`
+			var routeInfo string
+			if err != nil || domainSecret == "" {
+				// No secret found, no secret passed
+				routeInfo = fmt.Sprintf(`{"id":"%s","domain":"%s","path":"%s"}`,
+					rdot, r.Domain, r.Path)
+			} else {
+				// Pass the found secret
+				routeInfo = fmt.Sprintf(`{"id":"%s","domain":"%s","path":"%s","secret":"%s"}`,
+					rdot, r.Domain, r.Path, domainSecret)
+			}
+
+			rs = append(rs, routeInfo)
 		}
 		routesYaml = fmt.Sprintf(`[%s]`, strings.Join(rs, `,`))
 	}

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -100,12 +100,17 @@ func Deploy(logger logr.Logger, parameters ChartParameters) error {
 
 	routesYaml := "~"
 	if len(parameters.Routes) > 0 {
+
+		logger.Info("routes and domains")
+
 		rs := []string{}
 		for _, desired := range parameters.Routes {
 			r := routes.FromString(desired)
 			rdot := strings.ReplaceAll(r.String(), "/", ".")
 
 			domainSecret, err := domain.MatchDo(r.Domain, parameters.Domains)
+
+			logger.Info("domain match", "domain", r.Domain, "secret", domainSecret, "err", err)
 
 			// Should we treat a match error as something to stop for?
 			// The error can only come from `filepath.Match()`


### PR DESCRIPTION
May fix #1605

Done so far

- [x] loading domain map from secrets. secrets identified by label
- [x] matching domain against map. unit tests

To do

- [ ] perf tests for map loading using larger number of secrets
- [x] loading and using map on app deployment, passing result into app helm chart
- [x] extending standard app chart to use passed-in secrets
- [ ] trialing

