### PR TITLE
Enable S3 authentication with IAM Role

### DIFF
--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -397,11 +397,6 @@ func newJobRun(app stageParam) (*batchv1.Job, *corev1.Secret) {
 
 	volumeMounts := []corev1.VolumeMount{
 		{
-			Name:      "s3-creds",
-			MountPath: "/root/.aws",
-			ReadOnly:  true,
-		},
-		{
 			Name:      "source",
 			SubPath:   "source",
 			MountPath: "/workspace/source",
@@ -425,6 +420,15 @@ func newJobRun(app stageParam) (*batchv1.Job, *corev1.Secret) {
 			MountPath: "/workspace/source/appenv",
 			ReadOnly:  true,
 		},
+	}
+
+	// mount AWS credentials secret only if the credentials are provided
+	if app.S3ConnectionDetails.AccessKeyID != "" && app.S3ConnectionDetails.SecretAccessKey != "" {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "s3-creds",
+			MountPath: "/root/.aws",
+			ReadOnly:  true,
+		})
 	}
 
 	cacheClaim := &corev1.PersistentVolumeClaimVolumeSource{

--- a/internal/s3manager/s3manager.go
+++ b/internal/s3manager/s3manager.go
@@ -76,6 +76,11 @@ func New(connectionDetails ConnectionDetails) (*Manager, error) {
 		Region:    connectionDetails.Location,
 	}
 
+	// if no credentials are provided then we are going to try to connect with the IAM Role
+	if connectionDetails.AccessKeyID == "" && connectionDetails.SecretAccessKey == "" {
+		opts.Creds = credentials.NewIAM("")
+	}
+
 	if len(connectionDetails.CA) > 0 {
 		rootCAs := x509.NewCertPool()
 		if ok := rootCAs.AppendCertsFromPEM(connectionDetails.CA); !ok {


### PR DESCRIPTION
This PR enable the IAM role authentication for S3. If no credentials are specified then the IAM Role authentication will be used.