### PR TITLE
PR to Install Rancher Desktop and push Epinio

### DIFF
--- a/.github/workflows/rancher-desktop.yml
+++ b/.github/workflows/rancher-desktop.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   linter:
-      runs-on: self-hosted
+      runs-on: rdtest
 
       steps:
         - name: Checkout
@@ -99,7 +99,7 @@ jobs:
   acceptance-scenario7:
       needs:
         - linter
-      runs-on: self-hosted
+      runs-on: rdtest
 
       steps:
         - name: Checkout

--- a/.github/workflows/rancher-desktop.yml
+++ b/.github/workflows/rancher-desktop.yml
@@ -1,0 +1,32 @@
+name: Rancher Desktop Install
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - '.github/workflows/rancher-desktop.yaml'
+  # schedule:
+  #   - cron:  '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      keep_cluster:
+        description: "Keep the cluster afterwards? (empty/yes)"
+        required: false
+        default: ""
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check access to /dev/kvm
+        run: |
+          PRIVILEGES=$([ -r /dev/kvm ] && [ -w /dev/kvm ] || echo 'insufficient privileges')
+          if[ $(PRIVILEGES) = "insufficient privileges"];then sudo usermod -a -G kvm "$USER" fi
+
+      - name: Add Rancher Desktop repository
+        run: |
+          curl -s https://download.opensuse.org/repositories/isv:/Rancher:/stable/deb/Release.key | gpg --dearmor | sudo dd status=none of=/usr/share/keyrings/isv-rancher-stable-archive-keyring.gpg
+          echo 'deb [signed-by=/usr/share/keyrings/isv-rancher-stable-archive-keyring.gpg] https://download.opensuse.org/repositories/isv:/Rancher:/stable/deb/ ./' | sudo dd status=none of=/etc/apt/sources.list.d/isv-rancher-stable.list
+          apt-get update
+          apt-get install rancher-desktop

--- a/.github/workflows/rancher-desktop.yml
+++ b/.github/workflows/rancher-desktop.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/rancher-desktop.yaml'
+    - 'acceptance/install/scenario7_test.go'
+    - '.github/workflows/rancher-desktop.yml'
   # schedule:
   #   - cron:  '0 6 * * *'
   workflow_dispatch:
@@ -14,7 +15,47 @@ on:
         required: false
         default: ""
 
+env:
+  SETUP_GO_VERSION: '^1.18'
+  GINKGO_NODES: 1
+  FLAKE_ATTEMPTS: 1
+  PUBLIC_CLOUD: 1
+
 jobs:
+  linter:
+      runs-on: self-hosted
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+          with:
+            submodules: recursive
+
+        - name: Setup Go
+          uses: actions/setup-go@v3
+          with:
+            go-version: ${{ env.SETUP_GO_VERSION }}
+
+        - name: Cache Tools
+          uses: actions/cache@v3.0.4
+          with:
+            path: ${{ github.workspace }}/tools
+            key: ${{ runner.os }}-tools
+
+        - name: Install Tools
+          run: make tools-install
+
+        - name: Add Tools to PATH
+          run: |
+            echo "`pwd`/output/bin" >> $GITHUB_PATH
+
+        - name: Lint Epinio
+          run: make lint
+
+        - name: Clean all
+          if: always()
+          uses: colpal/actions-clean@v1
+
   build:
     runs-on: ubuntu-latest
 
@@ -22,7 +63,11 @@ jobs:
       - name: Check access to /dev/kvm
         run: |
           PRIVILEGES=$([ -r /dev/kvm ] && [ -w /dev/kvm ] || echo 'insufficient privileges')
-          if[ $(PRIVILEGES) = "insufficient privileges"];then sudo usermod -a -G kvm "$USER" fi
+          if [ ${PRIVILEGES}="insufficient privileges" ]; then 
+          sudo usermod -a -G kvm "$USER" 
+          else
+          echo "User has correct privileges for kvm"
+          fi
 
       - name: Add Rancher Desktop repository
         run: |
