### PR TITLE
Remove Ginkgo deprecated flag

### DIFF
--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -91,7 +91,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       # The system domain is managed by route53, we need credentials to update
       # it to the loadbalancer's IP

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -91,7 +91,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       # The system domain is managed by route53, we need credentials to update
       # it to the loadbalancer's IP

--- a/.github/workflows/clientsync.yml
+++ b/.github/workflows/clientsync.yml
@@ -40,7 +40,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Cache Tools
         uses: actions/cache@v3.0.8

--- a/.github/workflows/eks-test.yml
+++ b/.github/workflows/eks-test.yml
@@ -79,7 +79,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -95,7 +95,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -92,7 +92,7 @@ jobs:
           aws-region: us-east-2
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Authenticate to GCP
         uses: 'google-github-actions/auth@v1'

--- a/.github/workflows/gke-test.yml
+++ b/.github/workflows/gke-test.yml
@@ -84,7 +84,7 @@ jobs:
           aws-region: ${{ secrets.EKS_REGION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Authenticate to GCP
         uses: 'google-github-actions/auth@v1'

--- a/.github/workflows/gke-upgrade.yml
+++ b/.github/workflows/gke-upgrade.yml
@@ -100,7 +100,7 @@ jobs:
           aws-region: us-east-2
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Authenticate to GCP
         uses: 'google-github-actions/auth@v1'

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -92,7 +92,7 @@ jobs:
           aws-region: us-east-2
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Authenticate to GCP
         uses: 'google-github-actions/auth@v1'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Lint Epinio
         run: make lint
@@ -80,7 +80,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Cache Tools
         uses: actions/cache@v3
@@ -152,7 +152,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Cache Tools
         uses: actions/cache@v3
@@ -224,7 +224,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Cache Tools
         uses: actions/cache@v3
@@ -297,7 +297,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Cache Tools
         uses: actions/cache@v3
@@ -370,7 +370,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Cache Tools
         uses: actions/cache@v3
@@ -442,7 +442,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Cache Tools
         uses: actions/cache@v3
@@ -515,7 +515,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Cache Tools
         uses: actions/cache@v3

--- a/.github/workflows/rke-upgrade.yml
+++ b/.github/workflows/rke-upgrade.yml
@@ -82,7 +82,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Cache Tools
         uses: actions/cache@v3

--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -76,7 +76,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Cache Tools
         uses: actions/cache@v3

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -42,7 +42,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
 
       - name: Cache Tools
         uses: actions/cache@v3.0.8

--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,9 @@ tag:
 
 FLAKE_ATTEMPTS ?= 2
 GINKGO_NODES ?= 2
-GINKGO_SLOW_TRESHOLD ?= 200
+GINKGO_POLL_PROGRESS_AFTER ?= 200s
 REGEX ?= ""
-STANDARD_TEST_OPTIONS= -v --nodes ${GINKGO_NODES} --slow-spec-threshold ${GINKGO_SLOW_TRESHOLD}s --randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending
+STANDARD_TEST_OPTIONS= -v --nodes ${GINKGO_NODES} --poll-progress-after ${GINKGO_POLL_PROGRESS_AFTER} --randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending
 
 acceptance-cluster-delete:
 	k3d cluster delete epinio-acceptance


### PR DESCRIPTION
Remove Ginkgo `--slow-spec-thresold` deprecated flag, and used `--poll-progress-after` instead.

```
You're using deprecated Ginkgo functionality:
=============================================
  --ginkgo.slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo.  This feature has proved to be more noisy than useful.  You can use --poll-progress-after, instead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.
```

