### PR TITLE
Updating actions on rkes yaml  to avoid ::set-output annotation warnings

### DIFF
--- a/.github/workflows/rke-upgrade.yml
+++ b/.github/workflows/rke-upgrade.yml
@@ -38,7 +38,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
@@ -85,7 +85,7 @@ jobs:
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools

--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -39,7 +39,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
@@ -79,7 +79,7 @@ jobs:
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools


### PR DESCRIPTION
Related to https://github.com/epinio/epinio/issues/1797
Doing the same as in https://github.com/epinio/epinio/pull/1823 but for `RKE-CI`,`RKE-CI-UPGRADE` .

### Task:
Bumping  `.github/workflows/rke.yml` and `.github/workflows/rke-upgrade.yml` to remove annotation warnings related to deprecation of `save-state` and `set-output` commands among others

### Done: 
- Updating `Cache Tools` to use `actions/cache@v3` instead of fixed version

### Results:
[RKE-CI #481](https://github.com/epinio/epinio/actions/runs/3346758614) -> 0 annotations after fix
![image](https://user-images.githubusercontent.com/37271841/198683069-2784ceb1-92e4-4efc-b5de-3cd06ce78b4d.png)


