### PR TITLE
[CI] Updating actions on go lint and CI to avoid ::set-output / save-state gh annotation warnings

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -35,13 +35,14 @@ jobs:
         id: configfile
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "::set-output name=file::.golangci.yml"
+            echo "file=.golangci.yml" >> $GITHUB_OUTPUT
+
           else
-            echo "::set-output name=file::.golangci-schedule.yml"
+            echo "file=.golangci-schedule.yml" >> $GITHUB_OUTPUT
           fi
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.2.0
+        uses: golangci/golangci-lint-action@v3.3.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.49

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
@@ -155,7 +155,7 @@ jobs:
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
@@ -227,7 +227,7 @@ jobs:
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools


### PR DESCRIPTION
Related to https://github.com/epinio/epinio/issues/1797

### Task:
Bump `.github/workflows/main.yml` and  `.github/workflows/golangci-lint.yml` to remove annotation warnings related to deprecation of `save-state` and `set-output` commands among others

### Done in `main.yml`: 
- Updating `Cache Tools` to use `actions/cache@v3` instead of fixed version

### Done in `golangci-lint.yml`: 
- Changing `::set-output` to new `echo "{name}={value}" >> $GITHUB_OUTPUT`. Explained [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- Updating `golangci-lint-action@v3.2.0` to `golangci-lint-action@v3.3.0`

### Results:
[golangci-lint #3537](https://github.com/epinio/epinio/actions/runs/3359986353) ok and no annotation warnings:
![image](https://user-images.githubusercontent.com/37271841/198977196-0f5022fe-3354-46e9-9ee5-c366162dd68e.png)
