### PR TITLE
RKE2 EC2 provisioning: kubeconfig Tag and mode 0644

### DIFF
--- a/.github/workflows/rke2-lh-ec2.yml
+++ b/.github/workflows/rke2-lh-ec2.yml
@@ -262,7 +262,7 @@ jobs:
         env:
           EC2_INSTANCE_IDS: ${{ steps.provision-ec2-instances.outputs.EC2_INSTANCE_IDS }}
         run: |
-          helm delete nginx-ingress -n ingress-nginx
+          helm delete nginx-ingress -n ingress-nginx --wait
           aws ec2 terminate-instances --instance-ids $EC2_INSTANCE_IDS
 
       # Only on RKE, as it uses a self-hosted runner

--- a/.github/workflows/rke2-lh-ec2.yml
+++ b/.github/workflows/rke2-lh-ec2.yml
@@ -159,6 +159,10 @@ jobs:
             --output text)
           echo "EC2_INSTANCE_IDS=$EC2_INSTANCE_IDS" >> $GITHUB_OUTPUT
 
+          echo 'Adding Tag kubeconfig=true to the first EC2_INSTANCE_IDS entry'
+          server_instance_id=$(echo $EC2_INSTANCE_IDS | awk '{print $1}')
+          aws ec2 create-tags --resources $server_instance_id --tags Key=kubeconfig,Value=true
+
           echo 'Waiting until the instances are in ok state...'
           aws ec2 wait instance-status-ok \
             --instance-ids $EC2_INSTANCE_IDS \
@@ -197,6 +201,7 @@ jobs:
 
           # Configure rke2 with aws provider
           mkdir -p /etc/rancher/rke2/config.yaml.d
+          echo "write-kubeconfig-mode: \"0644\"" >> /etc/rancher/rke2/config.yaml.d/00-epinio.yam
           echo "cloud-provider-name: aws" >> /etc/rancher/rke2/config.yaml.d/00-epinio.yaml
           echo "disable: rke2-ingress-nginx" >> /etc/rancher/rke2/config.yaml.d/00-epinio.yaml
           # enable tls-san to be able communicate with cluster from runner over TLS when using its public hostname

--- a/.github/workflows/rke2-lh-ec2.yml
+++ b/.github/workflows/rke2-lh-ec2.yml
@@ -201,7 +201,7 @@ jobs:
 
           # Configure rke2 with aws provider
           mkdir -p /etc/rancher/rke2/config.yaml.d
-          echo "write-kubeconfig-mode: \"0644\"" >> /etc/rancher/rke2/config.yaml.d/00-epinio.yam
+          echo "write-kubeconfig-mode: \"0644\"" >> /etc/rancher/rke2/config.yaml.d/00-epinio.yaml
           echo "cloud-provider-name: aws" >> /etc/rancher/rke2/config.yaml.d/00-epinio.yaml
           echo "disable: rke2-ingress-nginx" >> /etc/rancher/rke2/config.yaml.d/00-epinio.yaml
           # enable tls-san to be able communicate with cluster from runner over TLS when using its public hostname


### PR DESCRIPTION
Needed for #2205

This PR adds:
* wait for nginx-ingress deletion by helm to prevent SG leftovers
* tag `kubeconfig=true` to the first EC2 instance
![aws-tag-kubeconfig](https://user-images.githubusercontent.com/12828077/234226686-52a7552a-0c0e-4a1b-84a2-2c871fb86488.png)

* additional config for rke2 `write-kubeconfig-mode: "0644"`