### PR TITLE
fix broken swagger generation

### DIFF
--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -336,6 +336,26 @@
             "$ref": "#/responses/NamespaceCreateResponse"
           }
         }
+      },
+      "delete": {
+        "summary": "Delete the named namespaces.",
+        "operationId": "NamespaceBatchDelete",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "in: url",
+            "name": "Namespaces",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/NamespaceDeleteResponse"
+          }
+        }
       }
     },
     "/namespaces/{Namespace}": {
@@ -1711,6 +1731,9 @@
           "type": "string",
           "x-go-name": "StageID"
         },
+        "stagingstatus": {
+          "$ref": "#/definitions/ApplicationStagingStatus"
+        },
         "status": {
           "$ref": "#/definitions/ApplicationStatus"
         },
@@ -1946,6 +1969,10 @@
           "x-go-name": "Path"
         }
       },
+      "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
+    },
+    "ApplicationStagingStatus": {
+      "type": "string",
       "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
     },
     "ApplicationStatus": {
@@ -2499,6 +2526,10 @@
           "type": "integer",
           "format": "int64",
           "x-go-name": "MemoryBytes"
+        },
+        "metricsOk": {
+          "type": "boolean",
+          "x-go-name": "MetricsOk"
         },
         "millicpus": {
           "type": "integer",

--- a/internal/api/v1/docs/docs.go
+++ b/internal/api/v1/docs/docs.go
@@ -13,17 +13,17 @@
 //
 // This is the API specification of the Epinio API
 //
-//	Schemes: http, https
-//	Host:
-//	BasePath: /api/v1
-//	Version: 1.0.0
+//     Schemes: http, https
+//     Host:
+//     BasePath: /api/v1
+//     Version: 1.0.0
 //
-//	SecurityDefinitions:
-//	basicAuth:
-//	     type: basic
+//     SecurityDefinitions:
+//     basicAuth:
+//          type: basic
 //
-//	Security:
-//	- basicAuth: []
+//     Security:
+//     - basicAuth: []
 //
 // swagger:meta
 package docs


### PR DESCRIPTION
fix: bad tabs in main swagger docs.go, breaking swagger execution
fix: outdated swagger.json

Issue was introduced with commit dc08fa0e41dedc7f47b6dd60951369dcf4a0d8b5.
Tabs vs spaces.
Swagger treats the meta section as YAML, tabs are bad.
