### PR TITLE
Fix golangci-lint for possible resource leak

### DIFF
--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -442,7 +442,7 @@ func (c *EpinioClient) AppExec(ctx context.Context, appName, instance string) er
 		TryDev: true,
 	}
 
-	return c.API.AppExec(c.Settings.Namespace, appName, instance, tty)
+	return c.API.AppExec(ctx, c.Settings.Namespace, appName, instance, tty)
 }
 
 func (c *EpinioClient) AppPortForward(ctx context.Context, appName, instance string, address, ports []string) error {

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -56,7 +56,7 @@ type APIClient interface {
 	AppLogs(namespace, appName, stageID string, follow bool, callback func(tailer.ContainerLogLine)) error
 	StagingComplete(namespace string, id string) (models.Response, error)
 	AppRunning(app models.AppRef) (models.Response, error)
-	AppExec(namespace string, appName, instance string, tty kubectlterm.TTY) error
+	AppExec(ctx context.Context, namespace string, appName, instance string, tty kubectlterm.TTY) error
 	AppPortForward(namespace string, appName, instance string, opts *epinioapi.PortForwardOpts) error
 	AppRestart(namespace string, appName string) error
 	AppGetPart(namespace, appName, part, destinationPath string) error

--- a/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
+++ b/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
@@ -13,6 +13,7 @@
 package usercmdfakes
 
 import (
+	"context"
 	"net/http"
 	"sync"
 
@@ -101,13 +102,14 @@ type FakeAPIClient struct {
 		result1 *models.DeployResponse
 		result2 error
 	}
-	AppExecStub        func(string, string, string, term.TTY) error
+	AppExecStub        func(context.Context, string, string, string, term.TTY) error
 	appExecMutex       sync.RWMutex
 	appExecArgsForCall []struct {
-		arg1 string
+		arg1 context.Context
 		arg2 string
 		arg3 string
-		arg4 term.TTY
+		arg4 string
+		arg5 term.TTY
 	}
 	appExecReturns struct {
 		result1 error
@@ -1156,21 +1158,22 @@ func (fake *FakeAPIClient) AppDeployReturnsOnCall(i int, result1 *models.DeployR
 	}{result1, result2}
 }
 
-func (fake *FakeAPIClient) AppExec(arg1 string, arg2 string, arg3 string, arg4 term.TTY) error {
+func (fake *FakeAPIClient) AppExec(arg1 context.Context, arg2 string, arg3 string, arg4 string, arg5 term.TTY) error {
 	fake.appExecMutex.Lock()
 	ret, specificReturn := fake.appExecReturnsOnCall[len(fake.appExecArgsForCall)]
 	fake.appExecArgsForCall = append(fake.appExecArgsForCall, struct {
-		arg1 string
+		arg1 context.Context
 		arg2 string
 		arg3 string
-		arg4 term.TTY
-	}{arg1, arg2, arg3, arg4})
+		arg4 string
+		arg5 term.TTY
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.AppExecStub
 	fakeReturns := fake.appExecReturns
-	fake.recordInvocation("AppExec", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("AppExec", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.appExecMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
@@ -1184,17 +1187,17 @@ func (fake *FakeAPIClient) AppExecCallCount() int {
 	return len(fake.appExecArgsForCall)
 }
 
-func (fake *FakeAPIClient) AppExecCalls(stub func(string, string, string, term.TTY) error) {
+func (fake *FakeAPIClient) AppExecCalls(stub func(context.Context, string, string, string, term.TTY) error) {
 	fake.appExecMutex.Lock()
 	defer fake.appExecMutex.Unlock()
 	fake.AppExecStub = stub
 }
 
-func (fake *FakeAPIClient) AppExecArgsForCall(i int) (string, string, string, term.TTY) {
+func (fake *FakeAPIClient) AppExecArgsForCall(i int) (context.Context, string, string, string, term.TTY) {
 	fake.appExecMutex.RLock()
 	defer fake.appExecMutex.RUnlock()
 	argsForCall := fake.appExecArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeAPIClient) AppExecReturns(result1 error) {

--- a/pkg/api/core/v1/client/apps.go
+++ b/pkg/api/core/v1/client/apps.go
@@ -12,6 +12,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -566,7 +567,7 @@ func (c *Client) AppRunning(app models.AppRef) (models.Response, error) {
 	return resp, nil
 }
 
-func (c *Client) AppExec(namespace string, appName, instance string, tty kubectlterm.TTY) error {
+func (c *Client) AppExec(ctx context.Context, namespace string, appName, instance string, tty kubectlterm.TTY) error {
 	endpoint := fmt.Sprintf("%s%s/%s",
 		c.Settings.API, api.WsRoot, api.WsRoutes.Path("AppExec", namespace, appName))
 
@@ -605,7 +606,7 @@ func (c *Client) AppExec(namespace string, appName, instance string, tty kubectl
 			TerminalSizeQueue: tty.MonitorSize(tty.GetSize()),
 		}
 
-		return exec.Stream(options)
+		return exec.StreamWithContext(ctx, options)
 	}
 
 	return tty.Safe(fn)


### PR DESCRIPTION
https://github.com/epinio/epinio/actions/runs/4180863172

```
SA1019: exec.Stream is deprecated: use StreamWithContext instead to avoid possible resource leaks.  
See https://github.com/kubernetes/kubernetes/pull/103177 for details. (staticcheck)
```