### PR TITLE
Remove outputs in rke2-lh-ec2 workflow

### DIFF
--- a/.github/workflows/rke2-lh-ec2.yml
+++ b/.github/workflows/rke2-lh-ec2.yml
@@ -82,11 +82,6 @@ jobs:
       - linter
     runs-on: [self-hosted, epinio]
 
-    outputs:
-      # Stores what's needed by another steps and jobs
-      EC2_INSTANCE_IDS: ${{ steps.provision-ec2-instances.outputs.EC2_INSTANCE_IDS }}
-      EC2_PUBLIC_HOSTNAMES: ${{ steps.provision-ec2-instances.outputs.EC2_PUBLIC_HOSTNAMES }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Without this change REK2-EC2 Github Action is reporting following Warning in Annotations:
```
acceptance-scenario4 Skip output 'EC2_PUBLIC_HOSTNAMES' since it may contain secret.
```