### PR TITLE
Update release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -27,7 +27,7 @@ exclude-labels:
 change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 tag-template: 'v$RESOLVED_VERSION'
-name-template: 'v$RESOLVED_VERSION 🌈'
+name-template: 'v$RESOLVED_VERSION'
 template: |
 
   # What's Changed


### PR DESCRIPTION
During the last release we have seen that Goreleaser created a new draft, probably because the latest draft was not matching the name because of the emoji.

This PR updates the release-drafter.yml to remove the emoji from the name (we usually add it later).