### PR TITLE
Add platforms for epinio-unpacker image

### DIFF
--- a/.github/workflows/unpacker-image.yml
+++ b/.github/workflows/unpacker-image.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Build and push unpacker
         uses: docker/build-push-action@v3
         with:
+          platforms: linux/amd64,linux/arm64,linux/s390x
           push: true
           context: images/.
           file: images/unpacker-Dockerfile


### PR DESCRIPTION
This should address https://github.com/epinio/epinio/issues/1847 and adding s390x in addition. It will override the current version of image `ghcr.io/epinio/epinio-unpacker:1.0` for `amd64`.

Tested on my custom runner with custom docker registry. Resulting image seems to be working - the image can be specified as `unpackImage: thehejik/epinio-unpacker:1.0` via `kubectl edit cm epinio-stage-scripts -n epinio`.