### PR TITLE
Fix "KUBECONFIG" env var quoting for AKS*-CI (Windows)

### DIFF
--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -38,9 +38,10 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  KUBECONFIG: ${{ github.workspace }}/kubeconfig-epinio-ci
   AKS_RESOURCE_GROUP: ${{ secrets.AKS_RESOURCE_GROUP }}
   AKS_MACHINE_TYPE: 'Standard_D3_v2'
+  # On Windows, github workspace path contains backslashes, we need to have the right quoting for bash export
+  KUBECONFIG: "'${{ github.workspace }}\\kubeconfig-epinio-ci'"
 
 jobs:
   linter:

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -38,9 +38,10 @@ env:
   GINKGO_NODES: 1
   FLAKE_ATTEMPTS: 1
   PUBLIC_CLOUD: 1
-  KUBECONFIG: ${{ github.workspace }}/kubeconfig-epinio-ci
   AKS_RESOURCE_GROUP: ${{ secrets.AKS_RESOURCE_GROUP }}
   AKS_MACHINE_TYPE: 'Standard_D3_v2'
+  # On Windows, github workspace path contains backslashes, we need to have the right quoting for bash export
+  KUBECONFIG: "'${{ github.workspace }}\\kubeconfig-epinio-ci'"
 
 jobs:
   linter:


### PR DESCRIPTION
Fix env var quoting and escaping for windows runners within AKS* workflows.