### PR TITLE
Refactor acceptance tests

### DIFF
--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -38,7 +38,7 @@ env:
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
   KUBECONFIG_NAME: 'kubeconfig-epinio-ci'
-  AWS_REGION: 'us-east-2'
+  AKS_RESOURCE_GROUP: ${{ secrets.AKS_RESOURCE_GROUP }}
   AKS_MACHINE_TYPE: 'Standard_D3_v2'
 
 jobs:
@@ -103,12 +103,12 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.EKS_REGION }}
 
       # Follow https://github.com/marketplace/actions/azure-login#configure-deployment-credentials
-      # az group create --name epinioCI --location eastus2
-      # az ad sp create-for-rbac --name "epinioCI" --sdk-auth --role contributor \
-      #   --scopes /subscriptions/{id}/resourceGroups/epinioCI
+      # az group create --name ${{ env.AKS_RESOURCE_GROUP }} --location eastus2
+      # az ad sp create-for-rbac --name ${{ env.AKS_RESOURCE_GROUP }} --sdk-auth --role contributor \
+      #   --scopes /subscriptions/{id}/resourceGroups/${{ env.AKS_RESOURCE_GROUP }}
       - name: Login to Azure
         uses: azure/login@v1
         with:
@@ -121,14 +121,14 @@ jobs:
         run: |
           id=$RANDOM
           echo "ID=$id" >> $GITHUB_OUTPUT
-          az aks create --resource-group epinioCI \
+          az aks create --resource-group ${{ env.AKS_RESOURCE_GROUP }} \
           --node-vm-size ${{ env.AKS_MACHINE_TYPE }} \
-          --name epinioCI$id \
+          --name ${{ env.AKS_RESOURCE_GROUP }}$id \
           --node-count 2 \
           --generate-ssh-keys
 
-          az aks get-credentials --resource-group epinioCI \
-          --name epinioCI$id \
+          az aks get-credentials --resource-group ${{ env.AKS_RESOURCE_GROUP }} \
+          --name ${{ env.AKS_RESOURCE_GROUP }}$id \
           --file ${{ env.KUBECONFIG_NAME }}
 
           # List existing clusters
@@ -139,7 +139,7 @@ jobs:
           REGEX: Scenario5
           REGISTRY_USERNAME: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
-          AWS_ZONE_ID: ${{ github.event.inputs.aws_zone_id || secrets.AWS_ZONE_ID }}
+          AWS_ZONE_ID: ${{ secrets.AWS_ZONE_ID }}
           # Use a random host name, so we don't collide with our workflows on AKS
           AKS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.aks_domain || secrets.AKS_DOMAIN }}
           EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.aks_domain || secrets.AKS_DOMAIN }}

--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -156,9 +156,13 @@ jobs:
       - name: Delete AKS cluster
         # We always tear down the cluster, to avoid costs. Except when running
         # manually and keep_cluster was set to a non-empty string, like "yes"
-        # TODO this was not called, when scheduled and tests failed
         if: ${{ always() && !github.event.inputs.keep_cluster }}
         shell: bash
         run: |
-          id="${{ steps.create-cluster.outputs.ID }}"
-          az aks delete --resource-group epinioCI --name epinioCI$id --yes
+          export RUN_ID=${{ steps.create-cluster.outputs.ID }}
+          export RUN_PCP="AKS"
+          export AWS_ZONE_ID=${{ secrets.AWS_ZONE_ID }}
+          export AKS_DOMAIN=${{ secrets.AKS_DOMAIN }}
+          export AKS_RESOURCE_GROUP=${{ env.AKS_RESOURCE_GROUP }}
+          export KUBECONFIG_NAME=${{ env.KUBECONFIG_NAME }}
+          go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -23,14 +23,14 @@ on:
     - cron:  '0 3 * * *'
   workflow_dispatch:
     inputs:
-      aks_domain:
-        description: "AKS_DOMAIN to use, managed via Route53's AWS_ZONE_ID"
-        required: false
-        default: ""
       keep_cluster:
-        description: "Keep the cluster afterwards? (empty/yes)"
-        required: false
-        default: ""
+        type: choice
+        description: "Keep the cluster afterwards?"
+        required: true
+        default: 'No'
+        options:
+        - No
+        - Yes
 
 env:
   SETUP_GO_VERSION: '~1.19'
@@ -142,8 +142,8 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
           AWS_ZONE_ID: ${{ secrets.AWS_ZONE_ID }}
           # Use a random host name, so we don't collide with our workflows on AKS
-          AKS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.aks_domain || secrets.AKS_DOMAIN }}
-          EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.aks_domain || secrets.AKS_DOMAIN }}
+          AKS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ secrets.AKS_DOMAIN }}
+          EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ secrets.AKS_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
           INGRESS_CONTROLLER: traefik
           # EXTRAENV_NAME: SESSION_KEY
@@ -157,7 +157,7 @@ jobs:
       - name: Delete AKS cluster
         # We always tear down the cluster, to avoid costs. Except when running
         # manually and keep_cluster was set to a non-empty string, like "yes"
-        if: ${{ always() && !github.event.inputs.keep_cluster }}
+        if: ${{ always() && github.event.inputs.keep_cluster == 'No' }}
         shell: bash
         run: |
           export RUN_ID=${{ steps.create-cluster.outputs.ID }}

--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -23,16 +23,8 @@ on:
     - cron:  '0 3 * * *'
   workflow_dispatch:
     inputs:
-      azure_credentials:
-        description: "AZURE_CREDENTIALS"
-        required: false
-        default: ""
       aks_domain:
         description: "AKS_DOMAIN to use, managed via Route53's AWS_ZONE_ID"
-        required: false
-        default: ""
-      aws_zone_id:
-        description: "AWS_ZONE_ID"
         required: false
         default: ""
       keep_cluster:
@@ -120,7 +112,7 @@ jobs:
       - name: Login to Azure
         uses: azure/login@v1
         with:
-          creds: ${{ github.event.inputs.azure_credentials || secrets.AZURE_CREDENTIALS }}
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Create AKS cluster
         id: create-cluster

--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -121,6 +121,7 @@ jobs:
         run: |
           id=$RANDOM
           echo "ID=$id" >> $GITHUB_OUTPUT
+          echo "RUN_ID: ${{ steps.create-cluster.outputs.ID }}"
           az aks create --resource-group ${{ env.AKS_RESOURCE_GROUP }} \
           --node-vm-size ${{ env.AKS_MACHINE_TYPE }} \
           --name ${{ env.AKS_RESOURCE_GROUP }}$id \

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -23,14 +23,14 @@ on:
     - cron:  '0 0 * * *'
   workflow_dispatch:
     inputs:
-      aks_domain:
-        description: "AKS_DOMAIN to use, managed via Route53's AWS_ZONE_ID"
-        required: false
-        default: ""
       keep_cluster:
-        description: "Keep the cluster afterwards? (empty/yes)"
-        required: false
-        default: ""
+        type: choice
+        description: "Keep the cluster afterwards?"
+        required: true
+        default: 'No'
+        options:
+        - No
+        - Yes
 
 env:
   SETUP_GO_VERSION: '~1.19'
@@ -142,8 +142,8 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
           AWS_ZONE_ID: ${{ secrets.AWS_ZONE_ID }}
           # Use a random host name, so we don't collide with our workflows on AKS
-          AKS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.aks_domain || secrets.AKS_DOMAIN }}
-          EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.aks_domain || secrets.AKS_DOMAIN }}
+          AKS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ secrets.AKS_DOMAIN }}
+          EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ secrets.AKS_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
           INGRESS_CONTROLLER: traefik
           # EXTRAENV_NAME: SESSION_KEY
@@ -157,7 +157,7 @@ jobs:
       - name: Delete AKS cluster
         # We always tear down the cluster, to avoid costs. Except when running
         # manually and keep_cluster was set to a non-empty string, like "yes"
-        if: ${{ always() && !github.event.inputs.keep_cluster }}
+        if: ${{ always() && github.event.inputs.keep_cluster == 'No' }}
         shell: bash
         run: |
           export RUN_ID=${{ steps.create-cluster.outputs.ID }}

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -38,7 +38,7 @@ env:
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
   KUBECONFIG_NAME: 'kubeconfig-epinio-ci'
-  AWS_REGION: 'us-east-2'
+  AKS_RESOURCE_GROUP: ${{ secrets.AKS_RESOURCE_GROUP }}
   AKS_MACHINE_TYPE: 'Standard_D3_v2'
 
 jobs:
@@ -103,12 +103,12 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.EKS_REGION }}
 
       # Follow https://github.com/marketplace/actions/azure-login#configure-deployment-credentials
-      # az group create --name epinioCI --location eastus2
-      # az ad sp create-for-rbac --name "epinioCI" --sdk-auth --role contributor \
-      #   --scopes /subscriptions/{id}/resourceGroups/epinioCI
+      # az group create --name ${{ env.AKS_RESOURCE_GROUP }} --location eastus2
+      # az ad sp create-for-rbac --name ${{ env.AKS_RESOURCE_GROUP }} --sdk-auth --role contributor \
+      #   --scopes /subscriptions/{id}/resourceGroups/${{ env.AKS_RESOURCE_GROUP }}
       - name: Login to Azure
         uses: azure/login@v1
         with:
@@ -121,14 +121,14 @@ jobs:
         run: |
           id=$RANDOM
           echo "ID=$id" >> $GITHUB_OUTPUT
-          az aks create --resource-group epinioCI \
+          az aks create --resource-group ${{ env.AKS_RESOURCE_GROUP }} \
           --node-vm-size ${{ env.AKS_MACHINE_TYPE }} \
-          --name epinioCI$id \
+          --name ${{ env.AKS_RESOURCE_GROUP }}$id \
           --node-count 2 \
           --generate-ssh-keys
 
-          az aks get-credentials --resource-group epinioCI \
-          --name epinioCI$id \
+          az aks get-credentials --resource-group ${{ env.AKS_RESOURCE_GROUP }} \
+          --name ${{ env.AKS_RESOURCE_GROUP }}$id \
           --file ${{ env.KUBECONFIG_NAME }}
 
           # List existing clusters
@@ -139,7 +139,7 @@ jobs:
           REGEX: Scenario6
           REGISTRY_USERNAME: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
-          AWS_ZONE_ID: ${{ github.event.inputs.aws_zone_id || secrets.AWS_ZONE_ID }}
+          AWS_ZONE_ID: ${{ secrets.AWS_ZONE_ID }}
           # Use a random host name, so we don't collide with our workflows on AKS
           AKS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.aks_domain || secrets.AKS_DOMAIN }}
           EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.aks_domain || secrets.AKS_DOMAIN }}

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -23,16 +23,8 @@ on:
     - cron:  '0 0 * * *'
   workflow_dispatch:
     inputs:
-      azure_credentials:
-        description: "AZURE_CREDENTIALS"
-        required: false
-        default: ""
       aks_domain:
         description: "AKS_DOMAIN to use, managed via Route53's AWS_ZONE_ID"
-        required: false
-        default: ""
-      aws_zone_id:
-        description: "AWS_ZONE_ID"
         required: false
         default: ""
       keep_cluster:
@@ -120,7 +112,7 @@ jobs:
       - name: Login to Azure
         uses: azure/login@v1
         with:
-          creds: ${{ github.event.inputs.azure_credentials || secrets.AZURE_CREDENTIALS }}
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Create AKS cluster
         id: create-cluster

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -156,9 +156,13 @@ jobs:
       - name: Delete AKS cluster
         # We always tear down the cluster, to avoid costs. Except when running
         # manually and keep_cluster was set to a non-empty string, like "yes"
-        # TODO this was not called, when scheduled and tests failed
         if: ${{ always() && !github.event.inputs.keep_cluster }}
         shell: bash
         run: |
-          id="${{ steps.create-cluster.outputs.ID }}"
-          az aks delete --resource-group epinioCI --name epinioCI$id --yes
+          export RUN_ID=${{ steps.create-cluster.outputs.ID }}
+          export RUN_PCP="AKS"
+          export AWS_ZONE_ID=${{ secrets.AWS_ZONE_ID }}
+          export AKS_DOMAIN=${{ secrets.AKS_DOMAIN }}
+          export AKS_RESOURCE_GROUP=${{ env.AKS_RESOURCE_GROUP }}
+          export KUBECONFIG_NAME=${{ env.KUBECONFIG_NAME }}
+          go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -121,6 +121,7 @@ jobs:
         run: |
           id=$RANDOM
           echo "ID=$id" >> $GITHUB_OUTPUT
