### PR TITLE
Fixed reuse of the existing Release draft

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -274,6 +274,10 @@ docker_manifests:
 release:
   # Do not auto-publish the release
   draft: true
+  # Replace the existing draft
+  replace_existing_draft: true
+  # Keep the release notes
+  mode: keep-existing
 
   extra_files:
     - glob: ./helm-charts/chart/epinio/crds/*


### PR DESCRIPTION
This PR SHOULD fix the issue of creating a new draft, while the already existing was not updated.

:warning: Please, remember to copy the releae notes, just in case this will not work!

From the doc: https://goreleaser.com/customization/release/?h=draft#github

```yaml
  # Whether to remove existing draft releases with the same name before creating
  # a new one.
  # Only effective if `draft` is set to true.
  # Available only for GitHub.
  #
  # Default: false.
  # Since: v1.11.
  replace_existing_draft: true

  # What to do with the release notes in case there the release already exists.
  #
  # Valid options are:
  # - `keep-existing`: keep the existing notes
  # - `append`: append the current release notes to the existing notes
  # - `prepend`: prepend the current release notes to the existing notes
  # - `replace`: replace existing notes
  #
  # Default is `keep-existing`.
  mode: append
```

The `mode` is set to the default value, but just as a clear indication that we want to keep the existing notes.