### PR TITLE
Unset EXTRAENV variables in workflows

### DIFF
--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -142,8 +142,8 @@ jobs:
           EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.aks_domain || secrets.AKS_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
           INGRESS_CONTROLLER: traefik
-          EXTRAENV_NAME: SESSION_KEY
-          EXTRAENV_VALUE: 12345
+          # EXTRAENV_NAME: SESSION_KEY
+          # EXTRAENV_VALUE: 12345
         shell: bash
         run: |
           echo "System Domain: $AKS_DOMAIN"

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -142,8 +142,8 @@ jobs:
           EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.aks_domain || secrets.AKS_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
           INGRESS_CONTROLLER: traefik
-          EXTRAENV_NAME: SESSION_KEY
-          EXTRAENV_VALUE: 12345
+          # EXTRAENV_NAME: SESSION_KEY
+          # EXTRAENV_VALUE: 12345
         shell: bash
         run: |
           echo "System Domain: $AKS_DOMAIN"

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -145,8 +145,8 @@ jobs:
           EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.aws_domain || secrets.AWS_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
           INGRESS_CONTROLLER: nginx
-          EXTRAENV_NAME: SESSION_KEY
-          EXTRAENV_VALUE: 12345
+          # EXTRAENV_NAME: SESSION_KEY
+          # EXTRAENV_VALUE: 12345
         run: |
           echo "System Domain: $AWS_DOMAIN"
           export KUBECONFIG=$PWD/${{ env.KUBECONFIG_NAME }}

--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -135,8 +135,8 @@ jobs:
           EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.gke_domain || secrets.GKE_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
           INGRESS_CONTROLLER: traefik
-          EXTRAENV_NAME: SESSION_KEY
-          EXTRAENV_VALUE: 12345
+          # EXTRAENV_NAME: SESSION_KEY
+          # EXTRAENV_VALUE: 12345
         run: |
           echo "System Domain: $GKE_DOMAIN"
           export KUBECONFIG=$HOME/.kube/config

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -135,8 +135,8 @@ jobs:
           EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.events.inputs.gke_domain || secrets.GKE_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
           INGRESS_CONTROLLER: traefik
-          EXTRAENV_NAME: SESSION_KEY
-          EXTRAENV_VALUE: 12345
+          # EXTRAENV_NAME: SESSION_KEY
+          # EXTRAENV_VALUE: 12345
         run: |
           echo "System Domain: $GKE_DOMAIN"
           export KUBECONFIG=$HOME/.kube/config

--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -124,8 +124,8 @@ jobs:
           REGISTRY_USERNAME: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
           INGRESS_CONTROLLER: traefik
-          EXTRAENV_NAME: SESSION_KEY
-          EXTRAENV_VALUE: 12345
+          # EXTRAENV_NAME: SESSION_KEY
+          # EXTRAENV_VALUE: 12345
         run: |
           # Get a free IP address on server's network
           export RANGE_IP="$(scripts/get-free-ip.sh)"


### PR DESCRIPTION
Once #1729 will be merged we can remove the extraEnv values by this PR.

Intentionally keeping the commented vars in place for future usage if needed.