@@ -30,3 +75,97 @@ jobs:
           echo 'deb [signed-by=/usr/share/keyrings/isv-rancher-stable-archive-keyring.gpg] https://download.opensuse.org/repositories/isv:/Rancher:/stable/deb/ ./' | sudo dd status=none of=/etc/apt/sources.list.d/isv-rancher-stable.list
           apt-get update
           apt-get install rancher-desktop
+
+      - name: Start Rancher Desktop prior installing Epinio
+        run: |
+          ## Note: this is a workaround. rdctl should be executable after rd install 
+          ## Directly start from rdctl when this bug is fixed: https://github.com/rancher-sandbox/rancher-desktop/issues/2683
+
+          ## Start Rancher Desktop
+          rancher-desktop >/dev/null 2>&1  &
+          sleep 40
+
+          ## Stop RD to later change to moby
+          rdctl shutdown
+          sleep 40
+
+          ## Change Engine
+          rdctl set --container-engine docker
+
+          ## Start again RD
+          rdctl start
+          sleep 60
+
+  acceptance-scenario7:
+      needs:
+        - linter
+      runs-on: self-hosted
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+          with:
+            submodules: recursive
+            fetch-depth: 0
+
+        - name: Setup Go
+          uses: actions/setup-go@v3
+          with:
+            go-version: ${{ env.SETUP_GO_VERSION }}
+
+        - name: Setup Ginkgo Test Framework
+          run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+
+        - name: Cache Tools
+          uses: actions/cache@v3.0.4
+          with:
+            path: ${{ github.workspace }}/tools
+            key: ${{ runner.os }}-tools
+
+        - name: Login to Docker Hub
+          uses: docker/login-action@v2
+          with:
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+        - name: Installation Acceptance Tests
+          env:
+            REGEX: Scenario7
+            PUBLIC_CLOUD: 1
+            REGISTRY_USERNAME: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
+            REGISTRY_PASSWORD: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
+            INGRESS_CONTROLLER: traefik
+          run: |
+            # Install Epinio CLI
+            curl -o epinio -L https://github.com/epinio/epinio/releases/download/v1.1.0/epinio-linux-x86_64
+            chmod +x epinio
+            sudo mv ./epinio /usr/local/bin/epinio
+
+            # Install Epinio
+            kubectl create namespace cert-manager 
+            helm repo add jetstack https://charts.jetstack.io 
+            helm repo update 
+            helm install cert-manager --namespace cert-manager jetstack/cert-manager  --set installCRDs=true  --set "extraArgs[0]=--enable-certificate-owner-ref=true"
+            helm repo add epinio https://epinio.github.io/helm-charts 
+            # MYEPINIODOMAIN=`kubectl get svc -n kube-system traefik | awk '{print $4}' | tail --lines=+2` 
+            MYEPINIODOMAIN='127.0.0.1'
+            helm upgrade --install epinio -n epinio --create-namespace epinio/epinio  --set global.domain=${MYEPINIODOMAIN}.sslip.io 
+            sleep 40
+
+        - name: Delete Rancher Dekstop
+          run: |
+            sudo apt remove --autoremove -y rancher-desktop 
+            sudo rm /etc/apt/sources.list.d/isv-rancher-stable.list 
+            sudo rm /usr/share/keyrings/isv-rancher-stable-archive-keyring.gpg 
+            sudo apt update 
+            sudo rm -rf .rd 
+            sudo rm -rf .local/share/rancher-desktop/ 
+            sudo rm -rf .config/rancher-desktop/
+            sudo rm -rf .config/Rancher\ Desktop/
+
+        - name: Clean all
+          if: always()
+          uses: colpal/actions-clean@v1
+
+
+          