+          echo "RUN_ID: ${{ steps.create-cluster.outputs.ID }}"
           az aks create --resource-group ${{ env.AKS_RESOURCE_GROUP }} \
           --node-vm-size ${{ env.AKS_MACHINE_TYPE }} \
           --name ${{ env.AKS_RESOURCE_GROUP }}$id \

--- a/.github/workflows/delete_clusters.yml
+++ b/.github/workflows/delete_clusters.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: "id - The plain random number from CI cluster creation, found in the respective github action logs (lookub the scenario* logs, cluster creation step, e.g. RUN_ID: 1234)"
+        description: "id - The plain random number from CI cluster creation, found in the respective github action logs (lookup the scenario* logs, cluster creation step, e.g. RUN_ID: 1234)"
         required: true
         default: ""
       pcp:

--- a/.github/workflows/delete_clusters.yml
+++ b/.github/workflows/delete_clusters.yml
@@ -20,13 +20,20 @@ on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: "id - The plain random number from CI cluster creation, found in the respective github action logs (lookup the scenario* logs, cluster creation step, e.g. RUN_ID: 1234)"
+        type: number
+        description: "id - The plain random number from CI cluster creation, found in the respective github action logs (lookub the scenario* logs, cluster creation step, e.g. RUN_ID: 1234)"
         required: true
         default: ""
       pcp:
-        description: "Public Cloud Provider Kubernetes service (enter AKS, EKS or GKE)"
+        type: choice
+        description: "Public Cloud Provider Kubernetes service (select AKS, EKS or GKE)"
         required: true
-        default: ""
+        default: None
+        options:
+        - None
+        - AKS
+        - EKS
+        - GKE
 
 env:
   SETUP_GO_VERSION: '~1.19'
@@ -34,6 +41,7 @@ env:
 
 jobs:
   delete-ci-acceptance-test-cluster:
+    if: ${{ github.event.inputs.pcp != 'None' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/delete_clusters.yml
+++ b/.github/workflows/delete_clusters.yml
@@ -1,0 +1,106 @@
+# Copyright © 2021 - 2023 SUSE LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+name: DELETE-KEPT-ACCEPTANCE-TEST-CLUSTER
+
+# This is a workflow_dispatch only, intended to be used to cleanup a PCP kubernetes cluster
+# after using keep_cluster, by just providing the acceptance test run-id and the PCP flavor.
+# It will cleanup DNS records, delete epinio namespaces and delete the public cloud kube cluster.
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "id - The plain random number from CI cluster creation, found in the respective github action logs (lookub the scenario* logs, cluster creation step, e.g. RUN_ID: 1234)"
+        required: true
+        default: ""
+      pcp:
+        description: "Public Cloud Provider Kubernetes service (enter AKS, EKS or GKE)"
+        required: true
+        default: ""
+
+env:
+  SETUP_GO_VERSION: '~1.19'
+  EKS_REGION: ${{ secrets.EKS_REGION }}
+
+jobs:
+  delete-ci-acceptance-test-cluster:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+
+      # The system domain is managed by route53, login to delete
+      # DNS records and for the EKS deletion case
+      - name: Configure AWS credentials for Route53
+        uses: aws-actions/configure-aws-credentials@v1.7.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.EKS_REGION }}
+
+      # Login to Azure for the AKS deletion case
+      - name: Login to Azure
+        if: ${{ github.event.inputs.pcp == 'AKS' }}
+        uses: azure/login@v1
+        with:
+          creds: ${{ github.events.inputs.azure_credentials || secrets.AZURE_CREDENTIALS }}
+
+      # Install EKSCTL for EKS deletion case
+      - name: Install EKSCTL
+        if: ${{ github.event.inputs.pcp == 'EKS' }}
+        run: |
+          EKSCTL_GH=https://github.com/weaveworks/eksctl/releases/latest/download
+          curl --location ${EKSCTL_GH}/eksctl_$(uname -s)_amd64.tar.gz | tar xz -C .
+          chmod +x eksctl
+          sudo mv eksctl /usr/local/bin
+
+      # Login to gcloud for the GKE case
+      - name: Authenticate to GCP
+        if: ${{ github.event.inputs.pcp == 'GKE' }}
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{ secrets.EPCI_GCP_CREDENTIALS }}
+
+      - name: Setup gcloud
+        if: ${{ github.event.inputs.pcp == 'GKE' }}
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Install gcloud kubectl version
+        if: ${{ github.event.inputs.pcp == 'GKE' }}
+        run: gcloud components install kubectl
+
+      # Delete PVCs, DNS records and Public Cloud Providers cluster
+      - name: Delete PCP Clusters and Resources
+        shell: bash
+        run: |
+          export RUN_ID=${{ github.event.inputs.run_id }}
+          export RUN_PCP=${{ github.event.inputs.pcp }}
+          export AWS_ZONE_ID=${{ secrets.AWS_ZONE_ID }}
+          export AKS_DOMAIN=${{ secrets.AKS_DOMAIN }}
+          export AKS_RESOURCE_GROUP=${{ secrets.AKS_RESOURCE_GROUP }}
+          export EKS_DOMAIN=${{ secrets.EKS_DOMAIN }}
+          export EKS_REGION=${{ env.EKS_REGION }}
+          export GKE_DOMAIN=${{ secrets.GKE_DOMAIN }}
+          export GKE_ZONE=${{ secrets.GKE_ZONE }}
+          export EPCI_GKE_PROJECT=${{ secrets.EPCI_GKE_PROJECT }}
+          export KUBECONFIG_NAME="kubeconfig-epinio-ci"
+          go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/delete_clusters.yml
+++ b/.github/workflows/delete_clusters.yml
@@ -28,7 +28,7 @@ on:
         type: choice
         description: "Public Cloud Provider Kubernetes service (select AKS, EKS or GKE)"
         required: true
-        default: None
+        default: 'None'
         options:
         - None
         - AKS

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -120,6 +120,7 @@ jobs:
         run: |
           id=$RANDOM
           echo "ID=$id" >> $GITHUB_OUTPUT
+          echo "RUN_ID: ${{ steps.create-cluster.outputs.ID }}"
           eksctl create cluster --name=epinio-ci$id \
           --region=${{ env.EKS_REGION }} \
           --nodes=2 \

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -23,20 +23,8 @@ on:
     - cron:  '0 4 * * *'
   workflow_dispatch:
     inputs:
-      aws_id:
-        description: "AWS_ACCESS_KEY_ID"
-        required: false
-        default: ""
-      aws_key:
-        description: "AWS_SECRET_ACCESS_KEY"
-        required: false
-        default: ""
       aws_domain:
         description: "AWS_DOMAIN to use, managed via Route53's AWS_ZONE_ID"
-        required: false
-        default: ""
-      aws_zone_id:
-        description: "AWS_ZONE_ID"
         required: false
         default: ""
       keep_cluster:
@@ -123,8 +111,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1.7.0
         with:
-          aws-access-key-id: ${{ github.event.inputs.aws_id || secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ github.event.inputs.aws_key || secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Create EKS cluster
@@ -167,9 +155,9 @@ jobs:
           REGEX: Scenario4
           REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-          AWS_ZONE_ID: ${{ github.event.inputs.aws_zone_id || secrets.AWS_ZONE_ID }}
-          AWS_ACCESS_KEY_ID: ${{ github.event.inputs.aws_id || secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ github.event.inputs.aws_key || secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ZONE_ID: ${{ secrets.AWS_ZONE_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           # Use a random host name, so we don't collide with our workflows on EKS
           AWS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.aws_domain || secrets.AWS_DOMAIN }}
           EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.aws_domain || secrets.AWS_DOMAIN }}

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -139,9 +139,6 @@ jobs:
           --node-volume-size=40 \
           --managed \
           --kubeconfig=kubeconfig-epinio-ci
-          # Workaround for https://github.com/aws/aws-cli/issues/6920
-          # https://stackoverflow.com/questions/71318743/kubectl-versions-error-exec-plugin-is-configured-to-use-api-version-client-auth
-          sed -i .bak -e 's/v1alpha1/v1beta1/' kubeconfig-epinio-ci
 
       - name: Configure EKS EBS CSI storage
         id: configure-storage

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -37,9 +37,9 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  AWS_REGION: 'eu-central-1'
-  AWS_MACHINE_TYPE: 't3.xlarge'
   KUBECONFIG_NAME: 'kubeconfig-epinio-ci'
+  EKS_REGION: ${{ secrets.EKS_REGION }}
+  AWS_MACHINE_TYPE: 't3.xlarge'
 
 jobs:
   linter:
@@ -113,7 +113,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ env.EKS_REGION }}
 
       - name: Create EKS cluster
         id: create-cluster
@@ -121,7 +121,7 @@ jobs:
           id=$RANDOM
           echo "ID=$id" >> $GITHUB_OUTPUT
           eksctl create cluster --name=epinio-ci$id \
-          --region=${{ env.AWS_REGION }} \
+          --region=${{ env.EKS_REGION }} \
           --nodes=2 \
           --node-type=${{ env.AWS_MACHINE_TYPE }} \
           --node-volume-size=40 \
@@ -131,7 +131,7 @@ jobs:
       - name: Configure EKS EBS CSI storage
         id: configure-storage
         run: |
-          id="${{ steps.create-cluster.outputs.ID }}"
+          id=${{ steps.create-cluster.outputs.ID }}
           # Get AWS Account ID
           AWS_ACCOUNT_ID=$(aws sts get-caller-identity | jq -r '.Account')
           # Assign OIDC provider to the cluster

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -23,14 +23,14 @@ on:
     - cron:  '0 4 * * *'
   workflow_dispatch:
     inputs:
-      aws_domain:
-        description: "AWS_DOMAIN to use, managed via Route53's AWS_ZONE_ID"
-        required: false
-        default: ""
       keep_cluster:
-        description: "Keep the cluster afterwards? (empty/yes)"
-        required: false
-        default: ""
+        type: choice
+        description: "Keep the cluster afterwards?"
+        required: true
+        default: 'No'
+        options:
+        - No
+        - Yes
 
 env:
   SETUP_GO_VERSION: '~1.19'
@@ -160,8 +160,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           # Use a random host name, so we don't collide with our workflows on EKS
-          AWS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.aws_domain || secrets.AWS_DOMAIN }}
-          EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.aws_domain || secrets.AWS_DOMAIN }}
+          AWS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ secrets.AWS_DOMAIN }}
+          EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ secrets.AWS_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
           INGRESS_CONTROLLER: nginx
           # EXTRAENV_NAME: SESSION_KEY
@@ -174,7 +174,7 @@ jobs:
       - name: Delete EKS cluster
         # We always tear down the cluster, to avoid costs. Except when running
         # manually and keep_cluster was set to a non-empty string, like "yes"
-        if: ${{ always() && !github.event.inputs.keep_cluster }}
+        if: ${{ always() && github.event.inputs.keep_cluster == 'No' }}
         env:
           KUBECONFIG: ${{ env.KUBECONFIG_NAME }}
         run: |

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -173,13 +173,14 @@ jobs:
       - name: Delete EKS cluster
         # We always tear down the cluster, to avoid costs. Except when running
         # manually and keep_cluster was set to a non-empty string, like "yes"
-        # TODO this was not called, when scheduled and tests failed
         if: ${{ always() && !github.event.inputs.keep_cluster }}
         env:
           KUBECONFIG: ${{ env.KUBECONFIG_NAME }}
         run: |
-          # Deleting namespaces will also remove PVs from EC2/EBS
-          id="${{ steps.create-cluster.outputs.ID }}"
-          kubectl delete namespace epinio || true
-          kubectl delete namespace workspace || true
-          eksctl delete cluster --region=${{ env.AWS_REGION }} --name=epinio-ci$id
+          export RUN_ID=${{ steps.create-cluster.outputs.ID }}
+          export RUN_PCP="EKS"
+          export AWS_ZONE_ID=${{ secrets.AWS_ZONE_ID }}
+          export EKS_DOMAIN=${{ secrets.EKS_DOMAIN }}
+          export EKS_REGION=${{ env.EKS_REGION }}
+          export KUBECONFIG_NAME=${{ env.KUBECONFIG_NAME }}
+          go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -159,7 +159,15 @@ jobs:
           make test-acceptance-install
 
       - name: Delete GKE cluster
