### PR TITLE
Delete ELB for EC2 RKE2 test

### DIFF
--- a/.github/workflows/rke2-lh-ec2.yml
+++ b/.github/workflows/rke2-lh-ec2.yml
@@ -251,11 +251,13 @@ jobs:
           # EXTRAENV_VALUE: 12345
         run: make test-acceptance-install
 
-      - name: Delete EC2 instances
+      - name: Delete EC2 instances and ELB
         if: ${{ always() && !github.event.inputs.keep_cluster }}
         env:
           EC2_INSTANCE_IDS: ${{ steps.provision-ec2-instances.outputs.EC2_INSTANCE_IDS }}
-        run: aws ec2 terminate-instances --instance-ids $EC2_INSTANCE_IDS
+        run: |
+          helm delete nginx-ingress -n ingress-nginx
+          aws ec2 terminate-instances --instance-ids $EC2_INSTANCE_IDS
 
       # Only on RKE, as it uses a self-hosted runner
       - name: Clean all


### PR DESCRIPTION
to prevent ELB leftovers

(it will basically remove nginx-ingress-controller svc hooked with ELB)