### PR TITLE
New flow for container cleanup

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -18,6 +18,6 @@ jobs:
           account-type: org
           org-name: epinio
           keep-at-least: 1
-          filter-tags: v*-g*
+          filter-tags: v*-[0-9]*-g*
           filter-include-untagged: true
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -1,0 +1,23 @@
+name: Delete old container images
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 1 * *"  # every day at 6 in the morning
+
+jobs:
+  clean-ghcr:
+    name: Delete old unused container images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete untagged and dev containers older than a week
+        uses: snok/container-retention-policy@v1.5.1
+        with:
+          image-names: epinio-server, epinio-unpacker
+          cut-off: A week ago UTC
+          account-type: org
+          org-name: epinio
+          keep-at-least: 1
+          filter-tags: v*-g*
+          filter-include-untagged: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Note: Pattern `v*-g*` for the dev images (they have a `g`-prefix commit id in the tag).  Including the untagged as well