### PR TITLE
Do not wait for service chart deployment by default, new option `--wait`

### DIFF
--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -2596,6 +2596,10 @@
         "name": {
           "type": "string",
           "x-go-name": "Name"
+        },
+        "wait": {
+          "type": "boolean",
+          "x-go-name": "Wait"
         }
       },
       "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"

--- a/internal/api/v1/service/create.go
+++ b/internal/api/v1/service/create.go
@@ -62,7 +62,7 @@ func (ctr Controller) Create(c *gin.Context) apierror.APIErrors {
 	}
 
 	// Now we can (attempt to) create the desired service
-	err = kubeServiceClient.Create(ctx, namespace, createRequest.Name, *catalogService)
+	err = kubeServiceClient.Create(ctx, namespace, createRequest.Name, createRequest.Wait, *catalogService)
 	if err != nil {
 		return apierror.InternalError(err)
 	}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -30,7 +30,11 @@ var CmdServices = &cobra.Command{
 }
 
 func init() {
+	CmdServiceCreate.Flags().Bool("wait", false, "Wait for deployment to complete")
 	CmdServiceDelete.Flags().Bool("unbind", false, "Unbind from applications before deleting")
+	CmdServiceList.Flags().Bool("all", false, "List all services")
+	CmdServiceDelete.Flags().Bool("all", false, "delete all services")
+
 	CmdServices.AddCommand(CmdServiceCatalog)
 	CmdServices.AddCommand(CmdServiceCreate)
 	CmdServices.AddCommand(CmdServiceBind)
@@ -38,9 +42,6 @@ func init() {
 	CmdServices.AddCommand(CmdServiceShow)
 	CmdServices.AddCommand(CmdServiceDelete)
 	CmdServices.AddCommand(CmdServiceList)
-
-	CmdServiceList.Flags().Bool("all", false, "list all services")
-	CmdServiceDelete.Flags().Bool("all", false, "delete all services")
 }
 
 var CmdServiceCatalog = &cobra.Command{
@@ -79,6 +80,11 @@ var CmdServiceCreate = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
+		wait, err := cmd.Flags().GetBool("wait")
+		if err != nil {
+			return errors.Wrap(err, "error reading option --wait")
+		}
+
 		client, err := usercmd.New(cmd.Context())
 		if err != nil {
 			return errors.Wrap(err, "error initializing cli")
@@ -87,7 +93,7 @@ var CmdServiceCreate = &cobra.Command{
 		catalogServiceName := args[0]
 		serviceName := args[1]
 
-		err = client.ServiceCreate(catalogServiceName, serviceName)
+		err = client.ServiceCreate(catalogServiceName, serviceName, wait)
 		return errors.Wrap(err, "error creating service")
 	},
 }

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -80,7 +80,7 @@ func (c *EpinioClient) ServiceCatalogShow(serviceName string) error {
 }
 
 // ServiceCreate creates a service
-func (c *EpinioClient) ServiceCreate(catalogServiceName, serviceName string) error {
+func (c *EpinioClient) ServiceCreate(catalogServiceName, serviceName string, wait bool) error {
 	log := c.Log.WithName("ServiceCreate")
 	log.Info("start")
 	defer log.Info("return")
@@ -88,11 +88,13 @@ func (c *EpinioClient) ServiceCreate(catalogServiceName, serviceName string) err
 	c.ui.Note().
 		WithStringValue("Catalog", catalogServiceName).
 		WithStringValue("Service", serviceName).
+		WithBoolValue("Wait For Completion", wait).
 		Msg("Creating Service...")
 
 	request := &models.ServiceCreateRequest{
 		CatalogService: catalogServiceName,
 		Name:           serviceName,
+		Wait:           wait,
 	}
 
 	err := c.API.ServiceCreate(request, c.Settings.Namespace)

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -153,7 +153,7 @@ func DeployService(logger logr.Logger, parameters ServiceParameters) error {
 		ChartName:   helmChart,
 		Version:     helmVersion,
 		Namespace:   parameters.Namespace,
-		Atomic:      parameters.Wait, // implies `Wait true`
+		Wait:        parameters.Wait,
 		ValuesYaml:  string(parameters.Values),
 		Timeout:     duration.ToDeployment(),
 		ReuseValues: true,

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -47,6 +47,7 @@ type ServiceParameters struct {
 	Version       string              // Version of helm chart to deploy
 	Repository    string              // Helm repository holding the chart to deploy
 	Values        string              // Chart customization (YAML-formatted string)
+	Wait          bool                // Wait for service to deploy
 }
 
 type ConfigParameter struct {
@@ -152,7 +153,7 @@ func DeployService(logger logr.Logger, parameters ServiceParameters) error {
 		ChartName:   helmChart,
 		Version:     helmVersion,
 		Namespace:   parameters.Namespace,
-		Atomic:      true,
+		Atomic:      parameters.Wait, // implies `Wait true`
 		ValuesYaml:  string(parameters.Values),
 		Timeout:     duration.ToDeployment(),
 		ReuseValues: true,
@@ -355,7 +356,7 @@ func Deploy(logger logr.Logger, parameters ChartParameters) error {
 		Version:     helmVersion,
 		Namespace:   parameters.Namespace,
 		Wait:        true,
-		Atomic:      true,
+		Atomic:      true, // implies `Wait true`
 		ValuesYaml:  string(yamlParameters),
 		Timeout:     duration.ToDeployment(),
 		ReuseValues: true,

--- a/internal/services/instances.go
+++ b/internal/services/instances.go
@@ -129,7 +129,7 @@ func GetInternalRoutes(ctx context.Context, servicesGetter v1.ServiceInterface, 
 	return internalRoutes, nil
 }
 
-func (s *ServiceClient) Create(ctx context.Context, namespace, name string, catalogService models.CatalogService) error {
+func (s *ServiceClient) Create(ctx context.Context, namespace, name string, wait bool, catalogService models.CatalogService) error {
 	// Resources, and names
 	//
 	// |Kind	|Name		|Notes			|
@@ -166,6 +166,7 @@ func (s *ServiceClient) Create(ctx context.Context, namespace, name string, cata
 			Version:    catalogService.ChartVersion,
 			Repository: catalogService.HelmRepo.URL,
 			Values:     catalogService.Values,
+			Wait:       wait,
 		})
 
 	if err != nil {

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -293,6 +293,7 @@ type CatalogMatchResponse struct {
 type ServiceCreateRequest struct {
 	CatalogService string `json:"catalog_service,omitempty"`
 	Name           string `json:"name,omitempty"`
+	Wait           bool   `json:"wait,omitempty"`
 }
 
 // CatalogService mostly matches github.com/epinio/application/api/v1 ServiceSpec


### PR DESCRIPTION
Fix #2133 
