### PR TITLE
Fixed missing release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+      
+      # Goreleaser will cleanup the draft, so we need to populate it again
+      - name: Run Releaser Drafter
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get current tag
         id: get_tag


### PR DESCRIPTION
Goreleaser will cleanup the release notes from the draft. This should repopulate it.

If not we will probably need to reopen the https://github.com/epinio/epinio/pull/2097, keeping two drafts.

