### PR TITLE
CI Wordpress - Bump tests to PHP 8.0.x.

### DIFF
--- a/acceptance/apps/wordpress_test.go
+++ b/acceptance/apps/wordpress_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Wordpress", func() {
 	It("can deploy Wordpress", func() {
 		out, err := env.EpinioPush(wordpress.Dir, wordpress.Name, "--name", wordpress.Name,
 			"-e", "BP_PHP_WEB_DIR=wordpress",
-			"-e", "BP_PHP_VERSION=7.4.x",
+			"-e", "BP_PHP_VERSION=8.0.x",
 			"-e", "BP_PHP_SERVER=nginx")
 		Expect(err).ToNot(HaveOccurred(), out)
 

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -185,7 +185,7 @@ configuration:
 				"--name", appName,
 				"--git", wordpress,
 				"-e", "BP_PHP_WEB_DIR=wordpress",
-				"-e", "BP_PHP_VERSION=7.4.x",
+				"-e", "BP_PHP_VERSION=8.0.x",
 				"-e", "BP_PHP_SERVER=nginx")
 			Expect(err).ToNot(HaveOccurred(), pushLog)
 
@@ -211,7 +211,7 @@ configuration:
 				"--name", appName,
 				"--git", wordpress+",main",
 				"-e", "BP_PHP_WEB_DIR=wordpress",
-				"-e", "BP_PHP_VERSION=7.4.x",
+				"-e", "BP_PHP_VERSION=8.0.x",
 				"-e", "BP_PHP_SERVER=nginx")
 			Expect(err).ToNot(HaveOccurred(), pushLog)
 
@@ -237,7 +237,7 @@ configuration:
 				"--name", appName,
 				"--git", wordpress+",68af5bad11d8f3b95bdf547986fe3348324919c5",
 				"-e", "BP_PHP_WEB_DIR=wordpress",
-				"-e", "BP_PHP_VERSION=7.4.x",
+				"-e", "BP_PHP_VERSION=8.0.x",
 				"-e", "BP_PHP_SERVER=nginx")
 			Expect(err).ToNot(HaveOccurred(), pushLog)
 
@@ -264,7 +264,7 @@ configuration:
 					"--name", appName,
 					"--git", wordpress+",main",
 					"-e", "BP_PHP_WEB_DIR=wordpress",
-					"-e", "BP_PHP_VERSION=7.4.x",
+					"-e", "BP_PHP_VERSION=8.0.x",
 					"-e", "BP_PHP_SERVER=nginx")
 				Expect(err).ToNot(HaveOccurred(), pushLog)
 


### PR DESCRIPTION
Fix #1936 
