### PR TITLE
Support appchart customization

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -69,9 +69,12 @@ jobs:
           export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
           make install-cert-manager
           make prepare_environment_k3d
+          # Note: prepare has run build-images!
+          scripts/get-latest-epinio.sh
 
       - name: Upgrade Epinio with latest code
         run: |
+          export EPINIO_CURRENT_TAG="$(git describe --tags)"
           # We have to export the EPINIO_SYSTEM_DOMAIN
           # before executing the ginkgo test
           source scripts/helpers.sh

--- a/acceptance/api/v1/appchart_index_test.go
+++ b/acceptance/api/v1/appchart_index_test.go
@@ -30,12 +30,13 @@ var _ = Describe("ChartList Endpoint", func() {
 		err = json.Unmarshal(bodyBytes, &appcharts)
 		Expect(err).ToNot(HaveOccurred())
 
-		// Note: Due to the concurrent nature of tests we may have a varying
-		// number of custom app charts from other tests visible here. In other
-		// words, while we can reliably test for the presence of the standard
-		// chart, the number of charts to expect is not checkable.
+		// Note to maintainers: Due to the concurrent nature of tests we may have a varying
+		// number of custom app charts from other tests visible here. In other words, while
+		// we can reliably test for the presence of the standard chart, the number of charts
+		// to expect is not checkable.
 		//
-		// Expect(len(appcharts)).To(Equal(1))
+		// A check like `Expect(len(appcharts)).To(Equal(1))` will introduce flakiness and
+		// spurious failures.
 
 		var names []string
 		names = append(names, appcharts[0].Meta.Name)

--- a/acceptance/api/v1/appchart_index_test.go
+++ b/acceptance/api/v1/appchart_index_test.go
@@ -30,7 +30,12 @@ var _ = Describe("ChartList Endpoint", func() {
 		err = json.Unmarshal(bodyBytes, &appcharts)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(len(appcharts)).To(Equal(1))
+		// Note: Due to the concurrent nature of tests we may have a varying
+		// number of custom app charts from other tests visible here. In other
+		// words, while we can reliably test for the presence of the standard
+		// chart, the number of charts to expect is not checkable.
+		//
+		// Expect(len(appcharts)).To(Equal(1))
 
 		var names []string
 		names = append(names, appcharts[0].Meta.Name)

--- a/acceptance/api/v1/application_validate_cv_test.go
+++ b/acceptance/api/v1/application_validate_cv_test.go
@@ -1,0 +1,180 @@
+package v1_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/epinio/epinio/acceptance/helpers/catalog"
+	v1 "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AppValidateCV Endpoint", func() {
+	var (
+		chartName string
+		tempFile  string
+		namespace string
+		appName   string
+		request   *http.Request
+	)
+
+	ping := func(code int, body string) {
+		// request setup
+
+		uri := fmt.Sprintf("%s%s/%s", serverURL, v1.Root,
+			v1.Routes.Path("AppValidateCV", namespace, appName))
+		var err error // We want `=` below to ensure that `request` is not a local variable.
+		request, err = http.NewRequest("GET", uri, strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		request.SetBasicAuth(env.EpinioUser, env.EpinioPassword)
+
+		// fire request, get response
+
+		resp, err := env.Client().Do(request)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp).ToNot(BeNil())
+		defer resp.Body.Close()
+
+		// get response body
+
+		bodyBytes, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+
+		// check status
+
+		Expect(resp.StatusCode).To(Equal(code), string(bodyBytes))
+
+		// decode and check response
+
+		if resp.StatusCode == http.StatusOK {
+			r := &models.Response{}
+			err = json.Unmarshal(bodyBytes, &r)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(r.Status).To(Equal(body))
+			return
+		}
+
+		r := &errors.ErrorResponse{}
+		err = json.Unmarshal(bodyBytes, &r)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(r.Errors[0].Error()).To(Equal(body))
+	}
+
+	BeforeEach(func() {
+		// Appchart
+		chartName = catalog.NewTmpName("chart-")
+		tempFile = env.MakeAppchart(chartName)
+
+		// Namespace
+		namespace = catalog.NewNamespaceName()
+		env.SetupAndTargetNamespace(namespace)
+
+		// Application, references new chart
+		appName = catalog.NewAppName()
+		out, err := env.Epinio("", "app", "create", appName, "--app-chart", chartName)
+		Expect(err).ToNot(HaveOccurred(), out)
+		Expect(out).To(ContainSubstring("Ok"))
+	})
+
+	AfterEach(func() {
+		env.DeleteApp(appName)
+		env.DeleteNamespace(namespace)
+		env.DeleteAppchart(tempFile)
+	})
+
+	It("returns ok when there are no chart values to validate", func() {
+		ping(http.StatusOK, "ok")
+	})
+
+	It("returns ok for good chart values", func() {
+		out, err := env.Epinio("", "app", "update", appName,
+			"-v", "fake=true",
+			"-v", "foo=bar",
+			"-v", "bar=sna",
+			"-v", "floof=3.1415926535",
+			"-v", "fox=99",
+			"-v", "cat=0.31415926535",
+			// unknowntype, badminton, maxbad - bad spec, no good values
+		)
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		ping(http.StatusOK, "ok")
+	})
+
+	It("fails for an unknown field", func() {
+		out, err := env.Epinio("", "app", "update", appName, "-v", "bogus=x")
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		ping(http.StatusInternalServerError, `Setting "bogus": Not known`)
+	})
+
+	It("fails for an unknown field type", func() {
+		out, err := env.Epinio("", "app", "update", appName, "-v", "unknowntype=x")
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		ping(http.StatusInternalServerError, `Setting "unknowntype": Bad spec: Unknown type "foofara"`)
+	})
+
+	It("fails for an integer field with a bad minimum", func() {
+		out, err := env.Epinio("", "app", "update", appName, "-v", "badminton=0")
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		ping(http.StatusInternalServerError, `Setting "badminton": Bad spec: Bad minimum "hello"`)
+	})
+
+	It("fails for an integer field with a bad maximum", func() {
+		out, err := env.Epinio("", "app", "update", appName, "-v", "maxbad=0")
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		ping(http.StatusInternalServerError, `Setting "maxbad": Bad spec: Bad maximum "world"`)
+	})
+
+	It("fails for a value out of range (< min)", func() {
+		out, err := env.Epinio("", "app", "update", appName, "-v", "floof=-2")
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		ping(http.StatusInternalServerError, `Setting "floof": Out of bounds, "-2" to small`)
+	})
+
+	It("fails for a value out of range (> max)", func() {
+		out, err := env.Epinio("", "app", "update", appName, "-v", "fox=1000")
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		ping(http.StatusInternalServerError, `Setting "fox": Out of bounds, "1000" to large`)
+	})
+
+	It("fails for a value out of range (not in enum)", func() {
+		out, err := env.Epinio("", "app", "update", appName, "-v", "bar=fox")
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		ping(http.StatusInternalServerError, `Setting "bar": Illegal string "fox"`)
+	})
+
+	It("fails for a non-integer value where integer required", func() {
+		out, err := env.Epinio("", "app", "update", appName, "-v", "fox=hound")
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		ping(http.StatusInternalServerError, `Setting "fox": Expected integer, got "hound"`)
+	})
+
+	It("fails for a non-numeric value where numeric required", func() {
+		out, err := env.Epinio("", "app", "update", appName, "-v", "cat=dog")
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		ping(http.StatusInternalServerError, `Setting "cat": Expected number, got "dog"`)
+	})
+
+	It("fails for a non-boolean value where boolean required", func() {
+		out, err := env.Epinio("", "app", "update", appName, "-v", "fake=news")
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		ping(http.StatusInternalServerError, `Setting "fake": Expected boolean, got "news"`)
+	})
+})

--- a/acceptance/api/v1/application_validate_cv_test.go
+++ b/acceptance/api/v1/application_validate_cv_test.go
@@ -112,69 +112,69 @@ var _ = Describe("AppValidateCV Endpoint", func() {
 		out, err := env.Epinio("", "app", "update", appName, "-v", "bogus=x")
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		ping(http.StatusInternalServerError, `Setting "bogus": Not known`)
+		ping(http.StatusBadRequest, `Setting "bogus": Not known`)
 	})
 
 	It("fails for an unknown field type", func() {
 		out, err := env.Epinio("", "app", "update", appName, "-v", "unknowntype=x")
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		ping(http.StatusInternalServerError, `Setting "unknowntype": Bad spec: Unknown type "foofara"`)
+		ping(http.StatusBadRequest, `Setting "unknowntype": Bad spec: Unknown type "foofara"`)
 	})
 
 	It("fails for an integer field with a bad minimum", func() {
 		out, err := env.Epinio("", "app", "update", appName, "-v", "badminton=0")
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		ping(http.StatusInternalServerError, `Setting "badminton": Bad spec: Bad minimum "hello"`)
+		ping(http.StatusBadRequest, `Setting "badminton": Bad spec: Bad minimum "hello"`)
 	})
 
 	It("fails for an integer field with a bad maximum", func() {
 		out, err := env.Epinio("", "app", "update", appName, "-v", "maxbad=0")
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		ping(http.StatusInternalServerError, `Setting "maxbad": Bad spec: Bad maximum "world"`)
+		ping(http.StatusBadRequest, `Setting "maxbad": Bad spec: Bad maximum "world"`)
 	})
 
 	It("fails for a value out of range (< min)", func() {
 		out, err := env.Epinio("", "app", "update", appName, "-v", "floof=-2")
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		ping(http.StatusInternalServerError, `Setting "floof": Out of bounds, "-2" to small`)
+		ping(http.StatusBadRequest, `Setting "floof": Out of bounds, "-2" too small`)
 	})
 
 	It("fails for a value out of range (> max)", func() {
 		out, err := env.Epinio("", "app", "update", appName, "-v", "fox=1000")
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		ping(http.StatusInternalServerError, `Setting "fox": Out of bounds, "1000" to large`)
+		ping(http.StatusBadRequest, `Setting "fox": Out of bounds, "1000" too large`)
 	})
 
 	It("fails for a value out of range (not in enum)", func() {
 		out, err := env.Epinio("", "app", "update", appName, "-v", "bar=fox")
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		ping(http.StatusInternalServerError, `Setting "bar": Illegal string "fox"`)
+		ping(http.StatusBadRequest, `Setting "bar": Illegal string "fox"`)
 	})
 
 	It("fails for a non-integer value where integer required", func() {
 		out, err := env.Epinio("", "app", "update", appName, "-v", "fox=hound")
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		ping(http.StatusInternalServerError, `Setting "fox": Expected integer, got "hound"`)
+		ping(http.StatusBadRequest, `Setting "fox": Expected integer, got "hound"`)
 	})
 
 	It("fails for a non-numeric value where numeric required", func() {
 		out, err := env.Epinio("", "app", "update", appName, "-v", "cat=dog")
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		ping(http.StatusInternalServerError, `Setting "cat": Expected number, got "dog"`)
+		ping(http.StatusBadRequest, `Setting "cat": Expected number, got "dog"`)
 	})
 
 	It("fails for a non-boolean value where boolean required", func() {
 		out, err := env.Epinio("", "app", "update", appName, "-v", "fake=news")
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		ping(http.StatusInternalServerError, `Setting "fake": Expected boolean, got "news"`)
+		ping(http.StatusBadRequest, `Setting "fake": Expected boolean, got "news"`)
 	})
 })

--- a/acceptance/appcharts_test.go
+++ b/acceptance/appcharts_test.go
@@ -71,7 +71,7 @@ var _ = Describe("apps chart", func() {
 					WithRow("Short", ""),
 					WithRow("Description", ""),
 					WithRow("Helm Repository", ""),
-					WithRow("Helm Chart", "fox"),
+					WithRow("Helm Chart", "https://github.com/epinio/helm-charts/releases/download/epinio-application-0.1.21/epinio-application-0.1.21.tgz"),
 				),
 			)
 

--- a/acceptance/appcharts_test.go
+++ b/acceptance/appcharts_test.go
@@ -1,12 +1,8 @@
 package acceptance_test
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/epinio/epinio/acceptance/helpers/catalog"
 	. "github.com/epinio/epinio/acceptance/helpers/matchers"
-	"github.com/epinio/epinio/acceptance/helpers/proc"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -17,62 +13,10 @@ var _ = Describe("apps chart", func() {
 
 	BeforeEach(func() {
 		chartName = catalog.NewTmpName("chart-")
-		tempFile = catalog.NewTmpName("chart-") + `.yaml`
-
-		err := os.WriteFile(tempFile, []byte(fmt.Sprintf(`apiVersion: application.epinio.io/v1
-kind: AppChart
-metadata:
-  namespace: epinio
-  name: %s
-  labels:
-    app.kubernetes.io/component: epinio
-    app.kubernetes.io/instance: default
-    app.kubernetes.io/name: epinio-standard-app-chart
-    app.kubernetes.io/part-of: epinio
-spec:
-  helmChart: fox
-  settings:
-    fake:
-      type: bool
-      enum:
-        - ignored
-    foo:
-      type: string
-      minimum: ignored
-    bar:
-      type: string
-      enum:
-        - sna
-        - fu
-    floof:
-      type: number
-      minimum: '0'
-    fox:
-      type: integer
-      maximum: '100'
-    cat:
-      type: number
-      minimum: '0'
-      maximum: '1'
-    primes:
-      type: integer
-      enum:
-        - '2'
-        - '3'
-        - '5'
-        - '7'
-        - '11'
-`, chartName)), 0600)
-		Expect(err).ToNot(HaveOccurred())
-
-		out, err := proc.Kubectl("apply", "-f", tempFile)
-		Expect(err).ToNot(HaveOccurred(), out)
+		tempFile = env.MakeAppchart(chartName)
 	})
 	AfterEach(func() {
-		out, err := proc.Kubectl("delete", "-f", tempFile)
-		Expect(err).ToNot(HaveOccurred(), out)
-
-		os.Remove(tempFile)
+		env.DeleteAppchart(tempFile)
 	})
 
 	Describe("app chart list", func() {
@@ -87,7 +31,7 @@ spec:
 				HaveATable(
 					WithHeaders("DEFAULT", "NAME", "CREATED", "DESCRIPTION", "#SETTINGS"),
 					WithRow("standard", WithDate(), "Epinio standard deployment", "0"),
-					WithRow(chartName, WithDate(), "", "7"),
+					WithRow(chartName, WithDate(), "", "9"),
 				),
 			)
 		})
@@ -140,7 +84,6 @@ spec:
 					WithRow("floof", "number", "\\[0 ... \\+inf]"),
 					WithRow("foo", "string", ""),
 					WithRow("fox", "integer", "\\[-inf ... 100]"),
-					WithRow("primes", "integer", "2, 3, 5, 7, 11"),
 				),
 			)
 		})

