### PR TITLE
Fix port forwarding for newer kube versions

### DIFF
--- a/internal/api/v1/application/exec.go
+++ b/internal/api/v1/application/exec.go
@@ -13,17 +13,13 @@ package application
 
 import (
 	"net/http"
-	"net/http/httputil"
-	"time"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/application"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/gin-gonic/gin"
 	v1 "k8s.io/api/core/v1"
-	thekubernetes "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 )
 
 func (hc Controller) Exec(c *gin.Context) apierror.APIErrors {
@@ -33,11 +29,6 @@ func (hc Controller) Exec(c *gin.Context) apierror.APIErrors {
 	instanceName := c.Query("instance")
 
 	cluster, err := kubernetes.GetCluster(ctx)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	clientSetHTTP1, err := kubernetes.GetHTTP1Client(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
 	}
@@ -87,41 +78,22 @@ func (hc Controller) Exec(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	proxyRequest(c.Writer, c.Request, podToConnect, namespace, appData.Name, clientSetHTTP1)
-
-	return nil
-}
-
-func proxyRequest(rw http.ResponseWriter, req *http.Request, podName, namespace, container string, client thekubernetes.Interface) {
 	// https://github.com/kubernetes/kubectl/blob/2acffc93b61e483bd26020df72b9aef64541bd56/pkg/cmd/exec/exec.go#L352
-	attachURL := client.CoreV1().RESTClient().
+	attachURL := cluster.Kubectl.CoreV1().RESTClient().
 		Post().
 		Namespace(namespace).
 		Resource("pods").
-		Name(podName).
+		Name(podToConnect).
 		SubResource("exec").
 		VersionedParams(&v1.PodExecOptions{
 			Stdin:     true,
 			Stdout:    true,
 			Stderr:    true,
 			TTY:       true,
-			Container: container,
+			Container: appData.Name,
 			// https://github.com/rancher/dashboard/blob/37f40d7213ff32096bfefd02de77be6a0e7f40ab/components/nav/WindowManager/ContainerShell.vue#L22
 			Command: []string{"/bin/sh", "-c", "TERM=xterm-256color; export TERM; exec /bin/bash"},
 		}, scheme.ParameterCodec).URL()
 
-	httpClient := client.CoreV1().RESTClient().(*rest.RESTClient).Client
-	p := httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			req.URL = attachURL
-			req.Host = attachURL.Host
-			// let kube authentication work
-			delete(req.Header, "Cookie")
-			delete(req.Header, "Authorization")
-		},
-		Transport:     httpClient.Transport,
-		FlushInterval: time.Millisecond * 100,
-	}
-
-	p.ServeHTTP(rw, req)
+	return runProxy(ctx, c.Writer, c.Request, attachURL)
 }

--- a/internal/api/v1/application/portforward.go
+++ b/internal/api/v1/application/portforward.go
@@ -13,15 +13,11 @@ package application
 
 import (
 	"net/http"
-	"net/http/httputil"
-	"time"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/application"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/gin-gonic/gin"
-	thekubernetes "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 func (hc Controller) PortForward(c *gin.Context) apierror.APIErrors {
@@ -31,11 +27,6 @@ func (hc Controller) PortForward(c *gin.Context) apierror.APIErrors {
 	instanceName := c.Query("instance")
 
 	cluster, err := kubernetes.GetCluster(ctx)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	clientSetHTTP1, err := kubernetes.GetHTTP1Client(ctx)
 	if err != nil {
 		return apierror.InternalError(err)
 	}
@@ -80,33 +71,14 @@ func (hc Controller) PortForward(c *gin.Context) apierror.APIErrors {
 		podToConnect = podNames[0]
 	}
 
-	forwardRequest(c.Writer, c.Request, podToConnect, namespace, clientSetHTTP1)
-
-	return nil
-}
-
-func forwardRequest(rw http.ResponseWriter, req *http.Request, podName, namespace string, client thekubernetes.Interface) {
 	// https://github.com/kubernetes/kubectl/blob/2acffc93b61e483bd26020df72b9aef64541bd56/pkg/cmd/portforward/portforward.go#L409
-	forwardURL := client.CoreV1().RESTClient().
+	forwardURL := cluster.Kubectl.CoreV1().RESTClient().
 		Post().
 		Resource("pods").
 		Namespace(namespace).
-		Name(podName).
+		Name(podToConnect).
 		SubResource("portforward").
 		URL()
 
-	httpClient := client.CoreV1().RESTClient().(*rest.RESTClient).Client
-	p := httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			req.URL = forwardURL
-			req.Host = forwardURL.Host
-			// let kube authentication work
-			delete(req.Header, "Cookie")
-			delete(req.Header, "Authorization")
-		},
-		Transport:     httpClient.Transport,
-		FlushInterval: time.Millisecond * 100,
-	}
-
-	p.ServeHTTP(rw, req)
+	return runProxy(ctx, c.Writer, c.Request, forwardURL)
 }

