### PR TITLE
Add helm to macos-12 runner

### DIFF
--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          brew install kubernetes-cli coreutils
+          brew install kubernetes-cli helm coreutils
 
       - name: Install EKSCTL
         run: |


### PR DESCRIPTION
Our CI eks.yml workflow is using `macos-latest` runner which has been recently migrated to `macos-12` image. 

One of the change is that `helm` utility is not present anymore by default as it was in `macos-11` image.

This PR will install `helm` over brew.

EKS test is passing: https://github.com/epinio/epinio/actions/runs/3846654499/jobs/6552214556