### PR TITLE
Configure EKS EBS CSI driver for k8s 1.23+

### DIFF
--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -132,6 +132,28 @@ jobs:
           # https://stackoverflow.com/questions/71318743/kubectl-versions-error-exec-plugin-is-configured-to-use-api-version-client-auth
           sed -i .bak -e 's/v1alpha1/v1beta1/' kubeconfig-epinio-ci
 
+      - name: Configure EKS EBS CSI storage
+        id: configure-storage
+        run: |
+          id="${{ steps.create-cluster.outputs.ID }}"
+          # Get AWS Account ID
+          AWS_ACCOUNT_ID=$(aws sts get-caller-identity | jq -r '.Account')
+          # Assign OIDC provider to the cluster
+          eksctl utils associate-iam-oidc-provider --cluster=epinio-ci$id --approve
+          # Assign existing policy Amazon_EBS_CSI_Driver to the cluster's serviceAccount via a new Role
+          eksctl create iamserviceaccount --cluster=epinio-ci$id \
+            --name=ebs-csi-controller-sa \
+            --namespace=kube-system \
+            --attach-policy-arn=arn:aws:iam::$AWS_ACCOUNT_ID:policy/Amazon_EBS_CSI_Driver \
+            --approve \
+            --role-only \
+            --role-name=AmazonEKS_epinio-ci$id-EBS_CSI_DriverRole
+          # Install the driver addon and use the Role
+          eksctl create addon --name=aws-ebs-csi-driver \
+            --cluster=epinio-ci$id \
+            --service-account-role-arn=arn:aws:iam::$AWS_ACCOUNT_ID:role/AmazonEKS_epinio-ci$id-EBS_CSI_DriverRole \
+            --force
+
       - name: Installation Acceptance Tests
         env:
           REGEX: Scenario4

--- a/scripts/patch-epinio-deployment.sh
+++ b/scripts/patch-epinio-deployment.sh
@@ -65,6 +65,16 @@ metadata:
   annotations:
     linkerd.io/inject: disabled
 spec:
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/component
+            operator: In
+            values:
+            - epinio-server
+        topologyKey: kubernetes.io/hostname
   volumes:
     - name: epinio-binary
       persistentVolumeClaim:


### PR DESCRIPTION
Resolves https://github.com/epinio/epinio/issues/1809

Successful test runs:
https://github.com/epinio/epinio/actions/runs/3513169605
https://github.com/epinio/epinio/actions/runs/3512660788 (failed later on something else)
https://github.com/epinio/epinio/actions/runs/3513477067

To resolve EKS EBS CSI driver [persistent volume's node affinity limitation](https://aws.amazon.com/premiumsupport/knowledge-center/eks-troubleshoot-ebs-volume-mounts/) I had to extend this PR by adding `epinio-copier` pod affinity with `epinio-server` pod. 

That garantees that the `epinio-binary` PV is getting created on the same node (also withtin the same zone) where the `epinio-server` pod is running hence this pod should be always able to mount the PV. I used generic `topologyKey` value `kubernetes.io/hostname` which should be also available out of EKS.