### PR TITLE
Automate upgrade responder config

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -47,3 +47,13 @@ jobs:
             Created by https://github.com/mislav/bump-homebrew-formula-action
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+
+      - name: Update Upgrade Responder Response JSON config
+        run: ./scripts/upgrade-responder-release-update.sh
+        env:
+          COGNITO_USERNAME: ${{ secrets.UPGRADE_RESPONDER_COGNITO_USERNAME }}
+          COGNITO_PASSWORD: ${{ secrets.UPGRADE_RESPONDER_COGNITO_PASSWORD }}
+          COGNITO_CLIENT_ID: ${{ secrets.UPGRADE_RESPONDER_COGNITO_CLIENT_ID }}
+          EKS_ENDPOINT: ${{ secrets.UPGRADE_RESPONDER_EKS_ENDPOINT }}
+          K8S_NAMESPACE: epinio
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}

--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -65,3 +65,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+
+      - name: Update Upgrade Responder Response JSON config
+        run: ./scripts/upgrade-responder-release-update.sh
+        env:
+          COGNITO_USERNAME: ${{ secrets.COGNITO_USERNAME }}
+          COGNITO_PASSWORD: ${{ secrets.COGNITO_PASSWORD }}
+          K8S_NAMESPACE: epinio

--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -66,9 +66,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 
-      - name: Update Upgrade Responder Response JSON config
+      - name: Update Upgrade Responder Response JSON config (dry run)
         run: ./scripts/upgrade-responder-release-update.sh
         env:
-          COGNITO_USERNAME: ${{ secrets.COGNITO_USERNAME }}
-          COGNITO_PASSWORD: ${{ secrets.COGNITO_PASSWORD }}
+          COGNITO_USERNAME: ${{ secrets.UPGRADE_RESPONDER_COGNITO_USERNAME }}
+          COGNITO_PASSWORD: ${{ secrets.UPGRADE_RESPONDER_COGNITO_PASSWORD }}
+          COGNITO_CLIENT_ID: ${{ secrets.UPGRADE_RESPONDER_COGNITO_CLIENT_ID }}
+          EKS_ENDPOINT: ${{ secrets.UPGRADE_RESPONDER_EKS_ENDPOINT }}
           K8S_NAMESPACE: epinio
+          K8S_DRY_RUN: client
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}