+        # We always tear down the cluster, to avoid costs. Except when running
+        # manually and keep_cluster was set to a non-empty string, like "yes"
         if: ${{ always() && !github.event.inputs.keep_cluster }}
         run: |
-          id="${{ steps.create-cluster.outputs.ID }}"
-          gcloud container clusters delete epinioci$id --zone ${{ env.GKE_ZONE }} --quiet
+          export RUN_ID=${{ steps.create-cluster.outputs.ID }}
+          export RUN_PCP="GKE"
+          export AWS_ZONE_ID=${{ secrets.AWS_ZONE_ID }}
+          export GKE_DOMAIN=${{ secrets.GKE_DOMAIN }}
+          export GKE_ZONE=${{ secrets.GKE_ZONE }}
+          export EPCI_GKE_PROJECT=${{ secrets.EPCI_GKE_PROJECT }}
+          export KUBECONFIG_NAME=${{ env.KUBECONFIG_NAME }}
+          go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -122,6 +122,7 @@ jobs:
         run: |
           id=$RANDOM
           echo "ID=$id" >> $GITHUB_OUTPUT
+          echo "RUN_ID: ${{ steps.create-cluster.outputs.ID }}"
           gcloud container clusters create epinioci$id \
           --disk-size 100 \
           --num-nodes=1 \

--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -23,14 +23,14 @@ on:
     - cron:  '0 5 * * *'
   workflow_dispatch:
     inputs:
-      gke_domain:
-        description: "GKE_DOMAIN to use, managed via Route53's AWS_ZONE_ID"
-        required: false
-        default: ""
       keep_cluster:
-        description: "Keep the cluster afterwards? (empty/yes)"
-        required: false
-        default: ""
+        type: choice
+        description: "Keep the cluster afterwards?"
+        required: true
+        default: 'No'
+        options:
+        - No
+        - Yes
 
 env:
   SETUP_GO_VERSION: '~1.19'
@@ -148,8 +148,8 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           AWS_ZONE_ID: ${{ secrets.AWS_ZONE_ID }}
           # Use a random host name, so we don't collide with our workflows on GKE
-          GKE_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.gke_domain || secrets.GKE_DOMAIN }}
-          EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.gke_domain || secrets.GKE_DOMAIN }}
+          GKE_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ secrets.GKE_DOMAIN }}
+          EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ secrets.GKE_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
           INGRESS_CONTROLLER: traefik
           # EXTRAENV_NAME: SESSION_KEY
@@ -162,7 +162,7 @@ jobs:
       - name: Delete GKE cluster
         # We always tear down the cluster, to avoid costs. Except when running
         # manually and keep_cluster was set to a non-empty string, like "yes"
-        if: ${{ always() && !github.event.inputs.keep_cluster }}
+        if: ${{ always() && github.event.inputs.keep_cluster == 'No' }}
         run: |
           export RUN_ID=${{ steps.create-cluster.outputs.ID }}
           export RUN_PCP="GKE"

--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -37,7 +37,8 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  GKE_ZONE: 'europe-west1-b'
+  KUBECONFIG_NAME: 'kubeconfig-epinio-ci'
+  GKE_ZONE: ${{ secrets.GKE_ZONE }}
   GKE_MACHINE_TYPE: 'n2-standard-4'
   GKE_NETWORK: 'epinio-ci'
 
@@ -100,7 +101,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
+          aws-region: ${{ secrets.EKS_REGION }}
 
       - name: Setup Ginkgo Test Framework
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
@@ -135,7 +136,8 @@ jobs:
           # Prevents using deprecated auth method in generated kubeconfig
           USE_GKE_GCLOUD_AUTH_PLUGIN: True
         run: |
-          id="${{ steps.create-cluster.outputs.ID }}"
+          id=${{ steps.create-cluster.outputs.ID }}
+          export KUBECONFIG=${{ env.KUBECONFIG_NAME }}
           gcloud container clusters get-credentials epinioci$id --zone ${{ env.GKE_ZONE }} --project ${{ secrets.EPCI_GKE_PROJECT }}
 
       - name: Installation Acceptance Tests
@@ -153,7 +155,7 @@ jobs:
           # EXTRAENV_VALUE: 12345
         run: |
           echo "System Domain: $GKE_DOMAIN"
-          export KUBECONFIG=$HOME/.kube/config
+          export KUBECONFIG=${{ env.KUBECONFIG_NAME }}
           make test-acceptance-install
 
       - name: Delete GKE cluster

--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -23,12 +23,12 @@ on:
     - cron:  '0 5 * * *'
   workflow_dispatch:
     inputs:
-      keep_cluster:
-        description: "Keep the cluster afterwards? (empty/yes)"
-        required: false
-        default: ""
       gke_domain:
         description: "GKE_DOMAIN to use, managed via Route53's AWS_ZONE_ID"
+        required: false
+        default: ""
+      keep_cluster:
+        description: "Keep the cluster afterwards? (empty/yes)"
         required: false
         default: ""
 

--- a/.github/workflows/gke-upgrade.yml
+++ b/.github/workflows/gke-upgrade.yml
@@ -24,14 +24,14 @@ on:
     - cron:  '30 1 * * *'
   workflow_dispatch:
     inputs:
-      gke_domain:
-        description: "GKE_DOMAIN to use, managed via Route53's AWS_ZONE_ID"
-        required: false
-        default: ""
       keep_cluster:
-        description: "Keep the cluster afterwards? (empty/yes)"
-        required: false
-        default: ""
+        type: choice
+        description: "Keep the cluster afterwards?"
+        required: true
+        default: 'No'
+        options:
+        - No
+        - Yes
 
 env:
   SETUP_GO_VERSION: '~1.19'
@@ -157,8 +157,8 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           AWS_ZONE_ID: ${{ secrets.AWS_ZONE_ID }}
           # Use a random host name, so we don't collide with our workflows on GKE
-          GKE_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.gke_domain || secrets.GKE_DOMAIN }}
-          EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.gke_domain || secrets.GKE_DOMAIN }}
+          GKE_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ secrets.GKE_DOMAIN }}
+          EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ secrets.GKE_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
           INGRESS_CONTROLLER: traefik
           # EXTRAENV_NAME: SESSION_KEY
@@ -176,7 +176,7 @@ jobs:
       - name: Delete GKE cluster
         # We always tear down the cluster, to avoid costs. Except when running
         # manually and keep_cluster was set to a non-empty string, like "yes"
-        if: ${{ always() && !github.event.inputs.keep_cluster }}
+        if: ${{ always() && github.event.inputs.keep_cluster == 'No' }}
         run: |
           export RUN_ID=${{ steps.create-cluster.outputs.ID }}
           export RUN_PCP="GKE"

--- a/.github/workflows/gke-upgrade.yml
+++ b/.github/workflows/gke-upgrade.yml
@@ -38,7 +38,8 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  GKE_ZONE: 'europe-west1-b'
+  KUBECONFIG_NAME: 'kubeconfig-epinio-ci'
+  GKE_ZONE: ${{ secrets.GKE_ZONE }}
   GKE_MACHINE_TYPE: 'n2-standard-4'
   GKE_NETWORK: 'epinio-ci'
 
@@ -108,7 +109,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
+          aws-region: ${{ secrets.EKS_REGION }}
 
       - name: Setup Ginkgo Test Framework
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
@@ -143,7 +144,8 @@ jobs:
           # Prevents using deprecated auth method in generated kubeconfig
           USE_GKE_GCLOUD_AUTH_PLUGIN: True
         run: |
-          id="${{ steps.create-cluster.outputs.ID }}"
+          id=${{ steps.create-cluster.outputs.ID }}
+          export KUBECONFIG=${{ env.KUBECONFIG_NAME }}
           gcloud container clusters get-credentials epinioci$id --zone ${{ env.GKE_ZONE }} --project ${{ secrets.EPCI_GKE_PROJECT }}
 
       - name: Installation Acceptance Tests
@@ -163,7 +165,7 @@ jobs:
         run: |
           # EPINIO_UPGRADED triggers starting with a released epinio in suite setup, and the upgrade sequence
           echo "System Domain: $GKE_DOMAIN"
-          export KUBECONFIG=$HOME/.kube/config
+          export KUBECONFIG=${{ env.KUBECONFIG_NAME }}
           export EPINIO_CURRENT_TAG="$(git describe --tags)"
           # Run GKE integrated install + upgrade test
           mkdir dist

--- a/.github/workflows/gke-upgrade.yml
+++ b/.github/workflows/gke-upgrade.yml
@@ -173,7 +173,15 @@ jobs:
           make test-acceptance-install
 
       - name: Delete GKE cluster
+        # We always tear down the cluster, to avoid costs. Except when running
+        # manually and keep_cluster was set to a non-empty string, like "yes"
         if: ${{ always() && !github.event.inputs.keep_cluster }}
         run: |
-          id="${{ steps.create-cluster.outputs.ID }}"
-          gcloud container clusters delete epinioci$id --zone ${{ env.GKE_ZONE }} --quiet
+          export RUN_ID=${{ steps.create-cluster.outputs.ID }}
+          export RUN_PCP="GKE"
+          export AWS_ZONE_ID=${{ secrets.AWS_ZONE_ID }}
+          export GKE_DOMAIN=${{ secrets.GKE_DOMAIN }}
+          export GKE_ZONE=${{ secrets.GKE_ZONE }}
+          export EPCI_GKE_PROJECT=${{ secrets.EPCI_GKE_PROJECT }}
+          export KUBECONFIG_NAME=${{ env.KUBECONFIG_NAME }}
+          go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/gke-upgrade.yml
+++ b/.github/workflows/gke-upgrade.yml
@@ -130,6 +130,7 @@ jobs:
         run: |
           id=$RANDOM
           echo "ID=$id" >> $GITHUB_OUTPUT
+          echo "RUN_ID: ${{ steps.create-cluster.outputs.ID }}"
           gcloud container clusters create epinioci$id \
           --disk-size 100 \
           --num-nodes=1 \

--- a/.github/workflows/gke-upgrade.yml
+++ b/.github/workflows/gke-upgrade.yml
@@ -24,12 +24,12 @@ on:
     - cron:  '30 1 * * *'
   workflow_dispatch:
     inputs:
-      keep_cluster:
-        description: "Keep the cluster afterwards? (empty/yes)"
-        required: false
-        default: ""
       gke_domain:
         description: "GKE_DOMAIN to use, managed via Route53's AWS_ZONE_ID"
+        required: false
+        default: ""
+      keep_cluster:
+        description: "Keep the cluster afterwards? (empty/yes)"
         required: false
         default: ""
 

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -159,7 +159,15 @@ jobs:
           make test-acceptance-install
 
       - name: Delete GKE cluster
+        # We always tear down the cluster, to avoid costs. Except when running
+        # manually and keep_cluster was set to a non-empty string, like "yes"
         if: ${{ always() && !github.event.inputs.keep_cluster }}
         run: |
-          id="${{ steps.create-cluster.outputs.ID }}"
-          gcloud container clusters delete epinioci$id --zone ${{ env.GKE_ZONE }} --quiet
+          export RUN_ID=${{ steps.create-cluster.outputs.ID }}
+          export RUN_PCP="GKE"
+          export AWS_ZONE_ID=${{ secrets.AWS_ZONE_ID }}
+          export GKE_DOMAIN=${{ secrets.GKE_DOMAIN }}
+          export GKE_ZONE=${{ secrets.GKE_ZONE }}
+          export EPCI_GKE_PROJECT=${{ secrets.EPCI_GKE_PROJECT }}
+          export KUBECONFIG_NAME=${{ env.KUBECONFIG_NAME }}
+          go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -23,12 +23,12 @@ on:
     - cron:  '0 1 * * *'
   workflow_dispatch:
     inputs:
-      keep_cluster:
-        description: "Keep the cluster afterwards? (empty/yes)"
-        required: false
-        default: ""
       gke_domain:
         description: "GKE_DOMAIN to use, managed via Route53's AWS_ZONE_ID"
