### PR TITLE
Updating all gke cis  to avoid gh-actions annotation warnings

### DIFF
--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -46,7 +46,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
@@ -85,7 +85,7 @@ jobs:
       # The system domain is managed by route53, we need credentials to update
       # it to the loadbalancer's IP
       - name: Configure AWS credentials for Route53
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -109,7 +109,7 @@ jobs:
         id: create-cluster
         run: |
           id=$RANDOM
-          echo '::set-output name=ID::'$id
+          echo "ID=$id" >> $GITHUB_OUTPUT
           gcloud container clusters create epinioci$id \
           --disk-size 100 \
           --num-nodes=1 \

--- a/.github/workflows/gke-upgrade.yml
+++ b/.github/workflows/gke-upgrade.yml
@@ -45,7 +45,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
@@ -91,7 +91,7 @@ jobs:
       # The system domain is managed by route53, we need credentials to update
       # it to the loadbalancer's IP
       - name: Configure AWS credentials for Route53
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -115,7 +115,7 @@ jobs:
         id: create-cluster
         run: |
           id=$RANDOM
-          echo '::set-output name=ID::'$id
+          echo "ID=$id" >> $GITHUB_OUTPUT
           gcloud container clusters create epinioci$id \
           --disk-size 100 \
           --num-nodes=1 \

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -46,7 +46,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
@@ -85,7 +85,7 @@ jobs:
       # The system domain is managed by route53, we need credentials to update
       # it to the loadbalancer's IP
       - name: Configure AWS credentials for Route53
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -109,7 +109,7 @@ jobs:
         id: create-cluster
         run: |
           id=$RANDOM
-          echo '::set-output name=ID::'$id
+          echo "ID=$id" >> $GITHUB_OUTPUT
           gcloud container clusters create epinioci$id \
           --disk-size 100 \
           --num-nodes=1 \


### PR DESCRIPTION
Related to https://github.com/epinio/epinio/issues/1797
Doing the same as in https://github.com/epinio/epinio/pull/1823 but for `GKE-CI`,`GKE-CI-UPGRADE` and `GKE-CI-LETSENCRYPT`

### Task:
Bumping  `.github/workflows/gke.yml`, `.github/workflows/gke-upgrade.yml` and `.github/workflows/gke-letsencrypt.yml`  to remove annotation warnings related to deprecation of `save-state` and `set-output` commands among others

### Done: 
- Updating `Cache Tools` to use `actions/cache@v3` instead of fixed version
- Updating `Configure AWS credentials for Route53`  to version `node16` to avoid deprecation warning. Explanation [here](https://github.com/aws-actions/configure-aws-credentials#notice-node12-deprecation-warning)
- Changing `::set-output` to new `echo "{name}={value}" >> $GITHUB_OUTPUT`. Explained [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

### Results:
[GKE-CI #506](https://github.com/epinio/epinio/actions/runs/3346418869) -> OK. 0 warning annotations
![image](https://user-images.githubusercontent.com/37271841/198678157-3788ffa2-65bb-4295-9811-30207fb1e1a3.png)
