### PR TITLE
Trial a `bci-micro` derived image as replacement for `library/bash`.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,6 +54,29 @@ snapshot:
 dockers:
   -
     use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+    - "ghcr.io/epinio/epinio-unpacker:{{ .Tag }}-amd64"
+
+    # Skips the docker push.
+    #skip_push: "true"
+
+    # Path to the Dockerfile (from the project root).
+    dockerfile: images/unpacker-Dockerfile
+
+    # Template of the docker build flags.
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/epinio/epinio"
+    - "--platform=linux/amd64"
+
+  -
+    use: buildx
 
     # GOOS of the built binaries/packages that should be used.
     goos: linux


### PR DESCRIPTION
Coming out of https://github.com/rancher/image-mirror/pull/286/files#r971150514

import helm chart work on the image for staging's unpack step.
trialing an image derived from bci-micro