### PR TITLE
Fix: exclude swagger:meta file from golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ fmt:
 	go fmt ./...
 
 check:
-	golangci-lint run
+	golangci-lint run --skip-files docs.go
 
 patch-epinio-deployment:
 	@./scripts/patch-epinio-deployment.sh


### PR DESCRIPTION
The comments syntax for swagger clashes with godoc/goimport/gofmt expectations.
This causes spurios golangci-lint failures.
