### PR TITLE
Added Claims-Roles mapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -202,6 +202,7 @@ require (
 	go.starlark.net v0.0.0-20221028183056-acb66ad56dd2 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
+	golang.org/x/exp v0.0.0-20221114191408-850992195362
 	golang.org/x/mod v0.6.0 // indirect
 	golang.org/x/net v0.1.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1017,6 +1017,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20221114191408-850992195362 h1:NoHlPRbyl1VFI6FjwHtPQCN7wAMXI6cKcqrmXhOOfBQ=
+golang.org/x/exp v0.0.0-20221114191408-850992195362/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -85,8 +85,8 @@ func (s *AuthService) SaveUser(ctx context.Context, user User) (User, error) {
 			Name:      userSecretName,
 			Namespace: "epinio",
 			Labels: map[string]string{
-				"epinio.io/api-user-credentials": "true",
-				"epinio.io/role":                 user.Role,
+				kubernetes.EpinioAPISecretLabelKey:     "true",
+				kubernetes.EpinioAPISecretRoleLabelKey: user.Role,
 			},
 		},
 		StringData: map[string]string{

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -86,7 +86,7 @@ func (s *AuthService) SaveUser(ctx context.Context, user User) (User, error) {
 			Namespace: "epinio",
 			Labels: map[string]string{
 				"epinio.io/api-user-credentials": "true",
-				"epinio.io/role":                 "user",
+				"epinio.io/role":                 user.Role,
 			},
 		},
 		StringData: map[string]string{

--- a/internal/cli/usercmd/login_oidc.go
+++ b/internal/cli/usercmd/login_oidc.go
@@ -127,7 +127,7 @@ func (c *EpinioClient) getAuthCodeAndVerifierWithServer(ctx context.Context, oid
 	if err != nil {
 		return "", "", errors.Wrap(err, "creating listener")
 	}
-	oidcProvider.Config.RedirectURL = fmt.Sprintf("http://localhost:%d", listener.Addr().(*net.TCPAddr).Port)
+	oidcProvider.Config.Oauth2.RedirectURL = fmt.Sprintf("http://localhost:%d", listener.Addr().(*net.TCPAddr).Port)
 
 	authCodeURL, codeVerifier := oidcProvider.AuthCodeURLWithPKCE()
 

--- a/internal/dex/config.go
+++ b/internal/dex/config.go
@@ -1,0 +1,77 @@
+package dex
+
+import (
+	"net/url"
+
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+	"gopkg.in/yaml.v2"
+)
+
+type Config struct {
+	Issuer          string
+	ClientID        string
+	Endpoint        *url.URL
+	ProvidersGroups []ProviderGroups
+
+	Oauth2 *oauth2.Config
+}
+
+type ProviderGroups struct {
+	ConnectorID string  `yaml:"connectorId"`
+	Groups      []Group `yaml:"groups"`
+}
+
+type Group struct {
+	ID   string `yaml:"id"`
+	Role string `yaml:"role"`
+}
+
+func NewConfig(issuer, clientID string) (Config, error) {
+	config := Config{
+		Issuer:   issuer,
+		ClientID: clientID,
+	}
+
+	endpoint, err := url.Parse(issuer)
+	if err != nil {
+		return config, errors.Wrap(err, "parsing the issuer URL")
+	}
+	config.Endpoint = endpoint
+
+	return config, nil
+}
+
+func NewConfigFromSecretData(clientID string, secretData map[string][]byte) (Config, error) {
+	config := Config{
+		ClientID: clientID,
+	}
+
+	issuer, found := secretData["issuer"]
+	if found {
+		config.Issuer = string(issuer)
+	}
+
+	endpoint, found := secretData["endpoint"]
+	if found {
+		endpointURL, err := url.Parse(string(endpoint))
+		if err != nil {
+			return config, errors.Wrap(err, "parsing the issuer URL")
+		}
+		config.Endpoint = endpointURL
+	}
+
+	rolesMapping, found := secretData["rolesMapping"]
+	if found {
+		providersGroups := []ProviderGroups{}
+
+		err := yaml.Unmarshal(rolesMapping, &providersGroups)
+		if err != nil {
+			return config, errors.Wrap(err, "parsing the issuer URL")
+		}
+
+		config.ProvidersGroups = providersGroups
+	}
+
+	return config, nil
+}

--- a/pkg/api/core/v1/client/client.go
+++ b/pkg/api/core/v1/client/client.go
@@ -50,7 +50,7 @@ func New(ctx context.Context, settings *epiniosettings.Settings) *Client {
 		} else {
 			// ask a token for the 'epinio-api' client
 			oidcProvider.AddScopes("audience:server:client_id:epinio-api")
-			tokenSource = oidcProvider.Config.TokenSource(ctx, token)
+			tokenSource = oidcProvider.Config.Oauth2.TokenSource(ctx, token)
 		}
 	}
 


### PR DESCRIPTION
Ref:
- #1816 
- https://github.com/epinio/docs/pull/191
---

This PR enable the possibility to assign roles to the Epinio users during the login with an OIDC provider.

Please note that the user role is assigned during the creation of the user, so just after the first login. If the groups are updated these updates will not be reflected in the next login, but you should manually update the role.

The update of the user could be possible, but there are some cases where it's not clear which could be the expected behaviour, so it's better to get a deeper understanding of this.

I.e: what is the expected behaviour when an admin manually change the role of a user? What if the user login with a different provider with different groups/roles, or none?