### PR TITLE
Added per-release synchronized Helm client

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,8 +48,6 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         timeout-minutes: 5
-        env:
-          ACTIONS_STEP_DEBUG: "true"
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         timeout-minutes: 5
+        env:
+          ACTIONS_STEP_DEBUG: "true"
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"context"
+	"sync"
 
 	hc "github.com/mittwald/go-helm-client"
 	"helm.sh/helm/v3/pkg/action"
@@ -15,136 +16,121 @@ var _ hc.Client = (*SynchronizedClient)(nil)
 
 // InstallOrUpgradeChart implements helmclient.Client
 func (c *SynchronizedClient) InstallOrUpgradeChart(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*release.Release, error) {
-	c.m.Lock()
-	defer c.m.Unlock()
+	anyMutex, _ := c.mutexMap.LoadOrStore(spec.ReleaseName, &sync.Mutex{})
+	if m, ok := anyMutex.(*sync.Mutex); ok {
+		m.Lock()
+		defer m.Unlock()
+	}
 
 	return c.helmClient.InstallOrUpgradeChart(ctx, spec, opts)
 }
 
 // RollbackRelease implements helmclient.Client
 func (c *SynchronizedClient) RollbackRelease(spec *hc.ChartSpec) error {
-	c.m.Lock()
-	defer c.m.Unlock()
+	anyMutex, _ := c.mutexMap.LoadOrStore(spec.ReleaseName, &sync.Mutex{})
+	if m, ok := anyMutex.(*sync.Mutex); ok {
+		m.Lock()
+		defer m.Unlock()
+	}
 
 	return c.helmClient.RollbackRelease(spec)
 }
 
 // AddOrUpdateChartRepo implements helmclient.Client
 func (c *SynchronizedClient) AddOrUpdateChartRepo(entry repo.Entry) error {
-	c.m.Lock()
-	defer c.m.Unlock()
-
 	return c.helmClient.AddOrUpdateChartRepo(entry)
 }
 
 // GetChart implements helmclient.Client
 func (c *SynchronizedClient) GetChart(chartName string, chartPathOptions *action.ChartPathOptions) (*chart.Chart, string, error) {
-	c.m.Lock()
-	defer c.m.Unlock()
-
 	return c.helmClient.GetChart(chartName, chartPathOptions)
 }
 
 // GetRelease implements helmclient.Client
 func (c *SynchronizedClient) GetRelease(name string) (*helmrelease.Release, error) {
-	c.m.Lock()
-	defer c.m.Unlock()
-
 	return c.helmClient.GetRelease(name)
 }
 
 // GetReleaseValues implements helmclient.Client
 func (c *SynchronizedClient) GetReleaseValues(name string, allValues bool) (map[string]interface{}, error) {
-	c.m.Lock()
-	defer c.m.Unlock()
-
 	return c.helmClient.GetReleaseValues(name, allValues)
 }
 
 // InstallChart implements helmclient.Client
 func (c *SynchronizedClient) InstallChart(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*helmrelease.Release, error) {
-	c.m.Lock()
-	defer c.m.Unlock()
+	anyMutex, _ := c.mutexMap.LoadOrStore(spec.ReleaseName, &sync.Mutex{})
+	if m, ok := anyMutex.(*sync.Mutex); ok {
+		m.Lock()
+		defer m.Unlock()
+	}
 
 	return c.helmClient.InstallChart(ctx, spec, opts)
 }
 
 // LintChart implements helmclient.Client
 func (c *SynchronizedClient) LintChart(spec *hc.ChartSpec) error {
-	c.m.Lock()
-	defer c.m.Unlock()
-
 	return c.helmClient.LintChart(spec)
 }
 
 // ListDeployedReleases implements helmclient.Client
 func (c *SynchronizedClient) ListDeployedReleases() ([]*helmrelease.Release, error) {
-	c.m.Lock()
-	defer c.m.Unlock()
-
 	return c.helmClient.ListDeployedReleases()
 }
 
 // ListReleaseHistory implements helmclient.Client
 func (c *SynchronizedClient) ListReleaseHistory(name string, max int) ([]*helmrelease.Release, error) {
-	c.m.Lock()
-	defer c.m.Unlock()
-
 	return c.helmClient.ListReleaseHistory(name, max)
 }
 
 // ListReleasesByStateMask implements helmclient.Client
 func (c *SynchronizedClient) ListReleasesByStateMask(actions action.ListStates) ([]*helmrelease.Release, error) {
-	c.m.Lock()
-	defer c.m.Unlock()
-
 	return c.helmClient.ListReleasesByStateMask(actions)
 }
 
 // SetDebugLog implements helmclient.Client
 func (c *SynchronizedClient) SetDebugLog(debugLog action.DebugLog) {
-	c.m.Lock()
-	defer c.m.Unlock()
-
 	c.helmClient.SetDebugLog(debugLog)
 }
 
 // TemplateChart implements helmclient.Client
 func (c *SynchronizedClient) TemplateChart(spec *hc.ChartSpec, options *hc.HelmTemplateOptions) ([]byte, error) {
-	c.m.Lock()
-	defer c.m.Unlock()
-
 	return c.helmClient.TemplateChart(spec, options)
 }
 
 // UninstallRelease implements helmclient.Client
 func (c *SynchronizedClient) UninstallRelease(spec *hc.ChartSpec) error {
-	c.m.Lock()
-	defer c.m.Unlock()
+	anyMutex, _ := c.mutexMap.LoadOrStore(spec.ReleaseName, &sync.Mutex{})
+	if m, ok := anyMutex.(*sync.Mutex); ok {
+		m.Lock()
+		defer m.Unlock()
+	}
 
 	return c.helmClient.UninstallRelease(spec)
 }
 
 // UninstallReleaseByName implements helmclient.Client
 func (c *SynchronizedClient) UninstallReleaseByName(name string) error {
-	c.m.Lock()
-	defer c.m.Unlock()
+	anyMutex, _ := c.mutexMap.LoadOrStore(name, &sync.Mutex{})
+	if m, ok := anyMutex.(*sync.Mutex); ok {
+		m.Lock()
+		defer m.Unlock()
+	}
 
 	return c.helmClient.UninstallReleaseByName(name)
 }
 
 // UpdateChartRepos implements helmclient.Client
 func (c *SynchronizedClient) UpdateChartRepos() error {
-	c.m.Lock()
-	defer c.m.Unlock()
-
 	return c.helmClient.UpdateChartRepos()
 }
 
 // UpgradeChart implements helmclient.Client
 func (c *SynchronizedClient) UpgradeChart(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*helmrelease.Release, error) {
-	c.m.Lock()
-	defer c.m.Unlock()
+	anyMutex, _ := c.mutexMap.LoadOrStore(spec.ReleaseName, &sync.Mutex{})
+	if m, ok := anyMutex.(*sync.Mutex); ok {
+		m.Lock()
+		defer m.Unlock()
+	}
 
 	return c.helmClient.UpgradeChart(ctx, spec, opts)
 }

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -85,7 +85,7 @@ var _ = Describe("SynchronizedClient", func() {
 
 	When("installing or upgrading chart", func() {
 
-		It("should wait for releases in the same namespace", func() {
+		It("should not wait for different releases in the same namespace", func() {
 			// setup the mock with a couple of releases
 
 			// release2s will take 2s
@@ -103,7 +103,7 @@ var _ = Describe("SynchronizedClient", func() {
 			wg := &sync.WaitGroup{}
 
 			// let's see how long the two installations are taking
-			// since they are done in the same namespace they should take 2s + 3s
+			// since they are done in the same namespace but they are different they should take 3s
 			start := time.Now()
 
 			// release2s will take 2s
@@ -128,7 +128,8 @@ var _ = Describe("SynchronizedClient", func() {
 
 			// the elapsed time should be greater than 5s
 			elapsed := time.Since(start)
-			Expect(elapsed).To(BeNumerically(">=", 5*time.Second))
+			Expect(elapsed).To(BeNumerically(">=", 3*time.Second))
+			Expect(elapsed).To(BeNumerically("<", 4*time.Second))
 		})
 
 		It("should not wait for releases in different namespaces and do them concurrently", func() {

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -27,6 +27,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+type CtxDuration struct{}
+
 var _ = Describe("SynchronizedClient", func() {
 	var (
 		ctx        context.Context
@@ -40,19 +42,19 @@ var _ = Describe("SynchronizedClient", func() {
 		mockClient = hcmock.NewMockClient(mockCtrl)
 	})
 
-	setupMockRelease := func(ctx context.Context, releaseName string, duration time.Duration) *hc.ChartSpec {
-		fakeRelease := &hc.ChartSpec{ReleaseName: releaseName}
-
+	// setupMockRelease will setup the mock. This mock will look into the context for the CtxDuration{} key
+	// to get the time.Duration used to time.Sleep() faking the release.
+	// This was needed to register different InstallOrUpgradeChart() calls (thanks to the difference in the Context)
+	setupMockRelease := func(ctx context.Context, myRelease *hc.ChartSpec) {
 		mockClient.
 			EXPECT().
-			InstallOrUpgradeChart(ctx, fakeRelease, nil).
+			InstallOrUpgradeChart(ctx, myRelease, nil).
 			DoAndReturn(func(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*release.Release, error) {
+				duration, _ := ctx.Value(CtxDuration{}).(time.Duration)
 				time.Sleep(duration)
 				return &release.Release{Name: spec.ReleaseName}, nil
 			}).
 			AnyTimes()
-
-		return fakeRelease
 	}
 
 	When("getting a namespace synchronized client", func() {
@@ -85,13 +87,66 @@ var _ = Describe("SynchronizedClient", func() {
 
 	When("installing or upgrading chart", func() {
 
+		It("should wait for the same release in the same namespace", func() {
+			// setup the mock with the same release, twice
+
+			ctx2s := context.WithValue(ctx, CtxDuration{}, 2*time.Second)
+			ctx3s := context.WithValue(ctx, CtxDuration{}, 3*time.Second)
+			myRelease := &hc.ChartSpec{ReleaseName: "my-release"}
+
+			setupMockRelease(ctx2s, myRelease)
+			setupMockRelease(ctx3s, myRelease)
+
+			// create a sync client
+			namespace := catalog.NewNamespaceName()
+			syncClient, err := helm.GetNamespaceSynchronizedHelmClient(namespace, mockClient)
+			Expect(err).To(BeNil())
+
+			// Begin TEST!
+
+			wg := &sync.WaitGroup{}
+
+			// let's see how long the two installations are taking
+			// since they are done in the same namespace and with the same release they should take 5s
+			start := time.Now()
+
+			// myRelease will take 2s the first time
+			wg.Add(1)
+			go func(wg *sync.WaitGroup) {
+				defer GinkgoRecover()
+
+				syncClient.InstallOrUpgradeChart(ctx2s, myRelease, nil)
+				wg.Done()
+			}(wg)
+
+			// second installation of myRelease will take 3s
+			wg.Add(1)
+			go func(wg *sync.WaitGroup) {
+				defer GinkgoRecover()
+
+				syncClient.InstallOrUpgradeChart(ctx3s, myRelease, nil)
+				wg.Done()
+			}(wg)
+
+			wg.Wait()
+
+			// the elapsed time should be greater than 5s
+			elapsed := time.Since(start)
+			Expect(elapsed).To(BeNumerically(">=", 5*time.Second))
+		})
+
 		It("should not wait for different releases in the same namespace", func() {
 			// setup the mock with a couple of releases
 
 			// release2s will take 2s
-			release2s := setupMockRelease(ctx, "release-2s", 2*time.Second)
+			ctx2s := context.WithValue(ctx, CtxDuration{}, 2*time.Second)
+			release2s := &hc.ChartSpec{ReleaseName: "release-2s"}
+			setupMockRelease(ctx2s, release2s)
+
 			// release3s will take 3s
-			release3s := setupMockRelease(ctx, "release-3s", 3*time.Second)
+			ctx3s := context.WithValue(ctx, CtxDuration{}, 3*time.Second)
+			release3s := &hc.ChartSpec{ReleaseName: "release-3s"}
+			setupMockRelease(ctx3s, release3s)
 
 			// create a sync client
 			namespace := catalog.NewNamespaceName()
@@ -111,7 +166,7 @@ var _ = Describe("SynchronizedClient", func() {
 			go func(wg *sync.WaitGroup) {
 				defer GinkgoRecover()
 
-				syncClient.InstallOrUpgradeChart(ctx, release2s, nil)
+				syncClient.InstallOrUpgradeChart(ctx2s, release2s, nil)
 				wg.Done()
 			}(wg)
 
@@ -120,7 +175,7 @@ var _ = Describe("SynchronizedClient", func() {
 			go func(wg *sync.WaitGroup) {
 				defer GinkgoRecover()
 
-				syncClient.InstallOrUpgradeChart(ctx, release3s, nil)
+				syncClient.InstallOrUpgradeChart(ctx3s, release3s, nil)
 				wg.Done()
 			}(wg)
 
@@ -133,12 +188,17 @@ var _ = Describe("SynchronizedClient", func() {
 		})
 
 		It("should not wait for releases in different namespaces and do them concurrently", func() {
-			// setup the mock with a couple of releases
+			// setup the mock with a couple of releases with the same 3s duration
+
+			ctx3s := context.WithValue(ctx, CtxDuration{}, 3*time.Second)
 
 			// releaseOne3s will take 3s in the first namespace
-			releaseOne3s := setupMockRelease(ctx, "release-ns1-3s", 3*time.Second)
-			// releaseTwo3s will take 3s in the second namespace
-			releaseTwo3s := setupMockRelease(ctx, "release-ns2-3s", 3*time.Second)
+			releaseOne3s := &hc.ChartSpec{ReleaseName: "release-ns1-3s"}
+			setupMockRelease(ctx3s, releaseOne3s)
+
+			// releaseOne3s will take 3s in the second namespace
+			releaseTwo3s := &hc.ChartSpec{ReleaseName: "release-ns2-3s"}
+			setupMockRelease(ctx3s, releaseTwo3s)
 
 			// create two sync clients
 			namespace1 := catalog.NewNamespaceName()
@@ -162,7 +222,7 @@ var _ = Describe("SynchronizedClient", func() {
 			go func(wg *sync.WaitGroup) {
 				defer GinkgoRecover()
 
-				syncClient1.InstallOrUpgradeChart(ctx, releaseOne3s, nil)
+				syncClient1.InstallOrUpgradeChart(ctx3s, releaseOne3s, nil)
 				wg.Done()
 			}(wg)
 
@@ -171,7 +231,7 @@ var _ = Describe("SynchronizedClient", func() {
 			go func(wg *sync.WaitGroup) {
 				defer GinkgoRecover()
 
-				syncClient2.InstallOrUpgradeChart(ctx, releaseTwo3s, nil)
+				syncClient2.InstallOrUpgradeChart(ctx3s, releaseTwo3s, nil)
 				wg.Done()
 			}(wg)
 
@@ -187,11 +247,19 @@ var _ = Describe("SynchronizedClient", func() {
 			// setup the mock with three releases
 
 			// release1s will take 1s
-			release1s := setupMockRelease(ctx, "release-1s", 1*time.Second)
+			ctx1s := context.WithValue(ctx, CtxDuration{}, 1*time.Second)
+			release1s := &hc.ChartSpec{ReleaseName: "release-1s"}
+			setupMockRelease(ctx1s, release1s)
+
 			// release3s will take 3s
-			release3s := setupMockRelease(ctx, "release-3s", 3*time.Second)
+			ctx3s := context.WithValue(ctx, CtxDuration{}, 3*time.Second)
+			release3s := &hc.ChartSpec{ReleaseName: "release-3s"}
+			setupMockRelease(ctx3s, release3s)
+
 			// release5s will take 5s
-			release5s := setupMockRelease(ctx, "release-5s", 5*time.Second)
+			ctx5s := context.WithValue(ctx, CtxDuration{}, 5*time.Second)
+			release5s := &hc.ChartSpec{ReleaseName: "release-5s"}
+			setupMockRelease(ctx5s, release5s)
 
 			// create two sync clients
 			namespace1 := catalog.NewNamespaceName()
@@ -215,7 +283,7 @@ var _ = Describe("SynchronizedClient", func() {
 			go func(wg *sync.WaitGroup) {
 				defer GinkgoRecover()
 
-				syncClient1.InstallOrUpgradeChart(ctx, release1s, nil)
+				syncClient1.InstallOrUpgradeChart(ctx1s, release1s, nil)
 				wg.Done()
 			}(wg)
 
@@ -224,7 +292,7 @@ var _ = Describe("SynchronizedClient", func() {
 			go func(wg *sync.WaitGroup) {
 				defer GinkgoRecover()
 
-				syncClient1.InstallOrUpgradeChart(ctx, release3s, nil)
+				syncClient1.InstallOrUpgradeChart(ctx3s, release3s, nil)
 				wg.Done()
 			}(wg)
 
@@ -233,7 +301,7 @@ var _ = Describe("SynchronizedClient", func() {
 			go func(wg *sync.WaitGroup) {
 				defer GinkgoRecover()
 
-				syncClient2.InstallOrUpgradeChart(ctx, release5s, nil)
+				syncClient2.InstallOrUpgradeChart(ctx5s, release5s, nil)
 				wg.Done()
 			}(wg)
 

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -390,8 +390,9 @@ func Status(ctx context.Context, logger logr.Logger, cluster *kubernetes.Cluster
 var syncNamespaceClientMap sync.Map
 
 type SynchronizedClient struct {
-	namespace  string
-	m          sync.Mutex
+	namespace string
+	// mutexMap is holding the mutexes for the same releases
+	mutexMap   sync.Map
 	helmClient hc.Client
 }
 


### PR DESCRIPTION
Fix: https://github.com/epinio/epinio/issues/2210

This PR adds a map of mutexes to the namespaced SynchronizedClient, that will now wait only for concurrent releases with the same name (different releases cannot conflicts).

It also removes the concurrency on other requests that can be done safely in a concurrent way (list, get, and so on).

The test was failing (it was expected) and it was fixed accordingly with the new implementation.