### PR TITLE
Fixed same suggestions for multiple resources

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -1883,6 +1883,7 @@ userConfig:
 		"restart",
 		"show",
 		"update",
+		"delete",
 	} {
 		Context(command+" command completion", func() {
 			BeforeEach(func() {

--- a/acceptance/configurations_test.go
+++ b/acceptance/configurations_test.go
@@ -200,8 +200,14 @@ var _ = Describe("Configurations", LConfiguration, func() {
 		})
 
 		Context("command completion", func() {
+
+			BeforeEach(func() {
+				env.MakeConfiguration(configurationName2)
+			})
+
 			AfterEach(func() {
 				env.CleanupConfiguration(configurationName1)
+				env.CleanupConfiguration(configurationName2)
 			})
 
 			It("matches empty prefix", func() {
@@ -222,7 +228,7 @@ var _ = Describe("Configurations", LConfiguration, func() {
 				Expect(out).ToNot(ContainSubstring(configurationName1))
 				Expect(out).To(ContainSubstring(configurationName2))
 
-				out, err = env.Epinio("", "__complete", "service", "delete", configurationName2, "")
+				out, err = env.Epinio("", "__complete", "configuration", "delete", configurationName2, "")
 				Expect(err).ToNot(HaveOccurred(), out)
 				Expect(out).To(ContainSubstring(configurationName1))
 				Expect(out).ToNot(ContainSubstring(configurationName2))

--- a/acceptance/configurations_test.go
+++ b/acceptance/configurations_test.go
@@ -215,6 +215,18 @@ var _ = Describe("Configurations", LConfiguration, func() {
 				Expect(err).ToNot(HaveOccurred(), out)
 				Expect(out).ToNot(ContainSubstring("bogus"))
 			})
+
+			It("does match for more than one configuration but only the remaining one", func() {
+				out, err := env.Epinio("", "__complete", "configuration", "delete", configurationName1, "")
+				Expect(err).ToNot(HaveOccurred(), out)
+				Expect(out).ToNot(ContainSubstring(configurationName1))
+				Expect(out).To(ContainSubstring(configurationName2))
+
+				out, err = env.Epinio("", "__complete", "service", "delete", configurationName2, "")
+				Expect(err).ToNot(HaveOccurred(), out)
+				Expect(out).To(ContainSubstring(configurationName1))
+				Expect(out).ToNot(ContainSubstring(configurationName2))
+			})
 		})
 	})
 

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -575,6 +575,25 @@ var _ = Describe("Services", LService, func() {
 					return out
 				}, "1m", "5s").Should(ContainSubstring("service '%s' does not exist", service2))
 			})
+
+			It("does match for more than one service", func() {
+				out, err := env.Epinio("", "__complete", "service", "delete", "")
+				Expect(err).ToNot(HaveOccurred(), out)
+				Expect(out).To(ContainSubstring(service))
+				Expect(out).To(ContainSubstring(service2))
+			})
+
+			It("does match for more than one service but only the remaining one", func() {
+				out, err := env.Epinio("", "__complete", "service", "delete", service, "")
+				Expect(err).ToNot(HaveOccurred(), out)
+				Expect(out).ToNot(ContainSubstring(service))
+				Expect(out).To(ContainSubstring(service2))
+
+				out, err = env.Epinio("", "__complete", "service", "delete", service2, "")
+				Expect(err).ToNot(HaveOccurred(), out)
+				Expect(out).To(ContainSubstring(service))
+				Expect(out).ToNot(ContainSubstring(service2))
+			})
 		})
 
 		When("bound to an app", func() {

--- a/internal/cli/commons.go
+++ b/internal/cli/commons.go
@@ -12,7 +12,6 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -70,7 +69,7 @@ func matchingConfigurationFinder(cmd *cobra.Command, args []string, toComplete s
 	}
 	app.API.DisableVersionWarning()
 
-	matches := app.ConfigurationMatching(context.Background(), toComplete)
+	matches := app.ConfigurationMatching(toComplete)
 
 	return matches, cobra.ShellCompDirectiveNoFileComp
 }
@@ -163,4 +162,26 @@ func matchingCatalogFinder(cmd *cobra.Command, args []string, toComplete string)
 	matches := app.CatalogMatching(toComplete)
 
 	return matches, cobra.ShellCompDirectiveNoFileComp
+}
+
+// filteredMatchingFinder will use the finder func to find the resources with the prefix name
+// It will then filter the matches removing the provided args
+func filteredMatchingFinder(args []string, prefix string, finder func(prefix string) []string) []string {
+	// map to check for already selected applications
+	alreadyMatchedApps := map[string]struct{}{}
+	for _, app := range args {
+		alreadyMatchedApps[app] = struct{}{}
+	}
+
+	filteredMatches := []string{}
+
+	matches := finder(prefix)
+	for _, app := range matches {
+		// return only the not matched apps
+		if _, found := alreadyMatchedApps[app]; !found {
+			filteredMatches = append(filteredMatches, app)
+		}
+	}
+
+	return filteredMatches
 }

--- a/internal/cli/commons.go
+++ b/internal/cli/commons.go
@@ -167,19 +167,19 @@ func matchingCatalogFinder(cmd *cobra.Command, args []string, toComplete string)
 // filteredMatchingFinder will use the finder func to find the resources with the prefix name
 // It will then filter the matches removing the provided args
 func filteredMatchingFinder(args []string, prefix string, finder func(prefix string) []string) []string {
-	// map to check for already selected applications
-	alreadyMatchedApps := map[string]struct{}{}
-	for _, app := range args {
-		alreadyMatchedApps[app] = struct{}{}
+	// map to check for already selected resources
+	alreadyMatched := map[string]struct{}{}
+	for _, resource := range args {
+		alreadyMatched[resource] = struct{}{}
 	}
 
 	filteredMatches := []string{}
 
 	matches := finder(prefix)
-	for _, app := range matches {
-		// return only the not matched apps
-		if _, found := alreadyMatchedApps[app]; !found {
-			filteredMatches = append(filteredMatches, app)
+	for _, resource := range matches {
+		// return only the not already matched resources
+		if _, found := alreadyMatched[resource]; !found {
+			filteredMatches = append(filteredMatches, resource)
 		}
 	}
 

--- a/internal/cli/configuration.go
+++ b/internal/cli/configuration.go
@@ -12,7 +12,6 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -103,7 +102,7 @@ var CmdConfigurationDelete = &cobra.Command{
 		}
 		epinioClient.API.DisableVersionWarning()
 
-		matches := epinioClient.ConfigurationMatching(context.Background(), toComplete)
+		matches := filteredMatchingFinder(args, toComplete, epinioClient.ConfigurationMatching)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
@@ -329,6 +328,6 @@ func findConfigurationApp(cmd *cobra.Command, args []string, toComplete string) 
 
 	// #args == 0: configuration name.
 
-	matches := app.ConfigurationMatching(context.Background(), toComplete)
+	matches := app.ConfigurationMatching(toComplete)
 	return matches, cobra.ShellCompDirectiveNoFileComp
 }

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -29,9 +29,8 @@ var CmdAppDelete = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		matches := epinioClient.AppsMatching(toComplete)
-
-		return matches, cobra.ShellCompDirectiveNoFileComp
+		filteredMatches := filteredMatchingFinder(args, toComplete, epinioClient.AppsMatching)
+		return filteredMatches, cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -57,10 +57,11 @@ var CmdEnvList = &cobra.Command{
 
 // CmdEnvSet implements the command: epinio app env set
 var CmdEnvSet = &cobra.Command{
-	Use:   "set APPNAME NAME VALUE",
-	Short: "Extend application environment",
-	Long:  "Add or change environment variable of named application",
-	Args:  cobra.ExactArgs(3),
+	Use:               "set APPNAME NAME VALUE",
+	Short:             "Extend application environment",
+	Long:              "Add or change environment variable of named application",
+	Args:              cobra.ExactArgs(3),
+	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
@@ -76,24 +77,6 @@ var CmdEnvSet = &cobra.Command{
 		}
 
 		return nil
-	},
-	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		// Ignore name and value of environment variable.
-		// EV may exist or not, the command will set or modify.
-		if len(args) > 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		app, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		app.API.DisableVersionWarning()
-
-		// #args == 0: application name.
-		matches := app.AppsMatching(toComplete)
-
-		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
 }
 

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -46,8 +46,6 @@ func bindOption(cmd *cobra.Command) {
 			// We are responsible for splitting into segments, and expanding only the last
 			// segment.
 
-			ctx := cmd.Context()
-
 			app, err := usercmd.New(cmd.Context())
 			if err != nil {
 				return nil, cobra.ShellCompDirectiveNoFileComp
@@ -56,7 +54,7 @@ func bindOption(cmd *cobra.Command) {
 			values := strings.Split(toComplete, ",")
 			if len(values) == 0 {
 				// Nothing. Report all possible matches
-				matches := app.ConfigurationMatching(ctx, toComplete)
+				matches := app.ConfigurationMatching(toComplete)
 				return matches, cobra.ShellCompDirectiveNoFileComp
 			}
 
@@ -65,7 +63,7 @@ func bindOption(cmd *cobra.Command) {
 			// expansions for that segment.
 
 			matches := []string{}
-			for _, match := range app.ConfigurationMatching(ctx, values[len(values)-1]) {
+			for _, match := range app.ConfigurationMatching(values[len(values)-1]) {
 				values[len(values)-1] = match
 				matches = append(matches, strings.Join(values, ","))
 			}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -128,8 +128,8 @@ var CmdServiceDelete = &cobra.Command{
 		}
 
 		app.API.DisableVersionWarning()
-		matches := app.ServiceMatching(toComplete)
 
+		matches := filteredMatchingFinder(args, toComplete, app.ServiceMatching)
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/usercmd/configuration.go
+++ b/internal/cli/usercmd/configuration.go
@@ -12,7 +12,6 @@
 package usercmd
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -111,7 +110,7 @@ func (c *EpinioClient) Configurations(all bool) error {
 
 // ConfigurationMatching returns all Epinio configurations having the specified prefix
 // in their name.
-func (c *EpinioClient) ConfigurationMatching(ctx context.Context, prefix string) []string {
+func (c *EpinioClient) ConfigurationMatching(prefix string) []string {
 	log := c.Log.WithName("ConfigurationMatching").WithValues("PrefixToMatch", prefix)
 	log.Info("start")
 	defer log.Info("return")


### PR DESCRIPTION
The `epinio app env set` command was not using the common `matchingAppsFinder` func.

Also some app/service/config commands (`delete`) accepts more than one resource, but our completion were suggesting also the already added resources.

A common `filteredMatchingFinder` func is used.