--- a/.github/workflows/rdtest.sh
+++ b/.github/workflows/rdtest.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Check priviledges
+PRIVILEGES=$([ -r /dev/kvm ] && [ -w /dev/kvm ] || echo 'insufficient privileges')
+if [ ${PRIVILEGES}="insufficient privileges" ]; then 
+sudo usermod -a -G kvm "$USER" 
+else
+echo "User has correct privileges for kvm"
+fi
+
+## Install RD
+curl -s https://download.opensuse.org/repositories/isv:/Rancher:/stable/deb/Release.key | gpg --dearmor | sudo dd status=none of=/usr/share/keyrings/isv-rancher-stable-archive-keyring.gpg
+echo 'deb [signed-by=/usr/share/keyrings/isv-rancher-stable-archive-keyring.gpg] https://download.opensuse.org/repositories/isv:/Rancher:/stable/deb/ ./' | sudo dd status=none of=/etc/apt/sources.list.d/isv-rancher-stable.list
+sudo apt update
+sudo apt install -y rancher-desktop
+
+## Start Rancher Desktop
+rancher-desktop >/dev/null 2>&1  &
+sleep 40
+
+## Stop RD to later change to moby
+rdctl shutdown
+sleep 40
+
+## Change Engine
+rdctl set --container-engine docker
+
+## Start again RD
+rdctl start
+sleep 60
+
+## Install Epinio CLI
+curl -o epinio -L https://github.com/epinio/epinio/releases/download/v1.1.0/epinio-linux-x86_64
+chmod +x epinio
+sudo mv ./epinio /usr/local/bin/epinio
+
+## Install Epino
+kubectl create namespace cert-manager 
+helm repo add jetstack https://charts.jetstack.io 
+helm repo update 
+helm install cert-manager --namespace cert-manager jetstack/cert-manager  --set installCRDs=true  --set "extraArgs[0]=--enable-certificate-owner-ref=true"
+helm repo add epinio https://epinio.github.io/helm-charts 
+MYEPINIODOMAIN=`kubectl get svc -n kube-system traefik | awk '{print $4}' | tail --lines=+2` 
+helm upgrade --install epinio -n epinio --create-namespace epinio/epinio  --set global.domain=${MYEPINIODOMAIN}.sslip.io 
+
+sleep 30
+## Check it can login
+epinio login -u admin https://epinio.${MYEPINIODOMAIN}.sslip.io
+read -sp 'Password: ' password
+
+# ## Remove Rancher Desktop
+# sudo apt remove --autoremove -y rancher-desktop 
+# sudo rm /etc/apt/sources.list.d/isv-rancher-stable.list 
+# sudo rm /usr/share/keyrings/isv-rancher-stable-archive-keyring.gpg 
+# sudo apt update 
+# sudo rm -rf .rd 
+# sudo rm -rf .local/share/rancher-desktop/ 

