### PR TITLE
Fix: mishandling of commit ids in git upload

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -177,7 +177,33 @@ configuration:
 	})
 
 	When("pushing an app from an external repository", func() {
-		It("pushes the app successfully", func() {
+		It("pushes the app successfully (repository alone)", func() {
+			wordpress := "https://github.com/epinio/example-wordpress"
+			pushLog, err := env.EpinioPush("",
+				appName,
+				"--name", appName,
+				"--git", wordpress,
+				"-e", "BP_PHP_WEB_DIR=wordpress",
+				"-e", "BP_PHP_VERSION=7.4.x",
+				"-e", "BP_PHP_SERVER=nginx")
+			Expect(err).ToNot(HaveOccurred(), pushLog)
+
+			Eventually(func() string {
+				out, err := env.Epinio("", "app", "list")
+				Expect(err).ToNot(HaveOccurred(), out)
+				return out
+			}, "5m").Should(
+				HaveATable(
+					WithHeaders("NAME", "CREATED", "STATUS", "ROUTES", "CONFIGURATIONS", "STATUS DETAILS"),
+					WithRow(appName, WithDate(), "1/1", appName+".*", "", ""),
+				),
+			)
+
+			By("deleting the app")
+			env.DeleteApp(appName)
+		})
+
+		It("pushes the app successfully (repository + branch name)", func() {
 			wordpress := "https://github.com/epinio/example-wordpress"
 			pushLog, err := env.EpinioPush("",
 				appName,
@@ -203,6 +229,31 @@ configuration:
 			env.DeleteApp(appName)
 		})
 
+		It("pushes the app successfully (repository + commit id)", func() {
+			wordpress := "https://github.com/epinio/example-wordpress"
+			pushLog, err := env.EpinioPush("",
+				appName,
+				"--name", appName,
+				"--git", wordpress+",68af5bad11d8f3b95bdf547986fe3348324919c5",
+				"-e", "BP_PHP_WEB_DIR=wordpress",
+				"-e", "BP_PHP_VERSION=7.4.x",
+				"-e", "BP_PHP_SERVER=nginx")
+			Expect(err).ToNot(HaveOccurred(), pushLog)
+
+			Eventually(func() string {
+				out, err := env.Epinio("", "app", "list")
+				Expect(err).ToNot(HaveOccurred(), out)
+				return out
+			}, "5m").Should(
+				HaveATable(
+					WithHeaders("NAME", "CREATED", "STATUS", "ROUTES", "CONFIGURATIONS", "STATUS DETAILS"),
+					WithRow(appName, WithDate(), "1/1", appName+".*", "", ""),
+				),
+			)
+
+			By("deleting the app")
+			env.DeleteApp(appName)
+		})
 		Describe("update", func() {
 			BeforeEach(func() {
 				wordpress := "https://github.com/epinio/example-wordpress"

--- a/internal/api/v1/application/importgit.go
+++ b/internal/api/v1/application/importgit.go
@@ -158,7 +158,7 @@ func getRepository(ctx context.Context, log logr.Logger, gitRepo, url, revision 
 	// Input B or C: Attempt to treat as B (revision is branch name)
 
 	log.Info("importgit, cloning branch", "url", url, "revision", revision)
-	repository, err := branchClone(ctx, gitRepo, url, revision)
+	_, err := branchClone(ctx, gitRepo, url, revision)
 	if err == nil {
 		// Was branch name, done.
 		return nil

--- a/internal/api/v1/application/importgit.go
+++ b/internal/api/v1/application/importgit.go
@@ -1,13 +1,74 @@
 package application
 
+// # Design Notes
+//
+// ## Possible inputs:
+//
+//   - (A) repository, no revision (empty string)
+//   - (B) repository, branch name
+//   - (C) repository, commit id
+//
+// ## Considerations:
+//
+//   - Correctness
+//   - Cloning performance
+//
+// The go-git cloning function has two attributes influencing performance
+//
+//   - `Depth` specifies the depth towards which to clone.
+//   - `SingleBranch` specifies the sole branch to check out.
+//
+// The second flag comes with a problem. Using it __demands__ a branch.  And whatever is
+// found in the `ReferenceName` of the CloneOptions is used.  Even if it is an empty
+// string. And leaving it completely unspecified makes the package use a hardwired default
+// (`master`).
+//
+// If we have a revision which is a branch name, then we can (try to) use `SingleBranch`.
+// Note however, that we cannot syntactically distinguish branch names from commit ids.
+//
+// ## Solutions
+//
+// The simplest code handling everything would be
+//
+//      Clone (Depth=1)
+//      if revision:
+//          hash = ResolveRevision (revision)
+//          Checkout (hash)
+//
+// with no `SingleBranch` in sight, just `Depth`.
+//
+// More complex, hopefully more performant would be
+//
+//  1:  if not revision:
+//  2:      Clone (Depth=1)                        // (A)
+//  3:  else
+//  4:      Clone (Depth=1,SingleBranch=revision)  // (B,C?)
+//  5:      if ok: done                            // (B!)
+//  7:      Clone (Depth=1)                        // (C)
+//  8:      hash = ResolveRevision (revision)
+//  9:      Checkout (hash)
+//
+// I.e. try to use a revision as branch name first, to get the `SingleBranch`
+// optimization.  When that fails fall back to regular cloning and checkout.  This fall
+// back should happen only for (C).
+//
+// ## Decision
+//
+// Going with the second solution. While there is more complexity it is not that much
+// more.  Note also that using a commit id (C) is considered unusual. Using a branch (B)
+// is much more expected.
+
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-logr/logr"
 
 	"github.com/epinio/epinio/helpers"
 	"github.com/epinio/epinio/helpers/kubernetes"
@@ -38,20 +99,11 @@ func (hc Controller) ImportGit(c *gin.Context) apierror.APIErrors {
 	}
 	defer os.RemoveAll(gitRepo)
 
-	// Fetch the git repo
-	// TODO: This is pulling the git repository on user request (synchronously).
-	// This can be a slow process. A solution with background workers would be
-	// more appropriate. The "pull from git" feature may be redesigned and implemented
-	// through an "external" component that monitors git repos. In that case this code
-	// will be removed.
-	_, err = git.PlainCloneContext(ctx, gitRepo, false, &git.CloneOptions{
-		URL:           url,
-		ReferenceName: plumbing.NewBranchReferenceName(revision),
-		SingleBranch:  true,
-		Depth:         1,
-	})
+	// clone/fetch/checkout
+	err = getRepository(ctx, log, gitRepo, url, revision)
 	if err != nil {
-		return apierror.InternalError(err, fmt.Sprintf("cloning the git repository: %s, revision: %s", url, revision))
+		return apierror.InternalError(err,
+			fmt.Sprintf("cloning the git repository: %s @ %s", url, revision))
 	}
 
 	// Create a tarball
@@ -93,4 +145,82 @@ func (hc Controller) ImportGit(c *gin.Context) apierror.APIErrors {
 		BlobUID: blobUID,
 	})
 	return nil
+}
+
+func getRepository(ctx context.Context, log logr.Logger, gitRepo, url, revision string) error {
+	if revision == "" {
+		// Input A: repository, no revision.
+		log.Info("importgit, cloning simple", "url", url)
+		_, err := generalClone(ctx, gitRepo, url)
+		return err
+	}
+
+	// Input B or C: Attempt to treat as B (revision is branch name)
+
+	log.Info("importgit, cloning branch", "url", url, "revision", revision)
+	repository, err := branchClone(ctx, gitRepo, url, revision)
+	if err == nil {
+		// Was branch name, done.
+		return nil
+	}
+	if !strings.Contains(err.Error(), `couldn't find remote ref`) || !plumbing.IsHash(revision) {
+		// Some other error, or the revision does not look like a commit id (C)
+
+		return err
+	}
+
+	// Attempt input C: revision might be commit id.
+	// 2 stage process - A simple clone followed by a checkout
+
+	log.Info("importgit, cloning simple, commit id", "url", url)
+	repository, err = generalClone(ctx, gitRepo, url)
+	if err != nil {
+		return err
+	}
+
+	log.Info("importgit, resolve", "revision", revision)
+	hash, err := repository.ResolveRevision(plumbing.Revision(revision))
+	if err != nil {
+		return err
+	}
+
+	log.Info("importgit, resolved", "revision", hash)
+
+	checkout, err := repository.Worktree()
+	if err != nil {
+		return err
+	}
+
+	log.Info("importgit, checking out", "url", url, "revision", hash)
+
+	return checkout.Checkout(&git.CheckoutOptions{
+		Hash:  *hash,
+		Force: true,
+	})
+}
+
+func branchClone(ctx context.Context, gitRepo, url, revision string) (*git.Repository, error) {
+	repository, err := git.PlainCloneContext(ctx, gitRepo, false, &git.CloneOptions{
+		URL:           url,
+		SingleBranch:  true,
+		ReferenceName: plumbing.NewBranchReferenceName(revision),
+		Depth:         1,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return repository, nil
+}
+
+func generalClone(ctx context.Context, gitRepo, url string) (*git.Repository, error) {
+	repository, err := git.PlainCloneContext(ctx, gitRepo, false, &git.CloneOptions{
+		URL:   url,
+		Depth: 1,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return repository, nil
 }

--- a/internal/api/v1/application/importgit.go
+++ b/internal/api/v1/application/importgit.go
@@ -173,7 +173,7 @@ func getRepository(ctx context.Context, log logr.Logger, gitRepo, url, revision 
 	// 2 stage process - A simple clone followed by a checkout
 
 	log.Info("importgit, cloning simple, commit id", "url", url)
-	repository, err = generalClone(ctx, gitRepo, url)
+	repository, err := generalClone(ctx, gitRepo, url)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #1642 

The code mishandled commit ids in the git upload code. It exclusively treated the revision as branch name, and a commit id usually (*) is not.

(*) Git is actually perfectly fine to use a commit id looking string as a branch name. On the other side, this make it impossible to syntactically distinguish commit id from branch.

This is why the code tries the `revision` as branch first, and then that fails tries it as commit id (if it looks like such).
