### PR TITLE
Added SynchronizedClient tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/go-logr/zapr v1.2.3
 	github.com/golang-jwt/jwt/v4 v4.4.3
+	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/h2non/filetype v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -386,6 +386,8 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -1366,6 +1368,7 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -2,7 +2,6 @@ package helm
 
 import (
 	"context"
-	"fmt"
 
 	hc "github.com/mittwald/go-helm-client"
 	"helm.sh/helm/v3/pkg/action"
@@ -16,14 +15,8 @@ var _ hc.Client = (*SynchronizedClient)(nil)
 
 // InstallOrUpgradeChart implements helmclient.Client
 func (c *SynchronizedClient) InstallOrUpgradeChart(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*release.Release, error) {
-	fmt.Printf("INSTALLING %s, ACQUIRING LOCK\n", spec.ReleaseName)
-
 	c.m.Lock()
-	defer func(c *SynchronizedClient) {
-		fmt.Printf("DONE %s, LEAVING LOCK\n", spec.ReleaseName)
-		c.m.Unlock()
-		fmt.Println("UNLOCKED")
-	}(c)
+	defer c.m.Unlock()
 
 	return c.helmClient.InstallOrUpgradeChart(ctx, spec, opts)
 }

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"context"
+	"fmt"
 
 	hc "github.com/mittwald/go-helm-client"
 	"helm.sh/helm/v3/pkg/action"
@@ -15,8 +16,14 @@ var _ hc.Client = (*SynchronizedClient)(nil)
 
 // InstallOrUpgradeChart implements helmclient.Client
 func (c *SynchronizedClient) InstallOrUpgradeChart(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*release.Release, error) {
+	fmt.Printf("INSTALLING %s, ACQUIRING LOCK\n", spec.ReleaseName)
+
 	c.m.Lock()
-	defer c.m.Unlock()
+	defer func(c *SynchronizedClient) {
+		fmt.Printf("DONE %s, LEAVING LOCK\n", spec.ReleaseName)
+		c.m.Unlock()
+		fmt.Println("UNLOCKED")
+	}(c)
 
 	return c.helmClient.InstallOrUpgradeChart(ctx, spec, opts)
 }

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = FDescribe("SynchronizedClient", func() {
+var _ = Describe("SynchronizedClient", func() {
 	var (
 		ctx        context.Context
 		mockCtrl   *gomock.Controller

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -1,0 +1,225 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/epinio/epinio/internal/helm"
+	"github.com/golang/mock/gomock"
+	hc "github.com/mittwald/go-helm-client"
+	hcmock "github.com/mittwald/go-helm-client/mock"
+	"helm.sh/helm/v3/pkg/release"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = FDescribe("SynchronizedClient", func() {
+	var (
+		mockCtrl   *gomock.Controller
+		mockClient *hcmock.MockClient
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockClient = hcmock.NewMockClient(mockCtrl)
+	})
+
+	setupMockRelease := func(ctx context.Context, releaseName string, duration time.Duration) *hc.ChartSpec {
+		fakeRelease := &hc.ChartSpec{ReleaseName: releaseName}
+
+		mockClient.
+			EXPECT().
+			InstallOrUpgradeChart(ctx, fakeRelease, nil).
+			DoAndReturn(func(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*release.Release, error) {
+				time.Sleep(duration)
+				return &release.Release{Name: spec.ReleaseName}, nil
+			}).
+			AnyTimes()
+
+		return fakeRelease
+	}
+
+	It("should wait for releases in the same namespace", func() {
+		ctx := context.Background()
+		namespace := "namespace"
+
+		// setup the mock with a couple of releases
+
+		// release2s will take 2s
+		release2s := setupMockRelease(ctx, "release-2s", 2*time.Second)
+		// release3s will take 3s
+		release3s := setupMockRelease(ctx, "release-3s", 3*time.Second)
+
+		// create a synch client
+		syncClient, err := helm.NewNamespaceSynchronizedHelmClient(namespace, mockClient)
+		Expect(err).To(BeNil())
+
+		// Begin TEST!
+		wg := &sync.WaitGroup{}
+
+		// let's see how long the two installation are taking
+		// since they are done in the same namespace they should take 2s + 3s
+		start := time.Now()
+
+		// release2s will take 2s
+		wg.Add(1)
+		go func(wg *sync.WaitGroup) {
+			defer GinkgoRecover()
+
+			syncClient.InstallOrUpgradeChart(ctx, release2s, nil)
+			fmt.Fprintln(GinkgoWriter, "done release2s")
+			wg.Done()
+		}(wg)
+
+		// and release3s this will take 3s
+		wg.Add(1)
+		go func(wg *sync.WaitGroup) {
+			defer GinkgoRecover()
+
+			syncClient.InstallOrUpgradeChart(ctx, release3s, nil)
+			fmt.Fprintln(GinkgoWriter, "done release3s")
+			wg.Done()
+		}(wg)
+
+		wg.Wait()
+
+		// at the end the elapsed time should be greater than 5s!
+		elapsed := time.Since(start)
+		Expect(elapsed).To(BeNumerically(">=", 5*time.Second))
+	})
+
+	FIt("should not wait for releases in different namespaces and to them concurrently", func() {
+		ctx := context.Background()
+		namespace1 := "namespace1"
+		namespace2 := "namespace2"
+
+		// setup the mock with a couple of releases
+
+		// releaseOne3s will take 3s
+		releaseOne3s := setupMockRelease(ctx, "release-ns1-3s", 3*time.Second)
+		// releaseTwo3s will take 3s
+		releaseTwo3s := setupMockRelease(ctx, "release-ns2-3s", 3*time.Second)
+
+		// create two sync client
+		syncClient1, err := helm.NewNamespaceSynchronizedHelmClient(namespace1, mockClient)
+		Expect(err).To(BeNil())
+		syncClient2, err := helm.NewNamespaceSynchronizedHelmClient(namespace2, mockClient)
+		Expect(err).To(BeNil())
+
+		// Begin TEST!
+		wg := &sync.WaitGroup{}
+
+		// let's see how long the two installation are taking
+		// since they are done in the same namespace they should take 2s + 3s
+		start := time.Now()
+
+		// releaseOne3s will take 3s
+		wg.Add(1)
+		go func(wg *sync.WaitGroup) {
+			defer GinkgoRecover()
+
+			syncClient1.InstallOrUpgradeChart(ctx, releaseOne3s, nil)
+			fmt.Fprintln(GinkgoWriter, "done releaseOne3s")
+			wg.Done()
+		}(wg)
+
+		// and releaseTwo3s this will take 3s
+		wg.Add(1)
+		go func(wg *sync.WaitGroup) {
+			defer GinkgoRecover()
+
+			syncClient2.InstallOrUpgradeChart(ctx, releaseTwo3s, nil)
+			fmt.Fprintln(GinkgoWriter, "done releaseTwo3s")
+			wg.Done()
+		}(wg)
+
+		wg.Wait()
+
+		// at the end the elapsed time should be greater than 3s but less than 4s!
+		elapsed := time.Since(start)
+		Expect(elapsed).To(BeNumerically(">=", 3*time.Second))
+		Expect(elapsed).To(BeNumerically("<", 4*time.Second))
+	})
+
+	FIt("should not wait for releases in the same namespace and to them concurrently, while waiting for the same", func() {
+		ctx := context.Background()
+		namespace1 := "namespace1"
+		namespace2 := "namespace2"
+
+		syncClient1, err := helm.NewNamespaceSynchronizedHelmClient(namespace1, mockClient)
+		Expect(err).To(BeNil())
+
+		syncClient2, err := helm.NewNamespaceSynchronizedHelmClient(namespace2, mockClient)
+		Expect(err).To(BeNil())
+
+		// setup the mock with a couple of releases
+
+		// releaseFoo2s will take 2s
+		releaseFoo2s := setupMockRelease(ctx, "release-foo-2s", 2*time.Second)
+		// releaseBar2s will take 2s
+		releaseBar2s := setupMockRelease(ctx, "release-bar-2s", 2*time.Second)
+		// release3s will take 3s
+		release3s := setupMockRelease(ctx, "release-3s", 3*time.Second)
+
+		// Begin TEST!
+		wg := &sync.WaitGroup{}
+
+		// let's see how long the two installation are taking
+		// since they are done in the same namespace they should take 2s + 3s
+		start := time.Now()
+
+		// releaseFoo2s will take 2s
+		wg.Add(1)
+		go func(wg *sync.WaitGroup) {
+			defer GinkgoRecover()
+
+			fmt.Fprintln(GinkgoWriter, "installing releaseFoo2s")
+			syncClient1.InstallOrUpgradeChart(ctx, releaseFoo2s, nil)
+			fmt.Fprintln(GinkgoWriter, "done releaseFoo2s")
+			wg.Done()
+		}(wg)
+
+		// releaseBar2s will take 2s
+		wg.Add(1)
+		go func(wg *sync.WaitGroup) {
+			defer GinkgoRecover()
+
+			fmt.Fprintln(GinkgoWriter, "installing releaseBar2s")
+			syncClient1.InstallOrUpgradeChart(ctx, releaseBar2s, nil)
+			fmt.Fprintln(GinkgoWriter, "done releaseBar2s")
+			wg.Done()
+		}(wg)
+
+		// and release3s will take 3s
+		wg.Add(1)
+		go func(wg *sync.WaitGroup) {
+			defer GinkgoRecover()
+
+			fmt.Fprintln(GinkgoWriter, "installing release3s")
+			syncClient2.InstallOrUpgradeChart(ctx, release3s, nil)
+			fmt.Fprintln(GinkgoWriter, "done release3s")
+			wg.Done()
+		}(wg)
+
+		wg.Wait()
+
+		// at the end the elapsed time should be greater than 4s but less than 5s!
+		elapsed := time.Since(start)
+		Expect(elapsed).To(BeNumerically(">=", 4*time.Second))
+		Expect(elapsed).To(BeNumerically("<", 5*time.Second))
+	})
+})

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -57,7 +57,7 @@ var _ = Describe("SynchronizedClient", func() {
 
 	When("getting a namespace synchronized client", func() {
 
-		It("should return the same client from the same namespace", func() {
+		It("should return the same client for the same namespace", func() {
 			namespace := catalog.NewNamespaceName()
 
 			syncClient1, err := helm.GetNamespaceSynchronizedHelmClient(namespace, mockClient)
@@ -69,7 +69,7 @@ var _ = Describe("SynchronizedClient", func() {
 			Expect(syncClient1).To(Equal(syncClient2))
 		})
 
-		It("should return a different client from different namespaces", func() {
+		It("should return a different client for different namespaces", func() {
 			namespace1 := catalog.NewNamespaceName()
 			namespace2 := catalog.NewNamespaceName()
 
@@ -102,7 +102,7 @@ var _ = Describe("SynchronizedClient", func() {
 
 			wg := &sync.WaitGroup{}
 
-			// let's see how long the two installation are taking
+			// let's see how long the two installations are taking
 			// since they are done in the same namespace they should take 2s + 3s
 			start := time.Now()
 
@@ -131,7 +131,7 @@ var _ = Describe("SynchronizedClient", func() {
 			Expect(elapsed).To(BeNumerically(">=", 5*time.Second))
 		})
 
-		It("should not wait for releases in different namespaces and to them concurrently", func() {
+		It("should not wait for releases in different namespaces and do them concurrently", func() {
 			// setup the mock with a couple of releases
 
 			// releaseOne3s will take 3s in the first namespace
@@ -139,7 +139,7 @@ var _ = Describe("SynchronizedClient", func() {
 			// releaseTwo3s will take 3s in the second namespace
 			releaseTwo3s := setupMockRelease(ctx, "release-ns2-3s", 3*time.Second)
 
-			// create two sync client
+			// create two sync clients
 			namespace1 := catalog.NewNamespaceName()
 			syncClient1, err := helm.GetNamespaceSynchronizedHelmClient(namespace1, mockClient)
 			Expect(err).To(BeNil())
@@ -151,7 +151,7 @@ var _ = Describe("SynchronizedClient", func() {
 			// Begin TEST!
 			wg := &sync.WaitGroup{}
 
-			// let's see how long the two installation are taking
+			// let's see how long the two installations are taking
 			// since they are done in two different namespaces they should take 3s in total
 			// because they will be done concurrently
 			start := time.Now()
@@ -182,7 +182,7 @@ var _ = Describe("SynchronizedClient", func() {
 			Expect(elapsed).To(BeNumerically("<", 4*time.Second))
 		})
 
-		It("should not wait for releases in different namespaces and to them concurrently, while waiting for the one in the same", func() {
+		It("should not wait for releases in different namespaces and do them concurrently, while waiting for the one in the same", func() {
 			// setup the mock with three releases
 
 			// release1s will take 1s
@@ -192,7 +192,7 @@ var _ = Describe("SynchronizedClient", func() {
 			// release5s will take 5s
 			release5s := setupMockRelease(ctx, "release-5s", 5*time.Second)
 
-			// create two sync client
+			// create two sync clients
 			namespace1 := catalog.NewNamespaceName()
 			syncClient1, err := helm.GetNamespaceSynchronizedHelmClient(namespace1, mockClient)
 			Expect(err).To(BeNil())
@@ -204,7 +204,7 @@ var _ = Describe("SynchronizedClient", func() {
 			// Begin TEST!
 			wg := &sync.WaitGroup{}
 
-			// let's see how long the installation will take
+			// let's see how long the installations will take
 			// since the first two are done in the same namespace they should take 1s + 3s
 			// and the other one whould take 5s. Total should be 5s!
 			start := time.Now()

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -390,7 +390,6 @@ func Status(ctx context.Context, logger logr.Logger, cluster *kubernetes.Cluster
 var syncNamespaceClientMap sync.Map
 
 type SynchronizedClient struct {
-	namespace  string
 	m          sync.Mutex
 	helmClient hc.Client
 }
@@ -414,10 +413,11 @@ func GetHelmClient(restConfig *rest.Config, logger logr.Logger, namespace string
 		return nil, err
 	}
 
-	synchronizedHelmClient := &SynchronizedClient{
-		namespace:  namespace,
-		helmClient: helmClient,
-	}
+	return NewNamespaceSynchronizedHelmClient(namespace, helmClient)
+}
+
+func NewNamespaceSynchronizedHelmClient(namespace string, helmClient hc.Client) (*SynchronizedClient, error) {
+	synchronizedHelmClient := &SynchronizedClient{helmClient: helmClient}
 
 	// we are loading the SynchronizedClient for this namespace, if any
 	loadedSynchronizedHelmClient, _ := syncNamespaceClientMap.LoadOrStore(namespace, synchronizedHelmClient)

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -390,6 +390,7 @@ func Status(ctx context.Context, logger logr.Logger, cluster *kubernetes.Cluster
 var syncNamespaceClientMap sync.Map
 
 type SynchronizedClient struct {
+	namespace  string
 	m          sync.Mutex
 	helmClient hc.Client
 }
@@ -413,11 +414,14 @@ func GetHelmClient(restConfig *rest.Config, logger logr.Logger, namespace string
 		return nil, err
 	}
 
-	return NewNamespaceSynchronizedHelmClient(namespace, helmClient)
+	return GetNamespaceSynchronizedHelmClient(namespace, helmClient)
 }
 
-func NewNamespaceSynchronizedHelmClient(namespace string, helmClient hc.Client) (*SynchronizedClient, error) {
-	synchronizedHelmClient := &SynchronizedClient{helmClient: helmClient}
+func GetNamespaceSynchronizedHelmClient(namespace string, helmClient hc.Client) (*SynchronizedClient, error) {
+	synchronizedHelmClient := &SynchronizedClient{
+		namespace:  namespace,
+		helmClient: helmClient,
+	}
 
 	// we are loading the SynchronizedClient for this namespace, if any
 	loadedSynchronizedHelmClient, _ := syncNamespaceClientMap.LoadOrStore(namespace, synchronizedHelmClient)


### PR DESCRIPTION
This PR adds just some unit tests to the current SynchronizedClient, to see if these will break with the next refactor.

It adds the `gomock` dependency since the mittwald/go-helm-client provides already a nice mock (`github.com/mittwald/go-helm-client/mock`).

Ref: https://github.com/epinio/epinio/issues/2210