### PR TITLE
Only add a dash when there is a prefix

### DIFF
--- a/acceptance/api/v1/appchart_index_test.go
+++ b/acceptance/api/v1/appchart_index_test.go
@@ -54,6 +54,6 @@ var _ = Describe("ChartList Endpoint", func() {
 		Expect(short).Should(ContainElements(
 			"Epinio standard deployment"))
 		Expect(chart).Should(ContainElements(
-			"https://github.com/epinio/helm-charts/releases/download/epinio-application-0.1.21/epinio-application-0.1.21.tgz"))
+			"https://github.com/epinio/helm-charts/releases/download/epinio-application-0.1.22/epinio-application-0.1.22.tgz"))
 	})
 })

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"os"
 	"os/exec"
@@ -1692,6 +1693,28 @@ userConfig:
 
 			// The command we run should have effects
 			Expect(strings.TrimSpace(remoteOut)).To(Equal("testthis"))
+		})
+	})
+
+	When("pushing an app with a numeric-only name", func() {
+		BeforeEach(func() {
+			rand.Seed(time.Now().UnixNano())
+			min := 9000
+			max := 10000
+			randNum := rand.Intn(max-min+1) + min
+			appName = strconv.Itoa(randNum)
+		})
+
+		AfterEach(func() {
+			env.DeleteApp(appName)
+		})
+
+		It("deploys successfully", func() {
+			pushOutput, err := env.Epinio("", "apps", "push",
+				"--name", appName,
+				"--container-image-url", containerImageURL,
+			)
+			Expect(err).ToNot(HaveOccurred(), pushOutput)
 		})
 	})
 })

--- a/internal/names/names.go
+++ b/internal/names/names.go
@@ -73,8 +73,11 @@ func GenerateResourceNameTruncated(originalName string, maxLen int) string {
 	}
 
 	safePrefix := Truncate(DNSLabelSafe(originalName), (maxLen - (Sha1sumLength + 1)))
+	if len(safePrefix) > 0 {
+		safePrefix = safePrefix + "-" // Split the prefix with a dash
+	}
 
-	return fmt.Sprintf("%s-%s", safePrefix, sum)
+	return fmt.Sprintf("%s%s", safePrefix, sum)
 }
 
 // ReleaseName returns the name of a helm release derived from the base string.


### PR DESCRIPTION
otherwise the generated name is invalid as a helm release name
(and possibly other uses).

Needs also: https://github.com/epinio/helm-charts/pull/270/files

Fixes #1696