### PR TITLE
Added internal Dex endpoint for Epinio server

### DIFF
--- a/internal/dex/dex.go
+++ b/internal/dex/dex.go
@@ -3,6 +3,7 @@ package dex
 import (
 	"context"
 	"net/url"
+	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/dchest/uniuri"
@@ -45,7 +46,7 @@ func NewOIDCProviderWithEndpoint(ctx context.Context, issuer, clientID string, e
 	// With this differentiation the Epinio server can reach the Dex service through the Kubernetes DNS
 	// instead of the external URL. This was causing issues when the host was going to be resolved as a local IP (i.e: Rancher Desktop).
 	// - https://github.com/epinio/epinio/issues/1781
-	if issuer != endpoint.String() {
+	if issuer != endpoint.String() && strings.HasSuffix(endpoint.Hostname(), ".svc.cluster.local") {
 		ctx = oidc.InsecureIssuerURLContext(ctx, issuer)
 	}
 

--- a/internal/dex/dex.go
+++ b/internal/dex/dex.go
@@ -2,6 +2,7 @@ package dex
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/dchest/uniuri"
@@ -22,13 +23,33 @@ var (
 
 // OIDCProvider wraps an oidc.Provider and its Configuration
 type OIDCProvider struct {
+	Issuer   string
+	Endpoint *url.URL
 	Provider *oidc.Provider
 	Config   *oauth2.Config
 }
 
 // NewOIDCProvider construct an OIDCProvider fetching its configuration
 func NewOIDCProvider(ctx context.Context, issuer, clientID string) (*OIDCProvider, error) {
-	provider, err := oidc.NewProvider(ctx, issuer)
+	endpoint, err := url.Parse(issuer)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing the issuer URL")
+	}
+
+	return NewOIDCProviderWithEndpoint(ctx, issuer, clientID, endpoint)
+}
+
+// NewOIDCProviderWithEndpoint construct an OIDCProvider fetching its configuration from the endpoint URL
+func NewOIDCProviderWithEndpoint(ctx context.Context, issuer, clientID string, endpoint *url.URL) (*OIDCProvider, error) {
+	// If the issuer is different from the endpoint we need to set it in the context.
+	// With this differentiation the Epinio server can reach the Dex service through the Kubernetes DNS
+	// instead of the external URL. This was causing issues when the host was going to be resolved as a local IP (i.e: Rancher Desktop).
+	// - https://github.com/epinio/epinio/issues/1781
+	if issuer != endpoint.String() {
+		ctx = oidc.InsecureIssuerURLContext(ctx, issuer)
+	}
+
+	provider, err := oidc.NewProvider(ctx, endpoint.String())
 	if err != nil {
 		return nil, errors.Wrap(err, "creating the provider")
 	}
@@ -41,6 +62,8 @@ func NewOIDCProvider(ctx context.Context, issuer, clientID string) (*OIDCProvide
 	}
 
 	return &OIDCProvider{
+		Issuer:   issuer,
+		Endpoint: endpoint,
 		Provider: provider,
 		Config:   config,
 	}, nil
@@ -79,7 +102,8 @@ func (pc *OIDCProvider) ExchangeWithPKCE(ctx context.Context, authCode, codeVeri
 
 // Verify will verify the token, and it will return an oidc.IDToken
 func (pc *OIDCProvider) Verify(ctx context.Context, rawIDToken string) (*oidc.IDToken, error) {
-	verifier := pc.Provider.Verifier(&oidc.Config{ClientID: pc.Config.ClientID})
+	keySet := oidc.NewRemoteKeySet(ctx, pc.Endpoint.String()+"/keys")
+	verifier := oidc.NewVerifier(pc.Issuer, keySet, &oidc.Config{ClientID: pc.Config.ClientID})
 
 	token, err := verifier.Verify(ctx, rawIDToken)
 	if err != nil {


### PR DESCRIPTION
Ref:
- Fixes: https://github.com/epinio/epinio/issues/1781
- https://github.com/epinio/helm-charts/pull/287
---

Using an issuer that resolves to an internal address was causing issues to the Epinio server. The `https://auth.127.0.0.1.sslip.io` used as the issuer was resolved as a local IP, failing the fetching of the configuration and token verification.

To correctly reach Dex we should have a different endpoint where to reach Dex for getting the configuration and the keys for the verification, while still having the correct issuer.

[Azure](https://github.com/coreos/go-oidc/issues/344) has a similar "misconfiguration", so having a look at [this issue](https://github.com/coreos/go-oidc/issues/233) I've seen how it was possibe to provide a different `KeySet` to the Verifier. Also digging a bit into the code I've find out the `oidc.InsecureIssuerURLContext(ctx, issuer)`, that can be used exactly in this case (as stated in the func comment declaration).