### PR TITLE
extended logging of log streaming

### DIFF
--- a/helpers/kubernetes/tailer/setup.go
+++ b/helpers/kubernetes/tailer/setup.go
@@ -215,6 +215,9 @@ func StreamLogs(ctx context.Context, logChan chan ContainerLogLine, wg *sync.Wai
 				logger.Info("tailer done", "id", id)
 				wg.Done()
 			}(id)
+
+			logger.Info("tailer added", "id", id)
+
 		case p := <-removed:
 			id := p.GetID()
 			if tails[id] == nil {
@@ -224,6 +227,8 @@ func StreamLogs(ctx context.Context, logChan chan ContainerLogLine, wg *sync.Wai
 			logger.Info("tailer remove", "id", id)
 
 			delete(tails, id)
+
+			logger.Info("tailer removed", "id", id)
 		case <-ctx.Done():
 			logger.Info("received stop request")
 			return nil

--- a/internal/api/v1/application/logs.go
+++ b/internal/api/v1/application/logs.go
@@ -155,6 +155,8 @@ func (hc Controller) streamPodLogs(ctx context.Context, conn *websocket.Conn, na
 	// Send logs received on logChan to the websockets connection until either
 	// logChan is closed or websocket connection is closed.
 	for logLine := range logChan {
+		logger.Info("streaming", "log line", logLine)
+
 		msg, err := json.Marshal(logLine)
 		if err != nil {
 			return err


### PR DESCRIPTION
Ref #2106 

This does not repro the issue, nor is it a fix.
Just extended the logging in that area a bit more to better see server activity.
  - add branch got `added` log, when adding the tailer is done, ditto for removal.
  - there was a bit of confusion about some events/reports not acted on.
  - more important, both tailer and streamer now report all log lines they generate, pass through.

This is just to hopefully have better logs should the issue happen again in the wild.