--- a/scripts/cognito-login.sh
+++ b/scripts/cognito-login.sh
@@ -1,0 +1,155 @@
+#! /bin/sh
+# Copyright © 2021 - 2023 SUSE LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o errexit
+
+#########################
+# External Dependencies #
+#########################
+
+${PROG_WHICH:="which"} \
+  ${PROG_CURL:="curl"} \
+  ${PROG_JQ:="jq"} \
+  ${PROG_KUBECTL:="kubectl"} \
+  ${PROG_WHICH} 1>/dev/null
+
+##################################
+# Configuration Helper Functions #
+##################################
+
+function ExtractRegionFromEndpoint
+{
+  local endpoint=${1}
+  endpoint=${endpoint##*://}
+  endpoint=${endpoint%.eks.amazonaws.com}
+  endpoint=${endpoint##*.}
+  echo "${endpoint}"
+}
+
+#################
+# Configuration #
+#################
+
+: ${COGNITO_USERNAME:=""}
+: ${COGNITO_PASSWORD:=""}
+:
+: ${COGNITO_CLIENT_ID:=""}
+: ${EKS_ENDPOINT:=""}
+:
+: ${COGNITO_REGION:=$(ExtractRegionFromEndpoint "${EKS_ENDPOINT}")}
+: ${COGNITO_ENDPOINT:="https://cognito-idp.${COGNITO_REGION}.amazonaws.com"}
+:
+: ${K8S_CLUSTER:="version.rancher.io"}
+: ${K8S_NAMESPACE:=""}
+:
+: ${K8S_CONTEXT:="${K8S_NAMESPACE}.${K8S_CLUSTER}"}
+: ${K8S_USER:="${COGNITO_USERNAME}@${COGNITO_ENDPOINT##*://}"}
+:
+: ${K8S_ROOT_CA_URL:="${EKS_ENDPOINT}/api/v1/namespaces/${K8S_NAMESPACE}/configmaps/kube-root-ca.crt"}
+
+function AuthRequestPayload
+{
+  ${PROG_JQ} -e -r \
+    --arg COGNITO_CLIENT_ID "${COGNITO_CLIENT_ID}" \
+    --arg COGNITO_USERNAME "${COGNITO_USERNAME}" \
+    --arg COGNITO_PASSWORD "${COGNITO_PASSWORD}" \
+    '.
+    | .ClientId=$ARGS.named.COGNITO_CLIENT_ID
+    | .AuthParameters.USERNAME=$ARGS.named.COGNITO_USERNAME
+    | .AuthParameters.PASSWORD=$ARGS.named.COGNITO_PASSWORD' \
+    <<<'{ "AuthFlow": "USER_PASSWORD_AUTH", "AuthParameters": {} }'
+}
+
+function AuthHeader
+{
+  "${PROG_JQ}" -e -r \
+    '.AuthenticationResult.IdToken
+    | ["Authorization: Bearer", .]
+    | join(" ")' \
+  <<<"${*}"
+}
+
+function InitiateAuth
+{
+  ${PROG_CURL} \
+    --fail \
+    --silent \
+    --header "X-Amz-Target: AWSCognitoIdentityProviderService.InitiateAuth" \
+    --header "Content-Type: application/x-amz-json-1.1" \
+    --request POST \
+    --data "$(AuthRequestPayload)" \
+    "${COGNITO_ENDPOINT}"
+}
+
+function AuthProviderParameters
+{
+  ${PROG_JQ} -e -r \
+    --arg COGNITO_CLIENT_ID "${COGNITO_CLIENT_ID}" \
+    '.AuthenticationResult
+    | {
+      "client-id": ($ARGS.named.COGNITO_CLIENT_ID),
+      "refresh-token": (.RefreshToken),
+      "id-token": (.IdToken),
+      "idp-issuer-url": (.IdToken | split(".")[1] | @base64d | fromjson | .iss),
+    }
+    | to_entries
+    | map(["--auth-provider-arg", .key, .value] | join("="))
+    | .[]' \
+    <<<"${*}"
+}
+
+function ClusterCertificate
+{
+  ${PROG_CURL} \
+    --insecure \
+    --fail \
+    --silent \
+    --header "$(AuthHeader $(InitiateAuth))" \
+    ${K8S_ROOT_CA_URL} \
+    | ${PROG_JQ} -e -r '.data["ca.crt"]'
+}
+
+function WriteUserToKubeConfig
+{
+  ${PROG_KUBECTL} config set-credentials "${K8S_USER}" \
+    --auth-provider=oidc \
+    $(AuthProviderParameters $(InitiateAuth))
+}
+
+function WriteClusterToKubeConfig
+{
+  ${PROG_KUBECTL} config set-cluster "${K8S_CLUSTER}" \
+    --server="${EKS_ENDPOINT}" \
+    --embed-certs=true \
+    --certificate-authority=/dev/stdin <<<"$(ClusterCertificate)"
+}
+
+function WriteContextToKubeConfig
+{
+  ${PROG_KUBECTL} config set-context "${K8S_CONTEXT}" \
+    --cluster="${K8S_CLUSTER}" \
+    --user="${K8S_USER}" \
+    --namespace="${K8S_NAMESPACE}"
+}
+
+function WriteKubeConfig
+{
+  WriteUserToKubeConfig
+  WriteClusterToKubeConfig
+  WriteContextToKubeConfig
+}
+
+if (( ${#} ))
+then eval "${@}"
+else WriteKubeConfig
+fi

--- a/scripts/upgrade-responder-release-update.sh
+++ b/scripts/upgrade-responder-release-update.sh
@@ -1,0 +1,54 @@
+#! /bin/sh
+#
+# Copyright © 2021 - 2023 SUSE LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o errexit
+
+K8S_NAMESPACE=${K8S_NAMESPACE}
+COGNITO_USERNAME=${COGNITO_USERNAME}
+COGNITO_PASSWORD=${COGNITO_PASSWORD}
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+source "${SCRIPT_DIR}/cognito-login.sh"
+
+# Fetch the releases and build the Upgrade Responder Response JSON config
+# Ref: https://github.com/longhorn/upgrade-responder#response-json-config-example
+function UpgradeResponderResponseJSON
+{
+  curl -s https://api.github.com/repos/epinio/epinio/releases | \
+  jq '.[] | {
+    Name: (.name | split(" ")[0]),
+    ReleaseDate: .published_at,
+    MinUpgradableVersion: "",
+    Tags: [ .tag_name ],
+    ExtraInfo: null
+  }' | \
+  jq -n '. |= [inputs]' | \
+  jq '(first | .Tags) |= .+ ["latest"] | { 
+    versions: .,
+    requestIntervalInMinutes: 60
+  }'
+}
+
+UPGRADE_RESPONDER_RESPONSE_JSON=$(UpgradeResponderResponseJSON)
+
+echo "Updating the Upgrade Responder Response JSON with the latest Epinio release:"
+echo ${UPGRADE_RESPONDER_RESPONSE_JSON} | jq .
+
+# Cleanup the JSON removing the spaces before updating the ConfigMap
+UPGRADE_RESPONDER_RESPONSE_JSON=$(echo ${UPGRADE_RESPONDER_RESPONSE_JSON} | jq -c .)
+
+kubectl get configmap configmap-upgrade-responder --namespace ${K8S_NAMESPACE} \
+    --context epinio.version.rancher.io -o json | \
+    jq --arg add ${UPGRADE_RESPONDER_RESPONSE_JSON} '.data["upgrade-responder-config.json"] = $add' # | kubectl apply -f -

--- a/scripts/upgrade-responder-release-update.sh
+++ b/scripts/upgrade-responder-release-update.sh
@@ -11,12 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o nounset
-set -o errexit
+set -euo pipefail
 
 K8S_NAMESPACE=${K8S_NAMESPACE}
+EKS_ENDPOINT=${EKS_ENDPOINT}
+
 COGNITO_USERNAME=${COGNITO_USERNAME}
 COGNITO_PASSWORD=${COGNITO_PASSWORD}
+COGNITO_CLIENT_ID=${COGNITO_CLIENT_ID}
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 


### PR DESCRIPTION
Fix https://github.com/epinio/epinio/issues/1884

This PR adds the automation to update the Upgrade Responder Response JSON configuration.

It will fetch the latest Epinio releases from Github and prepare a valid JSON (see the `UpgradeResponderResponseJSON` function), and it will apply it with `kubectl`. The credential are loaded from some secrets and they will be used with the `cognito-login.sh` script (see `rancher-sandbox/metrics-ops`).

The secrets are stored in the following vars:
- UPGRADE_RESPONDER_COGNITO_USERNAME
- UPGRADE_RESPONDER_COGNITO_PASSWORD
- UPGRADE_RESPONDER_COGNITO_CLIENT_ID
- UPGRADE_RESPONDER_EKS_ENDPOINT

The user is an Epinio service user, and it's available in our encrypted passwords repository. :lock: 

The script was also added in the `release-sandbox` with a DRY_RUN mode.