### PR TITLE
Fix and refactor various command completions

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -96,10 +96,9 @@ var CmdAppList = &cobra.Command{
 
 // CmdAppCreate implements the command: epinio apps create
 var CmdAppCreate = &cobra.Command{
-	Use:               "create NAME",
-	Short:             "Create just the app, without creating a workload",
-	Args:              cobra.ExactArgs(1),
-	ValidArgsFunction: matchingAppsFinder,
+	Use:   "create NAME",
+	Short: "Create just the app, without creating a workload",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -208,9 +208,10 @@ var CmdAppLogs = &cobra.Command{
 
 // CmdAppExec implements the command: epinio apps exec
 var CmdAppExec = &cobra.Command{
-	Use:   "exec NAME",
-	Short: "creates a shell to the application",
-	Args:  cobra.ExactArgs(1),
+	Use:               "exec NAME",
+	Short:             "creates a shell to the application",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -240,9 +240,10 @@ var (
 
 // CmdAppPortForward implements the command: epinio apps port-forward
 var CmdAppPortForward = &cobra.Command{
-	Use:   "port-forward NAME [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N]",
-	Short: "forward one or more local ports to a pod",
-	Args:  cobra.MinimumNArgs(2),
+	Use:               "port-forward NAME [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N]",
+	Short:             "forward one or more local ports to a pod",
+	Args:              cobra.MinimumNArgs(2),
+	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -171,9 +171,10 @@ var CmdAppExport = &cobra.Command{
 
 // CmdAppLogs implements the command: epinio apps logs
 var CmdAppLogs = &cobra.Command{
-	Use:   "logs NAME",
-	Short: "Streams the logs of the application",
-	Args:  cobra.ExactArgs(1),
+	Use:               "logs NAME",
+	Short:             "Streams the logs of the application",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 

--- a/internal/cli/commons.go
+++ b/internal/cli/commons.go
@@ -12,6 +12,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -54,6 +55,24 @@ func CreateKubeClient(configPath string) kubernetes.Interface {
 	ExitfIfError(err, "an unexpected error occurred")
 
 	return clientset
+}
+
+// matchingConfigurationFinder returns a list of configurations whose names match the provided
+// partial command. It only matches for the first command argument
+func matchingConfigurationFinder(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	app, err := usercmd.New(cmd.Context())
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	app.API.DisableVersionWarning()
+
+	matches := app.ConfigurationMatching(context.Background(), toComplete)
+
+	return matches, cobra.ShellCompDirectiveNoFileComp
 }
 
 // matchingAppsFinder returns a list of matching apps from the provided partial command. It only

--- a/internal/cli/configuration.go
+++ b/internal/cli/configuration.go
@@ -55,26 +55,12 @@ var CmdConfiguration = &cobra.Command{
 
 // CmdConfigurationShow implements the command: epinio configuration show
 var CmdConfigurationShow = &cobra.Command{
-	Use:   "show NAME",
-	Short: "Configuration information",
-	Long:  `Show detailed information of the named configuration.`,
-	Args:  cobra.ExactArgs(1),
-	RunE:  ConfigurationShow,
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		app, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		app.API.DisableVersionWarning()
-
-		matches := app.ConfigurationMatching(context.Background(), toComplete)
-
-		return matches, cobra.ShellCompDirectiveNoFileComp
-	},
+	Use:               "show NAME",
+	Short:             "Configuration information",
+	Long:              `Show detailed information of the named configuration.`,
+	Args:              cobra.ExactArgs(1),
+	RunE:              ConfigurationShow,
+	ValidArgsFunction: matchingConfigurationFinder,
 }
 
 // CmdConfigurationCreate implements the command: epinio configuration create
@@ -96,7 +82,7 @@ var CmdConfigurationCreate = &cobra.Command{
 
 // CmdConfigurationUpdate implements the command: epinio configuration create
 var CmdConfigurationUpdate = &cobra.Command{
-	Use:   "update NAME",
+	Use:   "update NAME [flags]",
 	Short: "Update a configuration",
 	Long:  `Update configuration by name and change instructions through flags.`,
 	Args:  cobra.ExactArgs(1),
@@ -125,65 +111,22 @@ var CmdConfigurationDelete = &cobra.Command{
 
 // CmdConfigurationBind implements the command: epinio configuration bind
 var CmdConfigurationBind = &cobra.Command{
-	Use:   "bind NAME APP",
-	Short: "Bind a configuration to an application",
-	Long:  `Bind configuration by name, to named application.`,
-	Args:  cobra.ExactArgs(2),
-	RunE:  ConfigurationBind,
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) > 1 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		app, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		app.API.DisableVersionWarning()
-
-		if len(args) == 1 {
-			// #args == 1: app name.
-			matches := app.AppsMatching(toComplete)
-			return matches, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		// #args == 0: configuration name.
-
-		matches := app.ConfigurationMatching(context.Background(), toComplete)
-
-		return matches, cobra.ShellCompDirectiveNoFileComp
-	},
+	Use:               "bind NAME APP",
+	Short:             "Bind a configuration to an application",
+	Long:              `Bind configuration by name, to named application.`,
+	Args:              cobra.ExactArgs(2),
+	RunE:              ConfigurationBind,
+	ValidArgsFunction: findConfigurationApp,
 }
 
 // CmdConfigurationUnbind implements the command: epinio configuration unbind
 var CmdConfigurationUnbind = &cobra.Command{
-	Use:   "unbind NAME APP",
-	Short: "Unbind configuration from an application",
-	Long:  `Unbind configuration by name, from named application.`,
-	Args:  cobra.ExactArgs(2),
-	RunE:  ConfigurationUnbind,
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) > 1 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		app, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		app.API.DisableVersionWarning()
-
-		if len(args) == 1 {
-			// #args == 1: app name.
-			matches := app.AppsMatching(toComplete)
-			return matches, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		// #args == 0: configuration name.
-		matches := app.ConfigurationMatching(context.Background(), toComplete)
-
-		return matches, cobra.ShellCompDirectiveNoFileComp
-	},
+	Use:               "unbind NAME APP",
+	Short:             "Unbind configuration from an application",
+	Long:              `Unbind configuration by name, from named application.`,
+	Args:              cobra.ExactArgs(2),
+	RunE:              ConfigurationUnbind,
+	ValidArgsFunction: findConfigurationApp,
 }
 
 // CmdConfigurationList implements the command: epinio configuration list
@@ -353,4 +296,27 @@ func changeOptions(cmd *cobra.Command) {
 	// Note: No completion functionality. This would require asking the configuration for
 	// its details so that the keys to remove can be matched. And add/modify cannot
 	// check anyway.
+}
+
+func findConfigurationApp(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 1 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	app, err := usercmd.New(cmd.Context())
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	app.API.DisableVersionWarning()
+
+	if len(args) == 1 {
+		// #args == 1: app name.
+		matches := app.AppsMatching(toComplete)
+		return matches, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// #args == 0: configuration name.
+
+	matches := app.ConfigurationMatching(context.Background(), toComplete)
+	return matches, cobra.ShellCompDirectiveNoFileComp
 }


### PR DESCRIPTION
Fix #2046 + completion for `port-forward`, `logs`, `create`. Note, `create` had a bogus completion on app name. As `create` is for making a new app, completing on the names of existing apps makes no sense.

Further, refactored the completion for configurations a bit (common code).
