### PR TITLE
Fix CI application-cli-apps stuckup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,6 @@ VERSION ?= $(shell git describe --tags)$(VSUFFIX)
 CGO_ENABLED ?= 0
 export LDFLAGS += -X github.com/epinio/epinio/internal/version.Version=$(VERSION)
 
-FAIL_PENDING = --fail-on-pending
-#FAIL_PENDING =
-
 build: build-amd64
 
 # amd64 variant
@@ -87,7 +84,7 @@ compress:
 	upx --brute -1 ./dist/epinio-darwin-arm64
 
 test:
-	ginkgo --nodes ${GINKGO_NODES} -r -p --cover -race ${FAIL_PENDING} --skip-file=acceptance
+	ginkgo --nodes ${GINKGO_NODES} -r -p --cover -race --fail-on-pending --skip-file=acceptance
 
 tag:
 	@git describe --tags --abbrev=0
@@ -99,7 +96,7 @@ FLAKE_ATTEMPTS ?= 2
 GINKGO_NODES ?= 2
 GINKGO_POLL_PROGRESS_AFTER ?= 200s
 REGEX ?= ""
-STANDARD_TEST_OPTIONS= -v --nodes ${GINKGO_NODES} --poll-progress-after ${GINKGO_POLL_PROGRESS_AFTER} --randomize-all --flake-attempts=${FLAKE_ATTEMPTS} ${FAIL_PENDING}
+STANDARD_TEST_OPTIONS= -v --nodes ${GINKGO_NODES} --poll-progress-after ${GINKGO_POLL_PROGRESS_AFTER} --randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending
 
 acceptance-cluster-delete:
 	k3d cluster delete epinio-acceptance

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ VERSION ?= $(shell git describe --tags)$(VSUFFIX)
 CGO_ENABLED ?= 0
 export LDFLAGS += -X github.com/epinio/epinio/internal/version.Version=$(VERSION)
 
+FAIL_PENDING = --fail-on-pending
+#FAIL_PENDING =
+
 build: build-amd64
 
 # amd64 variant
@@ -84,7 +87,7 @@ compress:
 	upx --brute -1 ./dist/epinio-darwin-arm64
 
 test:
-	ginkgo --nodes ${GINKGO_NODES} -r -p --cover -race --fail-on-pending --skip-file=acceptance
+	ginkgo --nodes ${GINKGO_NODES} -r -p --cover -race ${FAIL_PENDING} --skip-file=acceptance
 
 tag:
 	@git describe --tags --abbrev=0
@@ -96,7 +99,7 @@ FLAKE_ATTEMPTS ?= 2
 GINKGO_NODES ?= 2
 GINKGO_POLL_PROGRESS_AFTER ?= 200s
 REGEX ?= ""
-STANDARD_TEST_OPTIONS= -v --nodes ${GINKGO_NODES} --poll-progress-after ${GINKGO_POLL_PROGRESS_AFTER} --randomize-all --flake-attempts=${FLAKE_ATTEMPTS} --fail-on-pending
+STANDARD_TEST_OPTIONS= -v --nodes ${GINKGO_NODES} --poll-progress-after ${GINKGO_POLL_PROGRESS_AFTER} --randomize-all --flake-attempts=${FLAKE_ATTEMPTS} ${FAIL_PENDING}
 
 acceptance-cluster-delete:
 	k3d cluster delete epinio-acceptance

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -1736,18 +1736,21 @@ userConfig:
 			logLength = len(logs)
 
 			By("----------------------------------")
-			By(fmt.Sprintf("LOGS = %d lines", logLength))
+			By(fmt.Sprintf("LOGS = %d lines (raw)", logLength))
 
 			for idx, line := range logs {
+				// Exclude fake log lines caused by coverage collection.
+				if (line == "PASS") || strings.Contains(line, "coverage") {
+					logLength--
+					continue
+				}
 				By(fmt.Sprintf("LOG_ [%3d]: %s", idx, line))
 			}
 			By("----------------------------------")
+			By(fmt.Sprintf("LOGS = %d lines (filtered)", logLength))
 
-			// Skip correction dependent on coverage vs not.
+			// Skip correction (coverage, if present, is already accounted for, see above)
 			logLength = logLength - 1
-			if _, ok := os.LookupEnv("EPINIO_COVERAGE"); ok {
-				logLength = logLength - 2
-			}
 			By(fmt.Sprintf("SKIP %d lines", logLength))
 		})
 


### PR DESCRIPTION
The `follow logs` test got stuck up due to a higher amount of coverage lines appearing in the log output and then hanging the skip section trying to skip over non-existing actual log lines.

Fixed by dynamically filtering out the coverage related lines when computing the number of lines to skip.
