### PR TITLE
Added appchart script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ password
 .bash_history
 *.box
 *.vmdk
+*.tgz
 personal-setup
 .envrc
 /*values.yaml

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,9 @@ check:
 patch-epinio-deployment:
 	@./scripts/patch-epinio-deployment.sh
 
+appchart:
+	@./scripts/appchart.sh
+
 ########################################################################
 # Docs
 

--- a/scripts/appchart.sh
+++ b/scripts/appchart.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright © 2021 - 2023 SUSE LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script can be used to package a development version of the epinio-application helm chart.
+# It will also run a local nginx container attached to the epinio-acceptance network,
+# and patch the standard epinio appchart with this version.
+
+VERSION=0.0.0
+TARBALL=epinio-application-$VERSION.tgz
+
+echo "Packaging epinio-application chart"
+helm package --version $VERSION helm-charts/chart/application
+
+CONTAINER_ID=$(docker ps --filter name=nginx -qa)
+
+if [ -z "$CONTAINER_ID" ]; then
+    echo "Nginx is not running. Starting container"
+    docker run -it -d --rm --name nginx \
+        --network epinio-acceptance \
+        -v $PWD/$TARBALL:/usr/share/nginx/html/$TARBALL \
+        nginx
+else
+    echo "Nginx container already running (id: $CONTAINER_ID)"
+fi
+
+NGINX_IP=$(docker network inspect epinio-acceptance | \
+    jq -r '.[].Containers[] | select(.Name=="nginx").IPv4Address' | \
+    cut -d'/' -f1)
+
+echo "Nginx internal ip: $NGINX_IP (epinio-acceptance network)"
+
+echo "Patching appchart"
+
+kubectl patch appchart -n epinio standard --type json \
+    --patch '[{"op": "replace", "path": "/spec/helmChart", "value": "http://'$NGINX_IP'/'$TARBALL'"}]'
+
+echo "To stop the Nginx container just run 'docker stop nginx'"


### PR DESCRIPTION
Ref: https://github.com/epinio/epinio/issues/1792

---

While trying out something for the referenced issue I've seen how "difficult" is iterating the development of the application chart. It needs to be packaged and made reachable through an external endpoint.

This PR adds a `appchart.sh` script, that can be used to simplify this workflow.

The `make appchart` command will package the application chart in the `helm-charts/charts/application` folder, and it will run a nginx docker container that will serve this tarball. The container will be attached to the `epinio-acceptance` network (the same used in our `k3d` dev env), and it will patch the `standard` AppChart with this new endpoint.