### PR TITLE
ADR: extend the application manifest

### DIFF
--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -17,6 +17,9 @@ on:
   push:
     branches:
       - "main"
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
 
 permissions:
   contents: read

--- a/docs/decisions/adr-extend-application-manifest.md
+++ b/docs/decisions/adr-extend-application-manifest.md
@@ -1,0 +1,79 @@
+---
+# These are optional elements. Feel free to remove any of them.
+status: {proposed | rejected | accepted | deprecated | … | superseded by ADR-0005 <0005-example.md>}
+date: {YYYY-MM-DD when the decision was last updated}
+deciders: {list everyone involved in the decision}
+consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
+informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
+---
+
+# {short title of solved problem and solution}
+
+## Context and Problem Statement
+
+{Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story. You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Decision Drivers
+
+* {decision driver 1, e.g., a force, facing concern, …}
+* {decision driver 2, e.g., a force, facing concern, …}
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* {title of option 1}
+* {title of option 2}
+* {title of option 3}
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "{title of option 1}", because
+{justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force {force} | … | comes out best (see below)}.
+
+<!-- This is an optional element. Feel free to remove. -->
+### Consequences
+
+* Good, because {positive consequence, e.g., improvement of one or more desired qualities, …}
+* Bad, because {negative consequence, e.g., compromising one or more desired qualities, …}
+* … <!-- numbers of consequences can vary -->
+
+<!-- This is an optional element. Feel free to remove. -->
+## Validation
+
+{describe how the implementation of/compliance with the ADR is validated. E.g., by a review or an ArchUnit test}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Pros and Cons of the Options
+
+### {title of option 1}
+
+<!-- This is an optional element. Feel free to remove. -->
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+<!-- use "neutral" if the given argument weights neither for good nor bad -->
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* … <!-- numbers of pros and cons can vary -->
+
+### {title of other option}
+
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* …
+
+<!-- This is an optional element. Feel free to remove. -->
+## More Information
+
+{You might want to provide additional evidence/confidence for the decision outcome here and/or
+ document the team agreement on the decision and/or
+ define when and how this decision should be realized and if/when it should be re-visited and/or
+ how the decision is validated.
+ Links to other decisions and resources might appear here as well.}

--- a/docs/decisions/adr-extend-application-manifest.md
+++ b/docs/decisions/adr-extend-application-manifest.md
@@ -75,9 +75,8 @@ references.
 
 In the case of paths the Web UI enables the user to make use of a variety of archive files, whereas
 the CLI only supports directories. To this end a new field `archive` is added to the `origin`
-object, of type `string`. This field is exptected to contain values like `zip`, `tarball`, `tar+gz`,
-etc. Note however that this list of examples is not considered to be exhaustive and is definitely
-not a list of the only allowed values for the field.y
+object, of type `boolean`. True indicates that the path refers to some kind of (compressed) archive,
+instead of a directory.
 
 No additional information is managed for containers.
 
@@ -90,7 +89,9 @@ not considered to be exhaustive and is definitely not a list of the only allowed
 field.
 
 The second field, `branch`, records the name of the repository branch the `revision` is part of, in
-support of the Web UIs ability to ....
+support of the Web UI's ability to show the user a selection of commits to choose from when creating
+an application or editing it's source. This also helps telling the user where the source came from
+(`main`, `v2.7.6`, etc.)
 
 The modified part of the CRD is
 
@@ -98,7 +99,7 @@ The modified part of the CRD is
 origin:
   properties:
     archive:
-      type: string
+      type: boolean
     container:
       type: string
     git:

--- a/docs/decisions/adr-extend-application-manifest.md
+++ b/docs/decisions/adr-extend-application-manifest.md
@@ -61,9 +61,11 @@ The new API endpoint is an extension of the existing `AppPart` endpoint, i.e. of
 `/namespaces/:namespace/applications/:app/part/:part`.
 
 This endpoint is extended with a new allowed part value `manifest`, which, when requested delivers a
-`text/plain` result containing the application manifest serialized into its final form.
+`application/octet-stream` result containing the application manifest serialized into its final form.
 
 The chosen form is the YAML-formatted manifest currently written by the Epinio CLI.
+
+This matches the behaviour of the existing part `values`, both in content format, and content type.
 
 ### Extended Application CRD
 
@@ -92,6 +94,10 @@ The second field, `branch`, records the name of the repository branch the `revis
 support of the Web UI's ability to show the user a selection of commits to choose from when creating
 an application or editing it's source. This also helps telling the user where the source came from
 (`main`, `v2.7.6`, etc.)
+
+The names of the new fields in the CRD, i.e. `archive`, `provider`, and `branch` are translated as
+they are to the YAML serialization for these fields. In contrast to the existing `repository` field,
+which is translated to `url` in the YAML.
 
 The modified part of the CRD is
 


### PR DESCRIPTION
# ADR: extend the application manifest

While developing the  `v1.8.0` release we have faced multiple issues adding new features in the UI and in the Epinio server:

- https://github.com/epinio/ui/issues/140
- https://github.com/epinio/ui/issues/171
- https://github.com/epinio/ui/issues/173

In order to update the application sources and having the previous staging information available an `EPINIO_APP_DATA` environment variable was used, and that broke some tests, and led to a unexpected experience for the user. He will see this env var from the CLI (without having it set), and also from the CLI.
Furthermore this env var is not going to be persisted if the user is not going to provide this from the CLI, so it will be deleted in the next push/deploy.

We need to find a way to actually retrieve these data, instead of storing them in the application environment variables.

We have thought about two options:
- adding a new secret
- extending the application custom resource ([see](https://github.com/epinio/application/blob/main/config/crd/bases/application.epinio.io_apps.yaml))

IMHO while the first seems easier, the second seems cleaner.

## What's needed

From a meeting with the UI team it seems that we have covered most of the information but they are scattered along different APIs, or unclear. They should be all in the application manifest, and this manifest should be the same for the UI and the CLI. At the moment it's somehow generated from the two clients, but we should provide the same output.

Since the CLI is supporting only the yaml format we should provide an API that will return the manifest in this format. The same manifest can be exported, and used from the UI or CLI to deploy an application, or provide the starting point to actually update the sources.

- The Epinio backend will provide an **API** to retrieve this **application manifest**

To achieve this we need to agree about any new fields that need to be added (https://docs.epinio.io/references/manifests#manifest-format)

This is the current format:
```yaml
name: zanzibar
configuration:
  instances: 333
  configurations:
  - snafu
  environment:
    DOGMA: "no"
staging:
  builder: "paketobuildpacks/builder:tiny"
origin:
  path: /somewhere/over/there
```

As far as I understood we just need to tweak the `origin` object to support the `archive` and some information about `git`.

The current `origin` spec:

```yaml
origin:
  properties:
    container:
      type: string
    git:
      properties:
        repository:
          type: string
        revision:
          type: string
      required:
      - repository
      type: object
    path:
      type: string
  type: object
```

The `archive` is not supported by the CLI that is expecting a path with a folder to package:

```
-> % epinio push -n zip -p sample.zip

🚢  About to push an application with the given setup
Manifest: <<Defaults>>
Name: zip
Source Origin: /home/enrico/sample.zip
AppChart: 
Target Namespace: workspace
Routes: <<default>>

⚠️  Hit Enter to continue or Ctrl+C to abort (deployment will continue automatically in 5 seconds)


Create the application resource ...

Collecting the application sources ...

❌  error pushing app to server: cannot read the apps source files: readdirent /home/enrico/sample.zip: not a directory
```

Maybe we can fix this adding a new field to the origin spec:

```
    archive:
      type: string
```

and maybe adding a new type:

```golang
const (
	OriginNone = iota
	OriginPath
	OriginGit
	OriginContainer
	OriginArchive
)
```

Since the `path` is a string I cannot see any other option to support this.

About the `git` implementation we need to understand what are the only relevant information.
We probably need only the Git/Github/Gitlab "provider" (for any different API or implementation), and the canonical userOrg/repo string. Everything else can be probably derived, and it's not needed from a deployment point of view.
If currently the branch is derived from a request we can keep it like this, also because I'm not sure on what's going to happen for deleted branches (we should try this).
We should/could also support tags, instead of revs.

```yaml
git:
  provider: "git|github|gitlab"
  endpoint: "https://github.com"
  full_name: "epinio/epinio"
  url: "https://github.com/epinio/epinio"
  revision: "32u9nfjkrenf9ui34 or v1.3.4"
```

I'm not familiar with the Gitlab APIs but the projects seems to have similar structure:
- GH: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository
  - full_name: https://api.github.com/repos/epinio/epinio
- GL: https://docs.gitlab.com/ee/api/projects.html#get-single-project
  - path_with_namespace