--- a/acceptance/install/scenario7_test.go
+++ b/acceptance/install/scenario7_test.go
@@ -26,7 +26,7 @@ var _ = Describe("<Scenario7> Rancher Desktop install and push epinio on self ho
 		registryPassword  string
 		// rangeIP           string
 		domain            string
-		// domainIP          string
+		domainIP          string
 		// testenv.New is not needed for VerifyAppConfigurationBound helper :shrug:
 		env          testenv.EpinioEnv
 		// localpathURL = "https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.20/deploy/local-path-storage.yaml"

--- a/acceptance/install/scenario7_test.go
+++ b/acceptance/install/scenario7_test.go
@@ -1,0 +1,142 @@
+package install_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/epinio/epinio/acceptance/helpers/catalog"
+	"github.com/epinio/epinio/acceptance/helpers/epinio"
+	"github.com/epinio/epinio/acceptance/helpers/proc"
+	"github.com/epinio/epinio/acceptance/testenv"
+)
+
+var _ = Describe("<Scenario7> Rancher Desktop install and push epinio on self hosted runner", func() {
+	var (
+		flags             []string
+		epinioHelper      epinio.Epinio
+		configurationName = catalog.NewConfigurationName()
+		appName           string
+		loadbalancer      string
+		registryUsername  string
+		registryPassword  string
+		rangeIP           string
+		domain            string
+		domainIP          string
+		// testenv.New is not needed for VerifyAppConfigurationBound helper :shrug:
+		env          testenv.EpinioEnv
+		localpathURL = "https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.20/deploy/local-path-storage.yaml"
+	)
+
+	BeforeEach(func() {
+		epinioHelper = epinio.NewEpinioHelper(testenv.EpinioBinaryPath())
+
+		// Clean previous installed helm repos
+		// Done at the beginning because we don't know the runner's state
+		out, err := proc.Run(testenv.Root(), false, "bash", "./scripts/remove-helm-repos.sh")
+		Expect(err).NotTo(HaveOccurred(), out)
+
+		domain = os.Getenv("EPINIO_SYSTEM_DOMAIN")
+		Expect(domain).ToNot(BeEmpty())
+		domainIP = strings.TrimSuffix(domain, ".omg.howdoi.website")
+
+		appName = "external-reg-test-rke"
+
+		registryUsername = os.Getenv("REGISTRY_USERNAME")
+		Expect(registryUsername).ToNot(BeEmpty())
+
+		registryPassword = os.Getenv("REGISTRY_PASSWORD")
+		Expect(registryPassword).ToNot(BeEmpty())
+		flags = []string{
+			"--set", "global.domain=" + domain,
+			"--set", "global.tlsIssuer=private-ca",
+			"--set", "containerregistry.enabled=false",
+			"--set", "global.registryURL=registry.hub.docker.com",
+			"--set", "global.registryUsername=" + registryUsername,
+			"--set", "global.registryPassword=" + registryPassword,
+			"--set", "global.registryNamespace=splatform",
+		}
+
+	})
+
+	AfterEach(func() {
+		out, err := epinioHelper.Uninstall()
+		Expect(err).NotTo(HaveOccurred(), out)
+	})
+
+	It("Install Epinio in Rancher Desktop and push app", func() {
+		By("Checking LoadBalancer IP", func() {
+			// Ensure that Traefik LB is not in Pending state anymore, could take time
+			Eventually(func() string {
+				out, err := proc.RunW("kubectl", "get", "svc", "-n", "traefik", "traefik", "--no-headers")
+				Expect(err).NotTo(HaveOccurred(), out)
+				return out
+			}, "4m", "2s").ShouldNot(ContainSubstring("<pending>"))
+
+			out, err := proc.RunW("kubectl", "get", "service", "-n", "traefik", "traefik", "-o", "json")
+			Expect(err).NotTo(HaveOccurred(), out)
+
+			// Check that an IP address for LB is configured
+			status := &testenv.LoadBalancerHostname{}
+			err = json.Unmarshal([]byte(out), status)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status.Status.LoadBalancer.Ingress).To(HaveLen(1))
+			loadbalancer = status.Status.LoadBalancer.Ingress[0].IP
+			Expect(loadbalancer).ToNot(BeEmpty())
+		})
+
+		By("Installing Epinio", func() {
+			out, err := epinioHelper.Install(flags...)
+			Expect(err).NotTo(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("STATUS: deployed"))
+
+			out, err = testenv.PatchEpinio()
+			Expect(err).ToNot(HaveOccurred(), out)
+		})
+
+		By("Connecting to Epinio", func() {
+			Eventually(func() string {
+				out, _ := epinioHelper.Run("login", "-u", "admin", "-p", "password", "--trust-ca", "https://epinio."+domain)
+				return out
+			}, "2m", "5s").Should(ContainSubstring("Login successful"))
+		})
+
+		By("Checking Epinio info command", func() {
+			Eventually(func() string {
+				out, _ := epinioHelper.Run("info")
+				return out
+			}, "2m", "2s").Should(ContainSubstring("Epinio Server Version:"))
+		})
+
+		By("Creating a configuration and pushing an app", func() {
+			out, err := epinioHelper.Run("configuration", "create", configurationName, "mariadb", "10-3-22")
+			Expect(err).NotTo(HaveOccurred(), out)
+
+			out, err = epinioHelper.Run("push",
+				"--name", appName,
+				"--path", testenv.AssetPath("sample-app"),
+				"--bind", configurationName)
+			Expect(err).NotTo(HaveOccurred(), out)
+
+			env.VerifyAppConfigurationBound(appName, configurationName, testenv.DefaultWorkspace, 1)
+
+			// Verify cluster_issuer is used
+			out, err = proc.RunW("kubectl", "get", "certificate",
+				"-n", testenv.DefaultWorkspace,
+				"--selector", "app.kubernetes.io/name="+appName,
+				"-o", "jsonpath='{.items[*].spec.issuerRef.name}'")
+			Expect(err).NotTo(HaveOccurred(), out)
+			Expect(out).To(Equal("'private-ca'"))
+		})
+
+		By("Delete an app", func() {
+			out, err := epinioHelper.Run("apps", "delete", appName)
+			Expect(err).NotTo(HaveOccurred(), out)
+			Expect(out).To(Or(ContainSubstring("Application deleted")))
+		})
+	})
+})

