### PR TITLE
Add AWS_RKE2 setup deletion

### DIFF
--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -38,7 +38,7 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  KUBECONFIG_NAME: 'kubeconfig-epinio-ci'
+  KUBECONFIG: ${{ github.workspace }}/kubeconfig-epinio-ci
   AKS_RESOURCE_GROUP: ${{ secrets.AKS_RESOURCE_GROUP }}
   AKS_MACHINE_TYPE: 'Standard_D3_v2'
 
@@ -140,7 +140,7 @@ jobs:
 
           az aks get-credentials --resource-group ${{ env.AKS_RESOURCE_GROUP }} \
           --name ${{ env.AKS_RESOURCE_GROUP }}$id \
-          --file ${{ env.KUBECONFIG_NAME }}
+          --file ${{ env.KUBECONFIG }}
 
           # List existing clusters
           az aks list | jq '.[] | .name + " " + (.powerState|tostring)'
@@ -161,7 +161,7 @@ jobs:
         shell: bash
         run: |
           echo "System Domain: $AKS_DOMAIN"
-          export KUBECONFIG=$PWD/${{ env.KUBECONFIG_NAME }}
+          export KUBECONFIG=${{ env.KUBECONFIG }}
           make test-acceptance-install
 
       - name: Delete AKS cluster
@@ -175,5 +175,5 @@ jobs:
           export AWS_ZONE_ID=${{ secrets.AWS_ZONE_ID }}
           export AKS_DOMAIN=${{ secrets.AKS_DOMAIN }}
           export AKS_RESOURCE_GROUP=${{ env.AKS_RESOURCE_GROUP }}
-          export KUBECONFIG_NAME=${{ env.KUBECONFIG_NAME }}
+          export KUBECONFIG=${{ env.KUBECONFIG }}
           go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -38,7 +38,7 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  KUBECONFIG_NAME: 'kubeconfig-epinio-ci'
+  KUBECONFIG: ${{ github.workspace }}/kubeconfig-epinio-ci
   AKS_RESOURCE_GROUP: ${{ secrets.AKS_RESOURCE_GROUP }}
   AKS_MACHINE_TYPE: 'Standard_D3_v2'
 
@@ -140,7 +140,7 @@ jobs:
 
           az aks get-credentials --resource-group ${{ env.AKS_RESOURCE_GROUP }} \
           --name ${{ env.AKS_RESOURCE_GROUP }}$id \
-          --file ${{ env.KUBECONFIG_NAME }}
+          --file ${{ env.KUBECONFIG }}
 
           # List existing clusters
           az aks list | jq '.[] | .name + " " + (.powerState|tostring)'
@@ -161,7 +161,7 @@ jobs:
         shell: bash
         run: |
           echo "System Domain: $AKS_DOMAIN"
-          export KUBECONFIG=$PWD/${{ env.KUBECONFIG_NAME }}
+          export KUBECONFIG=${{ env.KUBECONFIG }}
           make test-acceptance-install
 
       - name: Delete AKS cluster
@@ -175,5 +175,5 @@ jobs:
           export AWS_ZONE_ID=${{ secrets.AWS_ZONE_ID }}
           export AKS_DOMAIN=${{ secrets.AKS_DOMAIN }}
           export AKS_RESOURCE_GROUP=${{ env.AKS_RESOURCE_GROUP }}
-          export KUBECONFIG_NAME=${{ env.KUBECONFIG_NAME }}
+          export KUBECONFIG=${{ env.KUBECONFIG }}
           go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/delete_clusters.yml
+++ b/.github/workflows/delete_clusters.yml
@@ -34,10 +34,12 @@ on:
         - AKS
         - EKS
         - GKE
+        - AWS_RKE2
 
 env:
   SETUP_GO_VERSION: '1.19.8'
   EKS_REGION: ${{ secrets.EKS_REGION }}
+  KUBECONFIG: ${{ github.workspace }}/kubeconfig-epinio-ci
 
 jobs:
   delete-ci-acceptance-test-cluster:
@@ -112,5 +114,9 @@ jobs:
           export GKE_DOMAIN=${{ secrets.GKE_DOMAIN }}
           export GKE_ZONE=${{ secrets.GKE_ZONE }}
           export EPCI_GKE_PROJECT=${{ secrets.EPCI_GKE_PROJECT }}