+        required: false
+        default: ""
+      keep_cluster:
+        description: "Keep the cluster afterwards? (empty/yes)"
         required: false
         default: ""
 

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -23,14 +23,14 @@ on:
     - cron:  '0 1 * * *'
   workflow_dispatch:
     inputs:
-      gke_domain:
-        description: "GKE_DOMAIN to use, managed via Route53's AWS_ZONE_ID"
-        required: false
-        default: ""
       keep_cluster:
-        description: "Keep the cluster afterwards? (empty/yes)"
-        required: false
-        default: ""
+        type: choice
+        description: "Keep the cluster afterwards?"
+        required: true
+        default: 'No'
+        options:
+        - No
+        - Yes
 
 env:
   SETUP_GO_VERSION: '~1.19'
@@ -148,8 +148,8 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           AWS_ZONE_ID: ${{ secrets.AWS_ZONE_ID }}
           # Use a random host name, so we don't collide with our workflows on GKE
-          GKE_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.gke_domain || secrets.GKE_DOMAIN }}
-          EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ github.event.inputs.gke_domain || secrets.GKE_DOMAIN }}
+          GKE_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ secrets.GKE_DOMAIN }}
+          EPINIO_SYSTEM_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ secrets.GKE_DOMAIN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
           INGRESS_CONTROLLER: traefik
           # EXTRAENV_NAME: SESSION_KEY
@@ -162,7 +162,7 @@ jobs:
       - name: Delete GKE cluster
         # We always tear down the cluster, to avoid costs. Except when running
         # manually and keep_cluster was set to a non-empty string, like "yes"
-        if: ${{ always() && !github.event.inputs.keep_cluster }}
+        if: ${{ always() && github.event.inputs.keep_cluster == 'No' }}
         run: |
           export RUN_ID=${{ steps.create-cluster.outputs.ID }}
           export RUN_PCP="GKE"

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -122,6 +122,7 @@ jobs:
         run: |
           id=$RANDOM
           echo "ID=$id" >> $GITHUB_OUTPUT
+          echo "RUN_ID: ${{ steps.create-cluster.outputs.ID }}"
           gcloud container clusters create epinioci$id \
           --disk-size 100 \
           --num-nodes=1 \

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -37,7 +37,8 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  GKE_ZONE: 'europe-west1-b'
+  KUBECONFIG_NAME: 'kubeconfig-epinio-ci'
+  GKE_ZONE: ${{ secrets.GKE_ZONE }}
   GKE_MACHINE_TYPE: 'n2-standard-4'
   GKE_NETWORK: 'epinio-ci'
 
@@ -100,7 +101,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
+          aws-region: ${{ secrets.EKS_REGION }}
 
       - name: Setup Ginkgo Test Framework
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
@@ -135,7 +136,8 @@ jobs:
           # Prevents using deprecated auth method in generated kubeconfig
           USE_GKE_GCLOUD_AUTH_PLUGIN: True
         run: |
-          id="${{ steps.create-cluster.outputs.ID }}"
+          id=${{ steps.create-cluster.outputs.ID }}
+          export KUBECONFIG=${{ env.KUBECONFIG_NAME }}
           gcloud container clusters get-credentials epinioci$id --zone ${{ env.GKE_ZONE }} --project ${{ secrets.EPCI_GKE_PROJECT }}
 
       - name: Installation Acceptance Tests
@@ -153,7 +155,7 @@ jobs:
           # EXTRAENV_VALUE: 12345
         run: |
           echo "System Domain: $GKE_DOMAIN"
-          export KUBECONFIG=$HOME/.kube/config
+          export KUBECONFIG=${{ env.KUBECONFIG_NAME }}
           make test-acceptance-install
 
       - name: Delete GKE cluster

