### PR TITLE
Fixed wrong flag in tests

### DIFF
--- a/acceptance/helpers/epinio/epinio.go
+++ b/acceptance/helpers/epinio/epinio.go
@@ -156,7 +156,7 @@ func (e *Epinio) Install(args ...string) (string, error) {
 		"epinio",
 		chart,
 		"--wait",
-		"--set server.disableTracking=true", // disable tracking during tests
+		"--set", "server.disableTracking=true", // disable tracking during tests
 	}
 
 	out, err = proc.Run(testenv.Root(), false, "helm", append(opts, args...)...)


### PR DESCRIPTION
This should fix the e2e tests. It was probably interpreting the whole string as a flag.