### PR TITLE
Block `configuration unbind|delete` for service-owned configurations

### DIFF
--- a/acceptance/api/v1/application_export_test.go
+++ b/acceptance/api/v1/application_export_test.go
@@ -17,15 +17,18 @@ var _ = Describe("AppPart Endpoint", func() {
 	var (
 		namespace string
 		app       string
+		domain    string
 	)
 	containerImageURL := "splatform/sample-app"
 
 	BeforeEach(func() {
+		domain = catalog.NewTmpName("exportdomain-") + ".org"
+
 		namespace = catalog.NewNamespaceName()
 		env.SetupAndTargetNamespace(namespace)
 
 		app = catalog.NewAppName()
-		env.MakeRoutedContainerImageApp(app, 1, containerImageURL, "exportdomain.org")
+		env.MakeRoutedContainerImageApp(app, 1, containerImageURL, domain)
 	})
 
 	AfterEach(func() {
@@ -55,14 +58,14 @@ var _ = Describe("AppPart Endpoint", func() {
   ingress: null
   replicaCount: 1
   routes:
-  - domain: exportdomain.org
-    id: exportdomain.org
+  - domain: %s
+    id: %s
     path: /
   stageID: ""
   start: null
   tlsIssuer: epinio-ca
   username: admin
-`, app)))
+`, app, domain, domain)))
 	})
 
 	It("returns a 404 when the namespace does not exist", func() {

--- a/acceptance/api/v1/configurations_mutation_test.go
+++ b/acceptance/api/v1/configurations_mutation_test.go
@@ -555,7 +555,6 @@ var _ = Describe("Configurations API Application Endpoints, Mutations", func() {
 
 		It("returns a 'not found' when the application does not exist", func() {
 			// This requires a valid configuration
-			configuration := catalog.NewConfigurationName()
 			env.MakeConfiguration(configuration)
 
 			response, err := env.Curl("DELETE",

--- a/acceptance/api/v1/configurations_mutation_test.go
+++ b/acceptance/api/v1/configurations_mutation_test.go
@@ -554,6 +554,10 @@ var _ = Describe("Configurations API Application Endpoints, Mutations", func() {
 		})
 
 		It("returns a 'not found' when the application does not exist", func() {
+			// This requires a valid configuration
+			configuration := catalog.NewConfigurationName()
+			env.MakeConfiguration(configuration)
+
 			response, err := env.Curl("DELETE",
 				fmt.Sprintf("%s%s/namespaces/%s/applications/bogus/configurationbindings/%s",
 					serverURL, api.Root, namespace, configuration),
@@ -569,6 +573,8 @@ var _ = Describe("Configurations API Application Endpoints, Mutations", func() {
 			json.Unmarshal(bodyBytes, &responseBody)
 			Expect(responseBody["errors"][0].Title).To(
 				Equal("application 'bogus' does not exist"))
+
+			env.CleanupConfiguration(configuration)
 		})
 
 		Context("with application", func() {

--- a/acceptance/api/v1/configurations_mutation_test.go
+++ b/acceptance/api/v1/configurations_mutation_test.go
@@ -556,6 +556,7 @@ var _ = Describe("Configurations API Application Endpoints, Mutations", func() {
 		It("returns a 'not found' when the application does not exist", func() {
 			// This requires a valid configuration
 			env.MakeConfiguration(configuration)
+			defer env.CleanupConfiguration(configuration)
 
 			response, err := env.Curl("DELETE",
 				fmt.Sprintf("%s%s/namespaces/%s/applications/bogus/configurationbindings/%s",
@@ -572,8 +573,6 @@ var _ = Describe("Configurations API Application Endpoints, Mutations", func() {
 			json.Unmarshal(bodyBytes, &responseBody)
 			Expect(responseBody["errors"][0].Title).To(
 				Equal("application 'bogus' does not exist"))
-
-			env.CleanupConfiguration(configuration)
 		})
 
 		Context("with application", func() {

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -1293,9 +1293,10 @@ configuration:
 			})
 
 			Context("exporting customized", func() {
-				var chartName, tempFile, app, exportPath, exportValues, exportChart string
+				var domain, chartName, tempFile, app, exportPath, exportValues, exportChart string
 
 				BeforeEach(func() {
+					domain = catalog.NewTmpName("exportdomain-") + ".org"
 					chartName = catalog.NewTmpName("chart-")
 					tempFile = env.MakeAppchart(chartName)
 
@@ -1305,7 +1306,7 @@ configuration:
 					exportValues = path.Join(exportPath, "values.yaml")
 					exportChart = path.Join(exportPath, "app-chart.tar.gz")
 
-					env.MakeRoutedContainerImageApp(app, 1, containerImageURL, "exportdomain.org",
+					env.MakeRoutedContainerImageApp(app, 1, containerImageURL, domain,
 						"--app-chart", chartName,
 						"--chart-value", "foo=bar",
 					)
@@ -1344,8 +1345,8 @@ epinio:
   ingress: null
   replicaCount: 1
   routes:
-  - domain: exportdomain.org
-    id: exportdomain.org
+  - domain: %s
+    id: %s
     path: /
   stageID: ""
   start: null
@@ -1353,23 +1354,24 @@ epinio:
   username: admin
 userConfig:
   foo: bar
-`, app)))
+`, app, domain, domain)))
 					// Not checking that exportChart is a proper tarball.
 				})
 			})
 		})
 
 		Context("exporting", func() {
-			var app, exportPath, exportValues, exportChart string
+			var domain, app, exportPath, exportValues, exportChart string
 
 			BeforeEach(func() {
+				domain = catalog.NewTmpName("exportdomain-") + ".org"
 				app = catalog.NewAppName()
 
 				exportPath = catalog.NewTmpName(app + "-export")
 				exportValues = path.Join(exportPath, "values.yaml")
 				exportChart = path.Join(exportPath, "app-chart.tar.gz")
 
-				env.MakeRoutedContainerImageApp(app, 1, containerImageURL, "exportdomain.org")
+				env.MakeRoutedContainerImageApp(app, 1, containerImageURL, domain)
 			})
 
 			AfterEach(func() {
@@ -1401,14 +1403,14 @@ userConfig:
   ingress: null
   replicaCount: 1
   routes:
-  - domain: exportdomain.org
-    id: exportdomain.org
+  - domain: %s
+    id: %s
     path: /
   stageID: ""
   start: null
   tlsIssuer: epinio-ca
   username: admin
-`, app)))
+`, app, domain, domain)))
 				// Not checking that exportChart is a proper tarball.
 			})
 
@@ -1449,13 +1451,13 @@ userConfig:
   imageURL: splatform/sample-app
   replicaCount: 1
   routes:
-  - domain: exportdomain.org
-    id: exportdomain.org
+  - domain: %s
+    id: %s
     path: /
   stageID: ""
   tlsIssuer: epinio-ca
   username: admin
-`, app)))
+`, app, domain, domain)))
 				// Not checking that exportChart is a proper tarball.
 			})
 		})

--- a/acceptance/configurations_test.go
+++ b/acceptance/configurations_test.go
@@ -393,7 +393,7 @@ var _ = Describe("Configurations", func() {
 		It("doesn't delete a bound service-owned configuration", func() {
 			out, err := env.Epinio("", "configuration", "delete", config)
 			Expect(err).To(HaveOccurred(), out)
-			Expect(out).To(ContainSubstring("Bad Request: Configuration belongs to service"))
+			Expect(out).To(ContainSubstring("Configuration belongs to service"))
 		})
 
 		It("doesn't delete any service-owned configuration", func() {
@@ -411,7 +411,7 @@ var _ = Describe("Configurations", func() {
 
 			out, err = env.Epinio("", "configuration", "delete", config)
 			Expect(err).To(HaveOccurred(), out)
-			Expect(out).To(ContainSubstring("Bad Request: Configuration belongs to service"))
+			Expect(out).To(ContainSubstring("Configuration belongs to service"))
 		})
 	})
 

--- a/acceptance/configurations_test.go
+++ b/acceptance/configurations_test.go
@@ -2,6 +2,7 @@ package acceptance_test
 
 import (
 	"github.com/epinio/epinio/acceptance/helpers/catalog"
+	"github.com/epinio/epinio/internal/names"
 
 	. "github.com/epinio/epinio/acceptance/helpers/matchers"
 	. "github.com/onsi/ginkgo/v2"
@@ -315,4 +316,103 @@ var _ = Describe("Configurations", func() {
 			)
 		})
 	})
+
+	Context("service-owned configurations", func() {
+		//var catalogService models.CatalogService
+		var service, appName, chart, config string
+
+		BeforeEach(func() {
+			service = catalog.NewServiceName()
+
+			By("make service instance: " + service)
+			// catalogService.Meta.Name
+			out, err := env.Epinio("", "service", "create", "mysql-dev", service)
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			By("wait for deployment")
+			Eventually(func() string {
+				out, _ := env.Epinio("", "service", "show", service)
+				return out
+			}, "2m", "5s").Should(HaveATable(WithRow("Status", "deployed")))
+
+			appName = catalog.NewAppName()
+			By("make app: " + appName)
+			env.MakeContainerImageApp(appName, 1, containerImageURL)
+
+			chart = names.ServiceHelmChartName(service, namespace)
+			config = chart + "-mysql"
+
+			By("chart: " + chart)
+			By("config: " + config)
+
+			// NOTE: The bind/unbind cycle below materializes the configuration of the service
+
+			By("bind service: " + service)
+
+			out, err = env.Epinio("", "service", "bind", service, appName)
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			By("wait for bound")
+			Eventually(func() string {
+				out, _ := env.Epinio("", "app", "show", appName)
+				return out
+			}, "2m", "5s").Should(HaveATable(WithRow("Bound Configurations", config)))
+
+			By("done before")
+		})
+
+		AfterEach(func() {
+			env.TargetNamespace(namespace)
+
+			By("remove app: " + appName)
+			env.DeleteApp(appName)
+
+			// The preceding removed the service/config binding as well, allowing us to
+			// remove the service and its configs without care.
+
+			By("remove service instance: " + service)
+
+			out, err := env.Epinio("", "service", "delete", service)
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("Service Removed"))
+
+			Eventually(func() string {
+				out, _ := env.Epinio("", "service", "delete", service)
+				return out
+			}, "1m", "5s").Should(ContainSubstring("service '%s' does not exist", service))
+
+			By("done after")
+		})
+
+		It("doesn't unbind a service-owned configuration", func() {
+			out, err := env.Epinio("", "configuration", "unbind", config, appName)
+			Expect(err).To(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("Bad Request: Configuration belongs to service"))
+		})
+
+		It("doesn't delete a bound service-owned configuration", func() {
+			out, err := env.Epinio("", "configuration", "delete", config)
+			Expect(err).To(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("Bad Request: Configuration belongs to service"))
+		})
+
+		It("doesn't delete any service-owned configuration", func() {
+			By("unbind service: " + appName)
+
+			out, err := env.Epinio("", "service", "unbind", service, appName)
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).ToNot(ContainSubstring("Available Commands:")) // Command should exist
+
+			By("wait for unbound")
+			Eventually(func() string {
+				out, _ := env.Epinio("", "app", "show", appName)
+				return out
+			}, "2m", "5s").ShouldNot(HaveATable(WithRow("Bound Configurations", config)))
+
+			out, err = env.Epinio("", "configuration", "delete", config)
+			Expect(err).To(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("Bad Request: Configuration belongs to service"))
+		})
+	})
+
 })

--- a/internal/api/v1/configuration/delete.go
+++ b/internal/api/v1/configuration/delete.go
@@ -41,8 +41,8 @@ func (sc Controller) Delete(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	// Reject operations on configurations belonging to a service. Their manipulation has to be
-	// done through service commands to keep the system in a consistent state
+	// [SERVICE] Reject operations on configurations belonging to a service. Their manipulation
+	// has to be done through service commands to keep the system in a consistent state.
 
 	if configuration.Origin != "" {
 		// [BELONG] keep in sync with same marker in the client
@@ -65,7 +65,9 @@ func (sc Controller) Delete(c *gin.Context) apierror.APIErrors {
 		}
 
 		for _, appName := range boundAppNames {
-			apiErr := configurationbinding.DeleteBinding(ctx, cluster, namespace, appName, configurationName, username, false)
+			// Note that we reach this location only when the [SERVICE] check above
+			// failed, i.e. the configuration is standalone.
+			apiErr := configurationbinding.DeleteBinding(ctx, cluster, namespace, appName, configurationName, username)
 			if apiErr != nil {
 				return apiErr
 			}

--- a/internal/api/v1/configurationbinding/delete.go
+++ b/internal/api/v1/configurationbinding/delete.go
@@ -22,7 +22,7 @@ func (hc Controller) Delete(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	apiErr := DeleteBinding(ctx, cluster, namespace, appName, configurationName, username)
+	apiErr := DeleteBinding(ctx, cluster, namespace, appName, configurationName, username, false)
 	if apiErr != nil {
 		return apiErr
 	}

--- a/internal/api/v1/configurationbinding/deletebinding.go
+++ b/internal/api/v1/configurationbinding/deletebinding.go
@@ -6,11 +6,10 @@ import (
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/deploy"
 	"github.com/epinio/epinio/internal/application"
-	"github.com/epinio/epinio/internal/configurations"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 )
 
-func DeleteBinding(ctx context.Context, cluster *kubernetes.Cluster, namespace, appName, configurationName, username string, fromService bool) apierror.APIErrors {
+func DeleteBinding(ctx context.Context, cluster *kubernetes.Cluster, namespace, appName, configurationName, username string) apierror.APIErrors {
 
 	app, err := application.Lookup(ctx, cluster, namespace, appName)
 	if err != nil {
@@ -18,19 +17,6 @@ func DeleteBinding(ctx context.Context, cluster *kubernetes.Cluster, namespace, 
 	}
 	if app == nil {
 		return apierror.AppIsNotKnown(appName)
-	}
-
-	config, err := configurations.Lookup(ctx, cluster, namespace, configurationName)
-	if err != nil && err.Error() == "configuration not found" {
-		return apierror.ConfigurationIsNotKnown(configurationName)
-	}
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	if !fromService && config.Origin != "" {
-		return apierror.NewBadRequestErrorf("Configuration belongs to service '%s', use service requests",
-			config.Origin)
 	}
 
 	err = application.BoundConfigurationsUnset(ctx, cluster, app.Meta, configurationName)

--- a/internal/api/v1/service/unbind.go
+++ b/internal/api/v1/service/unbind.go
@@ -92,7 +92,7 @@ func UnbindService(
 		// TODO: Don't `helm upgrade` after each removal. Do it once.
 		errors := configurationbinding.DeleteBinding(
 			ctx, cluster, namespace, appName, secret.Name,
-			userName, true,
+			userName,
 		)
 		if errors != nil {
 			return apierror.NewMultiError(errors.Errors())

--- a/internal/api/v1/service/unbind.go
+++ b/internal/api/v1/service/unbind.go
@@ -91,7 +91,8 @@ func UnbindService(
 	for _, secret := range serviceConfigurations {
 		// TODO: Don't `helm upgrade` after each removal. Do it once.
 		errors := configurationbinding.DeleteBinding(
-			ctx, cluster, namespace, appName, secret.Name, userName,
+			ctx, cluster, namespace, appName, secret.Name,
+			userName, true,
 		)
 		if errors != nil {
 			return apierror.NewMultiError(errors.Errors())

--- a/internal/cli/usercmd/configuration.go
+++ b/internal/cli/usercmd/configuration.go
@@ -225,7 +225,7 @@ func (c *EpinioClient) DeleteConfiguration(name string, unbind bool) error {
 			// [BELONG] keep in sync with same marker in the server
 			if strings.Contains(apiError.Errors[0].Title, "Configuration belongs to service") {
 				// (2.)
-				return err
+				return apiError.Errors[0]
 			}
 
 			// (1.)


### PR DESCRIPTION
Fix #1733 
