### PR TITLE
Fix conflation of empty and nil slice for routes, in app update handling

### DIFF
--- a/acceptance/api/v1/application_deploy_test.go
+++ b/acceptance/api/v1/application_deploy_test.go
@@ -26,7 +26,7 @@ var _ = Describe("AppDeploy Endpoint", func() {
 		appName = catalog.NewAppName()
 
 		By("creating application resource first")
-		_, err := createApplication(appName, namespace, []string{})
+		_, err := createApplication(appName, namespace, nil)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/acceptance/api/v1/application_importgit_test.go
+++ b/acceptance/api/v1/application_importgit_test.go
@@ -18,18 +18,12 @@ import (
 
 var _ = Describe("AppImportGit Endpoint", func() {
 	var (
-		appName   string
 		namespace string
 	)
 
 	BeforeEach(func() {
 		namespace = catalog.NewNamespaceName()
 		env.SetupAndTargetNamespace(namespace)
-		appName = catalog.NewAppName()
-
-		By("creating application resource first")
-		_, err := createApplication(appName, namespace, []string{})
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {

--- a/acceptance/api/v1/application_stage_test.go
+++ b/acceptance/api/v1/application_stage_test.go
@@ -33,7 +33,7 @@ var _ = Describe("AppStage Endpoint", func() {
 		appName = catalog.NewAppName()
 
 		By("creating application resource first")
-		_, err := createApplication(appName, namespace, []string{})
+		_, err := createApplication(appName, namespace, nil)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -49,7 +49,7 @@ var _ = Describe("AppStage Endpoint", func() {
 			appName2 = catalog.NewAppName()
 
 			By("creating the other application resource first")
-			_, err := createApplication(appName2, namespace, []string{})
+			_, err := createApplication(appName2, namespace, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("uploading the code of the other")

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -571,6 +571,8 @@ configuration:
 					return err
 				}
 
+				By("ZZZ JSON: ((" + statusJSON + "))")
+
 				var status map[string]string
 				err = json.Unmarshal([]byte(statusJSON), &status)
 				if err != nil {

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -631,8 +631,6 @@ configuration:
 					return err
 				}
 
-				By("ZZZ JSON: ((" + statusJSON + "))")
-
 				var status map[string]string
 				err = json.Unmarshal([]byte(statusJSON), &status)
 				if err != nil {

--- a/acceptance/helpers/machine/apps.go
+++ b/acceptance/helpers/machine/apps.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"strconv"
 
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
@@ -18,6 +19,8 @@ func (m *Machine) MakeApp(appName string, instances int, deployFromCurrentDir bo
 }
 
 func (m *Machine) MakeContainerImageApp(appName string, instances int, containerImageURL string) string {
+	By("making a container app:" + appName)
+
 	pushOutput, err := m.Epinio("", "apps", "push",
 		"--name", appName,
 		"--container-image-url", containerImageURL,

--- a/internal/api/v1/application/create.go
+++ b/internal/api/v1/application/create.go
@@ -76,7 +76,8 @@ func (hc Controller) Create(c *gin.Context) apierror.APIErrors {
 	}
 
 	var routes []string
-	if len(createRequest.Configuration.Routes) > 0 {
+	if createRequest.Configuration.Routes != nil {
+		// Note: Routes can be empty here!
 		routes = createRequest.Configuration.Routes
 	} else {
 		route, err := domain.AppDefaultRoute(ctx, createRequest.Name, namespace)

--- a/internal/api/v1/application/deploy.go
+++ b/internal/api/v1/application/deploy.go
@@ -60,8 +60,12 @@ func (hc Controller) Deploy(c *gin.Context) apierror.APIErrors {
 	}
 
 	desiredRoutes, found, err := unstructured.NestedStringSlice(applicationCR.Object, "spec", "routes")
-	if err != nil || !found {
+	if err != nil {
 		return apierror.InternalError(err, "failed to get the application routes")
+	}
+	if !found {
+		// [NO-ROUTES] See other places bearing this marker for explanations.
+		desiredRoutes = []string{}
 	}
 
 	apierr := validateRoutes(ctx, cluster, name, namespace, desiredRoutes)

--- a/internal/api/v1/application/update.go
+++ b/internal/api/v1/application/update.go
@@ -64,7 +64,7 @@ func (hc Controller) Update(c *gin.Context) apierror.APIErrors { // nolint:gocyc
 		len(updateRequest.Environment) == 0 &&
 		len(updateRequest.Settings) == 0 &&
 		updateRequest.Configurations == nil &&
-		len(updateRequest.Routes) == 0 &&
+		updateRequest.Routes == nil &&
 		updateRequest.AppChart == "" {
 		response.OK(c)
 		return nil
@@ -185,9 +185,10 @@ func (hc Controller) Update(c *gin.Context) apierror.APIErrors { // nolint:gocyc
 		}
 	}
 
-	// Only update the app if routes have been set, otherwise just leave it
-	// as it is.
-	if len(updateRequest.Routes) > 0 {
+	// Only update the app if routes have been set, otherwise just leave it as it is.
+	// Note that an empty slice is setting routes, i.e. removing all!
+	// No change is signaled by a nil slice.
+	if updateRequest.Routes != nil {
 		client, err := cluster.ClientApp()
 		if err != nil {
 			return apierror.InternalError(err)

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -92,6 +92,10 @@ func Create(ctx context.Context, cluster *kubernetes.Cluster, app models.AppRef,
 	us.SetKind("App")
 	us.SetName(app.Name)
 
+	// [NO-ROUTES] Note: An empty routes slice is not stored in the app kube resource.
+	// (`omitempty`!) See `DesiredRoutes` for the converse. Treat missing field as empty
+	// slice. Same marker as here.
+
 	_, err = client.Namespace(app.Namespace).Create(ctx, us, metav1.CreateOptions{})
 	return err
 }

--- a/internal/application/ingresses.go
+++ b/internal/application/ingresses.go
@@ -7,7 +7,6 @@ import (
 	"github.com/epinio/epinio/internal/routes"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
-	"github.com/pkg/errors"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,9 +27,10 @@ func DesiredRoutes(ctx context.Context, cluster *kubernetes.Cluster, appRef mode
 	}
 
 	desiredRoutes, found, err := unstructured.NestedStringSlice(applicationCR.Object, "spec", "routes")
-
 	if !found {
-		return []string{}, errors.New("couldn't parse the Application for Routes")
+		// [NO-ROUTES] Not an error. Signal that there are no desired routes.  See `Create`
+		// for the converse. An empty slice becomes an omitted field. Same marker as here.
+		return []string{}, nil
 	}
 	if err != nil {
 		return []string{}, err

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -40,8 +40,6 @@ func init() {
 	CmdAppCreate.Flags().String("app-chart", "", "App chart to use for deployment")
 	CmdAppUpdate.Flags().String("app-chart", "", "App chart to use for deployment")
 
-	CmdAppUpdate.Flags().BoolP("clear-routes", "z", false, "clear routes")
-
 	CmdApp.AddCommand(CmdAppCreate)
 	CmdApp.AddCommand(CmdAppChart) // See chart.go for implementation
 	CmdApp.AddCommand(CmdAppEnv)   // See env.go for implementation

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -40,6 +40,8 @@ func init() {
 	CmdAppCreate.Flags().String("app-chart", "", "App chart to use for deployment")
 	CmdAppUpdate.Flags().String("app-chart", "", "App chart to use for deployment")
 
+	CmdAppUpdate.Flags().BoolP("clear-routes", "z", false, "clear routes")
+
 	CmdApp.AddCommand(CmdAppCreate)
 	CmdApp.AddCommand(CmdAppChart) // See chart.go for implementation
 	CmdApp.AddCommand(CmdAppEnv)   // See env.go for implementation

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -15,6 +15,7 @@ func instancesOption(cmd *cobra.Command) {
 }
 
 func routeOption(cmd *cobra.Command) {
+	cmd.Flags().BoolP("clear-routes", "z", false, "clear routes / no routes")
 	cmd.Flags().StringSliceP("route", "r", []string{}, "Custom route to use for the application (a subdomain of the default domain will be used if this is not set). Can be set multiple times to use multiple routes with the same application.")
 }
 

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -131,7 +131,7 @@ func (c *EpinioClient) Apps(all bool) error {
 				sort.Strings(app.Configuration.Configurations)
 
 				var routes string
-				if len(app.Workload.Routes) == 0 {
+				if len(app.Workload.Routes) > 0 {
 					routes = strings.Join(app.Workload.Routes, ", ")
 				} else {
 					routes = "<<none>>"
@@ -164,11 +164,19 @@ func (c *EpinioClient) Apps(all bool) error {
 			} else {
 				sort.Strings(app.Workload.Routes)
 				sort.Strings(app.Configuration.Configurations)
+
+				var routes string
+				if len(app.Workload.Routes) > 0 {
+					routes = strings.Join(app.Workload.Routes, ", ")
+				} else {
+					routes = "<<none>>"
+				}
+
 				msg = msg.WithTableRow(
 					app.Meta.Name,
 					app.Meta.CreatedAt.String(),
 					app.Workload.Status,
-					strings.Join(app.Workload.Routes, ", "),
+					routes,
 					strings.Join(app.Configuration.Configurations, ", "),
 					app.StatusMessage,
 				)

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -127,22 +127,14 @@ func (c *EpinioClient) Apps(all bool) error {
 					app.StatusMessage,
 				)
 			} else {
-				sort.Strings(app.Workload.Routes)
 				sort.Strings(app.Configuration.Configurations)
-
-				var routes string
-				if len(app.Workload.Routes) > 0 {
-					routes = strings.Join(app.Workload.Routes, ", ")
-				} else {
-					routes = "<<none>>"
-				}
 
 				msg = msg.WithTableRow(
 					app.Meta.Namespace,
 					app.Meta.Name,
 					app.Meta.CreatedAt.String(),
 					app.Workload.Status,
-					routes,
+					formatRoutes(app.Workload.Routes),
 					strings.Join(app.Configuration.Configurations, ", "),
 					app.StatusMessage,
 				)
@@ -162,21 +154,13 @@ func (c *EpinioClient) Apps(all bool) error {
 					app.StatusMessage,
 				)
 			} else {
-				sort.Strings(app.Workload.Routes)
 				sort.Strings(app.Configuration.Configurations)
-
-				var routes string
-				if len(app.Workload.Routes) > 0 {
-					routes = strings.Join(app.Workload.Routes, ", ")
-				} else {
-					routes = "<<none>>"
-				}
 
 				msg = msg.WithTableRow(
 					app.Meta.Name,
 					app.Meta.CreatedAt.String(),
 					app.Workload.Status,
-					routes,
+					formatRoutes(app.Workload.Routes),
 					strings.Join(app.Configuration.Configurations, ", "),
 					app.StatusMessage,
 				)
@@ -647,4 +631,13 @@ func (c *EpinioClient) AppRestage(appName string) error {
 	// blocking function that wait until the staging is done
 	_, err = c.API.StagingComplete(app.Meta.Namespace, stageID)
 	return errors.Wrap(err, "waiting for staging failed")
+}
+
+func formatRoutes(routes []string) string {
+	if len(routes) > 0 {
+		sort.Strings(routes)
+		return strings.Join(routes, ", ")
+	} else {
+		return "<<none>>"
+	}
 }

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -129,12 +129,20 @@ func (c *EpinioClient) Apps(all bool) error {
 			} else {
 				sort.Strings(app.Workload.Routes)
 				sort.Strings(app.Configuration.Configurations)
+
+				var routes string
+				if len(app.Workload.Routes) == 0 {
+					routes = strings.Join(app.Workload.Routes, ", ")
+				} else {
+					routes = "<<none>>"
+				}
+
 				msg = msg.WithTableRow(
 					app.Meta.Namespace,
 					app.Meta.Name,
 					app.Meta.CreatedAt.String(),
 					app.Workload.Status,
-					strings.Join(app.Workload.Routes, ", "),
+					routes,
 					strings.Join(app.Configuration.Configurations, ", "),
 					app.StatusMessage,
 				)
@@ -525,12 +533,14 @@ func (c *EpinioClient) printAppDetails(app models.App) error {
 			msg = msg.WithTableRow("Status", "not deployed, staging failed")
 			msg = msg.WithTableRow("Last StageId", app.StageID)
 		}
-		msg = msg.WithTableRow("Desired Routes", "")
 
 		if len(app.Configuration.Routes) > 0 {
+			msg = msg.WithTableRow("Desired Routes", "")
 			for _, route := range app.Configuration.Routes {
 				msg = msg.WithTableRow("", route)
 			}
+		} else {
+			msg = msg.WithTableRow("Desired Routes", "<<none>>")
 		}
 	}
 

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -329,11 +329,15 @@ func (c *EpinioClient) AppUpdate(appName string, appConfig models.ApplicationUpd
 		WithStringValue("Namespace", c.Settings.Namespace).
 		WithStringValue("Application", appName)
 
-	if len(appConfig.Routes) > 0 {
-		msg = msg.WithStringValue("Routes", "")
-		sort.Strings(appConfig.Routes)
-		for i, d := range appConfig.Routes {
-			msg = msg.WithStringValue(strconv.Itoa(i+1), d)
+	if appConfig.Routes != nil {
+		if len(appConfig.Routes) == 0 {
+			msg = msg.WithStringValue("Routes", "<clearing all>")
+		} else {
+			msg = msg.WithStringValue("Routes", "")
+			sort.Strings(appConfig.Routes)
+			for i, d := range appConfig.Routes {
+				msg = msg.WithStringValue(strconv.Itoa(i+1), d)
+			}
 		}
 	}
 

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -259,17 +259,16 @@ func (c *EpinioClient) stageLogs(appRef models.AppRef, stageID string) {
 
 func routeMessage(msg *termui.Message, routes []string) *termui.Message {
 	if routes == nil {
-		if len(routes) > 0 {
-			msg = msg.WithStringValue("Routes", "")
-			sort.Strings(routes)
-			for i, d := range routes {
-				msg = msg.WithStringValue(strconv.Itoa(i+1), d)
-			}
-		} else {
-			msg = msg.WithStringValue("Routes", "<<none>>")
-		}
-	} else {
-		msg = msg.WithStringValue("Routes", "<<default>>")
+		return msg.WithStringValue("Routes", "<<default>>")
+	}
+	if len(routes) == 0 {
+		return msg.WithStringValue("Routes", "<<none>>")
+	}
+
+	msg = msg.WithStringValue("Routes", "")
+	sort.Strings(routes)
+	for i, d := range routes {
+		msg = msg.WithStringValue(strconv.Itoa(i+1), d)
 	}
 
 	return msg

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/epinio/epinio/helpers"
+	"github.com/epinio/epinio/helpers/termui"
 	"github.com/epinio/epinio/internal/duration"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 )
@@ -81,15 +82,8 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 		msg = msg.WithStringValue("Configurations",
 			strings.Join(params.Configuration.Configurations, ", "))
 	}
-	if len(params.Configuration.Routes) > 0 {
-		msg = msg.WithStringValue("Routes", "")
-		sort.Strings(params.Configuration.Routes)
-		for i, d := range params.Configuration.Routes {
-			msg = msg.WithStringValue(strconv.Itoa(i+1), d)
-		}
-	} else {
-		msg = msg.WithStringValue("Routes", "<<none>>")
-	}
+
+	msg = routeMessage(msg, params.Configuration.Routes)
 
 	msg.Msg("About to push an application with the given setup")
 
@@ -261,6 +255,24 @@ func (c *EpinioClient) stageLogs(appRef models.AppRef, stageID string) {
 			c.ui.Problem().Msg(fmt.Sprintf("failed to tail logs: %s", err.Error()))
 		}
 	}()
+}
+
+func routeMessage(msg *termui.Message, routes []string) *termui.Message {
+	if routes == nil {
+		if len(routes) > 0 {
+			msg = msg.WithStringValue("Routes", "")
+			sort.Strings(routes)
+			for i, d := range routes {
+				msg = msg.WithStringValue(strconv.Itoa(i+1), d)
+			}
+		} else {
+			msg = msg.WithStringValue("Routes", "<<none>>")
+		}
+	} else {
+		msg = msg.WithStringValue("Routes", "<<default>>")
+	}
+
+	return msg
 }
 
 func (c *EpinioClient) reportOK(appRef models.AppRef, builder string, routes []string) {

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -87,6 +87,8 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 		for i, d := range params.Configuration.Routes {
 			msg = msg.WithStringValue(strconv.Itoa(i+1), d)
 		}
+	} else {
+		msg = msg.WithStringValue("Routes", "<<none>>")
 	}
 
 	msg.Msg("About to push an application with the given setup")

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -29,15 +29,13 @@ func UpdateRoutes(manifest models.ApplicationManifest, cmd *cobra.Command) (mode
 		manifest.Configuration.Routes = routes
 	}
 
-	if cmd.Flags().Lookup("clear-routes") != nil {
-		clearRoutes, err := cmd.Flags().GetBool("clear-routes")
-		if err != nil {
-			return manifest, errors.Wrap(err, "could not read option --clear-routes")
-		}
-		if clearRoutes {
-			// Note: This is not the nil slice.
-			manifest.Configuration.Routes = []string{}
-		}
+	clearRoutes, err := cmd.Flags().GetBool("clear-routes")
+	if err != nil {
+		return manifest, errors.Wrap(err, "could not read option --clear-routes")
+	}
+	if clearRoutes {
+		// Note: This is not the nil slice.
+		manifest.Configuration.Routes = []string{}
 	}
 
 	return manifest, nil

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -29,6 +29,17 @@ func UpdateRoutes(manifest models.ApplicationManifest, cmd *cobra.Command) (mode
 		manifest.Configuration.Routes = routes
 	}
 
+	if cmd.Flags().Lookup("clear-routes") != nil {
+		clearRoutes, err := cmd.Flags().GetBool("clear-routes")
+		if err != nil {
+			return manifest, errors.Wrap(err, "could not read option --clear-routes")
+		}
+		if clearRoutes {
+			// Note: This is not the nil slice.
+			manifest.Configuration.Routes = []string{}
+		}
+	}
+
 	return manifest, nil
 }
 


### PR DESCRIPTION
Fix #1799 

nil   => no change
empty => clear routes

Feat: extend cli with ability send signal for clearing routes (new update-only option --clear-routes, -z)