### PR TITLE
Bump helm to v3.9.0 and get rid of traefik workaround

### DIFF
--- a/acceptance/install/suite_test.go
+++ b/acceptance/install/suite_test.go
@@ -69,9 +69,6 @@ func InstallTraefik() {
 		"--set", "ports.web.redirectTo=websecure",
 		"--set", "ingressClass.enabled=true",
 		"--set", "ingressClass.isDefaultClass=true",
-		// Workaround for https://github.com/traefik/traefik-helm-chart/issues/741
-		"--set", "metrics.prometheus.addEntryPointsLabels=false",
-		"--set", "metrics.prometheus.addServicesLabels=false",
 	)
 	Expect(err).NotTo(HaveOccurred(), out)
 }

--- a/scripts/tools/helm.sh
+++ b/scripts/tools/helm.sh
@@ -1,9 +1,9 @@
 set -e
 
-VERSION="3.6.3"
+VERSION="3.9.0"
 
 URL="https://get.helm.sh/helm-v${VERSION}-linux-amd64.tar.gz"
-SHA256="07c100849925623dc1913209cd1a30f0a9b80a5b4d6ff2153c609d11b043e262"
+SHA256="1484ffb0c7a608d8069470f48b88d729e88c41a1b6602f145231e8ea7b43b50a"
 
 pushd "$TMP_DIR" > /dev/null
 wget -q "$URL" -O "helm.tar.gz"


### PR DESCRIPTION
To make upstream traefik work in RKE scenarios I had to bump helm CLI to v3.9.0 and removed the workaround done in https://github.com/epinio/epinio/pull/1887

Latest helm chart for traefik requires helm v3.9.0+
Fails to install with lower versions  as visible here:
https://github.com/epinio/epinio/actions/runs/3570537605/jobs/6001604825

Ok with v3.9.0 on RKE:
https://github.com/epinio/epinio/actions/runs/3566938136