### PR TITLE
Extended app chart taking config names and their mount paths

### DIFF
--- a/acceptance/api/v1/appchart_index_test.go
+++ b/acceptance/api/v1/appchart_index_test.go
@@ -54,6 +54,6 @@ var _ = Describe("ChartList Endpoint", func() {
 		Expect(short).Should(ContainElements(
 			"Epinio standard deployment"))
 		Expect(chart).Should(ContainElements(
-			"https://github.com/epinio/helm-charts/releases/download/epinio-application-0.1.22/epinio-application-0.1.22.tgz"))
+			"https://github.com/epinio/helm-charts/releases/download/epinio-application-0.1.23/epinio-application-0.1.23.tgz"))
 	})
 })

--- a/acceptance/api/v1/appchart_index_test.go
+++ b/acceptance/api/v1/appchart_index_test.go
@@ -54,6 +54,6 @@ var _ = Describe("ChartList Endpoint", func() {
 		Expect(short).Should(ContainElements(
 			"Epinio standard deployment"))
 		Expect(chart).Should(ContainElements(
-			"https://github.com/epinio/helm-charts/releases/download/epinio-application-0.1.23/epinio-application-0.1.23.tgz"))
+			"https://github.com/epinio/helm-charts/releases/download/epinio-application-0.1.24/epinio-application-0.1.24.tgz"))
 	})
 })