--- a/acceptance/helpers/delete_clusters/delete_clusters.go
+++ b/acceptance/helpers/delete_clusters/delete_clusters.go
@@ -9,6 +9,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// delete_clusters.go called from acceptance test workflows and delete_clusters.yml
+
 package main
 
 import (
@@ -19,135 +21,165 @@ import (
 	"github.com/epinio/epinio/acceptance/helpers/route53"
 )
 
+var noaction []int
+
 func main() {
-	runID, runIDcheck := os.LookupEnv("RUN_ID")
-	pcp, pcpcheck := os.LookupEnv("RUN_PCP")
-	if !runIDcheck || !pcpcheck {
-		if !runIDcheck {
-			fmt.Println("Error: Variable RUN_ID not set in env")
-		}
-		if !pcpcheck {
-			fmt.Println("Error: Variable RUN_PCP not set in env")
-		}
-		return
-	}
+	runID := os.Getenv("RUN_ID")
+	pcp := os.Getenv("RUN_PCP")
 
 	DeleteCluster(runID, pcp)
 }
 
+// Function to verify AWS Route53 DNS records, and clean them up if needed
 func CleanupDNS(zoneID string, domainname string) {
+	// for each test run, there are two records: domain + wildcard domain
 	dnsrecords := [2]string{domainname + ".", "\\052." + domainname + "."}
 	fmt.Println("Cleaning up AWS Route53 DNS records ...")
 
 	for _, dnsrecord := range dnsrecords {
-		Name, Type, Record, err := route53.GetRecord(zoneID, dnsrecord)
+		var recordvalues route53.RecordValues
+		// We need to get the record by name first - we can only clean up by knowing the correct record type
+		recordvalues, err := route53.GetRecord(zoneID, dnsrecord)
 		if err != nil {
 			fmt.Println("Error: ", err)
+			os.Exit(1)
 		}
-		if Name != "Clean" {
-			var change route53.ChangeResourceRecordSet
-			switch Type {
-			case "A":
-				change = route53.A(Name, Record, "DELETE")
-			case "CNAME":
-				change = route53.CNAME(Name, Record, "DELETE")
-			}
-			out, err := route53.Update(zoneID, change, "")
-			if err != nil {
-				fmt.Println("Error: ", err, out)
-			} else {
-				fmt.Println("Cleaned up AWS Route53 DNS record: ", dnsrecord)
-			}
-		} else {
+		recordname := recordvalues.Name
+		recordtype := recordvalues.Type
+		recordvalue := recordvalues.Record
+		// If the record doesn't exist, we don't need to do anything
+		if recordname == "Clean" {
+			// Append to noaction array for each record that didn't exist
+			noaction = append(noaction, 1)
 			fmt.Println("AWS Route53 DNS record was cleaned up already, or does not exist: ", dnsrecord)
+			continue
+		}
+		var change route53.ChangeResourceRecordSet
+		switch recordtype {
+		case "A":
+			change = route53.A(recordname, recordvalue, "DELETE")
+		case "CNAME":
+			change = route53.CNAME(recordname, recordvalue, "DELETE")
+		}
+		// Delete existing DNS record
+		out, err := route53.Update(zoneID, change, "")
+		if err != nil {
+			fmt.Println("Error: ", err, out)
+			os.Exit(1)
+		} else {
+			fmt.Println("Cleaned up AWS Route53 DNS record: ", dnsrecord)
 		}
 	}
 
 }
 
-func ListCluster(runID string, pcp string) (exists bool) {
-	switch pcp {
-	case "AKS":
-		aks_resource_group := os.Getenv("AKS_RESOURCE_GROUP")
-		out, err := proc.RunW("az", "aks", "list", "--resource-group", aks_resource_group, "--query", "[].{name:name} | [? contains(name,'"+aks_resource_group+runID+"')]")
-		if err != nil {
-			fmt.Println("Error: ", err, out)
+// Check if AKS cluster exists
+func ListClusterAKS(runID string) (exists bool) {
+	aks_resource_group := os.Getenv("AKS_RESOURCE_GROUP")
+	out, err := proc.RunW("az", "aks", "list", "--resource-group", aks_resource_group, "--query", fmt.Sprintf("[].{name:name} | [? contains(name,'%s%s')]", aks_resource_group, runID))
+	if err != nil {
+		fmt.Println("Error: ", err, out)
+		os.Exit(1)
+	} else {
+		if out == "[]" || out == "[]\n" {
+			fmt.Println("AKS cluster does not exisit: " + aks_resource_group + runID)
 			exists = false
-		} else {
-			if out == "[]" || out == "[]\n" {
-				fmt.Println("AKS cluster does not exisit: " + aks_resource_group + runID)
-				exists = false
-			} else {
-				exists = true
+			// If no DNS record was cleaned up, we will exit here - wrong runID?
+			if len(noaction) > 1 {
+				fmt.Println("Error: Nothing was cleaned up. Please check your inputs.")
+				os.Exit(1)
 			}
-		}
-	case "EKS":
-		eks_region := os.Getenv("EKS_REGION")
-		out, err := proc.RunW("aws", "eks", "list-clusters", "--region="+eks_region, "--query", "clusters | [? contains(@,'epinio-ci"+runID+"')]", "--output", "text")
-		if err != nil {
-			fmt.Println("Error: ", err, out)
-			exists = false
 		} else {
-			if out == "" {
-				fmt.Println("EKS cluster does not exisit: epinio-ci" + runID)
-				exists = false
-			} else {
-				exists = true
-			}
-		}
-	case "GKE":
-		gke_zone := os.Getenv("GKE_ZONE")
-		os.Setenv("USE_GKE_GCLOUD_AUTH_PLUGIN", "true")
-		out, err := proc.RunW("gcloud", "container", "clusters", "list", "--filter", "epinioci"+runID, "--zone", gke_zone, "--quiet")
-		if err != nil {
-			fmt.Println("Error: ", err, out)
-			exists = false
-		} else {
-			if out == "" {
-				fmt.Println("GKE cluster does not exisit: epinioci" + runID)
-				exists = false
-			} else {
-				exists = true
-			}
+			exists = true
 		}
 	}
 	return exists
 }
 
-func GetKubeconfig(runID string, pcp string) {
-	kubeconfig_name := os.Getenv("KUBECONFIG_NAME")+"-Deletion"
-
-	switch pcp {
-		case "AKS":
-			aks_resource_group := os.Getenv("AKS_RESOURCE_GROUP")
-			out, err := proc.RunW("az", "aks", "get-credentials", "--admin", "--resource-group", aks_resource_group, "--name", aks_resource_group+runID, "--file", kubeconfig_name)
-			if err != nil {
-				fmt.Println("Error: ", err, out)
-			} else {
-				fmt.Println("Fetched current kubeconfig")
+// Check if EKS cluster exists
+func ListClusterEKS(runID string) (exists bool) {
+	eks_region := os.Getenv("EKS_REGION")
+	out, err := proc.RunW("aws", "eks", "list-clusters", "--region="+eks_region, "--query", fmt.Sprintf("clusters | [? contains(@,'epinio-ci%s')]", runID), "--output", "text")
+	if err != nil {
+		fmt.Println("Error: ", err, out)
+		os.Exit(1)
+	} else {
+		if out == "" {
+			fmt.Println("EKS cluster does not exisit: epinio-ci" + runID)
+			exists = false
+			// If no DNS record was cleaned up, we will exit here - wrong runID?
+			if len(noaction) > 1 {
+				fmt.Println("Error: Nothing was cleaned up. Please check your inputs.")
+				os.Exit(1)
 			}
-		case "EKS":
-			eks_region := os.Getenv("EKS_REGION")
-			out, err := proc.RunW("eksctl", "utils", "write-kubeconfig", "--region", eks_region, "--cluster", "epinio-ci"+runID, "--kubeconfig", kubeconfig_name)
-			if err != nil {
-				fmt.Println("Error: ", err, out)
-			} else {
-				fmt.Println("Fetched current kubeconfig")
-			}
-		case "GKE":
-			gke_zone := os.Getenv("GKE_ZONE")
-			epci_gke_project := os.Getenv("EPCI_GKE_PROJECT")
-			os.Setenv("USE_GKE_GCLOUD_AUTH_PLUGIN", "true")
-			os.Setenv("KUBECONFIG", kubeconfig_name)
-			out, err := proc.RunW("gcloud", "container", "clusters", "get-credentials", "epinioci"+runID, "--zone", gke_zone, "--project", epci_gke_project)
-			if err != nil {
-				fmt.Println("Error: ", err, out)
-			} else {
-				fmt.Println("Fetched current kubeconfig")
-			}
+		} else {
+			exists = true
 		}
+	}
+	return exists
 }
 
+// Check if GKE cluster exists
+func ListClusterGKE(runID string) (exists bool) {
+	gke_zone := os.Getenv("GKE_ZONE")
+	os.Setenv("USE_GKE_GCLOUD_AUTH_PLUGIN", "true")
+	out, err := proc.RunW("gcloud", "container", "clusters", "list", "--filter", "epinioci"+runID, "--zone", gke_zone, "--quiet")
+	if err != nil {
+		fmt.Println("Error: ", err, out)
+		os.Exit(1)
+	} else {
+		if out == "" {
+			fmt.Println("GKE cluster does not exisit: epinioci" + runID)
+			exists = false
+			// If no DNS record was cleaned up, we will exit here - wrong runID?
+			if len(noaction) > 1 {
+				fmt.Println("Error: Nothing was cleaned up. Please check your inputs.")
+				os.Exit(1)
+			}
+		} else {
+			exists = true
+		}
+	}
+	return exists
+}
+
+func GetKubeconfigAKS(runID string) {
+	kubeconfig_name := os.Getenv("KUBECONFIG_NAME")+"-Deletion"
+	aks_resource_group := os.Getenv("AKS_RESOURCE_GROUP")
+	out, err := proc.RunW("az", "aks", "get-credentials", "--admin", "--resource-group", aks_resource_group, "--name", aks_resource_group+runID, "--file", kubeconfig_name)
+	if err != nil {
+		fmt.Println("Error: ", err, out)
+	} else {
+		fmt.Println("Fetched current kubeconfig")
+	}
+}
+
+func GetKubeconfigEKS(runID string) {
+	kubeconfig_name := os.Getenv("KUBECONFIG_NAME")+"-Deletion"
+	eks_region := os.Getenv("EKS_REGION")
+	out, err := proc.RunW("eksctl", "utils", "write-kubeconfig", "--region", eks_region, "--cluster", "epinio-ci"+runID, "--kubeconfig", kubeconfig_name)
+	if err != nil {
+		fmt.Println("Error: ", err, out)
+	} else {
+		fmt.Println("Fetched current kubeconfig")
+	}
+}
+
+func GetKubeconfigGKE(runID string) {
+	kubeconfig_name := os.Getenv("KUBECONFIG_NAME")+"-Deletion"
+	gke_zone := os.Getenv("GKE_ZONE")
+	epci_gke_project := os.Getenv("EPCI_GKE_PROJECT")
+	os.Setenv("USE_GKE_GCLOUD_AUTH_PLUGIN", "true")
+	os.Setenv("KUBECONFIG", kubeconfig_name)
+	out, err := proc.RunW("gcloud", "container", "clusters", "get-credentials", "epinioci"+runID, "--zone", gke_zone, "--project", epci_gke_project)
+	if err != nil {
+		fmt.Println("Error: ", err, out)
+	} else {
+		fmt.Println("Fetched current kubeconfig")
+	}
+}
+
+// Clean up namespaces - therefore unused disks will be removed on cluster deletion
 func CleanupNamespaces() {
 	kubeconfig_name := os.Getenv("KUBECONFIG_NAME")+"-Deletion"
 	os.Setenv("KUBECONFIG", kubeconfig_name)
@@ -155,66 +187,83 @@ func CleanupNamespaces() {
 	out, err := proc.RunW("kubectl", "--kubeconfig", kubeconfig_name, "delete", "--force", "--ignore-not-found", "namespace", "epinio", "workspace")
 	if err != nil {
 		fmt.Println("Error: ", err, out)
+		os.Exit(1)
 	} else {
 		fmt.Println("Cleaning up test namespaces ...")
 	}
 }
 
-func DeleteCluster(runID string, pcp string) {
+// Complete cleanup steps for Azure AKS case
+func DeleteClusterAKS(runID string) {
 	aws_zone_id := os.Getenv("AWS_ZONE_ID")
+	aks_resource_group := os.Getenv("AKS_RESOURCE_GROUP")
+	domainname := fmt.Sprintf("id%s-%s", runID, os.Getenv("AKS_DOMAIN"))
+	CleanupDNS(aws_zone_id, domainname)
+	exists := ListClusterAKS(runID)
+	if exists {
+		GetKubeconfigAKS(runID)
+		CleanupNamespaces()
+		fmt.Println("Deleting AKS cluster ...")
+		out, err := proc.RunW("az", "aks", "delete", "--resource-group", aks_resource_group, "--name", aks_resource_group+runID, "--yes")
+		if err != nil {
+			fmt.Println("Error: ", err, out)
+			os.Exit(1)
+		} else {
+			fmt.Println("Deleted AKS cluster: ", aks_resource_group+runID)
+		}
+	}
+}
 
+// Complete cleanup steps for Amazon EKS case
+func DeleteClusterEKS(runID string) {
+	aws_zone_id := os.Getenv("AWS_ZONE_ID")
+	eks_region := os.Getenv("EKS_REGION")
+	domainname := fmt.Sprintf("id%s-%s", runID, os.Getenv("EKS_DOMAIN"))
+	CleanupDNS(aws_zone_id, domainname)
+	exists := ListClusterEKS(runID)
+	if exists {
+		GetKubeconfigEKS(runID)
+		CleanupNamespaces()
+		fmt.Println("Deleting EKS cluster ...")
+		out, err := proc.RunW("eksctl", "delete", "cluster", "--region="+eks_region, "--name=epinio-ci"+runID)
+		if err != nil {
+			fmt.Println("Error: ", err, out)
+			os.Exit(1)
+		} else {
+			fmt.Println("Deleted EKS cluster: ", "epinio-ci"+runID)
+		}
+	}
+}
+
+// Complete cleanup steps for Google GKE case
+func DeleteClusterGKE(runID string) {
+	aws_zone_id := os.Getenv("AWS_ZONE_ID")
+	gke_zone := os.Getenv("GKE_ZONE")
+	domainname := fmt.Sprintf("id%s-%s", runID, os.Getenv("GKE_DOMAIN"))
+	CleanupDNS(aws_zone_id, domainname)
+	exists := ListClusterGKE(runID)
+	if exists {
+		GetKubeconfigGKE(runID)
+		CleanupNamespaces()
+		fmt.Println("Deleting GKE cluster ...")
+		os.Setenv("USE_GKE_GCLOUD_AUTH_PLUGIN", "true")
+		out, err := proc.RunW("gcloud", "container", "clusters", "delete", "epinioci"+runID, "--zone", gke_zone, "--quiet")
+		if err != nil {
+			fmt.Println("Error: ", err, out)
+			os.Exit(1)
+		} else {
+			fmt.Println("Deleted GKE cluster: ", "epinioci"+runID)
+		}
+	}
+}
+
+func DeleteCluster(runID string, pcp string) {
 	switch pcp {
-	case "AKS":
-		aks_domain := os.Getenv("AKS_DOMAIN")
-		aks_resource_group := os.Getenv("AKS_RESOURCE_GROUP")
-		domainname := "id" + runID + "-" + aks_domain
-		CleanupDNS(aws_zone_id, domainname)
-		exists := ListCluster(runID, pcp)
-		if exists {
-			GetKubeconfig(runID, pcp)
-			CleanupNamespaces()
-			fmt.Println("Deleting AKS cluster ...")
-			out, err := proc.RunW("az", "aks", "delete", "--resource-group", aks_resource_group, "--name", aks_resource_group+runID, "--yes")
-			if err != nil {
-				fmt.Println("Error: ", err, out)
-			} else {
-				fmt.Println("Deleted AKS cluster: ", aks_resource_group+runID)
-			}
-		}
-	case "EKS":
-		eks_domain := os.Getenv("EKS_DOMAIN")
-		eks_region := os.Getenv("EKS_REGION")
-		domainname := "id" + runID + "-" + eks_domain
-		CleanupDNS(aws_zone_id, domainname)
-		exists := ListCluster(runID, pcp)
-		if exists {
-			GetKubeconfig(runID, pcp)
-			CleanupNamespaces()
-			fmt.Println("Deleting EKS cluster ...")
-			out, err := proc.RunW("eksctl", "delete", "cluster", "--region="+eks_region, "--name=epinio-ci"+runID)
-			if err != nil {
-				fmt.Println("Error: ", err, out)
-			} else {
-				fmt.Println("Deleted EKS cluster: ", "epinio-ci"+runID)
-			}
-		}
-	case "GKE":
-		gke_domain := os.Getenv("GKE_DOMAIN")
-		gke_zone := os.Getenv("GKE_ZONE")
-		domainname := "id" + runID + "-" + gke_domain
-		CleanupDNS(aws_zone_id, domainname)
-		exists := ListCluster(runID, pcp)
-		if exists {
-			GetKubeconfig(runID, pcp)
-			CleanupNamespaces()
-			fmt.Println("Deleting GKE cluster ...")
-			os.Setenv("USE_GKE_GCLOUD_AUTH_PLUGIN", "true")
-			out, err := proc.RunW("gcloud", "container", "clusters", "delete", "epinioci"+runID, "--zone", gke_zone, "--quiet")
-			if err != nil {
-				fmt.Println("Error: ", err, out)
-			} else {
-				fmt.Println("Deleted GKE cluster: ", "epinioci"+runID)
-			}
-		}
+		case "AKS":
+			DeleteClusterAKS(runID)
+		case "EKS":
+			DeleteClusterEKS(runID)
+		case "GKE":
+			DeleteClusterGKE(runID)
 	}
 }

--- a/acceptance/helpers/delete_clusters/delete_clusters.go
+++ b/acceptance/helpers/delete_clusters/delete_clusters.go
@@ -45,24 +45,19 @@ func CleanupDNS(zoneID string, domainname string) {
 			fmt.Println("Error: ", err)
 		}
 		if Name != "Clean" {
-			nodeTmpDir := ""
+			var change string
 			switch Type {
 			case "A":
-				change := route53.A(Name, Record, "DELETE")
-				out, err := route53.Update(zoneID, change, nodeTmpDir)
-				if err != nil {
-					fmt.Println("Error: ", err, out)
-				} else {
-					fmt.Println("Cleaned up AWS Route53 DNS record: ", dnsrecord)
-				}
+				change = route53.A(Name, Record, "DELETE")
 			case "CNAME":
-				change := route53.CNAME(Name, Record, "DELETE")
-				out, err := route53.Update(zoneID, change, nodeTmpDir)
-				if err != nil {
-					fmt.Println("Error: ", err, out)
-				} else {
-					fmt.Println("Cleaned up AWS Route53 DNS record: ", dnsrecord)
-				}
+				change = route53.CNAME(Name, Record, "DELETE")
+			}
+			
+			out, err := route53.Update(zoneID, change, "")
+			if err != nil {
+				fmt.Println("Error: ", err, out)
+			} else {
+				fmt.Println("Cleaned up AWS Route53 DNS record: ", dnsrecord)
 			}
 
 		} else {

--- a/acceptance/helpers/delete_clusters/delete_clusters.go
+++ b/acceptance/helpers/delete_clusters/delete_clusters.go
@@ -144,7 +144,7 @@ func ListClusterGKE(runID string) (exists bool) {
 }
 
 func GetKubeconfigAKS(runID string) {
-	kubeconfig_name := os.Getenv("KUBECONFIG_NAME")+"-Deletion"
+	kubeconfig_name := os.Getenv("KUBECONFIG_NAME") + "-Deletion"
 	aks_resource_group := os.Getenv("AKS_RESOURCE_GROUP")
 	out, err := proc.RunW("az", "aks", "get-credentials", "--admin", "--resource-group", aks_resource_group, "--name", aks_resource_group+runID, "--file", kubeconfig_name)
 	if err != nil {
@@ -155,7 +155,7 @@ func GetKubeconfigAKS(runID string) {
 }
 
 func GetKubeconfigEKS(runID string) {
-	kubeconfig_name := os.Getenv("KUBECONFIG_NAME")+"-Deletion"
+	kubeconfig_name := os.Getenv("KUBECONFIG_NAME") + "-Deletion"
 	eks_region := os.Getenv("EKS_REGION")
 	out, err := proc.RunW("eksctl", "utils", "write-kubeconfig", "--region", eks_region, "--cluster", "epinio-ci"+runID, "--kubeconfig", kubeconfig_name)
 	if err != nil {
@@ -166,7 +166,7 @@ func GetKubeconfigEKS(runID string) {
 }
 
 func GetKubeconfigGKE(runID string) {
-	kubeconfig_name := os.Getenv("KUBECONFIG_NAME")+"-Deletion"
+	kubeconfig_name := os.Getenv("KUBECONFIG_NAME") + "-Deletion"
 	gke_zone := os.Getenv("GKE_ZONE")
 	epci_gke_project := os.Getenv("EPCI_GKE_PROJECT")
 	os.Setenv("USE_GKE_GCLOUD_AUTH_PLUGIN", "true")
@@ -181,7 +181,7 @@ func GetKubeconfigGKE(runID string) {
 
 // Clean up namespaces - therefore unused disks will be removed on cluster deletion
 func CleanupNamespaces() {
-	kubeconfig_name := os.Getenv("KUBECONFIG_NAME")+"-Deletion"
+	kubeconfig_name := os.Getenv("KUBECONFIG_NAME") + "-Deletion"
 	os.Setenv("KUBECONFIG", kubeconfig_name)
 
 	out, err := proc.RunW("kubectl", "--kubeconfig", kubeconfig_name, "delete", "--force", "--ignore-not-found", "namespace", "epinio", "workspace")
@@ -259,11 +259,11 @@ func DeleteClusterGKE(runID string) {
 
 func DeleteCluster(runID string, pcp string) {
 	switch pcp {
-		case "AKS":
-			DeleteClusterAKS(runID)
-		case "EKS":
-			DeleteClusterEKS(runID)
-		case "GKE":
-			DeleteClusterGKE(runID)
+	case "AKS":
+		DeleteClusterAKS(runID)
+	case "EKS":
+		DeleteClusterEKS(runID)
+	case "GKE":
+		DeleteClusterGKE(runID)
 	}
 }

--- a/acceptance/helpers/delete_clusters/delete_clusters.go
+++ b/acceptance/helpers/delete_clusters/delete_clusters.go
@@ -45,21 +45,19 @@ func CleanupDNS(zoneID string, domainname string) {
 			fmt.Println("Error: ", err)
 		}
 		if Name != "Clean" {
-			var change string
+			var change route53.ChangeResourceRecordSet
 			switch Type {
 			case "A":
 				change = route53.A(Name, Record, "DELETE")
 			case "CNAME":
 				change = route53.CNAME(Name, Record, "DELETE")
 			}
-			
 			out, err := route53.Update(zoneID, change, "")
 			if err != nil {
 				fmt.Println("Error: ", err, out)
 			} else {
 				fmt.Println("Cleaned up AWS Route53 DNS record: ", dnsrecord)
 			}
-
 		} else {
 			fmt.Println("AWS Route53 DNS record was cleaned up already, or does not exist: ", dnsrecord)
 		}

--- a/acceptance/helpers/delete_clusters/delete_clusters.go
+++ b/acceptance/helpers/delete_clusters/delete_clusters.go
@@ -1,0 +1,227 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/epinio/epinio/acceptance/helpers/proc"
+	"github.com/epinio/epinio/acceptance/helpers/route53"
+)
+
+func main() {
+	runID, runIDcheck := os.LookupEnv("RUN_ID")
+	pcp, pcpcheck := os.LookupEnv("RUN_PCP")
+	if !runIDcheck || !pcpcheck {
+		if !runIDcheck {
+			fmt.Println("Error: Variable RUN_ID not set in env")
+		}
+		if !pcpcheck {
+			fmt.Println("Error: Variable RUN_PCP not set in env")
+		}
+		return
+	}
+
+	DeleteCluster(runID, pcp)
+}
+
+func CleanupDNS(zoneID string, domainname string) {
+	dnsrecords := [2]string{domainname + ".", "\\052." + domainname + "."}
+	fmt.Println("Cleaning up AWS Route53 DNS records ...")
+
+	for _, dnsrecord := range dnsrecords {
+		Name, Type, Record, err := route53.GetRecord(zoneID, dnsrecord)
+		if err != nil {
+			fmt.Println("Error: ", err)
+		}
+		if Name != "Clean" {
+			nodeTmpDir := ""
+			switch Type {
+			case "A":
+				change := route53.A(Name, Record, "DELETE")
+				out, err := route53.Update(zoneID, change, nodeTmpDir)
+				if err != nil {
+					fmt.Println("Error: ", err, out)
+				} else {
+					fmt.Println("Cleaned up AWS Route53 DNS record: ", dnsrecord)
+				}
+			case "CNAME":
+				change := route53.CNAME(Name, Record, "DELETE")
+				out, err := route53.Update(zoneID, change, nodeTmpDir)
+				if err != nil {
+					fmt.Println("Error: ", err, out)
+				} else {
+					fmt.Println("Cleaned up AWS Route53 DNS record: ", dnsrecord)
+				}
+			}
+
+		} else {
+			fmt.Println("AWS Route53 DNS record was cleaned up already, or does not exist: ", dnsrecord)
+		}
+	}
+
+}
+
+func ListCluster(runID string, pcp string) (exists bool) {
+	switch pcp {
+	case "AKS":
+		aks_resource_group := os.Getenv("AKS_RESOURCE_GROUP")
+		out, err := proc.RunW("az", "aks", "list", "--resource-group", aks_resource_group, "--query", "[].{name:name} | [? contains(name,'"+aks_resource_group+runID+"')]")
+		if err != nil {
+			fmt.Println("Error: ", err, out)
+			exists = false
+		} else {
+			if out == "[]" || out == "[]\n" {
+				fmt.Println("AKS cluster does not exisit: " + aks_resource_group + runID)
+				exists = false
+			} else {
+				exists = true
+			}
+		}
+	case "EKS":
+		eks_region := os.Getenv("EKS_REGION")
+		out, err := proc.RunW("aws", "eks", "list-clusters", "--region="+eks_region, "--query", "clusters | [? contains(@,'epinio-ci"+runID+"')]", "--output", "text")
+		if err != nil {
+			fmt.Println("Error: ", err, out)
+			exists = false
+		} else {
+			if out == "" {
+				fmt.Println("EKS cluster does not exisit: epinio-ci" + runID)
+				exists = false
+			} else {
+				exists = true
+			}
+		}
+	case "GKE":
+		gke_zone := os.Getenv("GKE_ZONE")
+		os.Setenv("USE_GKE_GCLOUD_AUTH_PLUGIN", "true")
+		out, err := proc.RunW("gcloud", "container", "clusters", "list", "--filter", "epinioci"+runID, "--zone", gke_zone, "--quiet")
+		if err != nil {
+			fmt.Println("Error: ", err, out)
+			exists = false
+		} else {
+			if out == "" {
+				fmt.Println("GKE cluster does not exisit: epinioci" + runID)
+				exists = false
+			} else {
+				exists = true
+			}
+		}
+	}
+	return exists
+}
+
+func GetKubeconfig(runID string, pcp string) {
+	kubeconfig_name := os.Getenv("KUBECONFIG_NAME")+"-Deletion"
+
+	switch pcp {
+		case "AKS":
+			aks_resource_group := os.Getenv("AKS_RESOURCE_GROUP")
+			out, err := proc.RunW("az", "aks", "get-credentials", "--admin", "--resource-group", aks_resource_group, "--name", aks_resource_group+runID, "--file", kubeconfig_name)
+			if err != nil {
+				fmt.Println("Error: ", err, out)
+			} else {
+				fmt.Println("Fetched current kubeconfig")
+			}
+		case "EKS":
+			eks_region := os.Getenv("EKS_REGION")
+			out, err := proc.RunW("eksctl", "utils", "write-kubeconfig", "--region", eks_region, "--cluster", "epinio-ci"+runID, "--kubeconfig", kubeconfig_name)
+			if err != nil {
+				fmt.Println("Error: ", err, out)
+			} else {
+				fmt.Println("Fetched current kubeconfig")
+			}
+		case "GKE":
+			gke_zone := os.Getenv("GKE_ZONE")
+			epci_gke_project := os.Getenv("EPCI_GKE_PROJECT")
+			os.Setenv("USE_GKE_GCLOUD_AUTH_PLUGIN", "true")
+			os.Setenv("KUBECONFIG", kubeconfig_name)
+			out, err := proc.RunW("gcloud", "container", "clusters", "get-credentials", "epinioci"+runID, "--zone", gke_zone, "--project", epci_gke_project)
+			if err != nil {
+				fmt.Println("Error: ", err, out)
+			} else {
+				fmt.Println("Fetched current kubeconfig")
+			}
+		}
+}
+
+func CleanupNamespaces() {
+	kubeconfig_name := os.Getenv("KUBECONFIG_NAME")+"-Deletion"
+	os.Setenv("KUBECONFIG", kubeconfig_name)
+
+	out, err := proc.RunW("kubectl", "--kubeconfig", kubeconfig_name, "delete", "--force", "--ignore-not-found", "namespace", "epinio", "workspace")
+	if err != nil {
+		fmt.Println("Error: ", err, out)
+	} else {
+		fmt.Println("Cleaning up test namespaces ...")
+	}
+}
+
+func DeleteCluster(runID string, pcp string) {
+	aws_zone_id := os.Getenv("AWS_ZONE_ID")
+
+	switch pcp {
+	case "AKS":
+		aks_domain := os.Getenv("AKS_DOMAIN")
+		aks_resource_group := os.Getenv("AKS_RESOURCE_GROUP")
+		domainname := "id" + runID + "-" + aks_domain
+		CleanupDNS(aws_zone_id, domainname)
+		exists := ListCluster(runID, pcp)
+		if exists {
+			GetKubeconfig(runID, pcp)
+			CleanupNamespaces()
+			fmt.Println("Deleting AKS cluster ...")
+			out, err := proc.RunW("az", "aks", "delete", "--resource-group", aks_resource_group, "--name", aks_resource_group+runID, "--yes")
+			if err != nil {
+				fmt.Println("Error: ", err, out)
+			} else {
+				fmt.Println("Deleted AKS cluster: ", aks_resource_group+runID)
+			}
+		}
+	case "EKS":
+		eks_domain := os.Getenv("EKS_DOMAIN")
+		eks_region := os.Getenv("EKS_REGION")
+		domainname := "id" + runID + "-" + eks_domain
+		CleanupDNS(aws_zone_id, domainname)
+		exists := ListCluster(runID, pcp)
+		if exists {
+			GetKubeconfig(runID, pcp)
+			CleanupNamespaces()
+			fmt.Println("Deleting EKS cluster ...")
+			out, err := proc.RunW("eksctl", "delete", "cluster", "--region="+eks_region, "--name=epinio-ci"+runID)
+			if err != nil {
+				fmt.Println("Error: ", err, out)
+			} else {
+				fmt.Println("Deleted EKS cluster: ", "epinio-ci"+runID)
+			}
+		}
+	case "GKE":
+		gke_domain := os.Getenv("GKE_DOMAIN")
+		gke_zone := os.Getenv("GKE_ZONE")
+		domainname := "id" + runID + "-" + gke_domain
+		CleanupDNS(aws_zone_id, domainname)
+		exists := ListCluster(runID, pcp)
+		if exists {
+			GetKubeconfig(runID, pcp)
+			CleanupNamespaces()
+			fmt.Println("Deleting GKE cluster ...")
+			os.Setenv("USE_GKE_GCLOUD_AUTH_PLUGIN", "true")
+			out, err := proc.RunW("gcloud", "container", "clusters", "delete", "epinioci"+runID, "--zone", gke_zone, "--quiet")
+			if err != nil {
+				fmt.Println("Error: ", err, out)
+			} else {
+				fmt.Println("Deleted GKE cluster: ", "epinioci"+runID)
+			}
+		}
+	}
+}

--- a/acceptance/helpers/delete_clusters/delete_clusters.go
+++ b/acceptance/helpers/delete_clusters/delete_clusters.go
@@ -16,22 +16,174 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/epinio/epinio/acceptance/helpers/proc"
 	"github.com/epinio/epinio/acceptance/helpers/route53"
+	"github.com/pkg/errors"
 )
-
-var noaction []int
 
 func main() {
 	runID := os.Getenv("RUN_ID")
 	pcp := os.Getenv("RUN_PCP")
 
-	DeleteCluster(runID, pcp)
+	err := DeleteCluster(runID, pcp)
+	if err != nil {
+		fmt.Println("something failed: " + err.Error())
+		os.Exit(1)
+	}
+}
+
+func DeleteCluster(runID string, pcp string) error {
+	switch pcp {
+	case "AKS":
+		return DeleteClusterAKS(runID)
+	case "EKS":
+		return DeleteClusterEKS(runID)
+	case "GKE":
+		return DeleteClusterGKE(runID)
+	}
+
+	return nil
+}
+
+// Complete cleanup steps for Azure AKS case
+func DeleteClusterAKS(runID string) error {
+	aws_zone_id := os.Getenv("AWS_ZONE_ID")
+	aks_resource_group := os.Getenv("AKS_RESOURCE_GROUP")
+
+	domainname := fmt.Sprintf("id%s-%s", runID, os.Getenv("AKS_DOMAIN"))
+	deletedRecords, err := CleanupDNS(aws_zone_id, domainname)
+	if err != nil {
+		return errors.Wrap(err, "cleanup DNS failed")
+	}
+
+	exists, err := ListClusterAKS(runID)
+	if err != nil {
+		return errors.Wrap(err, "ListClusterAKS failed")
+	}
+
+	// if the cluster didn't exists and we have not deleted any records something was wrong!
+	if !exists && len(deletedRecords) == 0 {
+		return errors.Wrap(err, "no cluster and no DNS records were deleted. Check your inputs!")
+	}
+
+	if exists {
+		err := GetKubeconfigAKS(runID)
+		if err != nil {
+			return errors.Wrap(err, "failed to get kubeconfig")
+		}
+
+		err = CleanupNamespaces()
+		if err != nil {
+			return errors.Wrap(err, "failed to cleanup namespace")
+		}
+
+		fmt.Println("Deleting AKS cluster ...")
+		out, err := proc.RunW("az", "aks", "delete", "--resource-group", aks_resource_group, "--name", aks_resource_group+runID, "--yes")
+		if err != nil {
+			return errors.Wrap(err, "failed to delete cluster: "+out)
+		}
+
+		fmt.Println("Deleted AKS cluster: ", aks_resource_group+runID)
+	}
+
+	return nil
+}
+
+// Complete cleanup steps for Amazon EKS case
+func DeleteClusterEKS(runID string) error {
+	aws_zone_id := os.Getenv("AWS_ZONE_ID")
+	eks_region := os.Getenv("EKS_REGION")
+
+	domainname := fmt.Sprintf("id%s-%s", runID, os.Getenv("EKS_DOMAIN"))
+	deletedRecords, err := CleanupDNS(aws_zone_id, domainname)
+	if err != nil {
+		return errors.Wrap(err, "cleanup DNS failed")
+	}
+
+	exists, err := ListClusterEKS(runID)
+	if err != nil {
+		return errors.Wrap(err, "ListClusterAKS failed")
+	}
+
+	// if the cluster didn't exists and we have not deleted any records something was wrong!
+	if !exists && len(deletedRecords) == 0 {
+		return errors.Wrap(err, "no cluster and no DNS records were deleted. Check your inputs!")
+	}
+
+	if exists {
+		err := GetKubeconfigEKS(runID)
+		if err != nil {
+			return errors.Wrap(err, "failed to get kubeconfig")
+		}
+
+		err = CleanupNamespaces()
+		if err != nil {
+			return errors.Wrap(err, "failed to cleanup namespace")
+		}
+
+		fmt.Println("Deleting EKS cluster ...")
+		out, err := proc.RunW("eksctl", "delete", "cluster", "--region="+eks_region, "--name=epinio-ci"+runID)
+		if err != nil {
+			return errors.Wrap(err, "failed to delete cluster: "+out)
+		}
+
+		fmt.Println("Deleted EKS cluster: ", "epinio-ci"+runID)
+	}
+
+	return nil
+}
+
+// Complete cleanup steps for Google GKE case
+func DeleteClusterGKE(runID string) error {
+	aws_zone_id := os.Getenv("AWS_ZONE_ID")
+	gke_zone := os.Getenv("GKE_ZONE")
+
+	domainname := fmt.Sprintf("id%s-%s", runID, os.Getenv("GKE_DOMAIN"))
+	deletedRecords, err := CleanupDNS(aws_zone_id, domainname)
+	if err != nil {
+		return errors.Wrap(err, "cleanup DNS failed")
+	}
+
+	exists, err := ListClusterGKE(runID)
+	if err != nil {
+		return errors.Wrap(err, "ListClusterAKS failed")
+	}
+
+	// if the cluster didn't exists and we have not deleted any records something was wrong!
+	if !exists && len(deletedRecords) == 0 {
+		return errors.Wrap(err, "no cluster and no DNS records were deleted. Check your inputs!")
+	}
+
+	if exists {
+		err := GetKubeconfigGKE(runID)
+		if err != nil {
+			return errors.Wrap(err, "failed to get kubeconfig")
+		}
+
+		err = CleanupNamespaces()
+		if err != nil {
+			return errors.Wrap(err, "failed to cleanup namespace")
+		}
+
+		fmt.Println("Deleting GKE cluster ...")
+		os.Setenv("USE_GKE_GCLOUD_AUTH_PLUGIN", "true")
+		out, err := proc.RunW("gcloud", "container", "clusters", "delete", "epinioci"+runID, "--zone", gke_zone, "--quiet")
+		if err != nil {
+			return errors.Wrap(err, "failed to delete cluster: "+out)
+		}
+
+		fmt.Println("Deleted GKE cluster: ", "epinioci"+runID)
+	}
+
+	return nil
 }
 
 // Function to verify AWS Route53 DNS records, and clean them up if needed
-func CleanupDNS(zoneID string, domainname string) {
+func CleanupDNS(zoneID string, domainname string) ([]route53.RecordValues, error) {
+	deletedRecordValues := []route53.RecordValues{}
+
 	// for each test run, there are two records: domain + wildcard domain
 	dnsrecords := [2]string{domainname + ".", "\\052." + domainname + "."}
 	fmt.Println("Cleaning up AWS Route53 DNS records ...")
@@ -41,19 +193,19 @@ func CleanupDNS(zoneID string, domainname string) {
 		// We need to get the record by name first - we can only clean up by knowing the correct record type
 		recordvalues, err := route53.GetRecord(zoneID, dnsrecord)
 		if err != nil {
-			fmt.Println("Error: ", err)
-			os.Exit(1)
+			return deletedRecordValues, errors.Wrap(err, "get record failed")
 		}
-		recordname := recordvalues.Name
-		recordtype := recordvalues.Type
-		recordvalue := recordvalues.Record
-		// If the record doesn't exist, we don't need to do anything
-		if recordname == "Clean" {
-			// Append to noaction array for each record that didn't exist
-			noaction = append(noaction, 1)
+
+		if recordvalues == (route53.RecordValues{}) {
 			fmt.Println("AWS Route53 DNS record was cleaned up already, or does not exist: ", dnsrecord)
 			continue
 		}
+
+		recordname := recordvalues.Name
+		recordtype := recordvalues.Type
+		recordvalue := recordvalues.Record
+
+		// If the record doesn't exist, we don't need to do anything
 		var change route53.ChangeResourceRecordSet
 		switch recordtype {
 		case "A":
@@ -61,111 +213,91 @@ func CleanupDNS(zoneID string, domainname string) {
 		case "CNAME":
 			change = route53.CNAME(recordname, recordvalue, "DELETE")
 		}
+
 		// Delete existing DNS record
 		out, err := route53.Update(zoneID, change, "")
 		if err != nil {
-			fmt.Println("Error: ", err, out)
-			os.Exit(1)
-		} else {
-			fmt.Println("Cleaned up AWS Route53 DNS record: ", dnsrecord)
+			return deletedRecordValues, errors.Wrap(err, "updating Route53 failed: "+out)
 		}
+		fmt.Println("Cleaned up AWS Route53 DNS record: ", dnsrecord)
+
+		deletedRecordValues = append(deletedRecordValues, recordvalues)
 	}
 
+	return deletedRecordValues, nil
 }
 
 // Check if AKS cluster exists
-func ListClusterAKS(runID string) (exists bool) {
+func ListClusterAKS(runID string) (exists bool, err error) {
 	aks_resource_group := os.Getenv("AKS_RESOURCE_GROUP")
 	out, err := proc.RunW("az", "aks", "list", "--resource-group", aks_resource_group, "--query", fmt.Sprintf("[].{name:name} | [? contains(name,'%s%s')]", aks_resource_group, runID))
 	if err != nil {
-		fmt.Println("Error: ", err, out)
-		os.Exit(1)
-	} else {
-		if out == "[]" || out == "[]\n" {
-			fmt.Println("AKS cluster does not exisit: " + aks_resource_group + runID)
-			exists = false
-			// If no DNS record was cleaned up, we will exit here - wrong runID?
-			if len(noaction) > 1 {
-				fmt.Println("Error: Nothing was cleaned up. Please check your inputs.")
-				os.Exit(1)
-			}
-		} else {
-			exists = true
-		}
+		return false, errors.Wrap(err, "azure listing failed")
 	}
-	return exists
+
+	if strings.TrimSpace(out) == "[]" {
+		fmt.Println("AKS cluster does not exists: " + aks_resource_group + runID)
+		return false, nil
+	}
+	return true, nil
 }
 
 // Check if EKS cluster exists
-func ListClusterEKS(runID string) (exists bool) {
+func ListClusterEKS(runID string) (exists bool, err error) {
 	eks_region := os.Getenv("EKS_REGION")
 	out, err := proc.RunW("aws", "eks", "list-clusters", "--region="+eks_region, "--query", fmt.Sprintf("clusters | [? contains(@,'epinio-ci%s')]", runID), "--output", "text")
 	if err != nil {
-		fmt.Println("Error: ", err, out)
-		os.Exit(1)
-	} else {
-		if out == "" {
-			fmt.Println("EKS cluster does not exisit: epinio-ci" + runID)
-			exists = false
-			// If no DNS record was cleaned up, we will exit here - wrong runID?
-			if len(noaction) > 1 {
-				fmt.Println("Error: Nothing was cleaned up. Please check your inputs.")
-				os.Exit(1)
-			}
-		} else {
-			exists = true
-		}
+		return false, errors.Wrap(err, "aws listing failed")
 	}
-	return exists
+
+	if strings.TrimSpace(out) == "" {
+		fmt.Println("EKS cluster does not exisit: epinio-ci" + runID)
+		return false, nil
+	}
+	return true, nil
 }
 
 // Check if GKE cluster exists
-func ListClusterGKE(runID string) (exists bool) {
+func ListClusterGKE(runID string) (exists bool, err error) {
 	gke_zone := os.Getenv("GKE_ZONE")
 	os.Setenv("USE_GKE_GCLOUD_AUTH_PLUGIN", "true")
 	out, err := proc.RunW("gcloud", "container", "clusters", "list", "--filter", "epinioci"+runID, "--zone", gke_zone, "--quiet")
 	if err != nil {
-		fmt.Println("Error: ", err, out)
-		os.Exit(1)
-	} else {
-		if out == "" {
-			fmt.Println("GKE cluster does not exisit: epinioci" + runID)
-			exists = false
-			// If no DNS record was cleaned up, we will exit here - wrong runID?
-			if len(noaction) > 1 {
-				fmt.Println("Error: Nothing was cleaned up. Please check your inputs.")
-				os.Exit(1)
-			}
-		} else {
-			exists = true
-		}
+		return false, errors.Wrap(err, "gke listing failed")
 	}
-	return exists
+
+	if strings.TrimSpace(out) == "" {
+		fmt.Println("GKE cluster does not exisit: epinioci" + runID)
+		return false, nil
+	}
+	return true, nil
 }
 
-func GetKubeconfigAKS(runID string) {
+func GetKubeconfigAKS(runID string) error {
 	kubeconfig_name := os.Getenv("KUBECONFIG_NAME") + "-Deletion"
 	aks_resource_group := os.Getenv("AKS_RESOURCE_GROUP")
 	out, err := proc.RunW("az", "aks", "get-credentials", "--admin", "--resource-group", aks_resource_group, "--name", aks_resource_group+runID, "--file", kubeconfig_name)
 	if err != nil {
-		fmt.Println("Error: ", err, out)
-	} else {
-		fmt.Println("Fetched current kubeconfig")
+		return errors.Wrap(err, "kubeconfig cannot be fetched: "+out)
 	}
+
+	fmt.Println("Fetched current kubeconfig")
+	return nil
 }
 
-func GetKubeconfigEKS(runID string) {
+func GetKubeconfigEKS(runID string) error {
 	kubeconfig_name := os.Getenv("KUBECONFIG_NAME") + "-Deletion"
 	eks_region := os.Getenv("EKS_REGION")
 	out, err := proc.RunW("eksctl", "utils", "write-kubeconfig", "--region", eks_region, "--cluster", "epinio-ci"+runID, "--kubeconfig", kubeconfig_name)
 	if err != nil {
-		fmt.Println("Error: ", err, out)
-	} else {
-		fmt.Println("Fetched current kubeconfig")
+		return errors.Wrap(err, "kubeconfig cannot be fetched: "+out)
 	}
+
+	fmt.Println("Fetched current kubeconfig")
+	return nil
 }
 
-func GetKubeconfigGKE(runID string) {
+func GetKubeconfigGKE(runID string) error {
 	kubeconfig_name := os.Getenv("KUBECONFIG_NAME") + "-Deletion"
 	gke_zone := os.Getenv("GKE_ZONE")
 	epci_gke_project := os.Getenv("EPCI_GKE_PROJECT")
@@ -173,97 +305,23 @@ func GetKubeconfigGKE(runID string) {
 	os.Setenv("KUBECONFIG", kubeconfig_name)
 	out, err := proc.RunW("gcloud", "container", "clusters", "get-credentials", "epinioci"+runID, "--zone", gke_zone, "--project", epci_gke_project)
 	if err != nil {
-		fmt.Println("Error: ", err, out)
-	} else {
-		fmt.Println("Fetched current kubeconfig")
+		return errors.Wrap(err, "kubeconfig cannot be fetched: "+out)
 	}
+
+	fmt.Println("Fetched current kubeconfig")
+	return nil
 }
 
 // Clean up namespaces - therefore unused disks will be removed on cluster deletion
-func CleanupNamespaces() {
+func CleanupNamespaces() error {
 	kubeconfig_name := os.Getenv("KUBECONFIG_NAME") + "-Deletion"
 	os.Setenv("KUBECONFIG", kubeconfig_name)
 
 	out, err := proc.RunW("kubectl", "--kubeconfig", kubeconfig_name, "delete", "--force", "--ignore-not-found", "namespace", "epinio", "workspace")
 	if err != nil {
-		fmt.Println("Error: ", err, out)
-		os.Exit(1)
-	} else {
-		fmt.Println("Cleaning up test namespaces ...")
+		return errors.Wrap(err, "failed to cleanup namespace: "+out)
 	}
-}
 
-// Complete cleanup steps for Azure AKS case
-func DeleteClusterAKS(runID string) {
-	aws_zone_id := os.Getenv("AWS_ZONE_ID")
-	aks_resource_group := os.Getenv("AKS_RESOURCE_GROUP")
-	domainname := fmt.Sprintf("id%s-%s", runID, os.Getenv("AKS_DOMAIN"))
-	CleanupDNS(aws_zone_id, domainname)
-	exists := ListClusterAKS(runID)
-	if exists {
-		GetKubeconfigAKS(runID)
-		CleanupNamespaces()
-		fmt.Println("Deleting AKS cluster ...")
-		out, err := proc.RunW("az", "aks", "delete", "--resource-group", aks_resource_group, "--name", aks_resource_group+runID, "--yes")
-		if err != nil {
-			fmt.Println("Error: ", err, out)
-			os.Exit(1)
-		} else {
-			fmt.Println("Deleted AKS cluster: ", aks_resource_group+runID)
-		}
-	}
-}
-
-// Complete cleanup steps for Amazon EKS case
-func DeleteClusterEKS(runID string) {
-	aws_zone_id := os.Getenv("AWS_ZONE_ID")
-	eks_region := os.Getenv("EKS_REGION")
-	domainname := fmt.Sprintf("id%s-%s", runID, os.Getenv("EKS_DOMAIN"))
-	CleanupDNS(aws_zone_id, domainname)
-	exists := ListClusterEKS(runID)
-	if exists {
-		GetKubeconfigEKS(runID)
-		CleanupNamespaces()
-		fmt.Println("Deleting EKS cluster ...")
-		out, err := proc.RunW("eksctl", "delete", "cluster", "--region="+eks_region, "--name=epinio-ci"+runID)
-		if err != nil {
-			fmt.Println("Error: ", err, out)
-			os.Exit(1)
-		} else {
-			fmt.Println("Deleted EKS cluster: ", "epinio-ci"+runID)
-		}
-	}
-}
-
-// Complete cleanup steps for Google GKE case
-func DeleteClusterGKE(runID string) {
-	aws_zone_id := os.Getenv("AWS_ZONE_ID")
-	gke_zone := os.Getenv("GKE_ZONE")
-	domainname := fmt.Sprintf("id%s-%s", runID, os.Getenv("GKE_DOMAIN"))
-	CleanupDNS(aws_zone_id, domainname)
-	exists := ListClusterGKE(runID)
-	if exists {
-		GetKubeconfigGKE(runID)
-		CleanupNamespaces()
-		fmt.Println("Deleting GKE cluster ...")
-		os.Setenv("USE_GKE_GCLOUD_AUTH_PLUGIN", "true")
-		out, err := proc.RunW("gcloud", "container", "clusters", "delete", "epinioci"+runID, "--zone", gke_zone, "--quiet")
-		if err != nil {
-			fmt.Println("Error: ", err, out)
-			os.Exit(1)
-		} else {
-			fmt.Println("Deleted GKE cluster: ", "epinioci"+runID)
-		}
-	}
-}
-
-func DeleteCluster(runID string, pcp string) {
-	switch pcp {
-	case "AKS":
-		DeleteClusterAKS(runID)
-	case "EKS":
-		DeleteClusterEKS(runID)
-	case "GKE":
-		DeleteClusterGKE(runID)
-	}
+	fmt.Println("Cleaning up test namespaces ...")
+	return nil
 }

--- a/acceptance/helpers/route53/change.go
+++ b/acceptance/helpers/route53/change.go
@@ -121,15 +121,16 @@ func GetRecord(zoneID string, domainname string) (RecordValues, error) {
 	if err != nil {
 		return r, err
 	}
+
 	v := []ResourceRecordSet{}
 	err = json.Unmarshal([]byte(b), &v)
 	if err != nil {
 		return r, err
 	}
 	if len(v) == 0 {
-		r = RecordValues{"Clean", "", ""}
-		return r, err
+		return r, nil
 	}
+
 	r = RecordValues{v[0].Name, v[0].Type, v[0].ResourceRecords[0].Value}
 	return r, nil
 }

--- a/acceptance/helpers/route53/change.go
+++ b/acceptance/helpers/route53/change.go
@@ -13,9 +13,9 @@ package route53
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
-	"fmt"
 
 	"github.com/epinio/epinio/acceptance/helpers/proc"
 )
@@ -55,8 +55,8 @@ type DNSAnswer struct {
 }
 
 type RecordValues struct {
-	Name string
-	Type string
+	Name   string
+	Type   string
 	Record string
 }
 

--- a/acceptance/install/scenario1_test.go
+++ b/acceptance/install/scenario1_test.go
@@ -172,15 +172,5 @@ var _ = Describe("<Scenario1> GKE, epinio-ca", func() {
 		if os.Getenv("EPINIO_UPGRADED") == "true" {
 			UpgradeSequence(epinioHelper, domain)
 		}
-
-		By("Cleaning DNS Entries", func() {
-			change := route53.A(domain, loadbalancer, "DELETE")
-			out, err := route53.Update(zoneID, change, nodeTmpDir)
-			Expect(err).NotTo(HaveOccurred(), out)
-
-			change = route53.A("*."+domain, loadbalancer, "DELETE")
-			out, err = route53.Update(zoneID, change, nodeTmpDir)
-			Expect(err).NotTo(HaveOccurred(), out)
-		})
 	})
 })

--- a/acceptance/install/scenario2_test.go
+++ b/acceptance/install/scenario2_test.go
@@ -204,15 +204,5 @@ var _ = Describe("<Scenario2> GKE, Letsencrypt-staging, Zero instance", func() {
 			Expect(err).NotTo(HaveOccurred(), out)
 			Expect(out).To(Equal("'letsencrypt-staging'"))
 		})
-
-		By("Cleaning DNS Entries", func() {
-			change := route53.A(domain, loadbalancer, "DELETE")
-			out, err := route53.Update(zoneID, change, nodeTmpDir)
-			Expect(err).NotTo(HaveOccurred(), out)
-
-			change = route53.A("*."+domain, loadbalancer, "DELETE")
-			out, err = route53.Update(zoneID, change, nodeTmpDir)
-			Expect(err).NotTo(HaveOccurred(), out)
-		})
 	})
 })

--- a/acceptance/install/scenario4_test.go
+++ b/acceptance/install/scenario4_test.go
@@ -217,15 +217,5 @@ var _ = Describe("<Scenario4> EKS, epinio-ca, on S3 storage", func() {
 			Expect(err).NotTo(HaveOccurred(), out)
 			Expect(out).To(Or(ContainSubstring("Applications Removed")))
 		})
-
-		By("Cleaning DNS Entries", func() {
-			change := route53.CNAME(domain, loadbalancer, "DELETE")
-			out, err := route53.Update(zoneID, change, nodeTmpDir)
-			Expect(err).NotTo(HaveOccurred(), out)
-
-			change = route53.CNAME("*."+domain, loadbalancer, "DELETE")
-			out, err = route53.Update(zoneID, change, nodeTmpDir)
-			Expect(err).NotTo(HaveOccurred(), out)
-		})
 	})
 })

--- a/acceptance/install/scenario5_test.go
+++ b/acceptance/install/scenario5_test.go
@@ -180,15 +180,5 @@ var _ = Describe("<Scenario5> Azure, Letsencrypt-staging, External Registry", fu
 			Expect(err).NotTo(HaveOccurred(), out)
 			Expect(out).To(Or(ContainSubstring("Applications Removed")))
 		})
-
-		By("Cleaning DNS Entries", func() {
-			change := route53.A(domain, loadbalancer, "DELETE")
-			out, err := route53.Update(zoneID, change, nodeTmpDir)
-			Expect(err).NotTo(HaveOccurred(), out)
-
-			change = route53.A("*."+domain, loadbalancer, "DELETE")
-			out, err = route53.Update(zoneID, change, nodeTmpDir)
-			Expect(err).NotTo(HaveOccurred(), out)
-		})
 	})
 })

--- a/acceptance/install/scenario6_test.go
+++ b/acceptance/install/scenario6_test.go
@@ -173,15 +173,5 @@ var _ = Describe("<Scenario6> Azure, epinio-ca, External Registry", func() {
 			Expect(err).NotTo(HaveOccurred(), out)
 			Expect(out).To(Or(ContainSubstring("Applications Removed")))
 		})
-
-		By("Cleaning DNS Entries", func() {
-			change := route53.A(domain, loadbalancer, "DELETE")
-			out, err := route53.Update(zoneID, change, nodeTmpDir)
-			Expect(err).NotTo(HaveOccurred(), out)
-
-			change = route53.A("*."+domain, loadbalancer, "DELETE")
-			out, err = route53.Update(zoneID, change, nodeTmpDir)
-			Expect(err).NotTo(HaveOccurred(), out)
-		})
 	})
 })


### PR DESCRIPTION
fix #1798 

This refactor addresses:
- Remove obsolete code
- Streamlines workflow files, i.e. variable names and secrets based on their usage for consistency
- Moves DNS cleanup to cluster deletion code
- Moves Namespace cleanup to cluster deletion code (and for all PCPs)
- Introduces delete_cluster dispatch workflow to run manually after using the 'keep_cluster' flag

Finally this will fix:
- leftover route53 DNS records when acceptance tests fail
- leftover PVs in all PCP accounts (fix issues with EKS/EC2 and GKE/GCP)
- failing/incomplete manual cluster deletions, when using e.g. PCP web consoles