### PR TITLE
updating eks.yml for set-output and other deprecation warnings

### DIFF
--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -58,7 +58,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
@@ -110,7 +110,7 @@ jobs:
           sudo mv eksctl /usr/local/bin
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ github.event.inputs.aws_id || secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ github.event.inputs.aws_key || secrets.AWS_SECRET_ACCESS_KEY }}
@@ -120,7 +120,7 @@ jobs:
         id: create-cluster
         run: |
           id=$RANDOM
-          echo '::set-output name=ID::'$id
+          echo "ID=$id" >> $GITHUB_OUTPUT
           eksctl create cluster --name=epinio-ci$id \
           --region=${{ env.AWS_REGION }} \
           --nodes=2 \


### PR DESCRIPTION
Related to https://github.com/epinio/epinio/issues/1797
Doing the same as in https://github.com/epinio/epinio/pull/1823 but for `EKS-CI`

### Task:
Bumping  `.github/workflows/eks.yml`  to remove annotation warnings related to deprecation of `save-state` and `set-output` commands among others

### Done: 
- Updating `Cache Tools` to use `actions/cache@v3` instead of fixed version
- Updating `Configure AWS credentials for Route53`  to version `node16` to avoid deprecation warning. Explanation [here](https://github.com/aws-actions/configure-aws-credentials#notice-node12-deprecation-warning)
- Changing `::set-output` to new `echo "{name}={value}" >> $GITHUB_OUTPUT`. Explained [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

### Results:
[EKS-CI #598](https://github.com/epinio/epinio/actions/runs/3360733508): 0 annotation warnings for `set-output` or `save-state`
![image](https://user-images.githubusercontent.com/37271841/199016236-af578440-92d7-412e-a9a6-460652f98e7e.png)

### Note:
I left on purpose the annotation warning `macOS-latest pipelines will use macOS-12 soon. For more details, see https://github.com/actions/runner-images/issues/6384` because as I see it our current configuration pointing to `macOs:latest` is correct. The issue is that currently on the action side this latest flag points to version 11 instead of 12, so I think is best to leave it as it is and let the update occur naturally on dec 22 instead of hard-coding this value