### PR TITLE
[CI] Updating actions on aks to avoid ::set-output gh annotation warnings

### DIFF
--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -54,7 +54,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
@@ -96,7 +96,7 @@ jobs:
       # The system domain is managed by route53, we need credentials to update
       # it to the loadbalancer's IP
       - name: Configure AWS credentials for Route53
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -117,7 +117,7 @@ jobs:
         shell: bash
         run: |
           id=$RANDOM
-          echo '::set-output name=ID::'$id
+          echo "ID=$id" >> $GITHUB_OUTPUT
           az aks create --resource-group epinioCI \
           --node-vm-size ${{ env.AKS_MACHINE_TYPE }} \
           --name epinioCI$id \


### PR DESCRIPTION
Related to https://github.com/epinio/epinio/issues/1797

### Task:
Bump `.github/workflows/aks.yml` to remove annotation warnings related to deprecation of `save-state` and `set-output` commands among others

### Done: 
- Updating `Cache Tools` to use ~`actions/cache@v3.0.8`~ `actions/cache@v3` instead of fixed version
- Updating `Configure AWS credentials for Route53`  to version `node16` to avoid deprecation warning. Explanation [here](https://github.com/aws-actions/configure-aws-credentials#notice-node12-deprecation-warning)
- Changing `::set-output` to new `echo "{name}={value}" >> $GITHUB_OUTPUT`. Explained [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

### Results:
[AKS-CI #635 ](https://github.com/epinio/epinio/actions/runs/3342253729), without fix: 4 annotations
[AKS-CI #636](https://github.com/epinio/epinio/actions/runs/3344266782), with fix: 0 annotation warnings, tests passing

![image](https://user-images.githubusercontent.com/37271841/198563377-406c4a1c-a30a-46b9-965d-ed90886dbe76.png)
