### PR TITLE
Disable version mismatch warning when doing tab autocompletion

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -93,7 +93,6 @@ var CmdAppCreate = &cobra.Command{
 		cmd.SilenceUsage = true
 
 		client, err := usercmd.New()
-
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
 		}
@@ -129,7 +128,6 @@ var CmdAppShow = &cobra.Command{
 		cmd.SilenceUsage = true
 
 		client, err := usercmd.New()
-
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
 		}
@@ -150,7 +148,6 @@ var CmdAppExport = &cobra.Command{
 		cmd.SilenceUsage = true
 
 		client, err := usercmd.New()
-
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
 		}
@@ -262,7 +259,6 @@ var CmdAppUpdate = &cobra.Command{
 		cmd.SilenceUsage = true
 
 		client, err := usercmd.New()
-
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
 		}
@@ -298,7 +294,6 @@ var CmdAppManifest = &cobra.Command{
 		cmd.SilenceUsage = true
 
 		client, err := usercmd.New()
-
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
 		}

--- a/internal/cli/chart.go
+++ b/internal/cli/chart.go
@@ -83,7 +83,6 @@ var CmdAppChartShow = &cobra.Command{
 		cmd.SilenceUsage = true
 
 		client, err := usercmd.New()
-
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
 		}

--- a/internal/cli/commons.go
+++ b/internal/cli/commons.go
@@ -55,8 +55,8 @@ func matchingAppsFinder(cmd *cobra.Command, args []string, toComplete string) ([
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-
 	app.API.DisableVersionWarning()
+
 	matches := app.AppsMatching(toComplete)
 
 	return matches, cobra.ShellCompDirectiveNoFileComp
@@ -72,8 +72,8 @@ func matchingNamespaceFinder(cmd *cobra.Command, args []string, toComplete strin
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-
 	app.API.DisableVersionWarning()
+
 	matches := app.NamespacesMatching(toComplete)
 
 	return matches, cobra.ShellCompDirectiveNoFileComp
@@ -89,8 +89,8 @@ func matchingChartFinder(cmd *cobra.Command, args []string, toComplete string) (
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-
 	app.API.DisableVersionWarning()
+
 	// #args == 0: chart name.
 	matches := app.ChartMatching(toComplete)
 
@@ -107,8 +107,8 @@ func matchingServiceFinder(cmd *cobra.Command, args []string, toComplete string)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-
 	app.API.DisableVersionWarning()
+
 	matches := app.ServiceMatching(toComplete)
 
 	return matches, cobra.ShellCompDirectiveNoFileComp
@@ -124,8 +124,8 @@ func matchingCatalogFinder(cmd *cobra.Command, args []string, toComplete string)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-
 	app.API.DisableVersionWarning()
+
 	matches := app.CatalogMatching(toComplete)
 
 	return matches, cobra.ShellCompDirectiveNoFileComp

--- a/internal/cli/commons.go
+++ b/internal/cli/commons.go
@@ -56,6 +56,7 @@ func matchingAppsFinder(cmd *cobra.Command, args []string, toComplete string) ([
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	app.API.DisableVersionWarning()
 	matches := app.AppsMatching(toComplete)
 
 	return matches, cobra.ShellCompDirectiveNoFileComp
@@ -72,6 +73,7 @@ func matchingNamespaceFinder(cmd *cobra.Command, args []string, toComplete strin
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	app.API.DisableVersionWarning()
 	matches := app.NamespacesMatching(toComplete)
 
 	return matches, cobra.ShellCompDirectiveNoFileComp
@@ -88,6 +90,7 @@ func matchingChartFinder(cmd *cobra.Command, args []string, toComplete string) (
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	app.API.DisableVersionWarning()
 	// #args == 0: chart name.
 	matches := app.ChartMatching(toComplete)
 
@@ -105,6 +108,7 @@ func matchingServiceFinder(cmd *cobra.Command, args []string, toComplete string)
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	app.API.DisableVersionWarning()
 	matches := app.ServiceMatching(toComplete)
 
 	return matches, cobra.ShellCompDirectiveNoFileComp
@@ -121,6 +125,7 @@ func matchingCatalogFinder(cmd *cobra.Command, args []string, toComplete string)
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	app.API.DisableVersionWarning()
 	matches := app.CatalogMatching(toComplete)
 
 	return matches, cobra.ShellCompDirectiveNoFileComp

--- a/internal/cli/configuration.go
+++ b/internal/cli/configuration.go
@@ -58,6 +58,7 @@ var CmdConfigurationShow = &cobra.Command{
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
+		app.API.DisableVersionWarning()
 
 		matches := app.ConfigurationMatching(context.Background(), toComplete)
 
@@ -103,6 +104,7 @@ var CmdConfigurationDelete = &cobra.Command{
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
+		epinioClient.API.DisableVersionWarning()
 
 		matches := epinioClient.ConfigurationMatching(context.Background(), toComplete)
 
@@ -126,6 +128,7 @@ var CmdConfigurationBind = &cobra.Command{
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
+		app.API.DisableVersionWarning()
 
 		if len(args) == 1 {
 			// #args == 1: app name.
@@ -157,6 +160,7 @@ var CmdConfigurationUnbind = &cobra.Command{
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
+		app.API.DisableVersionWarning()
 
 		if len(args) == 1 {
 			// #args == 1: app name.

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -79,6 +79,7 @@ var CmdEnvSet = &cobra.Command{
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
+		app.API.DisableVersionWarning()
 
 		// #args == 0: application name.
 		matches := app.AppsMatching(toComplete)
@@ -117,6 +118,7 @@ var CmdEnvShow = &cobra.Command{
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
+		app.API.DisableVersionWarning()
 
 		if len(args) == 1 {
 			// #args == 1: environment variable name (in application)
@@ -142,7 +144,6 @@ var CmdEnvUnset = &cobra.Command{
 		cmd.SilenceUsage = true
 
 		client, err := usercmd.New()
-
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
 		}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -202,6 +202,7 @@ func findServiceApp(cmd *cobra.Command, args []string, toComplete string) ([]str
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
+	app.API.DisableVersionWarning()
 
 	if len(args) == 1 {
 		// #args == 1: app name.

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -99,6 +99,9 @@ type APIClient interface {
 	ChartList() ([]models.AppChart, error)
 	ChartShow(name string) (models.AppChart, error)
 	ChartMatch(prefix string) (models.ChartMatchResponse, error)
+
+	DisableVersionWarning()
+	VersionWarningEnabled() bool
 }
 
 func New() (*EpinioClient, error) {

--- a/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
+++ b/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
@@ -463,6 +463,10 @@ type FakeAPIClient struct {
 		result1 models.ConfigurationResponseList
 		result2 error
 	}
+	DisableVersionWarningStub        func()
+	disableVersionWarningMutex       sync.RWMutex
+	disableVersionWarningArgsForCall []struct {
+	}
 	EnvListStub        func(string, string) (models.EnvVariableMap, error)
 	envListMutex       sync.RWMutex
 	envListArgsForCall []struct {
@@ -759,6 +763,16 @@ type FakeAPIClient struct {
 	stagingCompleteReturnsOnCall map[int]struct {
 		result1 models.Response
 		result2 error
+	}
+	VersionWarningEnabledStub        func() bool
+	versionWarningEnabledMutex       sync.RWMutex
+	versionWarningEnabledArgsForCall []struct {
+	}
+	versionWarningEnabledReturns struct {
+		result1 bool
+	}
+	versionWarningEnabledReturnsOnCall map[int]struct {
+		result1 bool
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -2867,6 +2881,30 @@ func (fake *FakeAPIClient) ConfigurationsReturnsOnCall(i int, result1 models.Con
 	}{result1, result2}
 }
 
+func (fake *FakeAPIClient) DisableVersionWarning() {
+	fake.disableVersionWarningMutex.Lock()
+	fake.disableVersionWarningArgsForCall = append(fake.disableVersionWarningArgsForCall, struct {
+	}{})
+	stub := fake.DisableVersionWarningStub
+	fake.recordInvocation("DisableVersionWarning", []interface{}{})
+	fake.disableVersionWarningMutex.Unlock()
+	if stub != nil {
+		fake.DisableVersionWarningStub()
+	}
+}
+
+func (fake *FakeAPIClient) DisableVersionWarningCallCount() int {
+	fake.disableVersionWarningMutex.RLock()
+	defer fake.disableVersionWarningMutex.RUnlock()
+	return len(fake.disableVersionWarningArgsForCall)
+}
+
+func (fake *FakeAPIClient) DisableVersionWarningCalls(stub func()) {
+	fake.disableVersionWarningMutex.Lock()
+	defer fake.disableVersionWarningMutex.Unlock()
+	fake.DisableVersionWarningStub = stub
+}
+
 func (fake *FakeAPIClient) EnvList(arg1 string, arg2 string) (models.EnvVariableMap, error) {
 	fake.envListMutex.Lock()
 	ret, specificReturn := fake.envListReturnsOnCall[len(fake.envListArgsForCall)]
@@ -4262,6 +4300,59 @@ func (fake *FakeAPIClient) StagingCompleteReturnsOnCall(i int, result1 models.Re
 	}{result1, result2}
 }
 
+func (fake *FakeAPIClient) VersionWarningEnabled() bool {
+	fake.versionWarningEnabledMutex.Lock()
+	ret, specificReturn := fake.versionWarningEnabledReturnsOnCall[len(fake.versionWarningEnabledArgsForCall)]
+	fake.versionWarningEnabledArgsForCall = append(fake.versionWarningEnabledArgsForCall, struct {
+	}{})
+	stub := fake.VersionWarningEnabledStub
+	fakeReturns := fake.versionWarningEnabledReturns
+	fake.recordInvocation("VersionWarningEnabled", []interface{}{})
+	fake.versionWarningEnabledMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeAPIClient) VersionWarningEnabledCallCount() int {
+	fake.versionWarningEnabledMutex.RLock()
+	defer fake.versionWarningEnabledMutex.RUnlock()
+	return len(fake.versionWarningEnabledArgsForCall)
+}
+
+func (fake *FakeAPIClient) VersionWarningEnabledCalls(stub func() bool) {
+	fake.versionWarningEnabledMutex.Lock()
+	defer fake.versionWarningEnabledMutex.Unlock()
+	fake.VersionWarningEnabledStub = stub
+}
+
+func (fake *FakeAPIClient) VersionWarningEnabledReturns(result1 bool) {
+	fake.versionWarningEnabledMutex.Lock()
+	defer fake.versionWarningEnabledMutex.Unlock()
+	fake.VersionWarningEnabledStub = nil
+	fake.versionWarningEnabledReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeAPIClient) VersionWarningEnabledReturnsOnCall(i int, result1 bool) {
+	fake.versionWarningEnabledMutex.Lock()
+	defer fake.versionWarningEnabledMutex.Unlock()
+	fake.VersionWarningEnabledStub = nil
+	if fake.versionWarningEnabledReturnsOnCall == nil {
+		fake.versionWarningEnabledReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.versionWarningEnabledReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
 func (fake *FakeAPIClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -4331,6 +4422,8 @@ func (fake *FakeAPIClient) Invocations() map[string][][]interface{} {
 	defer fake.configurationUpdateMutex.RUnlock()
 	fake.configurationsMutex.RLock()
 	defer fake.configurationsMutex.RUnlock()
+	fake.disableVersionWarningMutex.RLock()
+	defer fake.disableVersionWarningMutex.RUnlock()
 	fake.envListMutex.RLock()
 	defer fake.envListMutex.RUnlock()
 	fake.envMatchMutex.RLock()
@@ -4375,6 +4468,8 @@ func (fake *FakeAPIClient) Invocations() map[string][][]interface{} {
 	defer fake.serviceUnbindMutex.RUnlock()
 	fake.stagingCompleteMutex.RLock()
 	defer fake.stagingCompleteMutex.RUnlock()
+	fake.versionWarningEnabledMutex.RLock()
+	defer fake.versionWarningEnabledMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/api/core/v1/client/client.go
+++ b/pkg/api/core/v1/client/client.go
@@ -18,9 +18,10 @@ import (
 // Client provides functionality for talking to an Epinio API
 // server
 type Client struct {
-	log        logr.Logger
-	Settings   *epiniosettings.Settings
-	HttpClient *http.Client
+	log            logr.Logger
+	Settings       *epiniosettings.Settings
+	HttpClient     *http.Client
+	versionWarning *bool
 }
 
 // New returns a new Epinio API client

--- a/pkg/api/core/v1/client/client.go
+++ b/pkg/api/core/v1/client/client.go
@@ -18,10 +18,10 @@ import (
 // Client provides functionality for talking to an Epinio API
 // server
 type Client struct {
-	log            logr.Logger
-	Settings       *epiniosettings.Settings
-	HttpClient     *http.Client
-	versionWarning *bool
+	log              logr.Logger
+	Settings         *epiniosettings.Settings
+	HttpClient       *http.Client
+	noVersionWarning bool
 }
 
 // New returns a new Epinio API client

--- a/pkg/api/core/v1/client/http.go
+++ b/pkg/api/core/v1/client/http.go
@@ -37,15 +37,14 @@ func wrapResponseError(err error, code int) *responseError {
 }
 
 func (c *Client) DisableVersionWarning() {
-	value := false
-	c.versionWarning = &value
+	c.noVersionWarning = true
 }
 
 // VersionWarningEnabled returns true if versionWarning field is either not
 // set of true. That makes "true" the default value unless DisableVersionWarning
 // is called.
 func (c *Client) VersionWarningEnabled() bool {
-	return c.versionWarning == nil || *c.versionWarning
+	return !c.noVersionWarning
 }
 
 func (c *Client) get(endpoint string) ([]byte, error) {

--- a/pkg/api/core/v1/client/http.go
+++ b/pkg/api/core/v1/client/http.go
@@ -36,6 +36,18 @@ func wrapResponseError(err error, code int) *responseError {
 	return &responseError{error: err, statusCode: code}
 }
 
+func (c *Client) DisableVersionWarning() {
+	value := false
+	c.versionWarning = &value
+}
+
+// VersionWarningEnabled returns true if versionWarning field is either not
+// set of true. That makes "true" the default value unless DisableVersionWarning
+// is called.
+func (c *Client) VersionWarningEnabled() bool {
+	return c.versionWarning == nil || *c.versionWarning
+}
+
 func (c *Client) get(endpoint string) ([]byte, error) {
 	return c.do(endpoint, "GET", "")
 }
@@ -148,7 +160,7 @@ func (c *Client) do(endpoint, method, requestBody string) ([]byte, error) {
 	defer response.Body.Close()
 	reqLog.V(1).Info("request finished")
 
-	if serverVersion := response.Header.Get(api.VersionHeader); serverVersion != "" {
+	if serverVersion := response.Header.Get(api.VersionHeader); c.VersionWarningEnabled() && serverVersion != "" {
 		warnAboutVersionMismatch(serverVersion)
 	}
 


### PR DESCRIPTION
The warning was always printed and was messing up the autocompletion. Now we explicitly disable the warning when doing autocompletion. There is still a chance that an out-of-sync client can fail to do the autocompletion but it's better to let it try than break completely.