--- a/acceptance/install/scenario7_test.go
+++ b/acceptance/install/scenario7_test.go
@@ -2,7 +2,7 @@ package install_test
 
 import (
 	"encoding/json"
-	"fmt"
+	// "fmt"
 	"os"
 	"strings"
 
@@ -24,12 +24,12 @@ var _ = Describe("<Scenario7> Rancher Desktop install and push epinio on self ho
 		loadbalancer      string
 		registryUsername  string
 		registryPassword  string
-		rangeIP           string
+		// rangeIP           string
 		domain            string
-		domainIP          string
+		// domainIP          string
 		// testenv.New is not needed for VerifyAppConfigurationBound helper :shrug:
 		env          testenv.EpinioEnv
-		localpathURL = "https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.20/deploy/local-path-storage.yaml"
+		// localpathURL = "https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.20/deploy/local-path-storage.yaml"
 	)
 
 	BeforeEach(func() {

--- a/acceptance/install/scenario7_test.go
+++ b/acceptance/install/scenario7_test.go
@@ -26,7 +26,7 @@ var _ = Describe("<Scenario7> Rancher Desktop install and push epinio on self ho
 		registryPassword  string
 		// rangeIP           string
 		domain            string
-		domainIP          string
+		// domainIP          string
 		// testenv.New is not needed for VerifyAppConfigurationBound helper :shrug:
 		env          testenv.EpinioEnv
 		// localpathURL = "https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.20/deploy/local-path-storage.yaml"
@@ -42,7 +42,7 @@ var _ = Describe("<Scenario7> Rancher Desktop install and push epinio on self ho
 
 		domain = os.Getenv("EPINIO_SYSTEM_DOMAIN")
 		Expect(domain).ToNot(BeEmpty())
-		domainIP = strings.TrimSuffix(domain, ".omg.howdoi.website")
+		// domainIP = strings.TrimSuffix(domain, ".omg.howdoi.website")
 
 		appName = "external-reg-test-rke"
 

--- a/acceptance/install/scenario7_test.go
+++ b/acceptance/install/scenario7_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	// "fmt"
 	"os"
-	"strings"
+	// "strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
Implementation of related issue: https://github.com/epinio/epinio/issues/940

Recap:

- KVM needs to be enabled on runners to install RD
- Nightly CI should test Epinio against latest release of Rancher Desktop.
- use rdctl to install RD
- install epinio
- check if epinio endpoint can be reached
- push sample app
- check if sample app can be reached