### PR TITLE
Extended application with additional origin information maintained by the web ui, and centralized manifest formatting in the server

### DIFF
--- a/acceptance/api/v1/application_export_test.go
+++ b/acceptance/api/v1/application_export_test.go
@@ -100,7 +100,6 @@ configuration:
   appchart: standard
 origin:
   container: splatform/sample-app
-  git: {}
 namespace: %s
 `, app, domain, namespace)
 

--- a/acceptance/api/v1/application_export_test.go
+++ b/acceptance/api/v1/application_export_test.go
@@ -32,6 +32,10 @@ var _ = Describe("AppPart Endpoint", LApplication, func() {
 	)
 	containerImageURL := "splatform/sample-app"
 
+	// The testsuite checks using only part `values` and part `manifest`, as the smallest
+	// possible parts, and also (YAML-formatted) text.  The data returned for parts `chart` and
+	// `image` will be much much larger, and binary.
+
 	BeforeEach(func() {
 		domain = catalog.NewTmpName("exportdomain-") + ".org"
 
@@ -47,10 +51,7 @@ var _ = Describe("AppPart Endpoint", LApplication, func() {
 		env.DeleteNamespace(namespace)
 	})
 
-	It("retrieves the named application part", func() {
-		// The testsuite checks using only part `values`, as the smallest possible, and also text.
-		// The parts `chart` (and, in the future, maybe, `image`) are much larger, and binary.
-
+	It("retrieves the named application part, values", func() {
 		response, err := env.Curl("GET", fmt.Sprintf("%s%s/namespaces/%s/applications/%s/part/values",
 			serverURL, v1.Root, namespace, app), strings.NewReader(""))
 		Expect(err).ToNot(HaveOccurred())
@@ -78,6 +79,35 @@ var _ = Describe("AppPart Endpoint", LApplication, func() {
   tlsIssuer: epinio-ca
   username: admin
 `, app, domain, domain)))