--- a/acceptance/appcharts_test.go
+++ b/acceptance/appcharts_test.go
@@ -1,23 +1,93 @@
 package acceptance_test
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/epinio/epinio/acceptance/helpers/catalog"
 	. "github.com/epinio/epinio/acceptance/helpers/matchers"
+	"github.com/epinio/epinio/acceptance/helpers/proc"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("apps chart", func() {
+	var chartName string
+	var tempFile string
+
+	BeforeEach(func() {
+		chartName = catalog.NewTmpName("chart-")
+		tempFile = catalog.NewTmpName("chart-") + `.yaml`
+
+		err := os.WriteFile(tempFile, []byte(fmt.Sprintf(`apiVersion: application.epinio.io/v1
+kind: AppChart
+metadata:
+  namespace: epinio
+  name: %s
+  labels:
+    app.kubernetes.io/component: epinio
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/name: epinio-standard-app-chart
+    app.kubernetes.io/part-of: epinio
+spec:
+  helmChart: fox
+  settings:
+    fake:
+      type: bool
+      enum:
+        - ignored
+    foo:
+      type: string
+      minimum: ignored
+    bar:
+      type: string
+      enum:
+        - sna
+        - fu
+    floof:
+      type: number
+      minimum: '0'
+    fox:
+      type: integer
+      maximum: '100'
+    cat:
+      type: number
+      minimum: '0'
+      maximum: '1'
+    primes:
+      type: integer
+      enum:
+        - '2'
+        - '3'
+        - '5'
+        - '7'
+        - '11'
+`, chartName)), 0600)
+		Expect(err).ToNot(HaveOccurred())
+
+		out, err := proc.Kubectl("apply", "-f", tempFile)
+		Expect(err).ToNot(HaveOccurred(), out)
+	})
+	AfterEach(func() {
+		out, err := proc.Kubectl("delete", "-f", tempFile)
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		os.Remove(tempFile)
+	})
 
 	Describe("app chart list", func() {
 		It("lists the known app charts", func() {
+			// These are the standard chart and a custom one with settings for the user
+
 			out, err := env.Epinio("", "apps", "chart", "list")
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(ContainSubstring("Show Application Charts"))
 
 			Expect(out).To(
 				HaveATable(
-					WithHeaders("DEFAULT", "NAME", "CREATED", "DESCRIPTION"),
-					WithRow("standard", WithDate(), "Epinio standard deployment"),
+					WithHeaders("DEFAULT", "NAME", "CREATED", "DESCRIPTION", "#SETTINGS"),
+					WithRow("standard", WithDate(), "Epinio standard deployment", "0"),
+					WithRow(chartName, WithDate(), "", "7"),
 				),
 			)
 		})
@@ -39,6 +109,38 @@ var _ = Describe("apps chart", func() {
 					WithRow("", "for application deployment"),
 					WithRow("Helm Repository", ""),
 					WithRow("Helm Chart", "https.*epinio-application.*tgz"),
+				),
+			)
+			Expect(out).To(ContainSubstring("No settings"))
+		})
+
+		It("shows the details of the custom chart", func() {
+			out, err := env.Epinio("", "apps", "chart", "show", chartName)
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("Show application chart details"))
+
+			Expect(out).To(
+				HaveATable(
+					WithHeaders("KEY", "VALUE"),
+					WithRow("Name", chartName),
+					WithRow("Created", WithDate()),
+					WithRow("Short", ""),
+					WithRow("Description", ""),
+					WithRow("Helm Repository", ""),
+					WithRow("Helm Chart", "fox"),
+				),
+			)
+
+			Expect(out).To(
+				HaveATable(
+					WithHeaders("KEY", "TYPE", "ALLOWED VALUES"),
+					WithRow("bar", "string", "sna, fu"),
+					WithRow("cat", "number", "\\[0 ... 1]"),
+					WithRow("fake", "bool", ""),
+					WithRow("floof", "number", "\\[0 ... \\+inf]"),
+					WithRow("foo", "string", ""),
+					WithRow("fox", "integer", "\\[-inf ... 100]"),
+					WithRow("primes", "integer", "2, 3, 5, 7, 11"),
 				),
 			)
 		})

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -1297,6 +1297,48 @@ configuration:
 			)
 		})
 
