### PR TITLE
Bump helm-charts to fix Ingress pathTypes

### DIFF
--- a/internal/api/v1/application/create.go
+++ b/internal/api/v1/application/create.go
@@ -169,7 +169,7 @@ func validateRoutes(ctx context.Context, cluster *kubernetes.Cluster, appName, n
 
 // validateIngress checks if the desiredRoutesMap is in conflict with the passed
 // ingress object. Conflict means, the ingress already defines one of the desired
-// routes and it belongs to another or and unknown app.
+// routes and it belongs to another or an unknown app.
 func validateIngress(desiredRoutesMap map[string]struct{}, appName, namespace string, ingress networkingv1.Ingress) []apierror.APIError {
 	issues := []apierror.APIError{}
 
@@ -182,7 +182,7 @@ func validateIngress(desiredRoutesMap map[string]struct{}, appName, namespace st
 		routeStr := route.String()
 
 		// if a desired route is present within the ingresses then we have to check
-		// if it's already owned by the same app
+		// if it is already owned by the same app
 		if _, found := desiredRoutesMap[routeStr]; found {
 			ingressAppName, found := ingress.GetLabels()["app.kubernetes.io/name"]
 			if !found {

--- a/internal/application/ingresses.go
+++ b/internal/application/ingresses.go
@@ -50,12 +50,13 @@ func ListRoutes(ctx context.Context, cluster *kubernetes.Cluster, appRef models.
 
 	result := []string{}
 	for _, ingress := range ingressList.Items {
-		route, err := routes.FromIngress(ingress)
+		routes, err := routes.FromIngress(ingress)
 		if err != nil {
 			return result, err
 		}
-
-		result = append(result, route.String())
+		for _, r := range routes {
+			result = append(result, r.String())
+		}
 	}
 
 	return result, nil

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -66,13 +66,18 @@ func FromString(routeStr string) Route {
 // NOTE: Epinio doesn't create Ingresses with multiple rules. For that reason,
 // this function will try to construct a Route from the first rule of the passed
 // Ingress, ingoring all other rules if they exist.
-func FromIngress(ingress networkingv1.Ingress) (*Route, error) {
+func FromIngress(ingress networkingv1.Ingress) ([]Route, error) {
 	if len(ingress.Spec.Rules) == 0 {
 		return nil, errors.New("no Rules found on Ingress")
 	}
-	rule := ingress.Spec.Rules[0]
-	domain := rule.Host
-	path := rule.HTTP.Paths[0].Path
 
-	return &Route{Domain: domain, Path: path}, nil
+	result := []Route{}
+	for _, r := range ingress.Spec.Rules {
+		domain := r.Host
+		for _, p := range r.HTTP.Paths {
+			result = append(result, Route{Domain: domain, Path: p.Path})
+		}
+	}
+
+	return result, nil
 }

--- a/internal/routes/routes_test.go
+++ b/internal/routes/routes_test.go
@@ -67,6 +67,7 @@ var _ = Describe("Route", func() {
 			result, err := FromIngress(routeIngress)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result[0]).To(Equal(Route{Domain: "mydomain.org", Path: "/api/v1"}))
+			Expect(len(result)).To(Equal(1))
 		})
 		When("the Ingress has no rules defined", func() {
 			BeforeEach(func() {

--- a/internal/routes/routes_test.go
+++ b/internal/routes/routes_test.go
@@ -63,10 +63,10 @@ var _ = Describe("Route", func() {
 											Path: "/api/v1",
 										}}}}}}}}
 		})
-		It("returns a Route object", func() {
+		It("returns a list of Route objects", func() {
 			result, err := FromIngress(routeIngress)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(*result).To(Equal(Route{Domain: "mydomain.org", Path: "/api/v1"}))
+			Expect(result[0]).To(Equal(Route{Domain: "mydomain.org", Path: "/api/v1"}))
 		})
 		When("the Ingress has no rules defined", func() {
 			BeforeEach(func() {
@@ -89,12 +89,18 @@ var _ = Describe("Route", func() {
 									Path: "/otherapi/v1",
 								}}}}})
 			})
-			It("creates a Route out of the first rule", func() {
+			It("creates Routes out of every rule", func() {
 				result, err := FromIngress(routeIngress)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(*result).To(Equal(Route{
-					Domain: "mydomain.org",
-					Path:   "/api/v1",
+				Expect(result).To(Equal([]Route{
+					{
+						Domain: "mydomain.org",
+						Path:   "/api/v1",
+					},
+					{
+						Domain: "someotherdomain.org",
+						Path:   "/otherapi/v1",
+					},
 				}))
 			})
 		})


### PR DESCRIPTION
Fixes comment here: https://github.com/epinio/epinio/issues/1663#issuecomment-1206834066

There is no reason to use "ImplementationSpecific" when we know we want "Prefix". I'm not sure about the change in the order of rules. Most ingress controllers should prioritize rules, based on the length (e.g. https://kubernetes.github.io/ingress-nginx/user-guide/ingress-path-matching/#path-priority). In any case, it doesn't hurt putting the "catch all" rule at the end.

Sibling PR: https://github.com/epinio/helm-charts/pull/263