### PR TITLE
Remove dependency on `Deployment` resource as entry for app workload

### DIFF
--- a/internal/api/v1/application/exec.go
+++ b/internal/api/v1/application/exec.go
@@ -45,7 +45,7 @@ func (hc Controller) Exec(c *gin.Context) apierror.APIErrors {
 		return apierror.NewAPIError("Cannot connect to application without workload", http.StatusBadRequest)
 	}
 
-	workload := application.NewWorkload(cluster, app.Meta)
+	workload := application.NewWorkload(cluster, app.Meta, app.Workload.DesiredReplicas)
 	podNames, err := workload.PodNames(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
@@ -71,7 +71,7 @@ func (hc Controller) Exec(c *gin.Context) apierror.APIErrors {
 		podToConnect = podNames[0]
 	}
 
-	appData, err := workload.Get(ctx, 0)
+	appData, err := workload.Get(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
 	}

--- a/internal/api/v1/application/exec.go
+++ b/internal/api/v1/application/exec.go
@@ -71,12 +71,12 @@ func (hc Controller) Exec(c *gin.Context) apierror.APIErrors {
 		podToConnect = podNames[0]
 	}
 
-	deployment, err := workload.Deployment(ctx)
+	appData, err := workload.Get(ctx, 0)
 	if err != nil {
 		return apierror.InternalError(err)
 	}
 
-	proxyRequest(c.Writer, c.Request, podToConnect, namespace, deployment.Name, clientSetHTTP1)
+	proxyRequest(c.Writer, c.Request, podToConnect, namespace, appData.Name, clientSetHTTP1)
 
 	return nil
 }

