### PR TITLE
Fixed Epinio Tap (homebrew)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -47,16 +47,3 @@ jobs:
             Created by https://github.com/mislav/bump-homebrew-formula-action
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
-
-      - name: Bump Homebrew Epinio tap
-        uses: mislav/bump-homebrew-formula-action@v2
-        if: "!contains(github.ref, '-')" # skip prereleases
-        with:
-          homebrew-tap: epinio/homebrew-tap
-          download-url: https://github.com/epinio/epinio/archive/refs/tags/${{ steps.get_tag.outputs.TAG }}.tar.gz
-          commit-message: |
-            {{formulaName}} {{version}}
-
-            Created by https://github.com/mislav/bump-homebrew-formula-action
-        env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -271,6 +271,27 @@ docker_manifests:
     - "ghcr.io/epinio/epinio-unpacker:{{ .Tag }}-arm64v8"
     - "ghcr.io/epinio/epinio-unpacker:{{ .Tag }}-s390x"
 
+brews:
+  - name: epinio
+    description: "CLI for Epinio, the Application Development Engine for Kubernetes"
+    homepage: "https://epinio.io/"
+    license: "Apache-2.0"
+
+    tap:
+      owner: epinio
+      name: homebrew-tap
+      token: "{{ .Env.COMMITTER_TOKEN }}"
+
+    folder: Formula
+    url_template: "https://github.com/epinio/epinio/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+
+    test: |
+      output = shell_output("#{bin}/epinio version 2>&1")
+      assert_match "Epinio Version: #{version}", output
+      output = shell_output("#{bin}/epinio settings update-ca 2>&1")
+      assert_match "failed to get kube config", output
+      assert_match "no configuration has been provided", output
+
 release:
   # Do not auto-publish the release
   draft: true


### PR DESCRIPTION
The Github action that we were using to update the official Formula is not working with third-party Taps.

This PR partially revert the https://github.com/epinio/epinio/pull/1996/files

This will keep the bump of our Epinio Tap (https://github.com/epinio/homebrew-tap/blob/main/Formula/epinio.rb) with the tag action. The official Homebrew-Core repository will still need to wait the official publishing of the release.