### PR TITLE
Adding check if dex-tls secrets is repeated many times

### DIFF
--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -139,18 +139,16 @@ echo "-------------------------------------"
 
 # Check no tls-dex cert conflict issue 
 
-# Check the pod name
-target_cert_manager_pod=$(kubectl get pod -n cert-manager -lapp=cert-manager -o jsonpath="{.items[0].metadata.name}")
-
 # Counting logs of undesired message
-check_dex_log=$(kubectl logs ${target_cert_manager_pod} -n cert-manager | grep '"secret"="dex-tls" "message"="unexpected managed Secret Owner Reference field on Secret --enable-certificate-owner-ref=true"' | wc -l)
+message_dex_tls='"secret"="dex-tls" "message"="unexpected managed Secret Owner Reference field on Secret --enable-certificate-owner-ref=true"'
+check_dex_log_count=$(kubectl logs  -n cert-manager -lapp=cert-manager --tail=-1 | grep ${message_dex_tls} | wc -l)
 
 # Exiting with count of bad logs if more than 10 are found
 if [ $check_dex_log -gt 10 ]; then
  echo
  echo "-------------------------------------"
  echo "Warning: 'dex-tls' secrets may be be updated many times a second."
- echo "More than '${check_dex_log}' logs found in pod '${target_cert_manager_pod}' with entry = '"secret"="dex-tls" "message"="unexpected managed Secret Owner Reference field on Secret --enable-certificate-owner-ref=true"'"
+ echo "More than '${check_dex_log_count}' logs found in 'cert-manager/cert-manager' pod with entry = ' ${message_dex_tls} '"
  echo "Exiting installation"
  echo "-------------------------------------" 
  exit 1

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -121,6 +121,7 @@ else
       { "backend": { "service": { "name": "epinio-server", "port": { "number": 80 } } }, "path": "/exit", "pathType": "ImplementationSpecific" } }]'
   fi
 fi
+helm upgrade --install epinio -n epinio --version 1.6.1 --create-namespace epinio/epinio --set global.domain=172.19.0.3.omg.howdoi.website
 
 echo "-------------------------------------"
 echo "Cleanup old settings"
@@ -137,14 +138,13 @@ echo -n "Trying to getting info"
 retry 5 1 "${EPINIO_BINARY} info"
 echo "-------------------------------------"
 
-# Check no tls-dex cert conflict issue 
-
+# Check no tls-dex cert conflict issue
 # Counting logs of undesired message
-message_dex_tls='"secret"="dex-tls" "message"="unexpected managed Secret Owner Reference field on Secret --enable-certificate-owner-ref=true"'
-check_dex_log_count=$(kubectl logs  -n cert-manager -lapp=cert-manager --tail=-1 | grep ${message_dex_tls} | wc -l)
+message_dex_tls="unexpected managed Secret Owner Reference field on Secret --enable-certificate-owner-ref=true"
+check_dex_log_count="$(kubectl logs  -n cert-manager -lapp=cert-manager --tail=-1 | grep "${message_dex_tls}"  | wc -l)"
 
 # Exiting with count of bad logs if more than 10 are found
-if [ $check_dex_log -gt 10 ]; then
+if [ $check_dex_log_count -gt 10 ]; then
  echo
  echo "-------------------------------------"
  echo "Warning: 'dex-tls' secrets may be be updated many times a second."

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -140,10 +140,10 @@ echo "-------------------------------------"
 # Check no tls-dex cert conflict issue 
 
 # Check the pod name
-target_cert_manager_pod=`kubectl get pods -n cert-manager -o name --no-headers=true |  grep -vE 'webhook|cainjector' | cut -b 5-`
+target_cert_manager_pod=$(kubectl get pod -n cert-manager -lapp=cert-manager -o jsonpath="{.items[0].metadata.name}")
 
 # Counting logs of undesired message
-check_dex_log=`kubectl logs ${target_cert_manager_pod} -n cert-manager | grep '"secret"="dex-tls" "message"="unexpected managed Secret Owner Reference field on Secret --enable-certificate-owner-ref=true"' | wc -l`
+check_dex_log=$(kubectl logs ${target_cert_manager_pod} -n cert-manager | grep '"secret"="dex-tls" "message"="unexpected managed Secret Owner Reference field on Secret --enable-certificate-owner-ref=true"' | wc -l)
 
 # Exiting with count of bad logs if more than 10 are found
 if [ $check_dex_log -gt 10 ]; then

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -121,7 +121,6 @@ else
       { "backend": { "service": { "name": "epinio-server", "port": { "number": 80 } } }, "path": "/exit", "pathType": "ImplementationSpecific" } }]'
   fi
 fi