--- a/internal/api/v1/application/portforward.go
+++ b/internal/api/v1/application/portforward.go
@@ -40,7 +40,7 @@ func (hc Controller) PortForward(c *gin.Context) apierror.APIErrors {
 
 	// TODO: Find podName from application and params (e.g. instance number etc).
 	// The application may have more than one pods.
-	podNames, err := application.NewWorkload(cluster, app.Meta).PodNames(ctx)
+	podNames, err := application.NewWorkload(cluster, app.Meta, app.Workload.DesiredReplicas).PodNames(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
 	}

--- a/internal/api/v1/application/running.go
+++ b/internal/api/v1/application/running.go
@@ -57,7 +57,7 @@ func (hc Controller) Running(c *gin.Context) apierror.APIErrors {
 
 	if app.Workload.DesiredReplicas != app.Workload.ReadyReplicas {
 		err := wait.PollImmediate(time.Second, duration.ToAppBuilt(), func() (bool, error) {
-			podList, err := application.NewWorkload(cluster, app.Meta).Pods(ctx)
+			podList, err := application.NewWorkload(cluster, app.Meta, app.Workload.DesiredReplicas).Pods(ctx)
 			if err != nil {
 				return false, err
 			}

--- a/internal/api/v1/application/running.go
+++ b/internal/api/v1/application/running.go
@@ -1,20 +1,34 @@
 package application
 
 import (
+	"time"
+
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/duration"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/gin-gonic/gin"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubectl/pkg/util/podutils"
 )
 
 // Running handles the API endpoint GET /namespaces/:namespace/applications/:app/running
-// It waits for the specified application to be running (i.e. its
-// deployment to be complete), before it returns. An exception is if
-// the application does not become running without
-// `duration.ToAppBuilt()` (default: 10 minutes). In that case it
-// returns with an error after that time.
+//
+// It waits for the specified application to be running (i.e. its deployment to be
+// complete), before it returns. An exception is if the application does not become ready
+// within `duration.ToAppBuilt()` (default: 3 minutes). In that case it returns with an
+// error after that time.
+//
+// __API PORTABILITY NOTE__
+//
+// With the switch to deployment of apps via helm, and waiting for the helm deployment to
+// be ready before returning this endpoint is technically superfluous, and it should never
+// fail. The command line has been modified to not invoke it anymore.
+//
+// It is kept for older clients still calling on it. Because of that it is also kept
+// functional. Instead of checking for an app `Deployment` and its status it now checks
+// the app `Pod` stati.
 func (hc Controller) Running(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
 	namespace := c.Param("namespace")
@@ -39,10 +53,26 @@ func (hc Controller) Running(c *gin.Context) apierror.APIErrors {
 		return apierror.NewBadRequestError("no status available for application without workload")
 	}
 
-	err = cluster.WaitForDeploymentCompleted(
-		ctx, nil, namespace, app.Workload.Name, duration.ToAppBuilt())
-	if err != nil {
-		return apierror.InternalError(err)
+	// Check app readiness based on app pods. Wait only if we have non-ready pods.
+
+	if app.Workload.DesiredReplicas != app.Workload.ReadyReplicas {
+		err := wait.PollImmediate(time.Second, duration.ToAppBuilt(), func() (bool, error) {
+			podList, err := application.NewWorkload(cluster, app.Meta).Pods(ctx)
+			if err != nil {
+				return false, err
+			}
+			var ready int32
+			for _, pod := range podList {
+				tmp := pod
+				if podutils.IsPodReady(&tmp) {
+					ready = ready + 1
+				}
+			}
+			return ready == app.Workload.DesiredReplicas, nil
+		})
+		if err != nil {
+			return apierror.InternalError(err)
+		}
 	}
 
 	response.OK(c)

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -512,7 +512,7 @@ func fetch(ctx context.Context, cluster *kubernetes.Cluster, app *models.App) er
 	// Check if app is active, and if yes, fill the associated parts.
 	// May have to straighten the workload structure a bit further.
 
-	app.Workload, err = NewWorkload(cluster, app.Meta).Get(ctx)
+	app.Workload, err = NewWorkload(cluster, app.Meta).Get(ctx, instances)
 	return err
 }
 

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -512,7 +512,7 @@ func fetch(ctx context.Context, cluster *kubernetes.Cluster, app *models.App) er
 	// Check if app is active, and if yes, fill the associated parts.
 	// May have to straighten the workload structure a bit further.
 
-	app.Workload, err = NewWorkload(cluster, app.Meta).Get(ctx, instances)
+	app.Workload, err = NewWorkload(cluster, app.Meta, instances).Get(ctx)
 	return err
 }
 

--- a/internal/application/workload.go
+++ b/internal/application/workload.go
@@ -165,6 +165,11 @@ func (a *Workload) Get(ctx context.Context, desiredReplicas int32) (*models.AppD
 		return nil, err
 	}
 
+	// No pods => no workload
+	if len(podList) == 0 {
+		return nil, nil
+	}
+
 	var readyReplicas int32
 	var createdAt time.Time
 	var stageID string
@@ -178,7 +183,7 @@ func (a *Workload) Get(ctx context.Context, desiredReplicas int32) (*models.AppD
 		createdAt = podList[0].ObjectMeta.CreationTimestamp.Time
 		stageID = podList[0].ObjectMeta.Labels["epinio.io/stage-id"]
 		username = podList[0].ObjectMeta.Labels["app.kubernetes.io/created-by"]
-		controllerName = podList[0].ObjectMeta.OwnerReferences[0].Name
+		controllerName = podList[0].ObjectMeta.Labels["epinio.io/app-container"]
 
 		for _, pod := range podList {
 			// Choose oldest time of all pods.

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -237,11 +237,6 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 	details.Info("wait for application resources")
 	c.ui.ProgressNote().KeeplineUnder(1).Msg("Creating application resources")
 
-	// _, err = c.API.AppRunning(appRef)
-	// if err != nil {
-	// 	return errors.Wrap(err, "waiting for app failed")
-	// }
-
 	routes := []string{}
 	for _, d := range deployResponse.Routes {
 		routes = append(routes, fmt.Sprintf("https://%s", d))

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -237,10 +237,10 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 	details.Info("wait for application resources")
 	c.ui.ProgressNote().KeeplineUnder(1).Msg("Creating application resources")
 
-	_, err = c.API.AppRunning(appRef)
-	if err != nil {
-		return errors.Wrap(err, "waiting for app failed")
-	}
+	// _, err = c.API.AppRunning(appRef)
+	// if err != nil {
+	// 	return errors.Wrap(err, "waiting for app failed")
+	// }
 
 	routes := []string{}
 	for _, d := range deployResponse.Routes {


### PR DESCRIPTION
Fix #1629.

  - With our use of helm charts and --wait'ing for their deployment it is not really necessary any longer.
  - It is specific to kube Deployments.