### PR TITLE
Provide app namespace in file written by `app manifest`

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/epinio/epinio/internal/api/v1/application"
 	"github.com/epinio/epinio/internal/names"
 	"github.com/epinio/epinio/internal/routes"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	"gopkg.in/yaml.v2"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -146,19 +148,24 @@ var _ = Describe("Apps", LApplication, func() {
 					manifest, err := os.ReadFile(destinationPath)
 					Expect(err).ToNot(HaveOccurred(), destinationPath)
 
-					Expect(string(manifest)).To(MatchRegexp(fmt.Sprintf(`name: %s
-configuration:
-  instances: 2
-  configurations:
-  - %s
-  environment:
-    CREDO: up
-    DOGMA: "no"
-  routes:
-  - %s\..*
-  appchart: standard
-(?s:.*)namespace: %s
-`, appName, configurationName, appName, namespace)))
+					theManifest := models.ApplicationManifest{}
+					err = yaml.Unmarshal(manifest, &theManifest)
+					Expect(err).ToNot(HaveOccurred(), string(manifest))
+
+					// Note: Cannot use MatchYaml because of the `HavePrefix` check on the route.
+					// The MatchYAML asserts equality and we do not have the full route name here to put in.
+					Expect(theManifest.Name).To(Equal(appName))
+					var i int32 = 2
+					Expect(theManifest.Configuration.Instances).To(Equal(&i))
+					Expect(theManifest.Configuration.Configurations).To(HaveLen(1))
+					Expect(theManifest.Configuration.Routes).To(HaveLen(1))
+					Expect(theManifest.Configuration.Configurations[0]).To(Equal(configurationName))
+					Expect(theManifest.Configuration.Routes[0]).To(HavePrefix(appName))
+					Expect(theManifest.Configuration.Environment).To(HaveLen(2))
+					Expect(theManifest.Configuration.Environment).To(HaveKeyWithValue("CREDO", "up"))
+					Expect(theManifest.Configuration.Environment).To(HaveKeyWithValue("DOGMA", "no"))
+					Expect(theManifest.Configuration.AppChart).To(Equal("standard"))
+					Expect(theManifest.Namespace).To(Equal(namespace))
 				})
 			})
 		})

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -157,7 +157,8 @@ configuration:
   routes:
   - %s\..*
   appchart: standard
-`, appName, configurationName, appName)))
+(?s:.*)namespace: %s
+`, appName, configurationName, appName, namespace)))
 				})
 			})
 		})

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -286,6 +286,7 @@ func (c *EpinioClient) AppManifest(appName, manifestPath string) error {
 	m.Name = appName
 	m.Configuration = app.Configuration
 	m.Origin = app.Origin
+	m.Namespace = c.Settings.Namespace
 
 	yaml, err := yaml.Marshal(m)
 	if err != nil {

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -107,13 +107,14 @@ type BindResponse struct {
 }
 
 // ApplicationManifest represents and contains the data of an application's manifest file,
-// plus some auxiliary data never (un)marshaled. Namely, the file's location, and origin
+// plus some auxiliary data never (un)marshalled. Namely, the file's location, and origin
 // type tag.
 type ApplicationManifest struct {
 	ApplicationCreateRequest `yaml:",inline"`
 	Self                     string            `yaml:"-"` // Hidden from yaml. The file's location.
 	Origin                   ApplicationOrigin `yaml:"origin,omitempty"`
 	Staging                  ApplicationStage  `yaml:"staging,omitempty"`
+	Namespace                string            `yaml:"namespace,omitempty"`
 }
 
 // ApplicationStage is the part of the manifest holding information


### PR DESCRIPTION
Fix #2005

:notes: This data is purely informational. It is ignored when pushing the app via this manifest. As before the app goes into the targeted/current namespace.