### PR TITLE
image cleanup - Fix: daily cron, not just 1st of month

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -3,7 +3,7 @@ name: Delete old container images
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 6 1 * *"  # every day at 6 in the morning
+    - cron: "0 6 * * *"  # every day at 6 in the morning
 
 jobs:
   clean-ghcr:


### PR DESCRIPTION
Ref #1955 . The merged cron setup is wrong, causing a trigger only on the first of the month, instead of daily.
This PR fixes the issue.
