### PR TITLE
Update release_checklist.yaml for CIVO

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.yaml
+++ b/.github/ISSUE_TEMPLATE/release_checklist.yaml
@@ -97,8 +97,7 @@ body:
             Tag the repository with the next version. [LINK](https://github.com/epinio/extension-docker-desktop/tags)
             Check the result of the action. [LINK](https://github.com/epinio/extension-docker-desktop/actions/workflows/image.yml)
         - label: >
-            **( 📝 Manual step )** CIVO marketplace: check the [updatecli action](https://github.com/epinio/kubernetes-marketplace/actions/workflows/updatecli.yml).
-            It should have pushed a new branch in the repo. [LINK](https://github.com/epinio/kubernetes-marketplace)
-            From this new branch open a PR to the upstream repository. [CIVO Marketplace](https://github.com/civo/kubernetes-marketplace)
+            CIVO marketplace: check that the `civo/kubernetes-marketplace` has an open (or already closed) PR with the latest Epinio version.
+            [LINK](https://github.com/civo/kubernetes-marketplace/pulls?q=is%3Apr+epinio)
         - label: >
             **( 📝 Manual step )** [optional] Rancher marketplace: open a PR in the [Rancher Helm Chart repository](https://github.com/rancher/charts)


### PR DESCRIPTION
Updated Release Checklist. Now the CIVO Marketplace step is automated via `updatecli`.