### PR TITLE
Separate Epinio tag/build from release

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,5 +1,5 @@
-# This action will be triggered when the 'Product Release' will be published.
-# This will notify the external repositories about the new Epinio version
+# This action will be triggered when the 'Product Release' is published.
+# It notifies the external repositories about the new Epinio version
 name: Release Published
 
 on:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,51 @@
+# This action will be triggered when the 'Product Release' will be published.
+# This will notify the external repositories about the new Epinio version
+name: Release Published
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: self-hosted
+
+    steps:
+      - name: Get current tag
+        id: get_tag
+        run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+
+      # Allow to automate documentation update related to Epinio releases.
+      # The latest tag is sent to the documentation repository.
+      - name: epinio/docs Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.CHART_REPO_ACCESS_TOKEN }}
+          repository: epinio/docs
+          event-type: epinio-release
+          client-payload: '{"ref": "${{ steps.get_tag.outputs.TAG }}"}'
+
+      - name: Bump Homebrew formula
+        uses: mislav/bump-homebrew-formula-action@v2
+        if: "!contains(github.ref, '-')" # skip prereleases
+        with:
+          download-url: https://github.com/epinio/epinio/archive/refs/tags/${{ steps.get_tag.outputs.TAG }}.tar.gz
+          commit-message: |
+            {{formulaName}} {{version}}
+
+            Created by https://github.com/mislav/bump-homebrew-formula-action
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+
+      - name: Bump Homebrew Epinio tap
+        uses: mislav/bump-homebrew-formula-action@v2
+        if: "!contains(github.ref, '-')" # skip prereleases
+        with:
+          homebrew-tap: epinio/homebrew-tap
+          download-url: https://github.com/epinio/epinio/archive/refs/tags/${{ steps.get_tag.outputs.TAG }}.tar.gz
+          commit-message: |
+            {{formulaName}} {{version}}
+
+            Created by https://github.com/mislav/bump-homebrew-formula-action
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,19 @@
 name: Release-pipeline
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
 
 permissions:
+  id-token: write   # This is the key for OIDC!
   contents: write
   packages: write
 
 jobs:
   release:
     runs-on: self-hosted
-    permissions:
-      id-token: write   # This is the key for OIDC!
-      contents: write
-      packages: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -67,25 +66,3 @@ jobs:
           repository: epinio/helm-charts
           event-type: epinio-release
           client-payload: '{"ref": "${{ steps.get_tag.outputs.TAG }}"}'
-
-      # Allow to automate documentation update related to Epinio releases.
-      # The latest tag is sent to the documentation repository.
-      - name: epinio/docs Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.CHART_REPO_ACCESS_TOKEN }}
-          repository: epinio/docs
-          event-type: epinio-release
-          client-payload: '{"ref": "${{ steps.get_tag.outputs.TAG }}"}'
-
-      - name: Bump Homebrew formula
-        uses: mislav/bump-homebrew-formula-action@v2
-        if: "!contains(github.ref, '-')" # skip prereleases
-        with:
-          download-url: https://github.com/epinio/epinio/archive/refs/tags/${{ steps.get_tag.outputs.TAG }}.tar.gz
-          commit-message: |
-            {{formulaName}} {{version}}
-
-            Created by https://github.com/mislav/bump-homebrew-formula-action
-        env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -260,28 +260,10 @@ docker_manifests:
     - "ghcr.io/epinio/epinio-unpacker:{{ .Tag }}-arm64v8"
     - "ghcr.io/epinio/epinio-unpacker:{{ .Tag }}-s390x"
 
-brews:
-  - name: epinio
-    description: "CLI for Epinio, the Application Development Engine for Kubernetes"
-    homepage: "https://epinio.io/"
-    license: "Apache-2.0"
-
-    tap:
-      owner: epinio
-      name: homebrew-tap
-      token: "{{ .Env.COMMITTER_TOKEN }}"
-
-    folder: Formula
-    url_template: "https://github.com/epinio/epinio/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-
-    test: |
-      output = shell_output("#{bin}/epinio version 2>&1")
-      assert_match "Epinio Version: #{version}", output
-
-      output = shell_output("#{bin}/epinio settings update-ca 2>&1")
-      assert_match "failed to get kube config", output
-      assert_match "no configuration has been provided", output
 release:
+  # Do not auto-publish the release
+  draft: true
+
   extra_files:
     - glob: ./helm-charts/chart/epinio/crds/*
 


### PR DESCRIPTION
Ref:
- #1928 

Fixes #1952  and #1956

---

This PR changes the trigger for build from release publishing to a tag.
This enables us to tag and build an Epinio version without actually releasing and announcing it as a product version (since we should wait for the Helm charts to be released).

A new action was created. This action will be triggered after the actual publication of a release.
It notifies other repositories about the new Product Release of Epinio.
