### PR TITLE
Added ServiceAccountName to staging job

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,7 @@ linters-settings:
       severity: warning
   funlen:
     # Checks the number of lines in a function. Default: 60
-    lines: 270
+    lines: 250
     # Checks the number of statements in a function. Default: 40
     statements: 110
 

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -99,6 +99,12 @@ func init() {
 	err = viper.BindEnv("disable-tracking", "DISABLE_TRACKING")
 	checkErr(err)
 
+	flags.String("staging-service-account-name", "", "(STAGING_SERVICE_ACCOUNT_NAME)")
+	err = viper.BindPFlag("staging-service-account-name", flags.Lookup("staging-service-account-name"))
+	checkErr(err)
+	err = viper.BindEnv("staging-service-account-name", "STAGING_SERVICE_ACCOUNT_NAME")
+	checkErr(err)
+
 	flags.String("upgrade-responder-address", upgraderesponder.UpgradeResponderAddress, "(UPGRADE_RESPONDER_ADDRESS) Disable tracking of the running Epinio and Kubernetes versions")
 	err = viper.BindPFlag("upgrade-responder-address", flags.Lookup("upgrade-responder-address"))
 	checkErr(err)


### PR DESCRIPTION
Fix: https://github.com/epinio/epinio/issues/1926
Needs: https://github.com/epinio/helm-charts/pull/349

This PR adds the STAGING_SERVICE_ACCOUNT_NAME env var to the Epinio server. This variable is provided to the staging job and can be used to set a specific serviceaccount that will be used during the execution.

It also adds a small refactor of the staging job func, reducing a bit the length of the func (this probably needs a better and more complete refactoring but I didn't want to add to much noise to the PR).