### PR TITLE
Fix namespace in app internal routes

### DIFF
--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -517,7 +517,7 @@ func (c *EpinioClient) printAppDetails(app models.App) error {
 			WithTableRow("Running StageId", app.Workload.StageID).
 			WithTableRow("Last StageId", app.StageID).
 			WithTableRow("Age", time.Since(createdAt).Round(time.Second).String()).
-			WithTableRow("Internal Route", app.Workload.Name+".workspace.svc.cluster.local").
+			WithTableRow("Internal Route", fmt.Sprintf("%s.%s.svc.cluster.local", app.Workload.Name, app.Namespace())).
 			WithTableRow("Active Routes", "")
 
 		if len(app.Workload.Routes) > 0 {

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -517,7 +517,7 @@ func (c *EpinioClient) printAppDetails(app models.App) error {
 			WithTableRow("Running StageId", app.Workload.StageID).
 			WithTableRow("Last StageId", app.StageID).
 			WithTableRow("Age", time.Since(createdAt).Round(time.Second).String()).
-			WithTableRow("Internal Route", fmt.Sprintf("%s.%s.svc.cluster.local", app.Workload.Name, app.Namespace())).
+			WithTableRow("Internal Route", fmt.Sprintf("%s.%s.svc.cluster.local:8080", app.Workload.Name, app.Namespace())).
 			WithTableRow("Active Routes", "")
 
 		if len(app.Workload.Routes) > 0 {


### PR DESCRIPTION
This PR fixes the hardcoded namespace in the app internal route.
This is still strictly bound to the default app chart, and the `8080` port.