-helm upgrade --install epinio -n epinio --version 1.6.1 --create-namespace epinio/epinio --set global.domain=172.19.0.3.omg.howdoi.website
 
 echo "-------------------------------------"
 echo "Cleanup old settings"
@@ -141,14 +140,14 @@ echo "-------------------------------------"
 # Check no tls-dex cert conflict issue
 # Counting logs of undesired message
 message_dex_tls="unexpected managed Secret Owner Reference field on Secret --enable-certificate-owner-ref=true"
-check_dex_log_count="$(kubectl logs  -n cert-manager -lapp=cert-manager --tail=-1 | grep "${message_dex_tls}"  | wc -l)"
+check_dex_log_count=$(kubectl logs  -n cert-manager -lapp=cert-manager --tail=-1 | grep "${message_dex_tls}"  | wc -l)
 
 # Exiting with count of bad logs if more than 10 are found
 if [ $check_dex_log_count -gt 10 ]; then
  echo
  echo "-------------------------------------"
  echo "Warning: 'dex-tls' secrets may be be updated many times a second."
- echo "More than '${check_dex_log_count}' logs found in 'cert-manager/cert-manager' pod with entry = ' ${message_dex_tls} '"
+ echo "More than '${check_dex_log_count}' logs found in 'cert-manager/cert-manager' pod with entry = '${message_dex_tls}'"
  echo "Exiting installation"
  echo "-------------------------------------" 
  exit 1

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -137,6 +137,25 @@ echo -n "Trying to getting info"
 retry 5 1 "${EPINIO_BINARY} info"
 echo "-------------------------------------"
 
+# Check no tls-dex cert conflict issue 
+
+# Check the pod name
+target_cert_manager_pod=`kubectl get pods -n cert-manager -o name --no-headers=true |  grep -vE 'webhook|cainjector' | cut -b 5-`
+
+# Counting logs of undesired message
+check_dex_log=`kubectl logs ${target_cert_manager_pod} -n cert-manager | grep '"secret"="dex-tls" "message"="unexpected managed Secret Owner Reference field on Secret --enable-certificate-owner-ref=true"' | wc -l`
+
+# Exiting with count of bad logs if more than 10 are found
+if [ $check_dex_log -gt 10 ]; then
+ echo
+ echo "-------------------------------------"
+ echo "Warning: 'dex-tls' secrets may be be updated many times a second."
+ echo "More than '${check_dex_log}' logs found in pod '${target_cert_manager_pod}' with entry = '"secret"="dex-tls" "message"="unexpected managed Secret Owner Reference field on Secret --enable-certificate-owner-ref=true"'"
+ echo "Exiting installation"
+ echo "-------------------------------------" 
+ exit 1
+fi
+
 ${EPINIO_BINARY} info
 
 echo


### PR DESCRIPTION
PR for https://github.com/epinio/epinio/issues/2044

### Summary
I modified the place for the check. Originally it was thought in [acceptance-cluster-setup.sh](https://github.com/epinio/epinio/blob/f935d3cfdced05ba32b8e9535ab513257f52b9b2/scripts/acceptance-cluster-setup.sh) or  [acceptance-cluster-setup-kind.sh]( https://github.com/epinio/epinio/blob/f935d3cfdced05ba32b8e9535ab513257f52b9b2/scripts/acceptance-cluster-setup-kind.sh)  but I realized that the `cert-manager` pod is not set yet at this stage so I did it instead on the [prepare-environment-k3d.sh](https://github.com/epinio/epinio/blob/e7d671801630e0c383a45f0dcf9b72027bb48da3/scripts/prepare-environment-k3d.sh)

---
### Done
Added check on  cert-manager/cert-manager pod for log `"secret"="dex-tls" "message"="unexpected managed Secret Owner Reference field on Secret --enable-certificate-owner-ref=true"`

If successful the installation continues as normal
If found more than 10 times when installing epinio the test fails and displays:
- Reason of failure
- Counts of occurrences of that login

Error displayed:


```
-------------------------------------
Cleanup old settings
-------------------------------------
Trying to login. ✔️
-------------------------------------
Trying to getting info. ✔️
-------------------------------------

-------------------------------------
Warning: 'dex-tls' secrets may be be updated many times a second.
More than '3351' logs found in 'cert-manager/cert-manager' pod with entry = ' "secret"="dex-tls" "message"="unexpected managed Secret Owner Reference field on Secret --enable-certificate-owner-ref=true" '
Exiting installation
-------------------------------------
make: *** [Makefile:221: prepare_environment_k3d] Error 1
```
Note: 
To check it: deploy epinio with version `v1.6.1` . For instance add this after the `patch-epinio-deployment.sh` part of the original script: 

```
helm upgrade --install epinio -n epinio --version 1.6.1 --create-namespace epinio/epinio --set global.domain=172.19.0.3.omg.howdoi.website
```