### PR TITLE
Fixed release workflow, checklist and minor

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.yaml
+++ b/.github/ISSUE_TEMPLATE/release_checklist.yaml
@@ -39,6 +39,9 @@ body:
         - label: >
             Check the release page for the latest assets and changelog.
             [LINK](https://github.com/epinio/epinio/releases)
+        - label: >
+            Check the `epinio/homebrew-tap` for the latest version.
+            [LINK](https://github.com/epinio/homebrew-tap/blob/main/Formula/epinio.rb)
           
   - type: checkboxes
     id: helm-charts-checklist
@@ -71,9 +74,6 @@ body:
         - label: >
             Check the release published action.
             [LINK](https://github.com/epinio/epinio/actions/workflows/release-publish.yml)
-        - label: >
-            **( 📝 Manual step )** Check the `epinio/homebrew-tap` pull requests for the latest update, then merge the PR.
-            [LINK](https://github.com/epinio/homebrew-tap/blob/main/Formula/epinio.rb)
         - label: >
             Check that the `Homebrew/homebrew-core` has an open (or already closed) PR with the latest Epinio version.
             [LINK](https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+epinio)

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -22,6 +22,12 @@ jobs:
     runs-on: self-hosted
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
       - name: Get current tag
         id: get_tag
         run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
@@ -33,6 +39,16 @@ jobs:
         with:
           token: ${{ secrets.CHART_REPO_ACCESS_TOKEN }}
           repository: epinio/docs
+          event-type: epinio-release
+          client-payload: '{"ref": "${{ steps.get_tag.outputs.TAG }}"}'
+
+      # Allow to automate Docker extension update related to Epinio releases.
+      # The latest tag is sent to the extension-docker-desktop repository.
+      - name: epinio/extension-docker-desktop Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.CHART_REPO_ACCESS_TOKEN }}
+          repository: epinio/extension-docker-desktop
           event-type: epinio-release
           client-payload: '{"ref": "${{ steps.get_tag.outputs.TAG }}"}'
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -32,7 +32,7 @@ jobs:
         id: get_tag
         run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
 
-      # Allow to automate documentation update related to Epinio releases.
+      # Automate documentation update related to Epinio releases.
       # The latest tag is sent to the documentation repository.
       - name: epinio/docs Repository Dispatch
         uses: peter-evans/repository-dispatch@v2
@@ -42,7 +42,7 @@ jobs:
           event-type: epinio-release
           client-payload: '{"ref": "${{ steps.get_tag.outputs.TAG }}"}'
 
-      # Allow to automate Docker extension update related to Epinio releases.
+      # Automate Docker extension update related to Epinio releases.
       # The latest tag is sent to the extension-docker-desktop repository.
       - name: epinio/extension-docker-desktop Repository Dispatch
         uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/release-qa.yml
+++ b/.github/workflows/release-qa.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Build draft binaries - QA
+name: Release QA - Build draft binaries
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -9,14 +9,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Test Release
+name: Release Sandbox
 
 on:
+  workflow_dispatch:
+  pull_request:
   push:
     branches:
       - "main"
-  pull_request:
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Release-pipeline
+name: Release
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ Opinionated platform that runs on Kubernetes to take you from Code to URL in one
 
 [![godoc](https://pkg.go.dev/badge/epinio/epinio)](https://pkg.go.dev/github.com/epinio/epinio/internal/api/v1)
 [![CI](https://github.com/epinio/epinio/workflows/CI/badge.svg?branch=main)](https://github.com/epinio/epinio/actions/workflows/main.yml?query=branch%3Amain)
+[![golangci-lint](https://github.com/epinio/epinio/actions/workflows/golangci-lint.yml/badge.svg?branch=main)](https://github.com/epinio/epinio/actions/workflows/golangci-lint.yml?query=branch%3Amain)
 [![AKS-CI](https://github.com/epinio/epinio/actions/workflows/aks.yml/badge.svg?branch=main)](https://github.com/epinio/epinio/actions/workflows/aks.yml?query=branch%3Amain)
-[![AKS-LETSENCRYPT-CI](https://github.com/epinio/epinio/actions/workflows/aks-letsencrypt.yml/badge.svg?branch=main)](https://github.com/epinio/epinio/actions/workflows/aks-letsencrypt.yml?query=branch%3Amain)
 [![EKS-CI](https://github.com/epinio/epinio/actions/workflows/eks.yml/badge.svg?branch=main)](https://github.com/epinio/epinio/actions/workflows/eks.yml?query=branch%3Amain)
 [![GKE-CI](https://github.com/epinio/epinio/actions/workflows/gke.yml/badge.svg?branch=main)](https://github.com/epinio/epinio/actions/workflows/gke.yml??query=branch%3Amain)
-[![GKE-UPGRADE-CI](https://github.com/epinio/epinio/actions/workflows/gke-upgrade.yml/badge.svg?branch=main)](https://github.com/epinio/epinio/actions/workflows/gke-upgrade.yml??query=branch%3Amain)
+[![RKE-CI](https://github.com/epinio/epinio/actions/workflows/rke.yml/badge.svg?branch=main)](https://github.com/epinio/epinio/actions/workflows/rke.yml?query=branch%3Amain)  
+[![AKS-LETSENCRYPT-CI](https://github.com/epinio/epinio/actions/workflows/aks-letsencrypt.yml/badge.svg?branch=main)](https://github.com/epinio/epinio/actions/workflows/aks-letsencrypt.yml?query=branch%3Amain)
 [![GKE-LETSENCRYPT-CI](https://github.com/epinio/epinio/actions/workflows/gke-letsencrypt.yml/badge.svg?branch=main)](https://github.com/epinio/epinio/actions/workflows/gke-letsencrypt.yml?query=branch%3Amain)
-[![RKE-CI](https://github.com/epinio/epinio/actions/workflows/rke.yml/badge.svg?branch=main)](https://github.com/epinio/epinio/actions/workflows/rke.yml?query=branch%3Amain)
+[![GKE-UPGRADE-CI](https://github.com/epinio/epinio/actions/workflows/gke-upgrade.yml/badge.svg?branch=main)](https://github.com/epinio/epinio/actions/workflows/gke-upgrade.yml??query=branch%3Amain)
 [![RKE-UPGRADE-CI](https://github.com/epinio/epinio/actions/workflows/rke-upgrade.yml/badge.svg?branch=main)](https://github.com/epinio/epinio/actions/workflows/rke-upgrade.yml?query=branch%3Amain)
-[![golangci-lint](https://github.com/epinio/epinio/actions/workflows/golangci-lint.yml/badge.svg?branch=main)](https://github.com/epinio/epinio/actions/workflows/golangci-lint.yml?query=branch%3Amain)
 
 [E2E tests](https://github.com/epinio/epinio-end-to-end-tests):
 
@@ -32,7 +32,7 @@ Opinionated platform that runs on Kubernetes to take you from Code to URL in one
   - [Features](#features)
   - [Usage](#usage)
   - [Buildpacks](#buildpacks)
-  - [Example apps](#example-apps)
+    - [Example apps](#example-apps)
   - [Reach Us](#reach-us)
   - [Contributing](#contributing)
   - [License](#license)


### PR DESCRIPTION
During the last release we encountered some small issues:
- the script used to update the Upgrade Responder JSON was not working because of a missing checkout
- the Docker extension was not triggered because of a missing repository dispatch

I've also renamed some of the extension to be easily matched with the workflow filename, and reordered the badges in the README file.