-          export KUBECONFIG_NAME="kubeconfig-epinio-ci"
+          export AWS_RKE2_DOMAIN=${{ secrets.AWS_RKE2_DOMAIN }}
+          export AWS_RKE2_SSH_KEY=${{ secrets.AWS_RKE2_SSH_KEY }}
+          export KUBECONFIG=${{ env.KUBECONFIG }}
+          # in standalone mode we need to fetch the kubeconfig
+          export FETCH_KUBECONFIG='true'
           go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -38,7 +38,7 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  KUBECONFIG_NAME: 'kubeconfig-epinio-ci'
+  KUBECONFIG: ${{ github.workspace }}/kubeconfig-epinio-ci
   EKS_REGION: ${{ secrets.EKS_REGION }}
   AWS_MACHINE_TYPE: 't3.xlarge'
 
@@ -136,7 +136,7 @@ jobs:
           --node-type=${{ env.AWS_MACHINE_TYPE }} \
           --node-volume-size=40 \
           --managed \
-          --kubeconfig=kubeconfig-epinio-ci
+          --kubeconfig=${{ env.KUBECONFIG }}
 
       - name: Configure EKS EBS CSI storage
         id: configure-storage
@@ -177,20 +177,18 @@ jobs:
           # EXTRAENV_VALUE: 12345
         run: |
           echo "System Domain: $AWS_DOMAIN"
-          export KUBECONFIG=$PWD/${{ env.KUBECONFIG_NAME }}
+          export KUBECONFIG=${{ env.KUBECONFIG }}
           make test-acceptance-install
 
       - name: Delete EKS cluster
         # We always tear down the cluster, to avoid costs. Except when running
         # manually and keep_cluster was set to "Keep"
         if: ${{ always() && github.event.inputs.keep_cluster != 'Keep' }}
-        env:
-          KUBECONFIG: ${{ env.KUBECONFIG_NAME }}
         run: |
           export RUN_ID=${{ steps.create-cluster.outputs.ID }}
           export RUN_PCP="EKS"
           export AWS_ZONE_ID=${{ secrets.AWS_ZONE_ID }}
           export EKS_DOMAIN=${{ secrets.EKS_DOMAIN }}
           export EKS_REGION=${{ env.EKS_REGION }}
-          export KUBECONFIG_NAME=${{ env.KUBECONFIG_NAME }}
+          export KUBECONFIG=${{ env.KUBECONFIG }}
           go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/gke-letsencrypt.yml
+++ b/.github/workflows/gke-letsencrypt.yml
@@ -38,7 +38,6 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  KUBECONFIG_NAME: 'kubeconfig-epinio-ci' # Needed for delete_clusters.go
   KUBECONFIG: ${{ github.workspace }}/kubeconfig-epinio-ci
   GKE_ZONE: ${{ secrets.GKE_ZONE }}
   GKE_MACHINE_TYPE: 'n2-standard-4'
@@ -179,4 +178,5 @@ jobs:
           export GKE_DOMAIN=${{ secrets.GKE_DOMAIN }}
           export GKE_ZONE=${{ secrets.GKE_ZONE }}
           export EPCI_GKE_PROJECT=${{ secrets.EPCI_GKE_PROJECT }}
+          export KUBECONFIG=${{ env.KUBECONFIG }}
           go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/gke-upgrade.yml
+++ b/.github/workflows/gke-upgrade.yml
@@ -39,7 +39,6 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  KUBECONFIG_NAME: 'kubeconfig-epinio-ci' # Needed for delete_clusters.go
   KUBECONFIG: ${{ github.workspace }}/kubeconfig-epinio-ci
   GKE_ZONE: ${{ secrets.GKE_ZONE }}
   GKE_MACHINE_TYPE: 'n2-standard-4'
@@ -193,4 +192,5 @@ jobs:
           export GKE_DOMAIN=${{ secrets.GKE_DOMAIN }}
           export GKE_ZONE=${{ secrets.GKE_ZONE }}
           export EPCI_GKE_PROJECT=${{ secrets.EPCI_GKE_PROJECT }}
+          export KUBECONFIG=${{ env.KUBECONFIG }}
           go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -38,7 +38,6 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  KUBECONFIG_NAME: 'kubeconfig-epinio-ci' # Needed for delete_clusters.go
   KUBECONFIG: ${{ github.workspace }}/kubeconfig-epinio-ci
   GKE_ZONE: ${{ secrets.GKE_ZONE }}
   GKE_MACHINE_TYPE: 'n2-standard-4'
