### PR TITLE
EKS-CI 1.24+ workarounds

### DIFF
--- a/acceptance/install/scenario4_test.go
+++ b/acceptance/install/scenario4_test.go
@@ -143,6 +143,13 @@ var _ = Describe("<Scenario4> EKS, epinio-ca, on S3 storage", func() {
 			Expect(err).ToNot(HaveOccurred(), out)
 		})
 
+		By("Allow internal HTTP registry on EKS 1.24+", func() {
+			out, err := proc.Run(testenv.Root(), true, "kubectl", "apply", "-f", "./scripts/eks-cri-allow-http-registries.yaml")
+			Expect(err).ToNot(HaveOccurred(), out)
+			out, err = proc.Kubectl("wait", "--for=condition=complete", "job/setup-cri")
+			Expect(err).ToNot(HaveOccurred(), out)
+		})
+
 		By("Connecting to Epinio", func() {
 			Eventually(func() string {
 				out, _ := epinioHelper.Run("login", "-u", "admin", "-p", "password", "--trust-ca", "https://epinio."+domain)

--- a/scripts/eks-cri-allow-http-registries.yaml
+++ b/scripts/eks-cri-allow-http-registries.yaml
@@ -1,0 +1,51 @@
+# Enables pulling images from internal HTTP epinio registry on EKS nodes.
+# Configuration for containerd in /etc/containerd/certs.d is done on nodes.
+# Please set spec.completions and spec.parallelism values to the number of nodes.
+# This job needs to be retriggered once the nodes or their amount changes.
+# If needed it can be converted to a CronJob.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: setup-cri
+spec:
+  # Specify number of nodes for both values
+  completions: 2
+  parallelism: 2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: setup-cri
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - setup-cri
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - |
+          [ -f /tmp/containerd/certs.d/127.0.0.1:30500/hosts.toml ] && { echo 'Already configured'; exit 0; }
+          mkdir -p /tmp/containerd/certs.d/127.0.0.1:30500
+          cat > /tmp/containerd/certs.d/127.0.0.1:30500/hosts.toml <<EOF
+          server = "http://127.0.0.1:30500"
+          [host."http://127.0.0.1:30500"]
+            capabilities = ["pull"]
+          EOF
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        name: setup-cri
+        volumeMounts:
+          - name: etc-node-mount
+            mountPath: /tmp
+      restartPolicy: OnFailure
+      volumes:
+        - name: etc-node-mount
+          hostPath:
+            path: /etc


### PR DESCRIPTION
Ref. https://github.com/epinio/epinio/issues/2083
Testrun: https://github.com/epinio/epinio/actions/runs/4231512241/jobs/7350140610

This PR is dedicated to CI only, it can be used as a reference for documentation.

~* Add annotation for epinio ingress for enabling websocket communication when using EKS 1.24, ELB and nginx-ingress~ (not needed anymore, the annotation is now set by helm chart via https://github.com/epinio/helm-charts/pull/376)
* Configure containerd on EKS nodes to allow pulling from internal epinio HTTP registry