### PR TITLE
Routing validation (unique ingress host and random default route)

### DIFF
--- a/acceptance/api/v1/application_create_test.go
+++ b/acceptance/api/v1/application_create_test.go
@@ -16,23 +16,24 @@ var _ = Describe("AppCreate Endpoint", func() {
 	var (
 		namespace string
 		appName   string
-		appName2  string
 	)
 
 	BeforeEach(func() {
 		namespace = catalog.NewNamespaceName()
-		env.SetupAndTargetNamespace(namespace)
 		appName = catalog.NewAppName()
-		appName2 = catalog.NewAppName()
+		env.SetupAndTargetNamespace(namespace)
 	})
 
 	AfterEach(func() {
-		env.DeleteApp(appName)
-		env.DeleteApp(appName2)
 		env.DeleteNamespace(namespace)
 	})
 
 	When("creating a new app", func() {
+
+		AfterEach(func() {
+			env.DeleteApp(appName)
+		})
+
 		It("creates the app resource", func() {
 			response, err := createApplication(appName, namespace, []string{"mytestdomain.org"})
 			Expect(err).ToNot(HaveOccurred())
@@ -62,9 +63,11 @@ var _ = Describe("AppCreate Endpoint", func() {
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(Equal("standard"))
 		})
+	})
 
-		It("fails creating the app resource with the epinio route", func() {
-			epinioHost, err := proc.Kubectl("get", "ing", "-n", "epinio", "epinio", "-o", "jsonpath={.spec.rules[*].host}")
+	When("trying to create a new app with the epinio route", func() {
+		It("fails creating the app", func() {
+			epinioHost, err := proc.Kubectl("get", "ingress", "--namespace", "epinio", "epinio", "-o", "jsonpath={.spec.rules[*].host}")
 			Expect(err).ToNot(HaveOccurred())
 
 			response, err := createApplication(appName, namespace, []string{epinioHost})

--- a/acceptance/api/v1/application_deploy_test.go
+++ b/acceptance/api/v1/application_deploy_test.go
@@ -15,9 +15,9 @@ import (
 
 var _ = Describe("AppDeploy Endpoint", func() {
 	var (
-		namespace string
-		appName   string
-		request   models.DeployRequest
+		namespace     string
+		appName       string
+		deployRequest models.DeployRequest
 	)
 
 	BeforeEach(func() {
@@ -36,7 +36,6 @@ var _ = Describe("AppDeploy Endpoint", func() {
 	})
 
 	Context("with staging", func() {
-		var deployRequest models.DeployRequest
 
 		BeforeEach(func() {
 			deployRequest = models.DeployRequest{
@@ -152,7 +151,7 @@ var _ = Describe("AppDeploy Endpoint", func() {
 
 	Context("with non-staging using custom container image", func() {
 		BeforeEach(func() {
-			request = models.DeployRequest{
+			deployRequest = models.DeployRequest{
 				App: models.AppRef{
 					Meta: models.Meta{
 						Name:      appName,
@@ -169,9 +168,10 @@ var _ = Describe("AppDeploy Endpoint", func() {
 
 		When("deploying a new app", func() {
 			It("returns a success", func() {
-				deployResponse := deployApplication(appName, namespace, request)
+				deployResponse := deployApplication(appName, namespace, deployRequest)
 
-				Expect(deployResponse.Routes[0]).To(MatchRegexp(appName + `.*\.omg\.howdoi\.website`))
+				// check also the random suffix for the default route: '-[a-z0-9]{5}'
+				Expect(deployResponse.Routes[0]).To(MatchRegexp(appName + `-[a-z0-9]{5}.*\.omg\.howdoi\.website`))
 
 				Eventually(func() string {
 					return appFromAPI(namespace, appName).Workload.Status
@@ -190,6 +190,7 @@ var _ = Describe("AppDeploy Endpoint", func() {
 
 		When("deploying an app with custom routes", func() {
 			var routes []string
+
 			BeforeEach(func() {
 				routes = []string{"appdomain.org", "appdomain2.org"}
 				out, err := proc.Kubectl("patch", "apps", "--type", "json",
@@ -200,7 +201,45 @@ var _ = Describe("AppDeploy Endpoint", func() {
 
 			It("the app Ingress matches the specified route", func() {
 				// call the deploy action. Deploy should respect the routes on the App CR.
-				deployApplication(appName, namespace, request)
+				deployApplication(appName, namespace, deployRequest)
+
+				out, err := proc.Kubectl("get", "ingress",
+					"--namespace", namespace, "-o", "jsonpath={.items[*].spec.rules[0].host}")
+				Expect(err).NotTo(HaveOccurred(), out)
+				Expect(strings.Split(out, " ")).To(ConsistOf(routes))
+			})
+		})
+
+		When("deploying two apps with the same custom routes", func() {
+			var routes []string
+			var appName2 string
+
+			BeforeEach(func() {
+				appName2 = catalog.NewAppName()
+
+				By("creating application resource first")
+				_, err := createApplication(appName2, namespace, []string{})
+				Expect(err).ToNot(HaveOccurred())
+
+				routes = []string{"appdomain.org", "appdomain2.org"}
+				out, err := proc.Kubectl("patch", "apps", "--type", "json", "-n", namespace, appName, "--patch",
+					fmt.Sprintf(`[{"op": "replace", "path": "/spec/routes", "value": [%q, %q]}]`, routes[0], routes[1]))
+				Expect(err).NotTo(HaveOccurred(), out)
+
+				out, err = proc.Kubectl("patch", "apps", "--type", "json", "-n", namespace, appName2, "--patch",
+					fmt.Sprintf(`[{"op": "replace", "path": "/spec/routes", "value": [%q, %q]}]`, routes[0], routes[1]))
+				Expect(err).NotTo(HaveOccurred(), out)
+			})
+
+			AfterEach(func() {
+				env.DeleteApp(appName2)
+			})
+
+			It("should fail the second deployment", func() {
+				// call the deploy action. Deploy should respect the routes on the App CR.
+				deployApplication(appName, namespace, deployRequest)
+				deployRequest.App.Name = appName2
+				deployApplicationWithFailure(appName2, namespace, deployRequest)
 
 				out, err := proc.Kubectl("get", "ingress",
 					"--namespace", namespace, "-o", "jsonpath={.items[*].spec.rules[0].host}")

--- a/acceptance/api/v1/application_update_test.go
+++ b/acceptance/api/v1/application_update_test.go
@@ -192,13 +192,13 @@ var _ = Describe("AppUpdate Endpoint", func() {
 			env.MakeContainerImageApp(app, 1, containerImageURL)
 			defer env.DeleteApp(app)
 
-			mainDomain, err := domain.MainDomain(context.Background())
+			defaultRoute, err := domain.AppDefaultRoute(context.Background(), app, namespace)
 			Expect(err).ToNot(HaveOccurred())
 
-			checkRoutesOnApp(app, namespace, fmt.Sprintf("%s.%s", app, mainDomain))
-			checkIngresses(app, namespace, fmt.Sprintf("%s.%s", app, mainDomain))
-			checkCertificateDNSNames(app, namespace, fmt.Sprintf("%s.%s", app, mainDomain))
-			checkSecretsForCerts(app, namespace, fmt.Sprintf("%s.%s", app, mainDomain))
+			checkRoutesOnApp(app, namespace, defaultRoute)
+			checkIngresses(app, namespace, defaultRoute)
+			checkCertificateDNSNames(app, namespace, defaultRoute)
+			checkSecretsForCerts(app, namespace, defaultRoute)
 
 			appObj := appFromAPI(namespace, app)
 			Expect(appObj.Workload.Status).To(Equal("1/1"))

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -143,7 +143,7 @@ configuration:
     CREDO: up
     DOGMA: "no"
   routes:
-  - %s\..*
+  - %s-[a-z0-9]{5}\..*
   appchart: standard
 `, appName, configurationName, appName)))
 				})

--- a/internal/api/v1/application/deploy.go
+++ b/internal/api/v1/application/deploy.go
@@ -64,7 +64,7 @@ func (hc Controller) Deploy(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err, "failed to get the application routes")
 	}
 
-	apierr := validateRoutes(ctx, cluster, desiredRoutes)
+	apierr := validateRoutes(ctx, cluster, name, namespace, desiredRoutes)
 	if apierr != nil {
 		return apierr
 	}

--- a/internal/api/v1/application/upload.go
+++ b/internal/api/v1/application/upload.go
@@ -54,7 +54,7 @@ func (hc Controller) Upload(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err, "can't detect content type of archive")
 	}
 	if !isValidType(contentType) {
-		return apierror.NewBadRequestErrorf("archive type not supported %s", contentType)
+		return apierror.NewBadRequestErrorf("archive type not supported [%s]", contentType)
 	}
 
 	cluster, err := kubernetes.GetCluster(ctx)

--- a/internal/application/ingresses.go
+++ b/internal/application/ingresses.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
-	typednetworkingv1 "k8s.io/client-go/kubernetes/typed/networking/v1"
 )
 
 // DesiredRoutes lists all desired routes for the given application
@@ -71,23 +70,4 @@ func ingressListForApp(ctx context.Context, cluster *kubernetes.Cluster, appRef 
 	return cluster.Kubectl.NetworkingV1().Ingresses(appRef.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: ingressSelector,
 	})
-}
-
-func ListAllRoutes(ctx context.Context, k8sNetwork typednetworkingv1.NetworkingV1Interface) ([]string, error) {
-	ingressList, err := k8sNetwork.Ingresses("").List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return []string{}, err
-	}
-
-	result := []string{}
-	for _, ingress := range ingressList.Items {
-		route, err := routes.FromIngress(ingress)
-		if err != nil {
-			return result, err
-		}
-
-		result = append(result, route.String())
-	}
-
-	return result, nil
 }

--- a/internal/application/ingresses.go
+++ b/internal/application/ingresses.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	typednetworkingv1 "k8s.io/client-go/kubernetes/typed/networking/v1"
 )
 
 // DesiredRoutes lists all desired routes for the given application
@@ -70,4 +71,23 @@ func ingressListForApp(ctx context.Context, cluster *kubernetes.Cluster, appRef 
 	return cluster.Kubectl.NetworkingV1().Ingresses(appRef.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: ingressSelector,
 	})
+}
+
+func ListAllRoutes(ctx context.Context, k8sNetwork typednetworkingv1.NetworkingV1Interface) ([]string, error) {
+	ingressList, err := k8sNetwork.Ingresses("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return []string{}, err
+	}
+
+	result := []string{}
+	for _, ingress := range ingressList.Items {
+		route, err := routes.FromIngress(ingress)
+		if err != nil {
+			return result, err
+		}
+
+		result = append(result, route.String())
+	}
+
+	return result, nil
 }

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -18,13 +18,14 @@ import (
 var mainDomain = ""
 
 // AppDefaultRoute constructs and returns an application's default
-// route from the main domain and the name of the application
-func AppDefaultRoute(ctx context.Context, name string) (string, error) {
+// route from the main domain, the name of the application and the namespace.
+// The namespace is used to compute an MD5 hash to use as suffix
+func AppDefaultRoute(ctx context.Context, name, namespace string) (string, error) {
 	mainDomain, err := MainDomain(ctx)
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s-%s.%s", name, names.RandomDNSString(5), mainDomain), nil
+	return fmt.Sprintf("%s-%s.%s", name, names.MD5String(namespace, 5), mainDomain), nil
 }
 
 // MainDomain determines the name of the main domain of the currently

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/helmchart"
+	"github.com/epinio/epinio/internal/names"
 	"github.com/pkg/errors"
 )
 
@@ -23,7 +24,7 @@ func AppDefaultRoute(ctx context.Context, name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s.%s", name, mainDomain), nil
+	return fmt.Sprintf("%s-%s.%s", name, names.RandomDNSString(5), mainDomain), nil
 }
 
 // MainDomain determines the name of the main domain of the currently

--- a/internal/names/names.go
+++ b/internal/names/names.go
@@ -7,8 +7,10 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"math/rand"
 	"regexp"
 	"strings"
+	"time"
 )
 
 const (
@@ -16,6 +18,7 @@ const (
 )
 
 var allowedDNSLabelChars = regexp.MustCompile("[^-a-z0-9]*")
+var allowedDNSChars = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 
 // DNSLabelSafe filters invalid characters and returns a string that is safe to
 // use as Kubernetes resource name.
@@ -34,6 +37,18 @@ func DNSLabelSafe(name string) string {
 func GenerateResourceName(names ...string) string {
 	originalName := strings.Join(names, "-")
 	return GenerateResourceNameTruncated(originalName, 63)
+}
+
+// RandomDNSString returns a random string of len n that is valid for subdomains (RFC 1123)
+// Ref: https://stackoverflow.com/questions/22892120
+func RandomDNSString(n int) string {
+	rand.Seed(time.Now().UnixNano())
+
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = allowedDNSChars[rand.Intn(len(allowedDNSChars))] // nolint:gosec // Non-crypto use
+	}
+	return string(b)
 }
 
 // GenerateResourceNameTruncated joins the input strings with dashes("-")

--- a/pkg/api/core/v1/errors/errors.go
+++ b/pkg/api/core/v1/errors/errors.go
@@ -110,8 +110,8 @@ func NewBadRequestError(msg string) APIError {
 }
 
 // NewBadRequestErrorf constructs an API error for general issues with a request, with a formatted message
-func NewBadRequestErrorf(format string, values ...string) APIError {
-	return NewAPIError(fmt.Sprintf(format, values), http.StatusBadRequest)
+func NewBadRequestErrorf(format string, values ...any) APIError {
+	return NewAPIError(fmt.Sprintf(format, values...), http.StatusBadRequest)
 }
 
 // NewNotFoundError constructs a general API error for when something desired does not exist


### PR DESCRIPTION
Ref:
- #1585 
---

This PR fixes #1585 adding a check for already existing routes on the deployed ingresses, and it adds a short random suffix to the default route to prevent clashing with app with the same name, but in different namespaces.