### PR TITLE
Let epinio consume unpacker image like server image

### DIFF
--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -3,7 +3,9 @@
 set -e
 
 version="$(git describe --tags)"
-image="ghcr.io/epinio/epinio-server"
+imageEpServer="ghcr.io/epinio/epinio-server"
+imageUnpacker="ghcr.io/epinio/epinio-unpacker"
 
-# Build image
-docker build -t "${image}:${version}" -t "${image}:latest" -f images/Dockerfile .
+# Build images
+docker build -t "${imageEpServer}:${version}" -t "${imageEpServer}:latest" -f images/Dockerfile .
+docker build -t "${imageUnpacker}:${version}" -t "${imageUnpacker}:latest" -f images/unpacker-Dockerfile .

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -79,10 +79,14 @@ if [[ $EPINIO_RELEASED ]]; then
 else
   echo "Importing locally built epinio server image"
   k3d image import -c epinio-acceptance "ghcr.io/epinio/epinio-server:${IMAGE_TAG}"
+  echo "Importing locally built epinio unpacker image"
+  k3d image import -c epinio-acceptance "ghcr.io/epinio/epinio-unpacker:${IMAGE_TAG}"
+  echo "Importing locally built images: Completed"
 
   helm upgrade --install --create-namespace -n epinio \
     --set global.domain="$EPINIO_SYSTEM_DOMAIN" \
     --set image.epinio.tag="${IMAGE_TAG}" \
+    --set image.bash.tag="${IMAGE_TAG}" \
     epinio helm-charts/chart/epinio --wait "$@"
 
   # compile coverage binary and add required env var


### PR DESCRIPTION
Fix #1935 

Chart PR https://github.com/epinio/helm-charts/pull/315 does the main work.
Changes here update CI support code to build the unpacker image they now need, in the same way they need the server image.