@@ -179,4 +178,5 @@ jobs:
           export GKE_DOMAIN=${{ secrets.GKE_DOMAIN }}
           export GKE_ZONE=${{ secrets.GKE_ZONE }}
           export EPCI_GKE_PROJECT=${{ secrets.EPCI_GKE_PROJECT }}
+          export KUBECONFIG=${{ env.KUBECONFIG }}
           go run acceptance/helpers/delete_clusters/delete_clusters.go

--- a/.github/workflows/rke2-lh-ec2.yml
+++ b/.github/workflows/rke2-lh-ec2.yml
@@ -25,9 +25,13 @@ on:
   workflow_dispatch:
     inputs:
       keep_cluster:
-        description: "Keep the cluster afterwards? (empty/yes)"
-        required: false
-        default: ""
+        type: choice
+        description: "Keep the cluster afterwards?"
+        required: true
+        default: 'Delete'
+        options:
+        - Delete
+        - Keep
 
 env:
   SETUP_GO_VERSION: '1.19.8'
@@ -35,8 +39,7 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  AWS_REGION: eu-central-1
-  KUBECONFIG: ${{ github.workspace }}/rke2-ec2-kubeconfig.yaml
+  KUBECONFIG: ${{ github.workspace }}/kubeconfig-epinio-ci
 
 jobs:
   linter:
@@ -141,7 +144,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.EKS_REGION }}
 
       - name: Provision EC2 instances
         id: provision-ec2-instances
@@ -149,7 +152,9 @@ jobs:
           # Provision nodes by awscli
           id=$RANDOM
           echo "ID=$id" >> $GITHUB_OUTPUT
+          echo "RUN_ID: $id"
           echo 'Provisioning EC2 instances...'
+          # TODO: workflow and delete_clusters.go to support multiple EC2 instances/nodes
           INSTANCES_COUNT=1
           EC2_INSTANCE_IDS=$(aws ec2 run-instances \
             --launch-template='LaunchTemplateName=epinio-ci-sle15sp4-chost-template' \
@@ -218,7 +223,7 @@ jobs:
 
           # Write rke2 ec2 kubeconfig into runner workdir and configure the server endpoint
           kubeconfig=$(ssh_run_server "cat /etc/rancher/rke2/rke2.yaml")
-          echo "$kubeconfig" > rke2-ec2-kubeconfig.yaml
+          echo "$kubeconfig" > ${{ env.KUBECONFIG }}
           kubectl config set-cluster default --server=https://"$server_node":6443 2>/dev/null
 
           # TODO a new step for adding RKE2 agents to the cluster according to INSTANCES_COUNT
@@ -258,12 +263,17 @@ jobs:
         run: make test-acceptance-install
 
       - name: Delete EC2 instances and ELB
-        if: ${{ always() && !github.event.inputs.keep_cluster }}
-        env:
-          EC2_INSTANCE_IDS: ${{ steps.provision-ec2-instances.outputs.EC2_INSTANCE_IDS }}
+        # TODO: workflow and delete_clusters.go to support multiple EC2 instances/nodes 
+        if: ${{ always() && github.event.inputs.keep_cluster != 'Keep' }}
+        shell: bash
         run: |
-          helm delete nginx-ingress -n ingress-nginx --wait
-          aws ec2 terminate-instances --instance-ids $EC2_INSTANCE_IDS
+          export RUN_ID=${{ steps.create-cluster.outputs.ID }}
+          export RUN_PCP="AWS_RKE2"
+          export AWS_ZONE_ID=${{ secrets.AWS_ZONE_ID }}
+          export AWS_RKE2_DOMAIN=${{ secrets.AWS_RKE2_DOMAIN }}
+          export AWS_RKE2_SSH_KEY=${{ secrets.AWS_RKE2_SSH_KEY }}
+          export KUBECONFIG=${{ env.KUBECONFIG }}
+          go run acceptance/helpers/delete_clusters/delete_clusters.go
 
       # Only on RKE, as it uses a self-hosted runner
       - name: Clean all


### PR DESCRIPTION
Add AWS_RKE2 setup deletion and streamline kubeconfig handling
- always use `KUBECONFIG: ${{ github.workspace }}/kubeconfig-epinio-ci` over all workflows with external cluster resources
- delete-clusters.go only to fetch the kubeconfig when needed (standalone after keep cluster)
- delete-clusters.go to support AWS-RKE2 (EC2) deletion for rke2-lh-ec2.yml
- adjusted rke2-lh-ec2.yml to common dispatch input and make it use delete-clusters.go
+ fix typos in general