+	})
+
+	It("retrieves the named application part, manifest", func() {
+		response, err := env.Curl("GET", fmt.Sprintf("%s%s/namespaces/%s/applications/%s/part/manifest",
+			serverURL, v1.Root, namespace, app), strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		defer response.Body.Close()
+
+		bodyBytes, err := io.ReadAll(response.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+		expecting := fmt.Sprintf(`name: %s
+configuration:
+  instances: 1
+  routes:
+  - %s
+  appchart: standard
+origin:
+  container: splatform/sample-app
+  git:
+    url: ""
+namespace: %s
+`, app, domain, namespace)
+
+		By(string(bodyBytes))
+		By(expecting)
+		Expect(string(bodyBytes)).To(Equal(expecting))
 	})
 
 	It("returns a 404 when the namespace does not exist", func() {

--- a/acceptance/api/v1/application_export_test.go
+++ b/acceptance/api/v1/application_export_test.go
@@ -100,8 +100,7 @@ configuration:
   appchart: standard
 origin:
   container: splatform/sample-app
-  git:
-    url: ""
+  git: {}
 namespace: %s
 `, app, domain, namespace)
 

--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -1731,6 +1731,9 @@
           "type": "string",
           "x-go-name": "StageID"
         },
+        "staging": {
+          "$ref": "#/definitions/ApplicationStage"
+        },
         "stagingstatus": {
           "$ref": "#/definitions/ApplicationStagingStatus"
         },
@@ -1957,6 +1960,10 @@
           "type": "integer",
           "format": "int64"
         },
+        "archive": {
+          "type": "boolean",
+          "x-go-name": "Archive"
+        },
         "container": {
           "type": "string",
           "x-go-name": "Container"
@@ -1967,6 +1974,17 @@
         "path": {
           "type": "string",
           "x-go-name": "Path"
+        }
+      },
+      "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
+    },
+    "ApplicationStage": {
+      "description": "ApplicationStage is the part of the manifest holding information\nrelevant to staging the application's sources. This is, currently,\nonly the reference to the Paketo builder image to use.",
+      "type": "object",
+      "properties": {
+        "builder": {
+          "type": "string",
+          "x-go-name": "Builder"
         }
       },
       "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
@@ -2366,6 +2384,14 @@
     "GitRef": {
       "type": "object",
       "properties": {
+        "branch": {
+          "type": "string",
+          "x-go-name": "Branch"
+        },
+        "provider": {
+          "type": "string",
+          "x-go-name": "Provider"
+        },
         "repository": {
           "type": "string",
           "x-go-name": "URL"

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/briandowns/spinner v1.19.0
 	github.com/coreos/go-oidc/v3 v3.5.0
-	github.com/epinio/application v0.0.0-20220901082113-1f9503b4ae5a
+	github.com/epinio/application v0.0.0-20230426074828-5749af9ec363
 	github.com/fatih/color v1.14.1
 	github.com/gin-gonic/gin v1.8.2
 	github.com/go-git/go-git/v5 v5.4.2

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/epinio/application v0.0.0-20220901082113-1f9503b4ae5a h1:P3CPYm8t7vPk07NZBVi6hSogs6ivElmoM7drXlNmnSk=
-github.com/epinio/application v0.0.0-20220901082113-1f9503b4ae5a/go.mod h1:TsOLExnVfT4RDqLnOv6UHQ6ri26dDNG8RkQTyVqCU14=
+github.com/epinio/application v0.0.0-20230426074828-5749af9ec363 h1:zE2SYPUZ8/1lK0dJkKQljLUyGz1prEZ8NJ+GD86p7uI=
+github.com/epinio/application v0.0.0-20230426074828-5749af9ec363/go.mod h1:TsOLExnVfT4RDqLnOv6UHQ6ri26dDNG8RkQTyVqCU14=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/internal/api/v1/application/part.go
+++ b/internal/api/v1/application/part.go
@@ -333,12 +333,8 @@ func fetchAppManifest(c *gin.Context, app *models.App) apierror.APIErrors {
 		},
 		Namespace: app.Meta.Namespace,
 		Origin:    app.Origin,
+		Staging:   app.Staging,
 	}
-
-	// TODO -- determine and fill builder --
-	// Staging: models.ApplicationStage{
-	// 	Builder: "-- data not found -- placeholder -- fix --",
-	// },
 
 	yaml, err := yaml.Marshal(m)
 	if err != nil {

--- a/internal/api/v1/application/part.go
+++ b/internal/api/v1/application/part.go
@@ -342,12 +342,7 @@ func fetchAppManifest(c *gin.Context, app *models.App) apierror.APIErrors {
 		Staging:   app.Staging,
 	}
 
-	yaml, err := yaml.Marshal(m)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-
-	response.OKBytes(c, yaml)
+	response.OKYaml(c, m)
 	return nil
 }
 

--- a/internal/api/v1/response/response.go
+++ b/internal/api/v1/response/response.go
@@ -42,6 +42,16 @@ func OKBytes(c *gin.Context, response []byte) {
 	c.Data(http.StatusOK, "application/octet-stream", response)
 }
 
+// OKYaml reports a success with some YAML data
+func OKYaml(c *gin.Context, response interface{}) {
+	requestctx.Logger(c.Request.Context()).Info("OK",
+		"origin", c.Request.URL.String(),
+		"returning", response,
+	)
+
+	c.YAML(http.StatusOK, response)
+}
+
 // OKReturn reports a success with some data
 func OKReturn(c *gin.Context, response interface{}) {
 	requestctx.Logger(c.Request.Context()).Info("OK",

--- a/internal/application/origin.go
+++ b/internal/application/origin.go
@@ -27,9 +27,7 @@ import (
 // constructed from the stored information on the Application Custom
 // Resource.
 func Origin(app *unstructured.Unstructured) (models.ApplicationOrigin, error) {
-	result := models.ApplicationOrigin{
-		Git: &models.GitRef{},
-	}
+	result := models.ApplicationOrigin{}
 
 	origin, found, err := unstructured.NestedMap(app.Object, "spec", "origin")
 
@@ -94,6 +92,8 @@ func Origin(app *unstructured.Unstructured) (models.ApplicationOrigin, error) {
 		if repository == "" {
 			return result, errors.New("bad git origin, url is empty string")
 		}
+
+		result.Git = &models.GitRef{}
 
 		// For git check for the optional revision as well.
 		revision, found, err := unstructured.NestedString(origin, "git", "revision")

--- a/internal/application/origin.go
+++ b/internal/application/origin.go
@@ -57,6 +57,16 @@ func Origin(app *unstructured.Unstructured) (models.ApplicationOrigin, error) {
 			return result, errors.New("bad path origin, empty string")
 		}
 
+		// For path check the archive flag as well
+		isarchive, found, err := unstructured.NestedBool(origin, "archive")
+		if found {
+			if err != nil {
+				return result, err
+			}
+
+			result.Archive = isarchive
+		}
+
 		result.Kind = models.OriginPath
 		result.Path = path
 		return result, nil
@@ -95,6 +105,30 @@ func Origin(app *unstructured.Unstructured) (models.ApplicationOrigin, error) {
 				return result, errors.New("bad git origin, revision is empty string")
 			}
 			result.Git.Revision = revision
+		}
+
+		// For git check for the optional provider as well.
+		provider, found, err := unstructured.NestedString(origin, "git", "provider")
+		if found {
+			if err != nil {
+				return result, err
+			}
+			if provider == "" {
+				return result, errors.New("bad git origin, provider is empty string")
+			}
+			result.Git.Provider = provider
+		}
+
+		// For git check for the optional branch as well.
+		branch, found, err := unstructured.NestedString(origin, "git", "branch")
+		if found {
+			if err != nil {
+				return result, err
+			}
+			if branch == "" {
+				return result, errors.New("bad git origin, branch is empty string")
+			}
+			result.Git.Branch = branch
 		}
 
 		result.Kind = models.OriginGit

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -604,6 +604,7 @@ func (c *EpinioClient) printAppDetails(app models.App) error {
 
 	msg = msg.
 		WithTableRow("App Chart", app.Configuration.AppChart).
+		WithTableRow("Builder Image", app.Staging.Builder).
 		WithTableRow("Desired Instances", fmt.Sprintf("%d", *app.Configuration.Instances)).
 		WithTableRow("Bound Configurations", strings.Join(app.Configuration.Configurations, ", ")).
 		WithTableRow("Environment", "")

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/pkg/errors"
 
 	"github.com/epinio/epinio/helpers/bytes"
@@ -299,23 +297,7 @@ func (c *EpinioClient) AppManifest(appName, manifestPath string) error {
 
 	details.Info("show application")
 
-	app, err := c.API.AppShow(c.Settings.Namespace, appName)
-	if err != nil {
-		return err
-	}
-
-	m := models.ApplicationManifest{}
-	m.Name = appName
-	m.Configuration = app.Configuration
-	m.Origin = app.Origin
-	m.Namespace = c.Settings.Namespace
-
-	yaml, err := yaml.Marshal(m)
-	if err != nil {
-		return err
-	}
-
-	err = os.WriteFile(manifestPath, yaml, 0600)
+	err := c.API.AppGetPart(c.Settings.Namespace, appName, "manifest", manifestPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/core/v1/models/app.go
+++ b/pkg/api/core/v1/models/app.go
@@ -38,6 +38,8 @@ type ApplicationStagingStatus string
 type GitRef struct {
 	Revision string `json:"revision,omitempty" yaml:"revision,omitempty"`
 	URL      string `json:"repository"         yaml:"url"`
+	Provider string `json:"provider,omitempty" yaml:"provider,omitempty"`
+	Branch   string `json:"branch,omitempty"   yaml:"branch,omitempty"`
 }
 
 // App has all the application's properties, for at rest (Configuration), and active (Workload).
@@ -50,8 +52,9 @@ type App struct {
 	Configuration ApplicationUpdateRequest `json:"configuration"`
 	Origin        ApplicationOrigin        `json:"origin"`
 	Workload      *AppDeployment           `json:"deployment,omitempty"`
-	Status        ApplicationStatus        `json:"status"`
+	Staging       ApplicationStage         `json:"staging,omitempty"`
 	StagingStatus ApplicationStagingStatus `json:"stagingstatus"`
+	Status        ApplicationStatus        `json:"status"`
 	StatusMessage string                   `json:"statusmessage"`
 	StageID       string                   `json:"stage_id,omitempty"` // staging id, last run
 	ImageURL      string                   `json:"image_url"`

--- a/pkg/api/core/v1/models/app.go
+++ b/pkg/api/core/v1/models/app.go
@@ -37,7 +37,7 @@ type ApplicationStagingStatus string
 
 type GitRef struct {
 	Revision string `json:"revision,omitempty" yaml:"revision,omitempty"`
-	URL      string `json:"repository"         yaml:"url"`
+	URL      string `json:"repository"         yaml:"url,omitempty"`
 	Provider string `json:"provider,omitempty" yaml:"provider,omitempty"`
 	Branch   string `json:"branch,omitempty"   yaml:"branch,omitempty"`
 }

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -121,7 +121,7 @@ type ApplicationManifest struct {
 // relevant to staging the application's sources. This is, currently,
 // only the reference to the Paketo builder image to use.
 type ApplicationStage struct {
-	Builder string `yaml:"builder,omitempty"`
+	Builder string `yaml:"builder,omitempty" json:"builder,omitempty"`
 }
 
 // ApplicationOrigin is the part of the manifest describing the origin of the application
@@ -135,6 +135,7 @@ type ApplicationOrigin struct {
 	Container string  `yaml:"container,omitempty" json:"container,omitempty"`
 	Git       *GitRef `yaml:"git,omitempty"       json:"git,omitempty"`
 	Path      string  `yaml:"path,omitempty"      json:"path,omitempty"`
+	Archive   bool    `yaml:"archive,omitempty"   json:"archive,omitempty"`
 }
 
 // manifest origin codes for `Kind`.

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -149,10 +149,19 @@ const (
 func (o *ApplicationOrigin) String() string {
 	switch o.Kind {
 	case OriginPath:
+		if o.Archive {
+			return helpers.AbsPath(o.Path) + " (archive)"
+		}
 		return helpers.AbsPath(o.Path)
 	case OriginGit:
 		if o.Git.Revision == "" {
+			if o.Git.Branch != "" {
+				return fmt.Sprintf("%s on %s", o.Git.URL, o.Git.Branch)
+			}
 			return o.Git.URL
+		}
+		if o.Git.Branch != "" {
+			return fmt.Sprintf("%s @ %s (on %s)", o.Git.URL, o.Git.Revision, o.Git.Branch)
 		}
 		return fmt.Sprintf("%s @ %s", o.Git.URL, o.Git.Revision)
 	case OriginContainer:


### PR DESCRIPTION
fix #2237
fix #2224
fix #2225

feat: extended part endpoint to serve a formatted manifest
chore: new test for manifest retrieval
chore: updated client to pull manifest via part API instead of formatting it itself
note: no changes to existing manifest tests

subordinate PRs:

  - application - https://github.com/epinio/application/pull/12
  - helm chart - https://github.com/epinio/helm-charts/pull/419