--- a/acceptance/api/v1/application_export_test.go
+++ b/acceptance/api/v1/application_export_test.go
@@ -52,6 +52,7 @@ var _ = Describe("AppPart Endpoint", func() {
 
 		Expect(string(bodyBytes)).To(Equal(fmt.Sprintf(`epinio:
   appName: %s
+  configpaths: []
   configurations: []
   env: []
   imageURL: splatform/sample-app

--- a/acceptance/apps/rails_test.go
+++ b/acceptance/apps/rails_test.go
@@ -131,8 +131,11 @@ var _ = Describe("RubyOnRails", func() {
 			"--set", "username=myuser")
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		// Change Rails database configuration to match the configuration name
-		out, err = proc.Run(rails.Dir, false, "sed", "-i", fmt.Sprintf("s/mydb/%s/", configurationName), "config/database.yml")
+		// Change Rails database configuration to have the correct mount point in the access paths.
+		// For 1.22 this was the configuration name
+		// For 1.23+ it is the service name instead
+		out, err = proc.Run(rails.Dir, false, "sed", "-i", fmt.Sprintf("s/mydb/%s/", serviceName),
+			"config/database.yml")
 		Expect(err).ToNot(HaveOccurred(), out)
 	})
 

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -1418,6 +1418,7 @@ configuration:
   tuning: speed
 epinio:
   appName: %s
+  configpaths: []
   configurations: []
   env: []
   imageURL: splatform/sample-app
@@ -1476,6 +1477,7 @@ userConfig:
 				Expect(err).ToNot(HaveOccurred(), string(values))
 				Expect(string(values)).To(Equal(fmt.Sprintf(`epinio:
   appName: %s
+  configpaths: []
   configurations: []
   env: []
   imageURL: splatform/sample-app
@@ -1518,6 +1520,7 @@ userConfig:
 
 				Expect(string(values)).To(Equal(fmt.Sprintf(`epinio:
   appName: %s
+  configpaths: []
   configurations: []
   env:
   - name: complex

--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -2212,6 +2212,13 @@
           "type": "string",
           "x-go-name": "Origin"
         },
+        "siblings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Siblings"
+        },
         "type": {
           "type": "string",
           "x-go-name": "Type"

--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -2535,6 +2535,10 @@
           "type": "string",
           "x-go-name": "CatalogServiceVersion"
         },
+        "hcmanaged": {
+          "type": "boolean",
+          "x-go-name": "ManagedByHelmController"
+        },
         "meta": {
           "$ref": "#/definitions/Meta"
         },

--- a/internal/api/v1/deploy/deploy.go
+++ b/internal/api/v1/deploy/deploy.go
@@ -78,6 +78,14 @@ func DeployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppR
 				service[config.Origin] = serial
 				path = fmt.Sprintf("%s-%d", config.Origin, serial)
 			}
+
+			// ATTENTION: we are creating a mount for the old path as well, for backward
+			// compatibility.
+
+			bound = append(bound, helm.ConfigParameter{
+				Name: configName,
+				Path: configName,
+			})
 		}
 
 		// Record for passing into the helm core

--- a/internal/api/v1/deploy/deploy.go
+++ b/internal/api/v1/deploy/deploy.go
@@ -3,6 +3,8 @@ package deploy
 
 import (
 	"context"
+	"fmt"
+	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -10,6 +12,7 @@ import (
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
+	"github.com/epinio/epinio/internal/configurations"
 	"github.com/epinio/epinio/internal/domain"
 	"github.com/epinio/epinio/internal/helm"
 	"github.com/epinio/epinio/internal/helmchart"
@@ -40,6 +43,50 @@ func DeployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppR
 			WithDetailsf("expectedStageID: [%s] - stageID: [%s]", expectedStageID, stageID)
 	}
 
+	// Iterate over the bound configurations to determine their mount path ...
+
+	// (**) See below for explanation
+	sort.Strings(appObj.Configuration.Configurations)
+
+	bound := []helm.ConfigParameter{} // Configurations and their mount paths
+	service := map[string]int{}       // Seen services, and count of their configurations
+
+	for _, configName := range appObj.Configuration.Configurations {
+		config, err := configurations.Lookup(ctx, cluster, app.Namespace, configName)
+		if err != nil {
+			return nil, apierror.InternalError(err)
+		}
+
+		// Default path is config name itself
+		path := configName
+
+		// For configurations originating in a service, use the service name instead,
+		// possible extended to disambiguate multiple configurations of a single service.
+		if config.Origin != "" {
+			if serial, ok := service[config.Origin]; !ok {
+				path = config.Origin
+				service[config.Origin] = 1
+			} else {
+				// [CS-DISAMBI] With more than one configuration from the same service
+				// disambiguate using a serial number
+				//
+				// Attention! Having sorted the full set of configuration names (see
+				// above (**)), the various configurations of the service will
+				// always have the same serial (or none, for the first).
+
+				serial = serial + 1
+				service[config.Origin] = serial
+				path = fmt.Sprintf("%s-%d", config.Origin, serial)
+			}
+		}
+
+		// Record for passing into the helm core
+		bound = append(bound, helm.ConfigParameter{
+			Name: configName,
+			Path: path,
+		})
+	}
+
 	imageURL := appObj.ImageURL
 	routes := appObj.Configuration.Routes
 	chartName := appObj.Configuration.AppChart
@@ -58,7 +105,7 @@ func DeployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppR
 		AppRef:         app,
 		Chart:          chartName,
 		Environment:    appObj.Configuration.Environment,
-		Configurations: appObj.Configuration.Configurations,
+		Configurations: bound,
 		Instances:      *appObj.Configuration.Instances,
 		ImageURL:       imageURL,
 		Username:       username,

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -558,6 +558,10 @@ func (c *EpinioClient) printAppDetails(app models.App) error {
 
 	msg.Msg("Details:")
 
+	if len(app.Configuration.Configurations) > 0 {
+		c.ui.Exclamation().Msg("Attention: Migrate bound configurations derived from services to new access paths")
+	}
+
 	return nil
 }
 

--- a/internal/cli/usercmd/configuration.go
+++ b/internal/cli/usercmd/configuration.go
@@ -57,24 +57,38 @@ func (c *EpinioClient) Configurations(all bool) error {
 		msg = msg.WithTable("Namespace", "Name", "Created", "Type", "Origin", "Applications")
 
 		for _, configuration := range configurations {
+			apps := strings.Join(configuration.Configuration.BoundApps, ", ")
+
+			if configuration.Configuration.Origin != "" &&
+				len(configuration.Configuration.BoundApps) > 0 {
+				apps = fmt.Sprintf("%s (migrate to new mounts)", apps)
+			}
+
 			msg = msg.WithTableRow(
 				configuration.Meta.Namespace,
 				configuration.Meta.Name,
 				configuration.Meta.CreatedAt.String(),
 				configuration.Configuration.Type,
 				configuration.Configuration.Origin,
-				strings.Join(configuration.Configuration.BoundApps, ", "))
+				apps)
 		}
 	} else {
 		msg = msg.WithTable("Name", "Created", "Type", "Origin", "Applications")
 
 		for _, configuration := range configurations {
+			apps := strings.Join(configuration.Configuration.BoundApps, ", ")
+
+			if configuration.Configuration.Origin != "" &&
+				len(configuration.Configuration.BoundApps) > 0 {
+				apps = fmt.Sprintf("%s (migrate to new access paths)", apps)
+			}
+
 			msg = msg.WithTableRow(
 				configuration.Meta.Name,
 				configuration.Meta.CreatedAt.String(),
 				configuration.Configuration.Type,
 				configuration.Configuration.Origin,
-				strings.Join(configuration.Configuration.BoundApps, ", "))
+				apps)
 		}
 	}
 
@@ -390,6 +404,10 @@ func (c *EpinioClient) ConfigurationDetails(name string) error {
 		WithStringValue("Used-By", strings.Join(boundApps, ", ")).
 		WithStringValue("Siblings", strings.Join(siblings, ", ")).
 		Msg("")
+
+	if resp.Configuration.Origin != "" && len(boundApps) > 0 {
+		c.ui.Exclamation().Msg("Attention: Migrate bound apps to new access paths")
+	}
 
 	msg := c.ui.Success()
 

--- a/internal/cli/usercmd/configuration.go
+++ b/internal/cli/usercmd/configuration.go
@@ -377,8 +377,10 @@ func (c *EpinioClient) ConfigurationDetails(name string) error {
 	}
 	configurationDetails := resp.Configuration.Details
 	boundApps := resp.Configuration.BoundApps
+	siblings := resp.Configuration.Siblings
 
 	sort.Strings(boundApps)
+	sort.Strings(siblings)
 
 	c.ui.Note().
 		WithStringValue("Created", resp.Meta.CreatedAt.String()).
@@ -386,12 +388,36 @@ func (c *EpinioClient) ConfigurationDetails(name string) error {
 		WithStringValue("Type", resp.Configuration.Type).
 		WithStringValue("Origin", resp.Configuration.Origin).
 		WithStringValue("Used-By", strings.Join(boundApps, ", ")).
+		WithStringValue("Siblings", strings.Join(siblings, ", ")).
 		Msg("")
 
 	msg := c.ui.Success()
 
 	if len(configurationDetails) > 0 {
 		msg = msg.WithTable("Parameter", "Value", "Access Path")
+
+		path := name
+		if resp.Configuration.Origin != "" {
+			path = resp.Configuration.Origin
+
+			// Use the configuration's siblings (and itself) to determine if
+			// disambiguation is needed and if yes, where in the total order this
+			// configuration falls. See [CS-DISAMBI].
+			if len(siblings) > 0 {
+				siblings = append(siblings, name)
+				sort.Strings(siblings)
+				serial := 0
+				for idx, cName := range siblings {
+					serial = idx
+					if cName == name {
+						break
+					}
+				}
+				if serial > 1 {
+					path = fmt.Sprintf("%s-%d", path, serial)
+				}
+			}
+		}
 
 		keys := make([]string, 0, len(configurationDetails))
 		for k := range configurationDetails {
@@ -400,7 +426,7 @@ func (c *EpinioClient) ConfigurationDetails(name string) error {
 		sort.Strings(keys)
 		for _, k := range keys {
 			msg = msg.WithTableRow(k, configurationDetails[k],
-				fmt.Sprintf("/configurations/%s/%s", name, k))
+				fmt.Sprintf("/configurations/%s/%s", path, k))
 		}
 
 		msg.Msg("")

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -6,8 +6,10 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/epinio/epinio/helpers/termui"
 	apierrors "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	"github.com/kyokomi/emoji"
 	"github.com/pkg/errors"
 )
 
@@ -111,14 +113,24 @@ func (c *EpinioClient) ServiceShow(serviceName string) error {
 	boundApps := service.BoundApps
 	sort.Strings(boundApps)
 
-	c.ui.Success().WithTable("Key", "Value").
+	var msg *termui.Message
+	var m string
+	if service.ManagedByHelmController {
+		msg = c.ui.Exclamation()
+		m = "Managed by HelmController. Recreate to remove this dependency"
+	} else {
+		msg = c.ui.Success()
+		m = "Details:"
+	}
+
+	msg.WithTable("Key", "Value").
 		WithTableRow("Name", service.Meta.Name).
 		WithTableRow("Created", service.Meta.CreatedAt.String()).
 		WithTableRow("Catalog Service", service.CatalogService).
 		WithTableRow("Version", service.CatalogServiceVersion).
 		WithTableRow("Status", service.Status.String()).
 		WithTableRow("Used-By", strings.Join(boundApps, ", ")).
-		Msg("Details:")
+		Msg(m)
 
 	return nil
 }
@@ -244,20 +256,46 @@ func (c *EpinioClient) ServiceList() error {
 		return nil
 	}
 
+	notes := false
+	for _, service := range services {
+		notes = notes || service.ManagedByHelmController
+	}
+
 	sort.Sort(services)
 
-	msg := c.ui.Success().WithTable("Name", "Created", "Catalog Service", "Version", "Status", "Applications")
-	for _, service := range services {
-		msg = msg.WithTableRow(
-			service.Meta.Name,
-			service.Meta.CreatedAt.String(),
-			service.CatalogService,
-			service.CatalogServiceVersion,
-			service.Status.String(),
-			strings.Join(service.BoundApps, ", "),
-		)
+	if notes {
+		msg := c.ui.Exclamation().WithTable("", "Name", "Created", "Catalog Service", "Version", "Status", "Applications")
+		for _, service := range services {
+			note := ""
+			if service.ManagedByHelmController {
+				note = emoji.Sprintf(":warning: Recreate")
+			}
+
+			msg = msg.WithTableRow(
+				note,
+				service.Meta.Name,
+				service.Meta.CreatedAt.String(),
+				service.CatalogService,
+				service.CatalogServiceVersion,
+				service.Status.String(),
+				strings.Join(service.BoundApps, ", "),
+			)
+		}
+		msg.Msg("Recreate services managed by HelmController to remove this dependency")
+	} else {
+		msg := c.ui.Success().WithTable("Name", "Created", "Catalog Service", "Version", "Status", "Applications")
+		for _, service := range services {
+			msg = msg.WithTableRow(
+				service.Meta.Name,
+				service.Meta.CreatedAt.String(),
+				service.CatalogService,
+				service.CatalogServiceVersion,
+				service.Status.String(),
+				strings.Join(service.BoundApps, ", "),
+			)
+		}
+		msg.Msg("Details:")
 	}
-	msg.Msg("Details:")
 
 	return nil
 }

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -185,9 +185,18 @@ func Deploy(logger logr.Logger, parameters ChartParameters) error {
 
 	// Fill values.yaml structure
 
+	// ATTENTION: The Configurations slice may contain multiple mount points for the same
+	// configuration, for backward compatibility. We dedup this to have only one volume per
+	// config.
+
 	configurationNames := []string{}
+	have := map[string]bool{}
 	for _, c := range parameters.Configurations {
+		if _, found := have[c.Name]; found {
+			continue
+		}
 		configurationNames = append(configurationNames, c.Name)
+		have[c.Name] = true
 	}
 
 	params := chartParam{

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -38,6 +38,11 @@ type ServiceParameters struct {
 	Values        string              // Chart customization (YAML-formatted string)
 }
 
+type ConfigParameter struct {
+	Name string `yaml:"name"` // Configuration name
+	Path string `yaml:"path"` // Mounting path for configuration
+}
+
 type ChartParameters struct {
 	models.AppRef                        // Application: name & namespace
 	Context        context.Context       // Operation context
@@ -48,7 +53,7 @@ type ChartParameters struct {
 	Instances      int32                 // Number Of Desired Replicas
 	StageID        string                // Stage ID that produced ImageURL
 	Environment    models.EnvVariableMap // App Environment
-	Configurations []string              // Bound Configurations (list of names)
+	Configurations []ConfigParameter     // Bound Configurations (list of names and paths)
 	Routes         []string              // Desired application routes
 	Domains        domain.DomainMap      // Map of domains with secrets covering them
 	Start          *int64                // Nano-epoch of deployment. Optional. Used to force a restart, even when nothing else has changed.
@@ -161,6 +166,7 @@ func Deploy(logger logr.Logger, parameters ChartParameters) error {
 	type epinioParam struct {
 		AppName        string               `yaml:"appName"`
 		Configurations []string             `yaml:"configurations"`
+		ConfigPaths    []ConfigParameter    `yaml:"configpaths"`
 		Env            []models.EnvVariable `yaml:"env"`
 		ImageUrl       string               `yaml:"imageURL"`
 		Ingress        string               `yaml:"ingress,omitempty"`
@@ -179,13 +185,19 @@ func Deploy(logger logr.Logger, parameters ChartParameters) error {
 
 	// Fill values.yaml structure
 
+	configurationNames := []string{}
+	for _, c := range parameters.Configurations {
+		configurationNames = append(configurationNames, c.Name)
+	}
+
 	params := chartParam{
 		Epinio: epinioParam{
 			AppName:        parameters.Name,
 			Env:            parameters.Environment.List(),
 			ImageUrl:       parameters.ImageURL,
 			ReplicaCount:   parameters.Instances,
-			Configurations: parameters.Configurations,
+			Configurations: configurationNames,
+			ConfigPaths:    parameters.Configurations,
 			StageID:        parameters.StageID,
 			TlsIssuer:      viper.GetString("tls-issuer"),
 			Username:       parameters.Username,

--- a/internal/services/instances.go
+++ b/internal/services/instances.go
@@ -345,9 +345,10 @@ func (s *ServiceClient) GetForHelmController(ctx context.Context, namespace, nam
 			Namespace: targetNamespace,
 			CreatedAt: srv.GetCreationTimestamp(),
 		},
-		SecretTypes:           secretTypes,
-		CatalogService:        fmt.Sprintf("%s%s", catalogServicePrefix, catalogServiceName),
-		CatalogServiceVersion: catalogServiceVersion,
+		SecretTypes:             secretTypes,
+		CatalogService:          fmt.Sprintf("%s%s", catalogServicePrefix, catalogServiceName),
+		CatalogServiceVersion:   catalogServiceVersion,
+		ManagedByHelmController: true,
 	}
 
 	logger := tracelog.NewLogger().WithName("ServiceStatus")
@@ -445,8 +446,9 @@ func (s *ServiceClient) listForHelmController(ctx context.Context, namespace str
 				Namespace: srv.GetLabels()[TargetNamespaceLabelKey],
 				CreatedAt: srv.GetCreationTimestamp(),
 			},
-			CatalogService:        catalogServiceName,
-			CatalogServiceVersion: srv.GetLabels()[CatalogServiceVersionLabelKey],
+			CatalogService:          catalogServiceName,
+			CatalogServiceVersion:   srv.GetLabels()[CatalogServiceVersionLabelKey],
+			ManagedByHelmController: true,
 		}
 
 		logger := tracelog.NewLogger().WithName("ServiceStatus")

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -328,12 +328,13 @@ type ServiceShowRequest struct {
 }
 
 type Service struct {
-	Meta                  Meta          `json:"meta,omitempty"`
-	SecretTypes           []string      `json:"secretTypes,omitempty"`
-	CatalogService        string        `json:"catalog_service,omitempty"`
-	CatalogServiceVersion string        `json:"catalog_service_version,omitempty"`
-	Status                ServiceStatus `json:"status,omitempty"`
-	BoundApps             []string      `json:"boundapps"`
+	Meta                    Meta          `json:"meta,omitempty"`
+	SecretTypes             []string      `json:"secretTypes,omitempty"`
+	CatalogService          string        `json:"catalog_service,omitempty"`
+	CatalogServiceVersion   string        `json:"catalog_service_version,omitempty"`
+	Status                  ServiceStatus `json:"status,omitempty"`
+	BoundApps               []string      `json:"boundapps"`
+	ManagedByHelmController bool          `json:"hcmanaged"`
 }
 
 func (s Service) Namespace() string {

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -224,11 +224,12 @@ type EnvMatchResponse struct {
 
 // ConfigurationShowResponse contains details about a configuration
 type ConfigurationShowResponse struct {
-	Username  string            `json:"user"`
-	Details   map[string]string `json:"details,omitempty"`
-	BoundApps []string          `json:"boundapps"`
-	Type      string            `json:"type,omitempty"`
-	Origin    string            `json:"origin,omitempty"`
+	Username  string            `json:"user"`               // Name of user creating it
+	Details   map[string]string `json:"details,omitempty"`  // Main information, key/value map
+	BoundApps []string          `json:"boundapps"`          // Names of the apps using it
+	Type      string            `json:"type,omitempty"`     // User or service-created configuration
+	Origin    string            `json:"origin,omitempty"`   // Name of service it came from, if any
+	Siblings  []string          `json:"siblings,omitempty"` // Name of other configs from same service, if any
 }
 
 // ConfigurationMatchResponse contains the list of names for matching configurations


### PR DESCRIPTION
fix #1808

feat: pass in new field `configpath`, config names and mount paths
note: old field `configurations` is still served for use by old app charts

chart pr = https://github.com/epinio/helm-charts/pull/292

- [x] Show the proper mount paths in `configuration show`
- [x] To this end it has to know about sibling configurations from the same origin
- [x] Show these as well
- [x] Implement getting this information in a manner which is not O(n^2) for `configuration list`.
