### PR TITLE
Fixed Docker rate limiting

### DIFF
--- a/.github/workflows/aks-letsencrypt.yml
+++ b/.github/workflows/aks-letsencrypt.yml
@@ -149,8 +149,8 @@ jobs:
       - name: Installation Acceptance Tests
         env:
           REGEX: Scenario5
-          REGISTRY_USERNAME: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
+          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           AWS_ZONE_ID: ${{ secrets.AWS_ZONE_ID }}
           # Use a random host name, so we don't collide with our workflows on AKS
           AKS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ secrets.AKS_DOMAIN }}

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -149,8 +149,8 @@ jobs:
       - name: Installation Acceptance Tests
         env:
           REGEX: Scenario6
-          REGISTRY_USERNAME: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
+          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           AWS_ZONE_ID: ${{ secrets.AWS_ZONE_ID }}
           # Use a random host name, so we don't collide with our workflows on AKS
           AKS_DOMAIN: id${{ steps.create-cluster.outputs.ID }}-${{ secrets.AKS_DOMAIN }}

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release-qa.yml
+++ b/.github/workflows/release-qa.yml
@@ -46,18 +46,17 @@ jobs:
           cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-
-      # Login to avoid quota
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.JUADK_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.JUADK_DOCKERHUB_PASSWORD }}
 
       - uses: anchore/sbom-action/download-syft@v0.13.4
 

--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -47,18 +47,17 @@ jobs:
           cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
-      # Login to avoid quota
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
 
       - uses: anchore/sbom-action/download-syft@v0.13.4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,18 +47,18 @@ jobs:
           cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Login to GitHub Docker Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - uses: anchore/sbom-action/download-syft@v0.13.4
 

--- a/.github/workflows/rke-upgrade.yml
+++ b/.github/workflows/rke-upgrade.yml
@@ -154,8 +154,8 @@ jobs:
           REGEX: "Scenario3"
           PUBLIC_CLOUD: 1
           KUBECONFIG: rke2.yaml
-          REGISTRY_USERNAME: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
+          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           INGRESS_CONTROLLER: traefik
           # EXTRAENV_NAME: SESSION_KEY
           # EXTRAENV_VALUE: 12345

--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -142,8 +142,8 @@ jobs:
           REGEX: Scenario3
           PUBLIC_CLOUD: 1
           KUBECONFIG: /etc/rancher/rke2/rke2.yaml
-          REGISTRY_USERNAME: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
+          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           INGRESS_CONTROLLER: traefik
           # EXTRAENV_NAME: SESSION_KEY
           # EXTRAENV_VALUE: 12345

--- a/.github/workflows/unpacker-image.yml
+++ b/.github/workflows/unpacker-image.yml
@@ -21,18 +21,18 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Login to GitHub Docker Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Build and push unpacker
         uses: docker/build-push-action@v4


### PR DESCRIPTION
Some of our workflows are hitting the Docker rate limits because the authentication is done in later steps.

Moved docker login before docker setup, and also unified docker login credentials.