### PR TITLE
Added CIVO marketplace automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.yaml
+++ b/.github/ISSUE_TEMPLATE/release_checklist.yaml
@@ -98,7 +98,8 @@ body:
             Tag the repository with the next version. [LINK](https://github.com/epinio/extension-docker-desktop/tags)
             Check the result of the action. [LINK](https://github.com/epinio/extension-docker-desktop/actions/workflows/image.yml)
         - label: >
-            **( 📝 Manual step )** CIVO marketplace: open a PR in the [CIVO Marketplace](https://github.com/civo/kubernetes-marketplace) bumping the helm chart version in our fork `epinio/kubernetes-marketplace`
-            [LINK](https://github.com/epinio/kubernetes-marketplace)
+            **( 📝 Manual step )** CIVO marketplace: check the [updatecli action](https://github.com/epinio/kubernetes-marketplace/actions/workflows/updatecli.yml).
+            It should have pushed a new branch in the repo. [LINK](https://github.com/epinio/kubernetes-marketplace)
+            From this new branch open a PR to the upstream repository. [CIVO Marketplace](https://github.com/civo/kubernetes-marketplace)
         - label: >
             **( 📝 Manual step )** [optional] Rancher marketplace: open a PR in the [Rancher Helm Chart repository](https://github.com/rancher/charts)

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -51,6 +51,16 @@ jobs:
           repository: epinio/extension-docker-desktop
           event-type: epinio-release
           client-payload: '{"ref": "${{ steps.get_tag.outputs.TAG }}"}'
+      
+      # Automate CIVO marketplace update related to Epinio releases.
+      # The latest tag is sent to the kubernetes-marketplace repository.
+      - name: epinio/kubernetes-marketplace Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.CHART_REPO_ACCESS_TOKEN }}
+          repository: epinio/kubernetes-marketplace
+          event-type: epinio-release
+          client-payload: '{"ref": "${{ steps.get_tag.outputs.TAG }}"}'
 
       - name: Bump Homebrew formula
         uses: mislav/bump-homebrew-formula-action@v2


### PR DESCRIPTION
Fix: https://github.com/epinio/epinio/issues/1957

Last step for the automation. This PR adds the repository dispatch to notify the `epinio/kubernetes-marketplace` repo about the new release, and updates the release checklist.