### PR TITLE
Fix missing help output for root command given a bogus sub command

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -29,6 +29,7 @@ func NewEpinioCLI() *cobra.Command {
 }
 
 var rootCmd = &cobra.Command{
+	Args:          cobra.MaximumNArgs(0),
 	Use:           "epinio",
 	Short:         "Epinio cli",
 	Long:          `epinio cli is the official command line interface for Epinio PaaS `,


### PR DESCRIPTION
fix #1869