### PR TITLE
Delete namespaces to remove EC2/EBS volumes from AWS

### DIFF
--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -182,5 +182,8 @@ jobs:
         env:
           KUBECONFIG: ${{ env.KUBECONFIG_NAME }}
         run: |
+          # Deleting namespaces will also remove PVs from EC2/EBS
           id="${{ steps.create-cluster.outputs.ID }}"
+          kubectl delete namespace epinio || true
+          kubectl delete namespace workspace || true
           eksctl delete cluster --region=${{ env.AWS_REGION }} --name=epinio-ci$id


### PR DESCRIPTION
Fix #1931

There are no leftovers anymore in EC2/EBS volumes list after triggering 2 testruns:
https://github.com/epinio/epinio/actions/runs/3622662907
https://github.com/epinio/epinio/actions/runs/3623507118