### PR TITLE
fixed transfer of bad namespace information on login (to new cluster)

### DIFF
--- a/acceptance/helpers_test.go
+++ b/acceptance/helpers_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func ExpectGoodUserLogin(tmpSettingsPath, password, serverURL string) {
+func ExpectGoodUserLogin(tmpSettingsPath, password, serverURL string) string {
 	By("Regular login")
 	out, err := env.Epinio("", "login", "-u", "epinio", "-p", password,
 		"--trust-ca", "--settings-file", tmpSettingsPath, serverURL)
@@ -34,6 +34,8 @@ func ExpectGoodUserLogin(tmpSettingsPath, password, serverURL string) {
 	Expect(out).To(ContainSubstring(`Trusting certificate`))
 	Expect(out).To(ContainSubstring(`Login successful`))
 	By("Regular login done")
+
+	return out
 }
 
 func ExpectGoodTokenLogin(tmpSettingsPath, serverURL string) {
@@ -119,6 +121,19 @@ func ExpectEmptySettings(tmpSettingsPath string) {
 			WithRow("API Password", ""),
 			WithRow("API Token", ""),
 			WithRow("Certificates", "None defined"),
+		),
+	)
+}
+
+func ExpectNamespace(tmpSettingsPath, namespace string) {
+	By("Check for namespace `" + namespace + "`")
+	// check that the namespace is not set
+	settings, err := env.Epinio("", "settings", "show", "--settings-file", tmpSettingsPath)
+	Expect(err).ToNot(HaveOccurred(), settings)
+	Expect(settings).To(
+		HaveATable(
+			WithHeaders("KEY", "VALUE"),
+			WithRow("Current Namespace", namespace),
 		),
 	)
 }

--- a/acceptance/login_test.go
+++ b/acceptance/login_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Login", LMisc, func() {
 		// login with a valid user
 		out := ExpectGoodUserLogin(tmpSettingsPath, env.EpinioPassword, serverURL)
 
-		Expect(out).To(ContainSubstring("Current namespace 'bogus' invalid for targeted cluster"))
+		Expect(out).To(ContainSubstring("Current namespace 'bogus' not found in targeted cluster"))
 		Expect(out).To(ContainSubstring("Cleared current namespace"))
 		Expect(out).To(ContainSubstring("Please use `epinio target` to chose a new current namespace"))
 

--- a/internal/cli/usercmd/login.go
+++ b/internal/cli/usercmd/login.go
@@ -73,8 +73,28 @@ func (c *EpinioClient) Login(ctx context.Context, username, password, address st
 
 	c.ui.Success().Msg("Login successful")
 
+	// Verify that the targeted namespace (if any) exists in the targeted cluster.
+	// If not report the issue, clear the information, and ask the user to chose a proper namespace.
+
+	if updatedSettings.Namespace != "" {
+		// we don't need anything, just checking if the namespace exist and we have permissions
+		_, err := c.API.NamespaceShow(updatedSettings.Namespace)
+		if err != nil {
+			c.ui.Exclamation().Msgf("Current namespace '%s' invalid for targeted cluster",
+				updatedSettings.Namespace)
+
+			updatedSettings.Namespace = ""
+
+			c.ui.Exclamation().Msg("Cleared current namespace")
+			c.ui.Exclamation().Msg("Please use `epinio target` to chose a new current namespace")
+		}
+	}
+
 	err = updatedSettings.Save()
-	return errors.Wrap(err, "error saving new settings")
+	if err != nil {
+		return errors.Wrap(err, "error saving new settings")
+	}
+	return nil
 }
 
 func askUsername(ui *termui.UI) (string, error) {

--- a/internal/cli/usercmd/login.go
+++ b/internal/cli/usercmd/login.go
@@ -80,7 +80,7 @@ func (c *EpinioClient) Login(ctx context.Context, username, password, address st
 		// we don't need anything, just checking if the namespace exist and we have permissions
 		_, err := c.API.NamespaceShow(updatedSettings.Namespace)
 		if err != nil {
-			c.ui.Exclamation().Msgf("Current namespace '%s' invalid for targeted cluster",
+			c.ui.Exclamation().Msgf("Current namespace '%s' not found in targeted cluster",
 				updatedSettings.Namespace)
 
 			updatedSettings.Namespace = ""


### PR DESCRIPTION
fix #2299 

I went with the last option: check validity, clear data if not, and report the issue in that case too
(all other options do not really fit into the scope of 1.8.1 to come)

