### PR TITLE
Full PATH in KUBECONFIG for GKE CI

### DIFF
--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -38,7 +38,8 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  KUBECONFIG_NAME: 'kubeconfig-epinio-ci'
+  KUBECONFIG_NAME: 'kubeconfig-epinio-ci' # Needed for delete_clusters.go
+  KUBECONFIG: ${{ github.workspace }}/kubeconfig-epinio-ci
   GKE_ZONE: ${{ secrets.GKE_ZONE }}
   GKE_MACHINE_TYPE: 'n2-standard-4'
   GKE_NETWORK: 'epinio-ci'
@@ -143,7 +144,6 @@ jobs:
           USE_GKE_GCLOUD_AUTH_PLUGIN: True
         run: |
           id=${{ steps.create-cluster.outputs.ID }}
-          export KUBECONFIG=${{ env.KUBECONFIG_NAME }}
           gcloud container clusters get-credentials epinioci$id --zone ${{ env.GKE_ZONE }} --project ${{ secrets.EPCI_GKE_PROJECT }}
 
       - name: Installation Acceptance Tests
@@ -161,7 +161,6 @@ jobs:
           # EXTRAENV_VALUE: 12345
         run: |
           echo "System Domain: $GKE_DOMAIN"
-          export KUBECONFIG=${{ env.KUBECONFIG_NAME }}
           make test-acceptance-install
 
       - name: Delete GKE cluster
@@ -175,5 +174,4 @@ jobs:
           export GKE_DOMAIN=${{ secrets.GKE_DOMAIN }}
           export GKE_ZONE=${{ secrets.GKE_ZONE }}
           export EPCI_GKE_PROJECT=${{ secrets.EPCI_GKE_PROJECT }}
-          export KUBECONFIG_NAME=${{ env.KUBECONFIG_NAME }}
           go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/gke-upgrade.yml
+++ b/.github/workflows/gke-upgrade.yml
@@ -39,7 +39,8 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  KUBECONFIG_NAME: 'kubeconfig-epinio-ci'
+  KUBECONFIG_NAME: 'kubeconfig-epinio-ci' # Needed for delete_clusters.go
+  KUBECONFIG: ${{ github.workspace }}/kubeconfig-epinio-ci
   GKE_ZONE: ${{ secrets.GKE_ZONE }}
   GKE_MACHINE_TYPE: 'n2-standard-4'
   GKE_NETWORK: 'epinio-ci'
@@ -151,7 +152,6 @@ jobs:
           USE_GKE_GCLOUD_AUTH_PLUGIN: True
         run: |
           id=${{ steps.create-cluster.outputs.ID }}
-          export KUBECONFIG=${{ env.KUBECONFIG_NAME }}
           gcloud container clusters get-credentials epinioci$id --zone ${{ env.GKE_ZONE }} --project ${{ secrets.EPCI_GKE_PROJECT }}
 
       - name: Installation Acceptance Tests
@@ -171,7 +171,6 @@ jobs:
         run: |
           # EPINIO_UPGRADED triggers starting with a released epinio in suite setup, and the upgrade sequence
           echo "System Domain: $GKE_DOMAIN"
-          export KUBECONFIG=${{ env.KUBECONFIG_NAME }}
           export EPINIO_CURRENT_TAG="$(git describe --tags)"
           # Run GKE integrated install + upgrade test
           mkdir dist
@@ -189,5 +188,4 @@ jobs:
           export GKE_DOMAIN=${{ secrets.GKE_DOMAIN }}
           export GKE_ZONE=${{ secrets.GKE_ZONE }}
           export EPCI_GKE_PROJECT=${{ secrets.EPCI_GKE_PROJECT }}
-          export KUBECONFIG_NAME=${{ env.KUBECONFIG_NAME }}
           go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -38,7 +38,8 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  KUBECONFIG_NAME: 'kubeconfig-epinio-ci'
+  KUBECONFIG_NAME: 'kubeconfig-epinio-ci' # Needed for delete_clusters.go
+  KUBECONFIG: ${{ github.workspace }}/kubeconfig-epinio-ci
   GKE_ZONE: ${{ secrets.GKE_ZONE }}
   GKE_MACHINE_TYPE: 'n2-standard-4'
   GKE_NETWORK: 'epinio-ci'
@@ -143,7 +144,6 @@ jobs:
           USE_GKE_GCLOUD_AUTH_PLUGIN: True
         run: |
           id=${{ steps.create-cluster.outputs.ID }}
-          export KUBECONFIG=${{ env.KUBECONFIG_NAME }}
           gcloud container clusters get-credentials epinioci$id --zone ${{ env.GKE_ZONE }} --project ${{ secrets.EPCI_GKE_PROJECT }}
 
       - name: Installation Acceptance Tests
@@ -161,7 +161,6 @@ jobs:
           # EXTRAENV_VALUE: 12345
         run: |
           echo "System Domain: $GKE_DOMAIN"
-          export KUBECONFIG=${{ env.KUBECONFIG_NAME }}
           make test-acceptance-install
 
       - name: Delete GKE cluster
@@ -175,5 +174,4 @@ jobs:
           export GKE_DOMAIN=${{ secrets.GKE_DOMAIN }}
           export GKE_ZONE=${{ secrets.GKE_ZONE }}
           export EPCI_GKE_PROJECT=${{ secrets.EPCI_GKE_PROJECT }}
-          export KUBECONFIG_NAME=${{ env.KUBECONFIG_NAME }}
           go run acceptance/helpers/delete_clusters/delete_clusters.go


### PR DESCRIPTION
Fixes GKE CI jobs. Problem was that KUBECONFIG var didn't contain a full path to the kubeconfig file.

Note: gloud get-credentials saves the `kubeconfig` at location specified in KUBERCONFIG var if defined, otherwise it uses `~/.kube/config` instead.

Testrun https://github.com/epinio/epinio/actions/runs/4720674790