+		It("shows the details of a customized app", func() {
+			out, err := env.Epinio("", "app", "update", appName,
+				"--chart-value", "foo=bar")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			out, err = env.Epinio("", "app", "show", appName)
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			By(out)
+
+			Expect(out).To(ContainSubstring("Show application details"))
+			Expect(out).To(ContainSubstring("Application: " + appName))
+
+			Expect(out).To(
+				HaveATable(
+					WithHeaders("KEY", "VALUE"),
+					WithRow("Origin", containerImageURL),
+					WithRow("Bound Configurations", configurationName),
+					WithRow("Active Routes", ""),
+					WithRow("", appName+".*"),
+				),
+			)
+
+			Expect(out).To(
+				HaveATable(
+					WithRow("Chart Values", ""),
+					WithRow("- foo", "bar"),
+				),
+			)
+
+			Eventually(func() string {
+				out, err := env.Epinio("", "app", "show", appName)
+				Expect(err).ToNot(HaveOccurred(), out)
+				return out
+			}, "1m").Should(
+				HaveATable(
+					WithHeaders("KEY", "VALUE"),
+					WithRow("Status", "1/1"),
+				),
+			)
+		})
+
 		Context("", func() {
 			var app, exportPath, exportValues, exportChart string
 

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -313,32 +313,11 @@ configuration:
 
 				BeforeEach(func() {
 					chartName = catalog.NewTmpName("chart-")
-					tempFile = catalog.NewTmpName("chart-") + `.yaml`
-
-					err := os.WriteFile(tempFile, []byte(fmt.Sprintf(`apiVersion: application.epinio.io/v1
-kind: AppChart
-metadata:
-  namespace: epinio
-  name: %s
-  labels:
-    app.kubernetes.io/component: epinio
-    app.kubernetes.io/instance: default
-    app.kubernetes.io/name: epinio-standard-app-chart
-    app.kubernetes.io/part-of: epinio
-spec:
-  helmChart: fox
-`, chartName)), 0600)
-					Expect(err).ToNot(HaveOccurred())
-
-					out, err := proc.Kubectl("apply", "-f", tempFile)
-					Expect(err).ToNot(HaveOccurred(), out)
+					tempFile = env.MakeAppchart(chartName)
 				})
 
 				AfterEach(func() {
-					out, err := proc.Kubectl("delete", "-f", tempFile)
-					Expect(err).ToNot(HaveOccurred(), out)
-
-					os.Remove(tempFile)
+					env.DeleteAppchart(tempFile)
 				})
 
 				It("fails to change the app chart of the running app", func() {
@@ -454,41 +433,13 @@ spec:
 		var tempFile string
 
 		BeforeEach(func() {
-			// Create a custom chart referencing the tarball of the `standard-stateful` chart.
-			// It exists in the set of releases for helm charts.
-			// It is not distributed with epinio however.
-			// At this point in time we use it only internally, for testing.
-
 			chartName = catalog.NewTmpName("chart-")
-			tempFile = catalog.NewTmpName("chart-") + `.yaml`
-			err := os.WriteFile(tempFile, []byte(fmt.Sprintf(`apiVersion: application.epinio.io/v1
-kind: AppChart
-metadata:
-  namespace: epinio
-  name: %s
-  labels:
-    app.kubernetes.io/component: epinio
-    app.kubernetes.io/instance: default
-    app.kubernetes.io/name: epinio-standard-stateful-app-chart
-    app.kubernetes.io/part-of: epinio
-spec:
-  shortDescription: Epinio standard stateful deployment
-  description: Epinio standard support chart for stateful application deployment
-  helmChart: https://github.com/epinio/helm-charts/releases/download/epinio-application-stateful-0.1.21/epinio-application-stateful-0.1.21.tgz
-`, chartName)), 0600)
-			Expect(err).ToNot(HaveOccurred())
-
-			out, err := proc.Kubectl("apply", "-f", tempFile)
-			Expect(err).ToNot(HaveOccurred(), out)
+			tempFile = env.MakeAppchartStateful(chartName)
 		})
 
 		AfterEach(func() {
 			env.DeleteApp(appName)
-
-			out, err := proc.Kubectl("delete", "-f", tempFile)
-			Expect(err).ToNot(HaveOccurred(), out)
-
-			os.Remove(tempFile)
+			env.DeleteAppchart(tempFile)
 		})
 
 		It("pushes successfully", func() {
@@ -1297,46 +1248,48 @@ configuration:
 			)
 		})
 
-		It("shows the details of a customized app", func() {
-			out, err := env.Epinio("", "app", "update", appName,
-				"--chart-value", "foo=bar")
-			Expect(err).ToNot(HaveOccurred(), out)
+		Context("", func() {
+			var chartName string
+			var appName string
+			var tempFile string
 
-			out, err = env.Epinio("", "app", "show", appName)
-			Expect(err).ToNot(HaveOccurred(), out)
+			BeforeEach(func() {
+				chartName = catalog.NewTmpName("chart-")
+				tempFile = env.MakeAppchart(chartName)
 
-			By(out)
-
-			Expect(out).To(ContainSubstring("Show application details"))
-			Expect(out).To(ContainSubstring("Application: " + appName))
-
-			Expect(out).To(
-				HaveATable(
-					WithHeaders("KEY", "VALUE"),
-					WithRow("Origin", containerImageURL),
-					WithRow("Bound Configurations", configurationName),
-					WithRow("Active Routes", ""),
-					WithRow("", appName+".*"),
-				),
-			)
-
-			Expect(out).To(
-				HaveATable(
-					WithRow("Chart Values", ""),
-					WithRow("- foo", "bar"),
-				),
-			)
-
-			Eventually(func() string {
-				out, err := env.Epinio("", "app", "show", appName)
+				appName = catalog.NewAppName()
+				out, err := env.Epinio("", "app", "create", appName,
+					"--app-chart", chartName)
 				Expect(err).ToNot(HaveOccurred(), out)
-				return out
-			}, "1m").Should(
-				HaveATable(
-					WithHeaders("KEY", "VALUE"),
-					WithRow("Status", "1/1"),
-				),
-			)
+				Expect(out).To(ContainSubstring("Ok"))
+			})
+
+			AfterEach(func() {
+				env.DeleteApp(appName)
+				env.DeleteAppchart(tempFile)
+			})
+
+			It("shows the details of a customized app", func() {
+				out, err := env.Epinio("", "app", "update", appName,
+					"--chart-value", "foo=bar")
+				Expect(err).ToNot(HaveOccurred(), out)
+
+				out, err = env.Epinio("", "app", "show", appName)
+				Expect(err).ToNot(HaveOccurred(), out)
+
+				Expect(out).To(ContainSubstring("Show application details"))
+				Expect(out).To(ContainSubstring("Application: " + appName))
+
+				Expect(out).To(
+					HaveATable(
+						WithHeaders("KEY", "VALUE"),
+						WithRow("Origin", "<<undefined>>"),
+						WithRow("App Chart", chartName),
+						WithRow("Chart Values", ""),
+						WithRow("- foo", "bar"),
+					),
+				)
+			})
 		})
 
 		Context("", func() {

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -1249,7 +1249,7 @@ configuration:
 			)
 		})
 
-		Context("", func() {
+		Context("details customized", func() {
 			var chartName string
 			var appName string
 			var tempFile string
@@ -1292,7 +1292,7 @@ configuration:
 				)
 			})
 
-			Context("", func() {
+			Context("exporting customized", func() {
 				var chartName, tempFile, app, exportPath, exportValues, exportChart string
 
 				BeforeEach(func() {
@@ -1359,7 +1359,7 @@ userConfig:
 			})
 		})
 
-		Context("", func() {
+		Context("exporting", func() {
 			var app, exportPath, exportValues, exportChart string
 
 			BeforeEach(func() {

--- a/acceptance/helpers/machine/appcharts.go
+++ b/acceptance/helpers/machine/appcharts.go
@@ -1,0 +1,99 @@
+package machine
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/epinio/epinio/acceptance/helpers/proc"
+	. "github.com/onsi/gomega"
+)
+
+func (m *Machine) MakeAppchartStateful(chartName string) string {
+	// Create a custom chart referencing the tarball of the `standard-stateful` chart.
+	// It exists in the set of releases for helm charts.
+	// It is not distributed with epinio however.
+	// At this point in time we use it only internally, for testing.
+
+	tempFile := chartName + `.yaml`
+	err := os.WriteFile(tempFile, []byte(fmt.Sprintf(`apiVersion: application.epinio.io/v1
+kind: AppChart
+metadata:
+  namespace: epinio
+  name: %s
+  labels:
+    app.kubernetes.io/component: epinio
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/name: epinio-standard-stateful-app-chart
+    app.kubernetes.io/part-of: epinio
+spec:
+  shortDescription: Epinio standard stateful deployment
+  description: Epinio standard support chart for stateful application deployment
+  helmChart: https://github.com/epinio/helm-charts/releases/download/epinio-application-stateful-0.1.21/epinio-application-stateful-0.1.21.tgz
+`, chartName)), 0600)
+	Expect(err).ToNot(HaveOccurred())
+
+	out, err := proc.Kubectl("apply", "-f", tempFile)
+	Expect(err).ToNot(HaveOccurred(), out)
+
+	return tempFile
+}
+
+func (m *Machine) MakeAppchart(chartName string) string {
+	tempFile := chartName + `.yaml`
+	err := os.WriteFile(tempFile, []byte(fmt.Sprintf(`apiVersion: application.epinio.io/v1
+kind: AppChart
+metadata:
+  namespace: epinio
+  name: %s
+  labels:
+    app.kubernetes.io/component: epinio
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/name: epinio-standard-app-chart
+    app.kubernetes.io/part-of: epinio
+spec:
+  helmChart: fox
+  settings:
+    unknowntype:
+      type: foofara
+    badminton:
+      type: integer
+      minimum: hello
+    maxbad:
+      type: integer
+      maximum: world
+    fake:
+      type: bool
+      enum:
+        - ignored
+    foo:
+      type: string
+      minimum: ignored
+    bar:
+      type: string
+      enum:
+        - sna
+        - fu
+    floof:
+      type: number
+      minimum: '0'
+    fox:
+      type: integer
+      maximum: '100'
+    cat:
+      type: number
+      minimum: '0'
+      maximum: '1'
+`, chartName)), 0600)
+	Expect(err).ToNot(HaveOccurred())
+
+	out, err := proc.Kubectl("apply", "-f", tempFile)
+	Expect(err).ToNot(HaveOccurred(), out)
+
+	return tempFile
+}
+
+func (m *Machine) DeleteAppchart(tempFile string) {
+	out, err := proc.Kubectl("delete", "-f", tempFile)
+	Expect(err).ToNot(HaveOccurred(), out)
+	os.Remove(tempFile)
+}

--- a/acceptance/helpers/machine/appcharts.go
+++ b/acceptance/helpers/machine/appcharts.go
@@ -51,7 +51,9 @@ metadata:
     app.kubernetes.io/name: epinio-standard-app-chart
     app.kubernetes.io/part-of: epinio
 spec:
-  helmChart: fox
+  helmChart: https://github.com/epinio/helm-charts/releases/download/epinio-application-0.1.21/epinio-application-0.1.21.tgz
+  values:
+    tuning: speed
   settings:
     unknowntype:
       type: foofara

--- a/acceptance/helpers/machine/appcharts.go
+++ b/acceptance/helpers/machine/appcharts.go
@@ -66,10 +66,10 @@ spec:
     fake:
       type: bool
       enum:
-        - ignored
+        - "not sensible for type, ignored by validation"
     foo:
       type: string
-      minimum: ignored
+      minimum: "not sensible for type, ignored by validation"
     bar:
       type: string
       enum:

--- a/acceptance/helpers/machine/apps.go
+++ b/acceptance/helpers/machine/apps.go
@@ -33,12 +33,14 @@ func (m *Machine) MakeContainerImageApp(appName string, instances int, container
 	return pushOutput
 }
 
-func (m *Machine) MakeRoutedContainerImageApp(appName string, instances int, containerImageURL, route string) string {
-	pushOutput, err := m.Epinio("", "apps", "push",
+func (m *Machine) MakeRoutedContainerImageApp(appName string, instances int, containerImageURL, route string, more ...string) string {
+	pushOutput, err := m.Epinio("", "apps", append([]string{
+		"push",
 		"--name", appName,
 		"--route", route,
 		"--container-image-url", containerImageURL,
-		"--instances", strconv.Itoa(instances))
+		"--instances", strconv.Itoa(instances),
+	}, more...)...)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), pushOutput)
 
 	EventuallyWithOffset(1, func() string {

--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -1094,6 +1094,34 @@
         }
       }
     },
+    "/namespaces/{Namespace}/applications/{App}/validate-cv": {
+      "post": {
+        "description": "Validate the chart values configured for the named `App` in the given `Namespace` against the\nconfigured app chart.",
+        "tags": [
+          "application"
+        ],
+        "operationId": "AppValidateCV",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "Namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "App",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/AppValidateCVResponse"
+          }
+        }
+      }
+    },
     "/namespaces/{Namespace}/configurationapps": {
       "get": {
         "tags": [
@@ -1602,8 +1630,9 @@
       "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
     },
     "AppChart": {
-      "description": "AppChart matches github.com/epinio/application/api/v1 AppChartSpec\nReason for existence: Do not expose the internal CRD struct in the API.",
+      "description": "Differences:\nField `Values` is not made public here. It contains server-internal information the\nuser has no need for.",
       "type": "object",
+      "title": "AppChart nearly matches github.com/epinio/application/api/v1 AppChartSpec\nReason for existence: Do not expose the internal CRD struct in the API.",
       "properties": {
         "description": {
           "type": "string",
@@ -1620,6 +1649,13 @@
         "meta": {
           "$ref": "#/definitions/MetaLite"
         },
+        "settings": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AppChartSetting"
+          },
+          "x-go-name": "Settings"
+        },
         "short_description": {
           "type": "string",
           "x-go-name": "ShortDescription"
@@ -1632,6 +1668,36 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/AppChart"
+      },
+      "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
+    },
+    "AppChartSetting": {
+      "description": "AppChartSetting matches github.com/epinio/application/api/v1 AppChartSettings\nReason for existence: Do not expose the internal CRD struct in the API.",
+      "type": "object",
+      "properties": {
+        "enum": {
+          "description": "Enumeration of allowed values, for types string, number, integer",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Enum"
+        },
+        "maximum": {
+          "description": "Maximal allowed value, for number, integer",
+          "type": "string",
+          "x-go-name": "Maximum"
+        },
+        "minimum": {
+          "description": "Minimal allowed value, for number, integer",
+          "type": "string",
+          "x-go-name": "Minimum"
+        },
+        "type": {
+          "description": "Type of the setting (string, bool, number, or integer)",
+          "type": "string",
+          "x-go-name": "Type"
+        }
       },
       "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
     },
@@ -1731,6 +1797,14 @@
       },
       "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
     },
+    "AppSettings": {
+      "description": "AppSettings is a collection of key/value pairs describing the user's chosen settings with which\nto configure the helm chart referenced by the application's appchart.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
+    },
     "ApplicationCreateRequest": {
       "description": "ApplicationCreateRequest represents and contains the data needed to\ncreate an application (at rest), possibly with presets (configurations)",
       "type": "object",
@@ -1815,6 +1889,9 @@
             "type": "string"
           },
           "x-go-name": "Routes"
+        },
+        "settings": {
+          "$ref": "#/definitions/AppSettings"
         }
       },
       "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
@@ -1886,6 +1963,13 @@
         },
         "meta": {
           "$ref": "#/definitions/MetaLite"
+        },
+        "secretTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "SecretTypes"
         },
         "serviceIcon": {
           "type": "string",
@@ -2365,6 +2449,13 @@
         "meta": {
           "$ref": "#/definitions/Meta"
         },
+        "secretTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "SecretTypes"
+        },
         "status": {
           "$ref": "#/definitions/ServiceStatus"
         }
@@ -2607,6 +2698,12 @@
       "description": "",
       "schema": {
         "$ref": "#/definitions/UploadResponse"
+      }
+    },
+    "AppValidateCVResponse": {
+      "description": "",
+      "schema": {
+        "$ref": "#/definitions/Response"
       }
     },
     "AppsResponse": {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/alron/ginlogr v0.0.4
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/briandowns/spinner v1.18.1
-	github.com/epinio/application v0.0.0-20220531082924-9d01149e6946
+	github.com/epinio/application v0.0.0-20220818130656-68d19f063ac1
 	github.com/fatih/color v1.13.0
 	github.com/gin-gonic/gin v1.8.0
 	github.com/go-git/go-git/v5 v5.4.2

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/epinio/application v0.0.0-20220531082924-9d01149e6946 h1:squDrZJMHTDjpyjeyZ9WUvZo8Mbm7PAyk0DGysjg3cQ=
-github.com/epinio/application v0.0.0-20220531082924-9d01149e6946/go.mod h1:TsOLExnVfT4RDqLnOv6UHQ6ri26dDNG8RkQTyVqCU14=
+github.com/epinio/application v0.0.0-20220818130656-68d19f063ac1 h1:plGZHhqEcvdgFFY1n40/YzYBoYc3JDoRyKRFzWETOkE=
+github.com/epinio/application v0.0.0-20220818130656-68d19f063ac1/go.mod h1:TsOLExnVfT4RDqLnOv6UHQ6ri26dDNG8RkQTyVqCU14=
 github.com/evanphx/json-patch v0.0.0-20200808040245-162e5629780b/go.mod h1:NAJj0yf/KaRKURN6nyi7A9IZydMivZEm9oQLWNjfKDc=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/internal/api/v1/appchart/show.go
+++ b/internal/api/v1/appchart/show.go
@@ -28,6 +28,8 @@ func (hc Controller) Show(c *gin.Context) apierror.APIErrors {
 		return apierror.AppChartIsNotKnown(chartName)
 	}
 
-	response.OKReturn(c, app)
+	// Note: Returning only the public parts. The local config
+	// data is not handed to the user. Only the setting specs.
+	response.OKReturn(c, app.AppChart)
 	return nil
 }

--- a/internal/api/v1/application/create.go
+++ b/internal/api/v1/application/create.go
@@ -108,7 +108,8 @@ func (hc Controller) Create(c *gin.Context) apierror.APIErrors {
 
 	// Arguments found OK, now we can modify the system state
 
-	err = application.Create(ctx, cluster, appRef, username, routes, chart)
+	err = application.Create(ctx, cluster, appRef, username, routes, chart,
+		createRequest.Configuration.Settings)
 	if err != nil {
 		return apierror.InternalError(err)
 	}

--- a/internal/api/v1/application/part.go
+++ b/internal/api/v1/application/part.go
@@ -151,7 +151,7 @@ func fetchAppValues(c *gin.Context, logger logr.Logger, cluster *kubernetes.Clus
 // The advantage of this hack: We get a fetchable url we can feed into the
 // part invoked when the chart was specified as direct url. No going
 // through a temp file.
-func chartArchiveURL(c *models.AppChart, restConfig *restclient.Config, logger logr.Logger) (string, error) {
+func chartArchiveURL(c *models.AppChartFull, restConfig *restclient.Config, logger logr.Logger) (string, error) {
 	if c.HelmRepo == "" {
 		return c.HelmChart, nil
 	}

--- a/internal/api/v1/application/update.go
+++ b/internal/api/v1/application/update.go
@@ -1,4 +1,3 @@
-// -*- fill-column: 100 -*-
 package application
 
 import (

--- a/internal/api/v1/application/validatecv.go
+++ b/internal/api/v1/application/validatecv.go
@@ -59,7 +59,7 @@ func (hc Controller) ValidateChartValues(c *gin.Context) apierror.APIErrors {
 
 		var apiIssues []apierror.APIError
 		for _, err := range issues {
-			apiIssues = append(apiIssues, apierror.InternalError(err))
+			apiIssues = append(apiIssues, apierror.NewBadRequestError(err.Error()))
 		}
 
 		return apierror.NewMultiError(apiIssues)

--- a/internal/api/v1/application/validatecv.go
+++ b/internal/api/v1/application/validatecv.go
@@ -1,0 +1,72 @@
+// -*- fill-column: 100 -*-
+package application
+
+// Validate the custom chart values saved in the application CR against the declarations made by the
+// app chart referenced by the application CR.
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/appchart"
+	"github.com/epinio/epinio/internal/application"
+	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+)
+
+// ValidateChartValues handles the API endpoint /namespaces/:namespace/applications/:app/validate-cv
+// Given application by name, and namespace the custom chart values are checked against the
+// declarations in the referenced appchart.
+func (hc Controller) ValidateChartValues(c *gin.Context) apierror.APIErrors {
+	ctx := c.Request.Context()
+
+	namespace := c.Param("namespace")
+	appName := c.Param("app")
+
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	appRef := models.NewAppRef(appName, namespace)
+	exists, err := application.Exists(ctx, cluster, appRef)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	if !exists {
+		return apierror.AppIsNotKnown(appName)
+	}
+
+	app, err := application.Lookup(ctx, cluster, namespace, appName)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	appChart, err := appchart.Lookup(ctx, cluster, app.Configuration.AppChart)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	if appChart == nil {
+		return apierror.AppChartIsNotKnown(app.Configuration.AppChart)
+	}
+
+	issues := application.ValidateCV(app.Configuration.Settings, appChart.Settings)
+	if issues != nil {
+		// Treating all validation failures as internal errors.
+		// I can't find something better at the moment.
+
+		var apiIssues []apierror.APIError
+		for _, err := range issues {
+			apiIssues = append(apiIssues, apierror.InternalError(err))
+		}
+
+		return apierror.NewMultiError(apiIssues)
+	}
+
+	// Return the id of the new blob
+	response.OK(c)
+	return nil
+}

--- a/internal/api/v1/application/validatecv.go
+++ b/internal/api/v1/application/validatecv.go
@@ -1,4 +1,3 @@
-// -*- fill-column: 100 -*-
 package application
 
 // Validate the custom chart values saved in the application CR against the declarations made by the

--- a/internal/api/v1/deploy/deploy.go
+++ b/internal/api/v1/deploy/deploy.go
@@ -65,6 +65,7 @@ func DeployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppR
 		Routes:         routes,
 		Domains:        domains,
 		Start:          start,
+		Settings:       appObj.Configuration.Settings,
 	}
 
 	log.Info("deploying app", "namespace", app.Namespace, "app", app.Name)

--- a/internal/api/v1/docs/application.go
+++ b/internal/api/v1/docs/application.go
@@ -355,3 +355,23 @@ type AppRunningResponse struct {
 	// in: body
 	Body models.Response
 }
+
+// swagger:route POST /namespaces/{Namespace}/applications/{App}/validate-cv application AppValidateCV
+// Validate the chart values configured for the named `App` in the given `Namespace` against the
+// configured app chart.
+// responses:
+//   200: AppValidateCVResponse
+
+// swagger:parameters AppValidateCV
+type AppValidateCVParam struct {
+	// in: path
+	Namespace string
+	// in: path
+	App string
+}
+
+// swagger:response AppValidateCVResponse
+type AppValidateCVResponse struct {
+	// in: body
+	Body models.Response
+}

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -84,14 +84,15 @@ var Routes = routes.NamedRoutes{
 	"AppShow":         get("/namespaces/:namespace/applications/:app", errorHandler(application.Controller{}.Show)),
 	"StagingComplete": get("/namespaces/:namespace/staging/:stage_id/complete", errorHandler(application.Controller{}.Staged)), // See stage.go
 	"AppDelete":       delete("/namespaces/:namespace/applications/:app", errorHandler(application.Controller{}.Delete)),
-	"AppUpload":       post("/namespaces/:namespace/applications/:app/store", errorHandler(application.Controller{}.Upload)), // See upload.go
-	"AppImportGit":    post("/namespaces/:namespace/applications/:app/import-git", errorHandler(application.Controller{}.ImportGit)),
-	"AppStage":        post("/namespaces/:namespace/applications/:app/stage", errorHandler(application.Controller{}.Stage)), // See stage.go
 	"AppDeploy":       post("/namespaces/:namespace/applications/:app/deploy", errorHandler(application.Controller{}.Deploy)),
-	"AppRestart":      post("/namespaces/:namespace/applications/:app/restart", errorHandler(application.Controller{}.Restart)),
-	"AppUpdate":       patch("/namespaces/:namespace/applications/:app", errorHandler(application.Controller{}.Update)),
-	"AppRunning":      get("/namespaces/:namespace/applications/:app/running", errorHandler(application.Controller{}.Running)),
+	"AppImportGit":    post("/namespaces/:namespace/applications/:app/import-git", errorHandler(application.Controller{}.ImportGit)),
 	"AppPart":         get("/namespaces/:namespace/applications/:app/part/:part", errorHandler(application.Controller{}.GetPart)),
+	"AppRestart":      post("/namespaces/:namespace/applications/:app/restart", errorHandler(application.Controller{}.Restart)),
+	"AppRunning":      get("/namespaces/:namespace/applications/:app/running", errorHandler(application.Controller{}.Running)),
+	"AppStage":        post("/namespaces/:namespace/applications/:app/stage", errorHandler(application.Controller{}.Stage)), // See stage.go
+	"AppUpdate":       patch("/namespaces/:namespace/applications/:app", errorHandler(application.Controller{}.Update)),
+	"AppUpload":       post("/namespaces/:namespace/applications/:app/store", errorHandler(application.Controller{}.Upload)), // See upload.go
+	"AppValidateCV":   get("/namespaces/:namespace/applications/:app/validate-cv", errorHandler(application.Controller{}.ValidateChartValues)),
 
 	"AppMatch":  get("/namespaces/:namespace/appsmatches/:pattern", errorHandler(application.Controller{}.Match)),
 	"AppMatch0": get("/namespaces/:namespace/appsmatches", errorHandler(application.Controller{}.Match)),

--- a/internal/appchart/appchart.go
+++ b/internal/appchart/appchart.go
@@ -104,6 +104,38 @@ func toChart(chart *unstructured.Unstructured) (*models.AppChart, error) {
 		return nil, errors.New("helm repo should be string")
 	}
 
+	theSettings, _, err := unstructured.NestedMap(chart.UnstructuredContent(), "spec", "settings")
+	if err != nil {
+		return nil, errors.New("helm repo should be string")
+	}
+
+	settings := make(map[string]models.AppChartSetting)
+	for key := range theSettings {
+		fieldType, _, err := unstructured.NestedString(theSettings, key, "type")
+		if err != nil {
+			return nil, errors.New("settings type should be string")
+		}
+		fieldMin, _, err := unstructured.NestedString(theSettings, key, "minimum")
+		if err != nil {
+			return nil, errors.New("settings minimum should be string")
+		}
+		fieldMax, _, err := unstructured.NestedString(theSettings, key, "maximum")
+		if err != nil {
+			return nil, errors.New("settings maximum should be string")
+		}
+		fieldEnum, _, err := unstructured.NestedStringSlice(theSettings, key, "enum")
+		if err != nil {
+			return nil, errors.New("settings enum should be string slice")
+		}
+
+		settings[key] = models.AppChartSetting{
+			Type:    fieldType,
+			Minimum: fieldMin,
+			Maximum: fieldMax,
+			Enum:    fieldEnum,
+		}
+	}
+
 	createdAt := chart.GetCreationTimestamp()
 
 	return &models.AppChart{
@@ -115,5 +147,6 @@ func toChart(chart *unstructured.Unstructured) (*models.AppChart, error) {
 		ShortDescription: short,
 		HelmChart:        helmChart,
 		HelmRepo:         helmRepo,
+		Settings:         settings,
 	}, nil
 }

--- a/internal/appchart/appchart.go
+++ b/internal/appchart/appchart.go
@@ -33,7 +33,7 @@ func List(ctx context.Context, cluster *kubernetes.Cluster) (models.AppChartList
 		if err != nil {
 			return nil, err
 		}
-		apps = append(apps, *appChart)
+		apps = append(apps, appChart.AppChart)
 	}
 
 	return apps, nil
@@ -52,7 +52,7 @@ func Exists(ctx context.Context, cluster *kubernetes.Cluster, name string) (bool
 }
 
 // Lookup returns the named app chart, or nil
-func Lookup(ctx context.Context, cluster *kubernetes.Cluster, name string) (*models.AppChart, error) {
+func Lookup(ctx context.Context, cluster *kubernetes.Cluster, name string) (*models.AppChartFull, error) {
 	chartCR, err := Get(ctx, cluster, name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -77,7 +77,7 @@ func Get(ctx context.Context, cluster *kubernetes.Cluster, name string) (*unstru
 }
 
 // toChart converts the unstructured app chart CR into the proper model
-func toChart(chart *unstructured.Unstructured) (*models.AppChart, error) {
+func toChart(chart *unstructured.Unstructured) (*models.AppChartFull, error) {
 
 	name, _, err := unstructured.NestedString(chart.UnstructuredContent(), "metadata", "name")
 	if err != nil {
@@ -104,9 +104,14 @@ func toChart(chart *unstructured.Unstructured) (*models.AppChart, error) {
 		return nil, errors.New("helm repo should be string")
 	}
 
+	theValues, _, err := unstructured.NestedStringMap(chart.UnstructuredContent(), "spec", "values")
+	if err != nil {
+		return nil, errors.New("spec values should be string")
+	}
+
 	theSettings, _, err := unstructured.NestedMap(chart.UnstructuredContent(), "spec", "settings")
 	if err != nil {
-		return nil, errors.New("helm repo should be string")
+		return nil, errors.New("spec settings should be string")
 	}
 
 	settings := make(map[string]models.AppChartSetting)
@@ -138,15 +143,18 @@ func toChart(chart *unstructured.Unstructured) (*models.AppChart, error) {
 
 	createdAt := chart.GetCreationTimestamp()
 
-	return &models.AppChart{
-		Meta: models.MetaLite{
-			Name:      name,
-			CreatedAt: createdAt,
+	return &models.AppChartFull{
+		AppChart: models.AppChart{
+			Meta: models.MetaLite{
+				Name:      name,
+				CreatedAt: createdAt,
+			},
+			Description:      description,
+			ShortDescription: short,
+			HelmChart:        helmChart,
+			HelmRepo:         helmRepo,
+			Settings:         settings,
 		},
-		Description:      description,
-		ShortDescription: short,
-		HelmChart:        helmChart,
-		HelmRepo:         helmRepo,
-		Settings:         settings,
+		Values: theValues,
 	}, nil
 }

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -35,6 +36,84 @@ import (
 )
 
 const EpinioApplicationAreaLabel = "epinio.io/area"
+
+// ValidateCV checks the custom values against the declarations. It reports as many issues as it can find.
+func ValidateCV(cv models.AppSettings, decl map[string]models.AppChartSetting) []error {
+	var issues []error
+
+	for key, value := range cv {
+		spec, found := decl[key]
+		if !found {
+			issues = append(issues, fmt.Errorf(`Setting "%s": Not known`, key))
+			continue
+		}
+
+		err := validateField(key, value, spec)
+		if err != nil {
+			issues = append(issues, err)
+		}
+	}
+	return issues
+}
+
+// validateField checks a single custom value against its declaration.
+func validateField(key, value string, spec models.AppChartSetting) error {
+	if spec.Type == "string" {
+		if len(spec.Enum) > 0 {
+			for _, allowed := range spec.Enum {
+				if value == allowed {
+					return nil
+				}
+			}
+			return fmt.Errorf(`Setting "%s": Illegal string "%s"`, key, value)
+		}
+		return nil
+	}
+	if spec.Type == "bool" {
+		_, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf(`Setting "%s": %s`, key, err.Error())
+		}
+	}
+	if spec.Type == "integer" {
+		ivalue, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return fmt.Errorf(`Setting "%s": %s`, key, err.Error())
+		}
+		return validateRange(float64(ivalue), key, value, spec.Minimum, spec.Maximum)
+	}
+	if spec.Type == "number" {
+		fvalue, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return fmt.Errorf(`Setting "%s": %s`, key, err.Error())
+		}
+		return validateRange(fvalue, key, value, spec.Minimum, spec.Maximum)
+	}
+
+	return fmt.Errorf(`Setting "%s": Bad spec: Unknown type "%s"`, key, spec.Type)
+}
+
+func validateRange(v float64, key, value, min, max string) error {
+	if min != "" {
+		minval, err := strconv.ParseFloat(min, 64)
+		if err != nil {
+			return fmt.Errorf(`Setting "%s": Bad Spec: Bad minimum: "%s"`, key, min)
+		}
+		if v < minval {
+			return fmt.Errorf(`Setting "%s": Out of bounds, "%s" to small`, key, value)
+		}
+	}
+	if max != "" {
+		maxval, err := strconv.ParseFloat(max, 64)
+		if err != nil {
+			return fmt.Errorf(`Setting "%s": Bad Spec: Bad maximum "%s"`, key, max)
+		}
+		if v > maxval {
+			return fmt.Errorf(`Setting "%s": Out of bounds, "%s" to large`, key, value)
+		}
+	}
+	return nil
+}
 
 // Create generates a new kube app resource in the namespace of the
 // namespace. Note that this is the passive resource holding the

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -1,4 +1,3 @@
-// -*- fill-column: 100 -*-
 // Package application collects the structures and functions that deal
 // with application workloads on k8s
 package application

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -34,6 +34,8 @@ func init() {
 	envOption(CmdAppUpdate)
 	instancesOption(CmdAppCreate)
 	instancesOption(CmdAppUpdate)
+	chartValueOption(CmdAppCreate)
+	chartValueOption(CmdAppUpdate)
 
 	CmdAppCreate.Flags().String("app-chart", "", "App chart to use for deployment")
 	CmdAppUpdate.Flags().String("app-chart", "", "App chart to use for deployment")

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -66,3 +66,8 @@ func bindOption(cmd *cobra.Command) {
 func envOption(cmd *cobra.Command) {
 	cmd.Flags().StringSliceP("env", "e", []string{}, "environment variables to be used")
 }
+
+// chartValueOption initializes the --chartValue/-c option for the provided command
+func chartValueOption(cmd *cobra.Command) {
+	cmd.Flags().StringSliceP("chart-value", "v", []string{}, "chart customization to be used")
+}

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -25,6 +25,7 @@ func init() {
 	routeOption(CmdAppPush)
 	bindOption(CmdAppPush)
 	envOption(CmdAppPush)
+	chartValueOption(CmdAppPush)
 	instancesOption(CmdAppPush)
 }
 

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -541,6 +541,14 @@ func (c *EpinioClient) printAppDetails(app models.App) error {
 		}
 	}
 
+	msg = msg.WithTableRow("Chart Values", "")
+
+	if len(app.Configuration.Settings) > 0 {
+		for _, cv := range app.Configuration.Settings.List() {
+			msg = msg.WithTableRow("  - "+cv.Name, cv.Value)
+		}
+	}
+
 	msg.Msg("Details:")
 
 	return nil

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -48,6 +48,7 @@ type APIClient interface {
 	AppRestart(namespace string, appName string) error
 	AppGetPart(namespace, appName, part, destinationPath string) error
 	AppMatch(namespace, prefix string) (models.AppMatchResponse, error)
+	AppValidateCV(namespace string, name string) (models.Response, error)
 
 	// env
 	EnvList(namespace string, appName string) (models.EnvVariableMap, error)

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -129,6 +129,12 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 		}
 	}
 
+	// check customization
+	_, err = c.API.AppValidateCV(appRef.Namespace, appRef.Name)
+	if err != nil {
+		return err
+	}
+
 	// AppUpload / AppImportGit
 	var blobUID string
 	switch params.Origin.Kind {

--- a/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
+++ b/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
@@ -257,6 +257,20 @@ type FakeAPIClient struct {
 		result1 models.UploadResponse
 		result2 error
 	}
+	AppValidateCVStub        func(string, string) (models.Response, error)
+	appValidateCVMutex       sync.RWMutex
+	appValidateCVArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	appValidateCVReturns struct {
+		result1 models.Response
+		result2 error
+	}
+	appValidateCVReturnsOnCall map[int]struct {
+		result1 models.Response
+		result2 error
+	}
 	AppsStub        func(string) (models.AppList, error)
 	appsMutex       sync.RWMutex
 	appsArgsForCall []struct {
@@ -1882,6 +1896,71 @@ func (fake *FakeAPIClient) AppUploadReturnsOnCall(i int, result1 models.UploadRe
 	}
 	fake.appUploadReturnsOnCall[i] = struct {
 		result1 models.UploadResponse
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeAPIClient) AppValidateCV(arg1 string, arg2 string) (models.Response, error) {
+	fake.appValidateCVMutex.Lock()
+	ret, specificReturn := fake.appValidateCVReturnsOnCall[len(fake.appValidateCVArgsForCall)]
+	fake.appValidateCVArgsForCall = append(fake.appValidateCVArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.AppValidateCVStub
+	fakeReturns := fake.appValidateCVReturns
+	fake.recordInvocation("AppValidateCV", []interface{}{arg1, arg2})
+	fake.appValidateCVMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeAPIClient) AppValidateCVCallCount() int {
+	fake.appValidateCVMutex.RLock()
+	defer fake.appValidateCVMutex.RUnlock()
+	return len(fake.appValidateCVArgsForCall)
+}
+
+func (fake *FakeAPIClient) AppValidateCVCalls(stub func(string, string) (models.Response, error)) {
+	fake.appValidateCVMutex.Lock()
+	defer fake.appValidateCVMutex.Unlock()
+	fake.AppValidateCVStub = stub
+}
+
+func (fake *FakeAPIClient) AppValidateCVArgsForCall(i int) (string, string) {
+	fake.appValidateCVMutex.RLock()
+	defer fake.appValidateCVMutex.RUnlock()
+	argsForCall := fake.appValidateCVArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeAPIClient) AppValidateCVReturns(result1 models.Response, result2 error) {
+	fake.appValidateCVMutex.Lock()
+	defer fake.appValidateCVMutex.Unlock()
+	fake.AppValidateCVStub = nil
+	fake.appValidateCVReturns = struct {
+		result1 models.Response
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeAPIClient) AppValidateCVReturnsOnCall(i int, result1 models.Response, result2 error) {
+	fake.appValidateCVMutex.Lock()
+	defer fake.appValidateCVMutex.Unlock()
+	fake.AppValidateCVStub = nil
+	if fake.appValidateCVReturnsOnCall == nil {
+		fake.appValidateCVReturnsOnCall = make(map[int]struct {
+			result1 models.Response
+			result2 error
+		})
+	}
+	fake.appValidateCVReturnsOnCall[i] = struct {
+		result1 models.Response
 		result2 error
 	}{result1, result2}
 }
@@ -4212,6 +4291,8 @@ func (fake *FakeAPIClient) Invocations() map[string][][]interface{} {
 	defer fake.appUpdateMutex.RUnlock()
 	fake.appUploadMutex.RLock()
 	defer fake.appUploadMutex.RUnlock()
+	fake.appValidateCVMutex.RLock()
+	defer fake.appValidateCVMutex.RUnlock()
 	fake.appsMutex.RLock()
 	defer fake.appsMutex.RUnlock()
 	fake.authTokenMutex.RLock()

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -1,5 +1,3 @@
-// -*- fill-column: 90 -*-
-
 // Package helm contains the epinio-specific core to the helm client libraries. It exposes
 // the functionality to deploy and remove helm charts/releases.
 package helm

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -369,7 +369,7 @@ func validateRange(v float64, key, value, min, max string) error {
 			return fmt.Errorf(`Setting "%s": Bad spec: Bad minimum "%s"`, key, min)
 		}
 		if v < minval {
-			return fmt.Errorf(`Setting "%s": Out of bounds, "%s" to small`, key, value)
+			return fmt.Errorf(`Setting "%s": Out of bounds, "%s" too small`, key, value)
 		}
 	}
 	if max != "" {
@@ -378,7 +378,7 @@ func validateRange(v float64, key, value, min, max string) error {
 			return fmt.Errorf(`Setting "%s": Bad spec: Bad maximum "%s"`, key, max)
 		}
 		if v > maxval {
-			return fmt.Errorf(`Setting "%s": Out of bounds, "%s" to large`, key, value)
+			return fmt.Errorf(`Setting "%s": Out of bounds, "%s" too large`, key, value)
 		}
 	}
 	return nil

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -111,8 +111,8 @@ func Deploy(logger logr.Logger, parameters ChartParameters) error {
 	}
 	type chartParam struct {
 		Epinio epinioParam            `yaml:"epinio"`
-		Chart  map[string]string      `yaml:"chartConfig"`
-		User   map[string]interface{} `yaml:"userConfig"`
+		Chart  map[string]string      `yaml:"chartConfig,omitempty"`
+		User   map[string]interface{} `yaml:"userConfig,omitempty"`
 	}
 
 	// Fill values.yaml structure
@@ -337,21 +337,21 @@ func ValidateField(key, value string, spec models.AppChartSetting) (interface{},
 	if spec.Type == "bool" {
 		flag, err := strconv.ParseBool(value)
 		if err != nil {
-			return nil, fmt.Errorf(`Setting "%s": %s`, key, err.Error())
+			return nil, fmt.Errorf(`Setting "%s": Expected boolean, got "%s"`, key, value)
 		}
 		return flag, nil
 	}
 	if spec.Type == "integer" {
 		ivalue, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf(`Setting "%s": %s`, key, err.Error())
+			return nil, fmt.Errorf(`Setting "%s": Expected integer, got "%s"`, key, value)
 		}
 		return ivalue, validateRange(float64(ivalue), key, value, spec.Minimum, spec.Maximum)
 	}
 	if spec.Type == "number" {
 		fvalue, err := strconv.ParseFloat(value, 64)
 		if err != nil {
-			return nil, fmt.Errorf(`Setting "%s": %s`, key, err.Error())
+			return nil, fmt.Errorf(`Setting "%s": Expected number, got "%s"`, key, value)
 		}
 		return fvalue, validateRange(fvalue, key, value, spec.Minimum, spec.Maximum)
 	}
@@ -363,7 +363,7 @@ func validateRange(v float64, key, value, min, max string) error {
 	if min != "" {
 		minval, err := strconv.ParseFloat(min, 64)
 		if err != nil {
-			return fmt.Errorf(`Setting "%s": Bad Spec: Bad minimum: "%s"`, key, min)
+			return fmt.Errorf(`Setting "%s": Bad spec: Bad minimum "%s"`, key, min)
 		}
 		if v < minval {
 			return fmt.Errorf(`Setting "%s": Out of bounds, "%s" to small`, key, value)
@@ -372,7 +372,7 @@ func validateRange(v float64, key, value, min, max string) error {
 	if max != "" {
 		maxval, err := strconv.ParseFloat(max, 64)
 		if err != nil {
-			return fmt.Errorf(`Setting "%s": Bad Spec: Bad maximum "%s"`, key, max)
+			return fmt.Errorf(`Setting "%s": Bad spec: Bad maximum "%s"`, key, max)
 		}
 		if v > maxval {
 			return fmt.Errorf(`Setting "%s": Out of bounds, "%s" to large`, key, value)

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -1,3 +1,5 @@
+// -*- fill-column: 90 -*-
+
 // Package helm contains the epinio-specific core to the helm client libraries. It exposes
 // the functionality to deploy and remove helm charts/releases.
 package helm
@@ -6,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -41,6 +44,7 @@ type ChartParameters struct {
 	Routes         []string              // Desired application routes
 	Domains        domain.DomainMap      // Map of domains with secrets covering them
 	Start          *int64                // Nano-epoch of deployment. Optional. Used to force a restart, even when nothing else has changed.
+	Settings       models.AppSettings
 }
 
 func Values(cluster *kubernetes.Cluster, logger logr.Logger, app models.AppRef) ([]byte, error) {
@@ -94,19 +98,21 @@ func Deploy(logger logr.Logger, parameters ChartParameters) error {
 	}
 	type epinioParam struct {
 		AppName        string               `yaml:"appName"`
+		Configurations []string             `yaml:"configurations"`
 		Env            []models.EnvVariable `yaml:"env"`
 		ImageUrl       string               `yaml:"imageURL"`
 		Ingress        string               `yaml:"ingress,omitempty"`
 		ReplicaCount   int32                `yaml:"replicaCount"`
 		Routes         []routeParam         `yaml:"routes"`
-		Configurations []string             `yaml:"configurations"`
 		StageID        string               `yaml:"stageID"`
+		Start          string               `yaml:"start,omitempty"`
 		TlsIssuer      string               `yaml:"tlsIssuer"`
 		Username       string               `yaml:"username"`
-		Start          string               `yaml:"start,omitempty"`
 	}
 	type chartParam struct {
-		Epinio epinioParam `yaml:"epinio"`
+		Epinio epinioParam            `yaml:"epinio"`
+		Chart  map[string]string      `yaml:"chartConfig"`
+		User   map[string]interface{} `yaml:"userConfig"`
 	}
 
 	// Fill values.yaml structure
@@ -159,7 +165,39 @@ func Deploy(logger logr.Logger, parameters ChartParameters) error {
 		}
 	}
 
-	// And generate the properly quoted values.yaml string
+	// Add the settings, if any. This also performs last-minute validation.  See also
+	// internal/application ValidateCV. Both use the core helper `ValidateField`
+	// implemented here (Avoid import cycle).
+	//
+	// While nothing should trigger here we cannot be sure. Because it is currently
+	// technically possible to change the app settings in the time window between a
+	// client triggering validation and actually deploying the app image. This window
+	// can actually be quite large, due to the time taken by staging and image
+	// download.
+	//
+	// It doesn't even have to be malicious. Just a user B doing a normal update while
+	// user A deployed, and landing in the window.
+
+	for field, value := range parameters.Settings {
+		spec, found := appChart.Settings[field]
+		if !found {
+			return fmt.Errorf("Unable to deploy. Setting '%s' unknown", field)
+		}
+
+		// Note: Here the interface{} result of the properly typed value is
+		// important. It ensures that the map values are properly typed for yaml
+		// serialization.
+
+		v, err := ValidateField(field, value, spec)
+		if err != nil {
+			return fmt.Errorf(`Unable to deploy. %s`, err.Error())
+		}
+		params.User[field] = v
+	}
+
+	params.Chart = appChart.Values
+
+	// At last generate the properly quoted values.yaml string
 
 	logger.Info("app helm setup", "parameters", params)
 
@@ -280,6 +318,65 @@ func cleanupReleaseIfNeeded(l logr.Logger, c hc.Client, name string) error {
 			return errors.Wrapf(err, "uninstalling the release with status: %s", r.Info.Status)
 		}
 	}
+	return nil
+}
 
+// validateField checks a single custom value against its declaration.
+func ValidateField(key, value string, spec models.AppChartSetting) (interface{}, error) {
+	if spec.Type == "string" {
+		if len(spec.Enum) > 0 {
+			for _, allowed := range spec.Enum {
+				if value == allowed {
+					return value, nil
+				}
+			}
+			return nil, fmt.Errorf(`Setting "%s": Illegal string "%s"`, key, value)
+		}
+		return value, nil
+	}
+	if spec.Type == "bool" {
+		flag, err := strconv.ParseBool(value)
+		if err != nil {
+			return nil, fmt.Errorf(`Setting "%s": %s`, key, err.Error())
+		}
+		return flag, nil
+	}
+	if spec.Type == "integer" {
+		ivalue, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf(`Setting "%s": %s`, key, err.Error())
+		}
+		return ivalue, validateRange(float64(ivalue), key, value, spec.Minimum, spec.Maximum)
+	}
+	if spec.Type == "number" {
+		fvalue, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return nil, fmt.Errorf(`Setting "%s": %s`, key, err.Error())
+		}
+		return fvalue, validateRange(fvalue, key, value, spec.Minimum, spec.Maximum)
+	}
+
+	return nil, fmt.Errorf(`Setting "%s": Bad spec: Unknown type "%s"`, key, spec.Type)
+}
+
+func validateRange(v float64, key, value, min, max string) error {
+	if min != "" {
+		minval, err := strconv.ParseFloat(min, 64)
+		if err != nil {
+			return fmt.Errorf(`Setting "%s": Bad Spec: Bad minimum: "%s"`, key, min)
+		}
+		if v < minval {
+			return fmt.Errorf(`Setting "%s": Out of bounds, "%s" to small`, key, value)
+		}
+	}
+	if max != "" {
+		maxval, err := strconv.ParseFloat(max, 64)
+		if err != nil {
+			return fmt.Errorf(`Setting "%s": Bad Spec: Bad maximum "%s"`, key, max)
+		}
+		if v > maxval {
+			return fmt.Errorf(`Setting "%s": Out of bounds, "%s" to large`, key, value)
+		}
+	}
 	return nil
 }

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -1,0 +1,91 @@
+package helm
+
+import (
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ValidateField()", func() {
+
+	It("fails for an unknown field type", func() {
+		_, err := ValidateField("field", "dummy", models.AppChartSetting{
+			Type: "foofara",
+		})
+		Expect(err).To(HaveOccurred(), err.Error())
+		Expect(err.Error()).To(Equal(`Setting "field": Bad spec: Unknown type "foofara"`))
+	})
+
+	It("fails for an integer field with a bad minimum", func() {
+		_, err := ValidateField("field", "1", models.AppChartSetting{
+			Type:    "integer",
+			Minimum: "hello",
+		})
+		Expect(err).To(HaveOccurred(), err.Error())
+		Expect(err.Error()).To(Equal(`Setting "field": Bad spec: Bad minimum "hello"`))
+	})
+
+	It("fails for an integer field with a bad maximum", func() {
+		_, err := ValidateField("field", "1", models.AppChartSetting{
+			Type:    "integer",
+			Maximum: "hello",
+		})
+		Expect(err).To(HaveOccurred(), err.Error())
+		Expect(err.Error()).To(Equal(`Setting "field": Bad spec: Bad maximum "hello"`))
+	})
+
+	It("fails for a value out of range (< min)", func() {
+		_, err := ValidateField("field", "-2", models.AppChartSetting{
+			Type:    "integer",
+			Minimum: "0",
+		})
+		Expect(err).To(HaveOccurred(), err.Error())
+		Expect(err.Error()).To(Equal(`Setting "field": Out of bounds, "-2" too small`))
+	})
+
+	It("fails for a value out of range (> max)", func() {
+		_, err := ValidateField("field", "1000", models.AppChartSetting{
+			Type:    "integer",
+			Maximum: "100",
+		})
+		Expect(err).To(HaveOccurred(), err.Error())
+		Expect(err.Error()).To(Equal(`Setting "field": Out of bounds, "1000" too large`))
+	})
+
+	It("fails for a value out of range (not in enum)", func() {
+		_, err := ValidateField("field", "fox", models.AppChartSetting{
+			Type: "string",
+			Enum: []string{
+				"cat",
+				"dog",
+			},
+		})
+		Expect(err).To(HaveOccurred(), err.Error())
+		Expect(err.Error()).To(Equal(`Setting "field": Illegal string "fox"`))
+	})
+
+	It("fails for a non-integer value where integer required", func() {
+		_, err := ValidateField("field", "hound", models.AppChartSetting{
+			Type: "integer",
+		})
+		Expect(err).To(HaveOccurred(), err.Error())
+		Expect(err.Error()).To(Equal(`Setting "field": Expected integer, got "hound"`))
+	})
+
+	It("fails for a non-numeric value where numeric required", func() {
+		_, err := ValidateField("field", "hound", models.AppChartSetting{
+			Type: "number",
+		})
+		Expect(err).To(HaveOccurred(), err.Error())
+		Expect(err.Error()).To(Equal(`Setting "field": Expected number, got "hound"`))
+	})
+
+	It("fails for a non-boolean value where boolean required", func() {
+		_, err := ValidateField("field", "hound", models.AppChartSetting{
+			Type: "bool",
+		})
+		Expect(err).To(HaveOccurred(), err.Error())
+		Expect(err.Error()).To(Equal(`Setting "field": Expected boolean, got "hound"`))
+	})
+})

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -9,6 +9,126 @@ import (
 
 var _ = Describe("ValidateField()", func() {
 
+	It("is ok for unconstrained integer", func() {
+		val, err := ValidateField("field", "1", models.AppChartSetting{
+			Type: "integer",
+		})
+		Expect(err).ToNot(HaveOccurred(), val)
+		Expect(val).To(Equal(int64(1)))
+	})
+
+	It("is ok for unconstrained number", func() {
+		val, err := ValidateField("field", "3.1415926", models.AppChartSetting{
+			Type: "number",
+		})
+		Expect(err).ToNot(HaveOccurred(), val)
+		Expect(val).To(Equal(float64(3.1415926)))
+	})
+
+	It("is ok for unconstrained string", func() {
+		val, err := ValidateField("field", "hallodria", models.AppChartSetting{
+			Type: "string",
+		})
+		Expect(err).ToNot(HaveOccurred(), val)
+		Expect(val).To(Equal("hallodria"))
+	})
+
+	It("is ok for boolean", func() {
+		val, err := ValidateField("field", "true", models.AppChartSetting{
+			Type: "bool",
+		})
+		Expect(err).ToNot(HaveOccurred(), val)
+		Expect(val).To(Equal(true))
+	})
+
+	It("is ok for constrained integer in range", func() {
+		val, err := ValidateField("field", "50", models.AppChartSetting{
+			Type:    "integer",
+			Minimum: "0",
+			Maximum: "100",
+		})
+		Expect(err).ToNot(HaveOccurred(), val)
+		Expect(val).To(Equal(int64(50)))
+	})
+
+	It("is ok for constrained number in range", func() {
+		val, err := ValidateField("field", "50", models.AppChartSetting{
+			Type:    "number",
+			Minimum: "0",
+			Maximum: "100",
+		})
+		Expect(err).ToNot(HaveOccurred(), val)
+		Expect(val).To(Equal(float64(50)))
+	})
+
+	It("is ok for constrained string in enum", func() {
+		val, err := ValidateField("field", "cat", models.AppChartSetting{
+			Type: "string",
+			Enum: []string{
+				"cat",
+				"dog",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred(), val)
+		Expect(val).To(Equal("cat"))
+	})
+
+	It("is ok for unconstrained integer, enum ignored", func() {
+		val, err := ValidateField("field", "100", models.AppChartSetting{
+			Type: "integer",
+			Enum: []string{
+				"cat",
+				"dog",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred(), val)
+		Expect(val).To(Equal(int64(100)))
+	})
+
+	It("is ok for unconstrained number, enum ignored", func() {
+		val, err := ValidateField("field", "100", models.AppChartSetting{
+			Type: "number",
+			Enum: []string{
+				"cat",
+				"dog",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred(), val)
+		Expect(val).To(Equal(float64(100)))
+	})
+
+	It("is ok for unconstrained string, range ignored", func() {
+		val, err := ValidateField("field", "foo", models.AppChartSetting{
+			Type:    "string",
+			Minimum: "0",
+			Maximum: "100",
+		})
+		Expect(err).ToNot(HaveOccurred(), val)
+		Expect(val).To(Equal("foo"))
+	})
+
+	It("is ok for unconstrained bool, range ignored", func() {
+		val, err := ValidateField("field", "false", models.AppChartSetting{
+			Type:    "bool",
+			Minimum: "0",
+			Maximum: "100",
+		})
+		Expect(err).ToNot(HaveOccurred(), val)
+		Expect(val).To(Equal(false))
+	})
+
+	It("is ok for unconstrained bool, enum ignored", func() {
+		val, err := ValidateField("field", "true", models.AppChartSetting{
+			Type: "bool",
+			Enum: []string{
+				"cat",
+				"dog",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred(), val)
+		Expect(val).To(Equal(true))
+	})
+
 	It("fails for an unknown field type", func() {
 		_, err := ValidateField("field", "dummy", models.AppChartSetting{
 			Type: "foofara",

--- a/internal/helm/suite_test.go
+++ b/internal/helm/suite_test.go
@@ -1,0 +1,13 @@
+package helm_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEpinio(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Helm Suite")
+}

--- a/pkg/api/core/v1/client/apps.go
+++ b/pkg/api/core/v1/client/apps.go
@@ -276,7 +276,7 @@ func (c *Client) AppUpload(namespace string, name string, tarball string) (model
 	return resp, nil
 }
 
-// AppValidateCV uploads vlaidates the chart values of the specified app against its appchart
+// AppValidateCV validates the chart values of the specified app against its appchart
 func (c *Client) AppValidateCV(namespace string, name string) (models.Response, error) {
 	resp := models.Response{}
 

--- a/pkg/api/core/v1/client/apps.go
+++ b/pkg/api/core/v1/client/apps.go
@@ -276,6 +276,24 @@ func (c *Client) AppUpload(namespace string, name string, tarball string) (model
 	return resp, nil
 }
 
+// AppValidateCV uploads vlaidates the chart values of the specified app against its appchart
+func (c *Client) AppValidateCV(namespace string, name string) (models.Response, error) {
+	resp := models.Response{}
+
+	data, err := c.get(api.Routes.Path("AppValidateCV", namespace, name))
+	if err != nil {
+		return resp, errors.Wrap(err, "can't validate app")
+	}
+
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, errors.Wrap(err, "response body is not JSON")
+	}
+
+	c.log.V(1).Info("response decoded", "response", resp)
+
+	return resp, nil
+}
+
 // AppImportGit asks the server to import a git repo and put in into the blob store
 func (c *Client) AppImportGit(app models.AppRef, gitRef models.GitRef) (*models.ImportGitResponse, error) {
 	data := url.Values{}

--- a/pkg/api/core/v1/models/env.go
+++ b/pkg/api/core/v1/models/env.go
@@ -1,5 +1,8 @@
 package models
 
+// __ATTENTION__ Functionally identical to AppSettings, AppSettingList
+// Identical structures
+
 import (
 	"fmt"
 	"sort"

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -169,7 +169,12 @@ type ApplicationUpdateRequest struct {
 	Environment    EnvVariableMap `json:"environment"        yaml:"environment,omitempty"`
 	Routes         []string       `json:"routes"             yaml:"routes,omitempty"`
 	AppChart       string         `json:"appchart,omitempty" yaml:"appchart,omitempty"`
+	Settings       AppSettings    `json:"settings,omitempty" yaml:"settings,omitempty"`
 }
+
+// AppSettings is a collection of key/value pairs describing the user's chosen settings
+// with which to configure the helm chart referenced by the application's appchart.
+type AppSettings map[string]string
 
 type ImportGitResponse struct {
 	BlobUID string `json:"blobuid,omitempty"`
@@ -366,14 +371,38 @@ func NewServiceStatusFromHelmRelease(status helmrelease.Status) ServiceStatus {
 
 func (s ServiceStatus) String() string { return string(s) }
 
-// AppChart matches github.com/epinio/application/api/v1 AppChartSpec
+// AppChart nearly matches github.com/epinio/application/api/v1 AppChartSpec
 // Reason for existence: Do not expose the internal CRD struct in the API.
+//
+// Differences:
+//   - Field `Values` is not made public here. It contains server-internal information the
+//     user has no need for.
 type AppChart struct {
-	Meta             MetaLite `json:"meta,omitempty"`
-	Description      string   `json:"description,omitempty"`
-	ShortDescription string   `json:"short_description,omitempty"`
-	HelmChart        string   `json:"helm_chart,omitempty"`
-	HelmRepo         string   `json:"helm_repo,omitempty"`
+	Meta             MetaLite                   `json:"meta,omitempty"`
+	Description      string                     `json:"description,omitempty"`
+	ShortDescription string                     `json:"short_description,omitempty"`
+	HelmChart        string                     `json:"helm_chart,omitempty"`
+	HelmRepo         string                     `json:"helm_repo,omitempty"`
+	Settings         map[string]AppChartSetting `json:"settings,omitempty"`
+}
+
+// AppChartSetting matches github.com/epinio/application/api/v1 AppChartSettings
+// Reason for existence: Do not expose the internal CRD struct in the API.
+type AppChartSetting struct {
+	// Type of the setting (string, bool, number, or integer)
+	Type string `json:"type"`
+
+	// Minimal allowed value, for number, integer
+	Minimum string `json:"minimum,omitempty"`
+
+	// Maximal allowed value, for number, integer
+	Maximum string `json:"maximum,omitempty"`
+
+	// Enumeration of allowed values, for types string, number, integer
+	Enum []string `json:"enum,omitempty"`
+
+	// Presence of an enum for number and integer overrides the min/max
+	// specifications
 }
 
 // AppChartList is a collection of app charts

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -172,10 +172,6 @@ type ApplicationUpdateRequest struct {
 	Settings       AppSettings    `json:"settings,omitempty" yaml:"settings,omitempty"`
 }
 
-// AppSettings is a collection of key/value pairs describing the user's chosen settings
-// with which to configure the helm chart referenced by the application's appchart.
-type AppSettings map[string]string
-
 type ImportGitResponse struct {
 	BlobUID string `json:"blobuid,omitempty"`
 }

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -1,4 +1,3 @@
-// -*- fill-column: 90 -*-
 // Package models contains the types (mostly structures) encapsulating
 // the API requests and reponses used by the communication between
 // epinio client and APIserver.

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -382,6 +382,11 @@ type AppChart struct {
 	Settings         map[string]AppChartSetting `json:"settings,omitempty"`
 }
 
+type AppChartFull struct {
+	AppChart
+	Values map[string]string
+}
+
 // AppChartSetting matches github.com/epinio/application/api/v1 AppChartSettings
 // Reason for existence: Do not expose the internal CRD struct in the API.
 type AppChartSetting struct {

--- a/pkg/api/core/v1/models/settings.go
+++ b/pkg/api/core/v1/models/settings.go
@@ -11,7 +11,7 @@ import (
 
 // This subsection of models provides structures related to the chart values of applications.
 
-// AppSetting represents the Show Response for a single environment variable
+// AppSetting represents the Show Response for a chart value variable
 type AppSetting struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`

--- a/pkg/api/core/v1/models/settings.go
+++ b/pkg/api/core/v1/models/settings.go
@@ -1,0 +1,68 @@
+// -*- fill-column: 100 -*-
+package models
+
+// __ATTENTION__ Functionally identical to EnvVariableMap, EnvVariableList
+// Identical structures
+
+import (
+	"fmt"
+	"sort"
+)
+
+// This subsection of models provides structures related to the chart values of applications.
+
+// AppSetting represents the Show Response for a single environment variable
+type AppSetting struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// AppSettingList is a collection of chart value assignments
+type AppSettingList []AppSetting
+
+// AppSettings is a collection of key/value pairs describing the user's chosen settings with which
+// to configure the helm chart referenced by the application's appchart.
+type AppSettings map[string]string
+
+func (cvm AppSettings) List() AppSettingList {
+	result := AppSettingList{}
+	for name, value := range cvm {
+		result = append(result, AppSetting{
+			Name:  name,
+			Value: value,
+		})
+	}
+	sort.Sort(result)
+	return result
+}
+
+// Implement the Sort interface for CV definition slices
+
+// Len (Sort interface) returns the length of the AppSettingList
+func (cvl AppSettingList) Len() int {
+	return len(cvl)
+}
+
+// Swap (Sort interface) exchanges the contents of specified indices
+// in the AppSettingList
+func (cvl AppSettingList) Swap(i, j int) {
+	cvl[i], cvl[j] = cvl[j], cvl[i]
+}
+
+// Less (Sort interface) compares the contents of the specified
+// indices in the AppSettingList and returns true if the condition
+// holds, and else false.
+func (cvl AppSettingList) Less(i, j int) bool {
+	return cvl[i].Name < cvl[j].Name
+}
+
+func (cvl AppSettingList) Assignments() []string {
+	assignments := []string{}
+
+	for _, cv := range cvl {
+		assignments = append(assignments, fmt.Sprintf(`{"name":"%s","value":"%s"}`,
+			cv.Name, cv.Value))
+	}
+
+	return assignments
+}

--- a/pkg/api/core/v1/models/settings.go
+++ b/pkg/api/core/v1/models/settings.go
@@ -1,4 +1,3 @@
-// -*- fill-column: 100 -*-
 package models
 
 // __ATTENTION__ Functionally identical to EnvVariableMap, EnvVariableList

--- a/scripts/get-latest-epinio.sh
+++ b/scripts/get-latest-epinio.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+ORG=epinio
+PROJECT=epinio
+ARTI=epinio-linux-x86_64
+
+echo
+echo Locating latest ...
+echo = Release
+LATEST_RELEASE="$(curl -L -s -H 'Accept: application/json' https://github.com/${ORG}/${PROJECT}/releases/latest)"
+echo = $LATEST_RELEASE
+echo = Version
+LATEST_VERSION="$(echo "${LATEST_RELEASE}" | jq .tag_name | sed -e 's/"//g')"
+echo = $LATEST_VERSION
+echo = Artifact
+ARTIFACT_URL="https://github.com/${ORG}/${PROJECT}/releases/download/${LATEST_VERSION}/${ARTI}"
+echo = $ARTIFACT_URL
+
+echo
+echo Retrieving artifact ...
+curl -L -o epinio.bin $ARTIFACT_URL
+chmod u+x epinio.bin
+
+echo
+echo Version Old: $(dist/epinio-linux-amd64 version)
+echo Version Got: $(./epinio.bin version)
+
+cp epinio.bin dist/epinio-linux-amd64
+
+echo Version Now: $(dist/epinio-linux-amd64 version)
+
+echo
+dist/epinio-linux-amd64 info

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -74,6 +74,7 @@ create_docker_pull_secret
 echo "Installing Epinio"
 # Deploy epinio latest release to test upgrade
 if [[ $EPINIO_RELEASED ]]; then
+  echo "Deploying latest released epinio server image"
   deploy_epinio_latest_released
 else
   echo "Importing locally built epinio server image"


### PR DESCRIPTION
Fix: https://github.com/epinio/epinio/issues/1252

- [x] Extend manifest structures with key/value map for customization
- [x] Extend app structures with the same
- [x] Extend appchart API structures with the  user-visible app chart customization settings
- [x] Extend display of appchart details with table of the user-visible app chart customization settings
- [x] Test new display (list, details)
- [x] Add option `--chart-value` (`create`, `update`, `push`). See handling of `--env` for analogous code.
- [x] Implement server-side storage of chart values provided by `--chart-value`. See `--route` for basic analogous code.
- [x] Retrieve chart values when retrieving app data
- [x] Extend display of app details, show chart values (cli side validation for awareness ?)
- [x] Test extended display
- [x] Implement endpoint to validate app customization against app chart declarations
- [x] Test validation
- [x] Add validation of chart values to the app update endpoint as well, to be run when the app is active
- [x] Extend low-level app deployment code to merge chart customization (user-visible, app chart) into the deployed helm chart.
- [x] Test customized app deployment
- [x] Update swagger

