### PR TITLE
Fix mishandling of --all when no resources are found/available.

### DIFF
--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -490,6 +490,10 @@ func (c *EpinioClient) Delete(ctx context.Context, appNames []string, all bool) 
 		if err != nil {
 			return err
 		}
+		if len(match.Names) == 0 {
+			c.ui.Exclamation().Msg("No applications found to delete")
+			return nil
+		}
 
 		appNames = match.Names
 		sort.Strings(appNames)

--- a/internal/cli/usercmd/configuration.go
+++ b/internal/cli/usercmd/configuration.go
@@ -223,6 +223,10 @@ func (c *EpinioClient) DeleteConfiguration(names []string, unbind, all bool) err
 		if err != nil {
 			return err
 		}
+		if len(match.Names) == 0 {
+			c.ui.Exclamation().Msg("No configurations found to delete")
+			return nil
+		}
 
 		names = match.Names
 		sort.Strings(names)

--- a/internal/cli/usercmd/namespace.go
+++ b/internal/cli/usercmd/namespace.go
@@ -169,6 +169,10 @@ func (c *EpinioClient) DeleteNamespace(namespaces []string, force, all bool) err
 		if err != nil {
 			return err
 		}
+		if len(match.Names) == 0 {
+			c.ui.Exclamation().Msg("No namespaces found to delete")
+			return nil
+		}
 
 		namespaces = match.Names
 		sort.Strings(namespaces)

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -169,6 +169,10 @@ func (c *EpinioClient) ServiceDelete(serviceNames []string, unbind, all bool) er
 		if err != nil {
 			return err
 		}
+		if len(match.Names) == 0 {
+			c.ui.Exclamation().Msg("No services found to delete")
+			return nil
+		}
 
 		serviceNames = match.Names
 		sort.Strings(serviceNames)


### PR DESCRIPTION
Properly exist with sensible message.

note: testing this new code path is as difficult as testing --all in general, due to the concurrent executon of multiple tests cases. We generally will not have "no resources".
result: no new tests for this