### PR TITLE
Skip cache in setup-go and golangci-lint actions

### DIFF
--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -56,6 +56,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
@@ -73,11 +74,11 @@ jobs:
 
       - name: Lint Epinio
         uses: golangci/golangci-lint-action@v3.4.0
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
-          skip-pkg-cache: true
+          skip-cache: true
 
       - name: Clean all
         if: always()
@@ -99,6 +100,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -56,6 +56,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
@@ -73,11 +74,11 @@ jobs:
 
       - name: Lint Epinio
         uses: golangci/golangci-lint-action@v3.4.0
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
-          skip-pkg-cache: true
+          skip-cache: true
 
       - name: Clean all
         if: always()
@@ -99,6 +100,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework

--- a/.github/workflows/clientsync.yml
+++ b/.github/workflows/clientsync.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework

--- a/.github/workflows/delete_clusters.yml
+++ b/.github/workflows/delete_clusters.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       # The system domain is managed by route53, login to delete

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -56,6 +56,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
@@ -73,11 +74,11 @@ jobs:
 
       - name: Lint Epinio
         uses: golangci/golangci-lint-action@v3.4.0
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
-          skip-pkg-cache: true
+          skip-cache: true
 
       - name: Clean all
         if: always()

--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -58,6 +58,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
@@ -75,11 +76,11 @@ jobs:
 
       - name: Lint Epinio
         uses: golangci/golangci-lint-action@v3.4.0
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
-          skip-pkg-cache: true
+          skip-cache: true
 
       - name: Clean all
         if: always()
@@ -101,6 +102,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       # The system domain is managed by route53, we need credentials to update

--- a/.github/workflows/gke-upgrade.yml
+++ b/.github/workflows/gke-upgrade.yml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
@@ -76,11 +77,11 @@ jobs:
 
       - name: Lint Epinio
         uses: golangci/golangci-lint-action@v3.4.0
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
-          skip-pkg-cache: true
+          skip-cache: true
 
       - name: Clean all
         if: always()
@@ -102,6 +103,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Login to GitHub Docker Registry

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -58,6 +58,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
@@ -75,11 +76,11 @@ jobs:
 
       - name: Lint Epinio
         uses: golangci/golangci-lint-action@v3.4.0
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
-          skip-pkg-cache: true
+          skip-cache: true
 
       - name: Clean all
         if: always()
@@ -101,6 +102,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       # The system domain is managed by route53, we need credentials to update

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -36,8 +36,8 @@ jobs:
       
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.4.0
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
-          skip-pkg-cache: true
+          skip-cache: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
@@ -56,11 +57,11 @@ jobs:
 
       - name: Lint Epinio
         uses: golangci/golangci-lint-action@v3.4.0
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
-          skip-pkg-cache: true
+          skip-cache: true
 
       - name: Unit Tests
         run: make test
@@ -96,6 +97,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
@@ -169,6 +171,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
@@ -242,6 +245,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
@@ -316,6 +320,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
@@ -390,6 +395,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
@@ -463,6 +469,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework
@@ -537,6 +544,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework

--- a/.github/workflows/release-qa.yml
+++ b/.github/workflows/release-qa.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Set up QEMU

--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Set up QEMU

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Set up QEMU

--- a/.github/workflows/rke-upgrade.yml
+++ b/.github/workflows/rke-upgrade.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
@@ -65,11 +66,11 @@ jobs:
 
       - name: Lint Epinio
         uses: golangci/golangci-lint-action@v3.4.0
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
-          skip-pkg-cache: true
+          skip-cache: true
 
       - name: Clean all
         if: always()
@@ -91,6 +92,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Login to GitHub Docker Registry

--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
@@ -66,11 +67,11 @@ jobs:
 
       - name: Lint Epinio
         uses: golangci/golangci-lint-action@v3.4.0
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
-          skip-pkg-cache: true
+          skip-cache: true
 
       - name: Clean all
         if: always()
@@ -92,6 +93,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework

--- a/.github/workflows/rke2-lh-ec2.yml
+++ b/.github/workflows/rke2-lh-ec2.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Cache Tools
@@ -69,11 +70,11 @@ jobs:
 
       - name: Lint Epinio
         uses: golangci/golangci-lint-action@v3.4.0
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=10m --skip-files docs.go
-          skip-pkg-cache: true
+          skip-cache: true
 
       - name: Clean all
         if: always()
@@ -95,6 +96,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/setup-go@v4
         timeout-minutes: 5
         with:
+          cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Setup Ginkgo Test Framework


### PR DESCRIPTION
The caches were enabled in the latest version ([V4](https://github.com/actions/setup-go#v4)) but since we are using self hosted runners we are already caching by ourselves.

Also the download of the caches from GH was actually taking time and hanging probably for hitting the limits.

Extending also the limit timeout to 10m for the linter (it was using a 10m limit anyway during its execution).