--- a/internal/api/v1/application/portforward.go
+++ b/internal/api/v1/application/portforward.go
@@ -35,6 +35,11 @@ func (hc Controller) PortForward(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
+	clientSetHTTP1, err := kubernetes.GetHTTP1Client(ctx)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
 	app, err := application.Lookup(ctx, cluster, namespace, appName)
 	if err != nil {
 		return apierror.InternalError(err)
@@ -75,7 +80,7 @@ func (hc Controller) PortForward(c *gin.Context) apierror.APIErrors {
 		podToConnect = podNames[0]
 	}
 
-	forwardRequest(c.Writer, c.Request, podToConnect, namespace, cluster.Kubectl)
+	forwardRequest(c.Writer, c.Request, podToConnect, namespace, clientSetHTTP1)
 
 	return nil
 }

--- a/internal/api/v1/application/proxy.go
+++ b/internal/api/v1/application/proxy.go
@@ -1,0 +1,49 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package application
+
+import (
+	"context"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+
+	"github.com/epinio/epinio/helpers/kubernetes"
+	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"k8s.io/client-go/rest"
+)
+
+func runProxy(ctx context.Context, rw http.ResponseWriter, req *http.Request, destination *url.URL) apierror.APIErrors {
+	clientSetHTTP1, err := kubernetes.GetHTTP1Client(ctx)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	httpClient := clientSetHTTP1.CoreV1().RESTClient().(*rest.RESTClient).Client
+
+	p := httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL = destination
+			req.Host = destination.Host
+			// let kube authentication work
+			delete(req.Header, "Cookie")
+			delete(req.Header, "Authorization")
+		},
+		Transport:     httpClient.Transport,
+		FlushInterval: time.Millisecond * 100,
+	}
+
+	p.ServeHTTP(rw, req)
+
+	return nil
+}

--- a/internal/auth/certs.go
+++ b/internal/auth/certs.go
@@ -42,7 +42,7 @@ func ExtendLocalTrust(certs string) {
 	}
 
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = config
-	websocket.DefaultDialer.TLSClientConfig = config
+	websocket.DefaultDialer.TLSClientConfig = config.Clone()
 
 	// See https://github.com/gorilla/websocket/issues/601 for
 	// what this is a work around for.

--- a/internal/cli/settings/settings.go
+++ b/internal/cli/settings/settings.go
@@ -132,13 +132,11 @@ func LoadFrom(file string) (*Settings, error) {
 			}
 
 			http.DefaultTransport.(*http.Transport).TLSClientConfig = tlsInsecure
-			websocket.DefaultDialer.TLSClientConfig = tlsInsecure
 		} else {
 			// nolint:gosec // Controlled by user option
 			http.DefaultTransport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
-			// websocket.DefaultDialer.TLSClientConfig refers to the same structure,
-			// and the assignment has modified it also.
 		}
+		websocket.DefaultDialer.TLSClientConfig = http.DefaultTransport.(*http.Transport).TLSClientConfig.Clone()
 	}
 
 	if !cfg.Colors || viper.GetBool("no-colors") {

--- a/scripts/acceptance-cluster-setup.sh
+++ b/scripts/acceptance-cluster-setup.sh
@@ -17,7 +17,7 @@ NETWORK_NAME=epinio-acceptance
 MIRROR_NAME=epinio-acceptance-registry-mirror
 CLUSTER_NAME=epinio-acceptance
 export KUBECONFIG=$SCRIPT_DIR/../tmp/acceptance-kubeconfig
-K3S_IMAGE=${K3S_IMAGE:-rancher/k3s:v1.20.11-k3s2}
+K3S_IMAGE=${K3S_IMAGE:-rancher/k3s:v1.25.4-k3s1}
 
 check_deps() {
   if ! command -v k3d &> /dev/null


### PR DESCRIPTION
Fix #2009 

In the end some code used in (possibly a fix) `app exec` was not propagated to the code for `app port-forward`.
The PR synches `exec` and `port-forward` implementations, and factors the common parts to be shared.
Some other cleanups are also done.

The CI will test that the changes do not break for older kube versions.
When that is done another commit will be pushed, bumping the CI kube version to a point where it broke, and verify that this is ok then too.

CI :heavy_check_mark: pre kube bump.
CI :heavy_check_mark:  post kube bump.