### PR TITLE
HttpClient in ApiClient

### DIFF
--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -104,7 +104,7 @@ func New() (*EpinioClient, error) {
 		return nil, errors.Wrap(err, "error loading settings")
 	}
 
-	apiClient := epinioapi.New(cfg.API, cfg.WSS, cfg.User, cfg.Password)
+	apiClient := epinioapi.New(cfg)
 
 	return NewEpinioClient(cfg, apiClient)
 }

--- a/internal/cli/usercmd/login.go
+++ b/internal/cli/usercmd/login.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 
 	"github.com/epinio/epinio/helpers/termui"
-	"github.com/epinio/epinio/internal/auth"
 	"github.com/epinio/epinio/internal/cli/settings"
 	epinioapi "github.com/epinio/epinio/pkg/api/core/v1/client"
 	"github.com/pkg/errors"
@@ -228,12 +227,7 @@ func updateSettings(address, username, password, serverCertificate string) (*set
 }
 
 func verifyCredentials(epinioSettings *settings.Settings) error {
-	if epinioSettings.Certs != "" {
-		auth.ExtendLocalTrust(epinioSettings.Certs)
-	}
-
-	apiClient := epinioapi.New(epinioSettings.API, epinioSettings.WSS, epinioSettings.User, epinioSettings.Password)
-
+	apiClient := epinioapi.New(epinioSettings)
 	_, err := apiClient.Namespaces()
 	return errors.Wrap(err, "error while connecting to the Epinio server")
 }

--- a/pkg/api/core/v1/client/app_restart_test.go
+++ b/pkg/api/core/v1/client/app_restart_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	"github.com/epinio/epinio/internal/cli/settings"
 	"github.com/epinio/epinio/pkg/api/core/v1/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -22,7 +23,7 @@ func DescribeAppRestart() {
 			fmt.Fprint(w, responseBody)
 		}))
 
-		epinioClient = client.New(srv.URL, "", "", "")
+		epinioClient = client.New(&settings.Settings{API: srv.URL})
 	})
 
 	When("app restart successfully", func() {

--- a/pkg/api/core/v1/client/client.go
+++ b/pkg/api/core/v1/client/client.go
@@ -2,29 +2,33 @@
 package client
 
 import (
+	"net/http"
+
 	"github.com/epinio/epinio/helpers/tracelog"
+	"github.com/epinio/epinio/internal/auth"
+	epiniosettings "github.com/epinio/epinio/internal/cli/settings"
 	"github.com/go-logr/logr"
 )
 
 // Client provides functionality for talking to an Epinio API
 // server
 type Client struct {
-	log      logr.Logger
-	URL      string
-	WsURL    string // only stored here for the memo, the websocket client is not part of the epinioapi, yet.
-	user     string
-	password string
+	log        logr.Logger
+	Settings   *epiniosettings.Settings
+	HttpClient *http.Client
 }
 
 // New returns a new Epinio API client
-func New(url string, wsURL string, user string, password string) *Client {
+func New(settings *epiniosettings.Settings) *Client {
 	log := tracelog.NewLogger().WithName("EpinioApiClient").V(3)
 
+	if settings.Certs != "" {
+		auth.ExtendLocalTrust(settings.Certs)
+	}
+
 	return &Client{
-		log:      log,
-		URL:      url,
-		WsURL:    wsURL,
-		user:     user,
-		password: password,
+		log:        log,
+		Settings:   settings,
+		HttpClient: http.DefaultClient,
 	}
 }

--- a/pkg/api/core/v1/client/http.go
+++ b/pkg/api/core/v1/client/http.go
@@ -51,7 +51,7 @@ func (c *Client) delete(endpoint string) ([]byte, error) {
 
 // upload the given path as param "file" in a multipart form
 func (c *Client) upload(endpoint string, path string) ([]byte, error) {
-	uri := fmt.Sprintf("%s%s/%s", c.URL, api.Root, endpoint)
+	uri := fmt.Sprintf("%s%s/%s", c.Settings.API, api.Root, endpoint)
 
 	// open the tarball
 	file, err := os.Open(path)
@@ -84,10 +84,10 @@ func (c *Client) upload(endpoint string, path string) ([]byte, error) {
 		return nil, errors.Wrap(err, "failed to build request")
 	}
 
-	request.SetBasicAuth(c.user, c.password)
+	request.SetBasicAuth(c.Settings.User, c.Settings.Password)
 	request.Header.Add("Content-Type", writer.FormDataContentType())
 
-	response, err := (&http.Client{}).Do(request)
+	response, err := c.HttpClient.Do(request)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to POST to upload")
 	}
@@ -109,7 +109,7 @@ func (c *Client) upload(endpoint string, path string) ([]byte, error) {
 }
 
 func (c *Client) do(endpoint, method, requestBody string) ([]byte, error) {
-	uri := fmt.Sprintf("%s%s/%s", c.URL, api.Root, endpoint)
+	uri := fmt.Sprintf("%s%s/%s", c.Settings.API, api.Root, endpoint)
 	c.log.Info(fmt.Sprintf("%s %s", method, uri))
 
 	reqLog := requestLogger(c.log, method, uri, requestBody)
@@ -120,9 +120,9 @@ func (c *Client) do(endpoint, method, requestBody string) ([]byte, error) {
 		return []byte{}, err
 	}
 
-	request.SetBasicAuth(c.user, c.password)
+	request.SetBasicAuth(c.Settings.User, c.Settings.Password)
 
-	response, err := (&http.Client{}).Do(request)
+	response, err := c.HttpClient.Do(request)
 	if err != nil {
 		reqLog.V(1).Error(err, "request failed")
 		castedErr, ok := err.(*url.Error)
@@ -177,7 +177,7 @@ type ErrorFunc = func(response *http.Response, bodyBytes []byte, err error) erro
 // it's data in a normal Response, instead of an error?
 func (c *Client) doWithCustomErrorHandling(endpoint, method, requestBody string, f ErrorFunc) ([]byte, error) {
 
-	uri := fmt.Sprintf("%s%s/%s", c.URL, api.Root, endpoint)
+	uri := fmt.Sprintf("%s%s/%s", c.Settings.API, api.Root, endpoint)
 	c.log.Info(fmt.Sprintf("%s %s", method, uri))
 
 	reqLog := requestLogger(c.log, method, uri, requestBody)
@@ -188,9 +188,9 @@ func (c *Client) doWithCustomErrorHandling(endpoint, method, requestBody string,
 		return []byte{}, err
 	}
 
-	request.SetBasicAuth(c.user, c.password)
+	request.SetBasicAuth(c.Settings.User, c.Settings.Password)
 
-	response, err := (&http.Client{}).Do(request)
+	response, err := c.HttpClient.Do(request)
 	if err != nil {
 		reqLog.V(1).Error(err, "request failed")
 		return []byte{}, err


### PR DESCRIPTION
This PR is a small refactor that adds the HttpClient to the Epinio ApiClient, so that can be configured once at the beginning, and it will be then used by default during the API calls.

This will be useful when moving to the oauth2 implementation (see #1650)