### PR TITLE
dependabot image bump integration

### DIFF
--- a/images/unpacker-Dockerfile
+++ b/images/unpacker-Dockerfile
@@ -12,7 +12,7 @@
 FROM registry.suse.com/bci/bci-base AS stage
 RUN zypper refresh && zypper --non-interactive  install -f tar gzip unzip bzip2 xz findutils
 
-FROM registry.suse.com/bci/bci-micro:15.4.17.1
+FROM registry.suse.com/bci/bci-micro:15.4.18.4
 COPY --from=stage /bin/tar       /bin/tar
 COPY --from=stage /usr/bin/unzip /usr/bin/unzip
 COPY --from=stage /bin/gzip      /bin/gzip


### PR DESCRIPTION
ref #2175

Bumps bci/bci-micro from 15.4.17.1 to 15.4.18.4.

---
updated-dependencies:
- dependency-name: bci/bci-micro dependency-type: direct:production update-type: version-update:semver-patch ...