### PR TITLE
Disable cache for linter

### DIFF
--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
+          skip-pkg-cache: true
 
       - name: Clean all
         if: always()

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
+          skip-pkg-cache: true
 
       - name: Clean all
         if: always()

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
+          skip-pkg-cache: true
 
       - name: Clean all
         if: always()

--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
+          skip-pkg-cache: true
 
       - name: Clean all
         if: always()

--- a/.github/workflows/gke-upgrade.yml
+++ b/.github/workflows/gke-upgrade.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
+          skip-pkg-cache: true
 
       - name: Clean all
         if: always()

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
+          skip-pkg-cache: true
 
       - name: Clean all
         if: always()

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -39,3 +39,4 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
+          skip-pkg-cache: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
+          skip-pkg-cache: true
 
       - name: Unit Tests
         run: make test

--- a/.github/workflows/rke-upgrade.yml
+++ b/.github/workflows/rke-upgrade.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
+          skip-pkg-cache: true
 
       - name: Clean all
         if: always()

--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
+          skip-pkg-cache: true
 
       - name: Clean all
         if: always()

--- a/.github/workflows/rke2-lh-ec2.yml
+++ b/.github/workflows/rke2-lh-ec2.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
+          skip-pkg-cache: true
 
       - name: Clean all
         if: always()


### PR DESCRIPTION
This PR will address linter Errors `Cannot open: File exists` n Github Actions Annotations. 

Doesn't address linter Warnings  `Failed to restore: Tar failed with error: The process '/usr/bin/tar' failed with exit code 2`