### PR TITLE
Fix workflows and delete clusters to read ssh-key from file

### DIFF
--- a/.github/workflows/delete_clusters.yml
+++ b/.github/workflows/delete_clusters.yml
@@ -100,6 +100,16 @@ jobs:
         if: ${{ github.event.inputs.pcp == 'GKE' }}
         run: gcloud components install kubectl
 
+      # Save EC2 user ssh-key for the AWS_RKE2 case
+      - name: Store ssh-key for EC2 user
+        if: ${{ github.event.inputs.pcp == 'AWS_RKE2' }}
+        env:
+          AWS_RKE2_SSH_KEY: ${{ secrets.AWS_RKE2_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "${AWS_RKE2_SSH_KEY}" > ~/.ssh/id_rsa_ec2.pem
+          chmod 600 ~/.ssh/id_rsa_ec2.pem
+
       # Delete PVCs, DNS records and Public Cloud Providers cluster
       - name: Delete PCP Clusters and Resources
         shell: bash
@@ -115,7 +125,6 @@ jobs:
           export GKE_ZONE=${{ secrets.GKE_ZONE }}
           export EPCI_GKE_PROJECT=${{ secrets.EPCI_GKE_PROJECT }}
           export AWS_RKE2_DOMAIN=${{ secrets.AWS_RKE2_DOMAIN }}
-          export AWS_RKE2_SSH_KEY=${{ secrets.AWS_RKE2_SSH_KEY }}
           export KUBECONFIG=${{ env.KUBECONFIG }}
           # in standalone mode we need to fetch the kubeconfig
           export FETCH_KUBECONFIG='true'

--- a/.github/workflows/rke2-lh-ec2.yml
+++ b/.github/workflows/rke2-lh-ec2.yml
@@ -271,7 +271,6 @@ jobs:
           export RUN_PCP="AWS_RKE2"
           export AWS_ZONE_ID=${{ secrets.AWS_ZONE_ID }}
           export AWS_RKE2_DOMAIN=${{ secrets.AWS_RKE2_DOMAIN }}
-          export AWS_RKE2_SSH_KEY=${{ secrets.AWS_RKE2_SSH_KEY }}
           export KUBECONFIG=${{ env.KUBECONFIG }}
           go run acceptance/helpers/delete_clusters/delete_clusters.go
 

--- a/.github/workflows/rke2-lh-ec2.yml
+++ b/.github/workflows/rke2-lh-ec2.yml
@@ -267,7 +267,7 @@ jobs:
         if: ${{ always() && github.event.inputs.keep_cluster != 'Keep' }}
         shell: bash
         run: |
-          export RUN_ID=${{ steps.create-cluster.outputs.ID }}
+          export RUN_ID=${{ steps.provision-ec2-instances.outputs.ID }}
           export RUN_PCP="AWS_RKE2"
           export AWS_ZONE_ID=${{ secrets.AWS_ZONE_ID }}
           export AWS_RKE2_DOMAIN=${{ secrets.AWS_RKE2_DOMAIN }}

--- a/acceptance/helpers/delete_clusters/delete_clusters.go
+++ b/acceptance/helpers/delete_clusters/delete_clusters.go
@@ -388,11 +388,6 @@ func GetKubeconfigGKE(runID string) error {
 
 func GetKubeconfigAWS_RKE2(runID string) error {
 	kubeconfig := os.Getenv("KUBECONFIG")
-	aws_rke2_ssh_key := []byte(os.Getenv("AWS_RKE2_SSH_KEY"))
-	err := os.WriteFile("id_rsa_ec2.pem", aws_rke2_ssh_key, 0600)
-	if err != nil {
-		return errors.Wrap(err, "Failed to create id_rsa_ec2.pem")
-	}
 
 	out, err := proc.RunW("aws", "ec2", "describe-instances", "--filters", fmt.Sprintf("Name=tag:Name,Values='epinio-rke2-ci%s'", runID), "--query", "Reservations[*].Instances[*].PublicDnsName", "--output", "text")
 	if err != nil {
@@ -400,7 +395,7 @@ func GetKubeconfigAWS_RKE2(runID string) error {
 	}
 
 	server_hostname := strings.TrimSpace(out)
-	server_config, err := proc.RunW("ssh", "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", "-o", "LogLevel=error", "-o", "ConnectTimeout=30", "-o", "User=ec2-user", "-i", "id_rsa_ec2.pem", server_hostname, "cat /etc/rancher/rke2/rke2.yaml")
+	server_config, err := proc.RunW("ssh", "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", "-o", "LogLevel=error", "-o", "ConnectTimeout=30", "-o", "User=ec2-user", "-i", "~/.ssh/id_rsa_ec2.pem", server_hostname, "cat /etc/rancher/rke2/rke2.yaml")
 	if err != nil {
 		return errors.Wrap(err, "Failed to get /etc/rancher/rke2/rke2.yaml "+server_config)
 	}


### PR DESCRIPTION
Currently cluster deletion for AWS_RKE2 (rke2-lh-ec2.yml) fails - as well as any dispatch deletion via delete_clusters.yml would - because you can't just use a multiline secret in github env.
Therfore I changed the code to always write the ssh-key to ~/.ssh/, and delete_clusters.go will read it from there.