### PR TITLE
bring back image k3s:v1.20.11-k3s2 for ci tests

### DIFF
--- a/scripts/acceptance-cluster-setup.sh
+++ b/scripts/acceptance-cluster-setup.sh
@@ -7,7 +7,7 @@ NETWORK_NAME=epinio-acceptance
 MIRROR_NAME=epinio-acceptance-registry-mirror
 CLUSTER_NAME=epinio-acceptance
 export KUBECONFIG=$SCRIPT_DIR/../tmp/acceptance-kubeconfig
-K3S_IMAGE=${K3S_IMAGE:-rancher/k3s:v1.25.4-k3s1}
+K3S_IMAGE=${K3S_IMAGE:-rancher/k3s:v1.20.11-k3s2}
 
 check_deps() {
   if ! command -v k3d &> /dev/null


### PR DESCRIPTION
Bringing back `K3S_IMAGE` to `k3s:v1.20.11-k3s2` in `scripts/acceptance-cluster-setup.sh` (revert of https://github.com/epinio/epinio/pull/2001/files) until issues related to port-forwarding are fixed 