### PR TITLE
Wired up version field in AppChart

### DIFF
--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -1734,6 +1734,10 @@
           "type": "string",
           "x-go-name": "HelmChart"
         },
+        "chartVersion": {
+          "type": "string",
+          "x-go-name": "ChartVersion"
+        },
         "helm_repo": {
           "type": "string",
           "x-go-name": "HelmRepo"

--- a/internal/appchart/appchart.go
+++ b/internal/appchart/appchart.go
@@ -110,6 +110,11 @@ func toChart(chart *unstructured.Unstructured) (*models.AppChartFull, error) {
 		return nil, errors.New("helm chart should be string")
 	}
 
+	chartVersion, _, err := unstructured.NestedString(chart.UnstructuredContent(), "spec", "chartVersion")
+	if err != nil {
+		return nil, errors.New("chart version should be string")
+	}
+
 	helmRepo, _, err := unstructured.NestedString(chart.UnstructuredContent(), "spec", "helmRepo")
 	if err != nil {
 		return nil, errors.New("helm repo should be string")
@@ -163,6 +168,7 @@ func toChart(chart *unstructured.Unstructured) (*models.AppChartFull, error) {
 			Description:      description,
 			ShortDescription: short,
 			HelmChart:        helmChart,
+			ChartVersion:     chartVersion,
 			HelmRepo:         helmRepo,
 			Settings:         settings,
 		},

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -321,7 +321,7 @@ func Deploy(logger logr.Logger, parameters ChartParameters) error {
 	}
 
 	helmChart := appChart.HelmChart
-	helmVersion := ""
+	helmVersion := appChart.ChartVersion
 
 	// See also part.go, fetchAppChart
 	if appChart.HelmRepo != "" {

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -392,7 +392,7 @@ type AppChart struct {
 	Description      string                     `json:"description,omitempty"`
 	ShortDescription string                     `json:"short_description,omitempty"`
 	HelmChart        string                     `json:"helm_chart,omitempty"`
-	ChartVersion     string                     `json:"chartVersion,omitempty"`
+	ChartVersion     string                     `json:"chart_version,omitempty"`
 	HelmRepo         string                     `json:"helm_repo,omitempty"`
 	Settings         map[string]AppChartSetting `json:"settings,omitempty"`
 }

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -392,6 +392,7 @@ type AppChart struct {
 	Description      string                     `json:"description,omitempty"`
 	ShortDescription string                     `json:"short_description,omitempty"`
 	HelmChart        string                     `json:"helm_chart,omitempty"`
+	ChartVersion     string                     `json:"chartVersion,omitempty"`
 	HelmRepo         string                     `json:"helm_repo,omitempty"`
 	Settings         map[string]AppChartSetting `json:"settings,omitempty"`
 }


### PR DESCRIPTION
Currently, you can't specify the needed fields to use an OCI chart as an application template: 
https://github.com/epinio/epinio/issues/1485

Opening as draft since I've confirmed that the code compiles but I ran out of time to test the new functionality :( 