### PR TITLE
Moved test coverage upload at the end of tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -625,4 +625,5 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           name: codecov-epinio
+          files: ./acceptance-api/coverprofile.out,./acceptance-cli/coverprofile.out
           verbose: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -592,8 +592,10 @@ jobs:
 
   upload-coverage:
     needs:
-      - acceptance-api-services
-      - acceptance-cli-services
+      - acceptance-api
+      - acceptance-api-apps
+      - acceptance-apps
+      - acceptance-cli-apps
 
     runs-on: [self-hosted, epinio]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,163 +65,161 @@ jobs:
 
       - name: Unit Tests
         run: make test
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+      
+      - uses: actions/upload-artifact@v2
         with:
-          files: ./coverprofile.out
-          flags: unittests
-          name: codecov-epinio
-          verbose: true
+          name: unittests
+          path: ./coverprofile.out
 
-  acceptance-cli:
-    needs:
-      - linter
-    runs-on: [self-hosted, epinio]
+  # acceptance-cli:
+  #   needs:
+  #     - linter
+  #   runs-on: [self-hosted, epinio]
 
-    env:
-      EPINIO_COVERAGE: true
+  #   env:
+  #     EPINIO_COVERAGE: true
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: recursive
+  #         fetch-depth: 0
 
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        timeout-minutes: 5
-        with:
-          cache: false
-          go-version: ${{ env.SETUP_GO_VERSION }}
+  #     - name: Setup Go
+  #       uses: actions/setup-go@v4
+  #       timeout-minutes: 5
+  #       with:
+  #         cache: false
+  #         go-version: ${{ env.SETUP_GO_VERSION }}
 
-      - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+  #     - name: Setup Ginkgo Test Framework
+  #       run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
 
-      - name: Cache Tools
-        uses: actions/cache@v3
-        with:
-          path: ${{ github.workspace }}/tools
-          key: ${{ runner.os }}-tools
+  #     - name: Cache Tools
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: ${{ github.workspace }}/tools
+  #         key: ${{ runner.os }}-tools
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Install Tools
-        run: make tools-install
+  #     - name: Install Tools
+  #       run: make tools-install
 
-      - name: Add Tools to PATH
-        run: |
-          echo "`pwd`/output/bin" >> $GITHUB_PATH
+  #     - name: Add Tools to PATH
+  #       run: |
+  #         echo "`pwd`/output/bin" >> $GITHUB_PATH
 
-      - name: CLI Acceptance Tests
-        env:
-          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-          EPINIO_TIMEOUT_MULTIPLIER: 3
-        run: |
-          rm -f /tmp/cover*
-          make acceptance-cluster-setup
-          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
-          make install-cert-manager
-          make prepare_environment_k3d
-          make test-acceptance-cli-other
-          scripts/collect-coverage.sh
+  #     - name: CLI Acceptance Tests
+  #       env:
+  #         REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+  #         EPINIO_TIMEOUT_MULTIPLIER: 3
+  #       run: |
+  #         rm -f /tmp/cover*
+  #         make acceptance-cluster-setup
+  #         export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+  #         make install-cert-manager
+  #         make prepare_environment_k3d
+  #         make test-acceptance-cli-other
+  #         scripts/collect-coverage.sh
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: ./coverprofile.out
-          flags: acceptance-cli
-          name: codecov-epinio
-          verbose: true
+  #     - name: Upload coverage to Codecov
+  #       uses: codecov/codecov-action@v3
+  #       with:
+  #         files: ./coverprofile.out
+  #         flags: acceptance-cli
+  #         name: codecov-epinio
+  #         verbose: true
 
-      - name: Cleanup k3d cluster
-        if: always()
-        run: make acceptance-cluster-delete
+  #     - name: Cleanup k3d cluster
+  #       if: always()
+  #       run: make acceptance-cluster-delete
 
-      - name: Clean all
-        if: always()
-        uses: colpal/actions-clean@v1
+  #     - name: Clean all
+  #       if: always()
+  #       uses: colpal/actions-clean@v1
 
-  acceptance-cli-apps:
-    needs:
-      - linter
-    runs-on: [self-hosted, epinio]
+  # acceptance-cli-apps:
+  #   needs:
+  #     - linter
+  #   runs-on: [self-hosted, epinio]
 
-    env:
-      EPINIO_COVERAGE: true
+  #   env:
+  #     EPINIO_COVERAGE: true
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: recursive
+  #         fetch-depth: 0
 
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        timeout-minutes: 5
-        with:
-          cache: false
-          go-version: ${{ env.SETUP_GO_VERSION }}
+  #     - name: Setup Go
+  #       uses: actions/setup-go@v4
+  #       timeout-minutes: 5
+  #       with:
+  #         cache: false
+  #         go-version: ${{ env.SETUP_GO_VERSION }}
 
-      - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+  #     - name: Setup Ginkgo Test Framework
+  #       run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
 
-      - name: Cache Tools
-        uses: actions/cache@v3
-        with:
-          path: ${{ github.workspace }}/tools
-          key: ${{ runner.os }}-tools
+  #     - name: Cache Tools
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: ${{ github.workspace }}/tools
+  #         key: ${{ runner.os }}-tools
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Install Tools
-        run: make tools-install
+  #     - name: Install Tools
+  #       run: make tools-install
 
-      - name: Add Tools to PATH
-        run: |
-          echo "`pwd`/output/bin" >> $GITHUB_PATH
+  #     - name: Add Tools to PATH
+  #       run: |
+  #         echo "`pwd`/output/bin" >> $GITHUB_PATH
 
-      - name: CLI Acceptance Tests
-        env:
-          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-          EPINIO_TIMEOUT_MULTIPLIER: 3
-        run: |
-          rm -f /tmp/cover*
-          make acceptance-cluster-setup
-          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
-          make install-cert-manager
-          make prepare_environment_k3d
-          make test-acceptance-cli-apps
-          scripts/collect-coverage.sh
+  #     - name: CLI Acceptance Tests
+  #       env:
+  #         REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+  #         EPINIO_TIMEOUT_MULTIPLIER: 3
+  #       run: |
+  #         rm -f /tmp/cover*
+  #         make acceptance-cluster-setup
+  #         export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+  #         make install-cert-manager
+  #         make prepare_environment_k3d
+  #         make test-acceptance-cli-apps
+  #         scripts/collect-coverage.sh
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: ./coverprofile.out
-          flags: acceptance-cli
-          name: codecov-epinio
-          verbose: true
+  #     - name: Upload coverage to Codecov
+  #       uses: codecov/codecov-action@v3
+  #       with:
+  #         files: ./coverprofile.out
+  #         flags: acceptance-cli
+  #         name: codecov-epinio
+  #         verbose: true
 
-      - name: Cleanup k3d cluster
-        if: always()
-        run: make acceptance-cluster-delete
+  #     - name: Cleanup k3d cluster
+  #       if: always()
+  #       run: make acceptance-cluster-delete
 
-      - name: Clean all
-        if: always()
-        uses: colpal/actions-clean@v1
+  #     - name: Clean all
+  #       if: always()
+  #       uses: colpal/actions-clean@v1
 
+  # KEEP
   acceptance-cli-services:
     needs:
       - linter
@@ -280,13 +278,10 @@ jobs:
           make test-acceptance-cli-services
           scripts/collect-coverage.sh
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+      - uses: actions/upload-artifact@v2
         with:
-          files: ./coverprofile.out
-          flags: acceptance-cli
-          name: codecov-epinio
-          verbose: true
+          name: acceptance-cli
+          path: ./coverprofile.out
 
       - name: Cleanup k3d cluster
         if: always()
@@ -296,156 +291,157 @@ jobs:
         if: always()
         uses: colpal/actions-clean@v1
 
-  acceptance-api:
-    needs:
-      - linter
-      - acceptance-api-services
-    runs-on: [self-hosted, epinio]
+  # acceptance-api:
+  #   needs:
+  #     - linter
+  #     - acceptance-api-services
+  #   runs-on: [self-hosted, epinio]
 
-    env:
-      EPINIO_COVERAGE: true
+  #   env:
+  #     EPINIO_COVERAGE: true
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: recursive
+  #         fetch-depth: 0
 
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        timeout-minutes: 5
-        with:
-          cache: false
-          go-version: ${{ env.SETUP_GO_VERSION }}
+  #     - name: Setup Go
+  #       uses: actions/setup-go@v4
+  #       timeout-minutes: 5
+  #       with:
+  #         cache: false
+  #         go-version: ${{ env.SETUP_GO_VERSION }}
 
-      - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+  #     - name: Setup Ginkgo Test Framework
+  #       run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
 
-      - name: Cache Tools
-        uses: actions/cache@v3
-        with:
-          path: ${{ github.workspace }}/tools
-          key: ${{ runner.os }}-tools
+  #     - name: Cache Tools
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: ${{ github.workspace }}/tools
+  #         key: ${{ runner.os }}-tools
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Install Tools
-        run: make tools-install
+  #     - name: Install Tools
+  #       run: make tools-install
 
-      - name: Add Tools to PATH
-        run: |
-          echo "`pwd`/output/bin" >> $GITHUB_PATH
+  #     - name: Add Tools to PATH
+  #       run: |
+  #         echo "`pwd`/output/bin" >> $GITHUB_PATH
 
-      - name: API Acceptance Tests
-        env:
-          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-          EPINIO_TIMEOUT_MULTIPLIER: 3
-        run: |
-          rm -f /tmp/cover*
-          make acceptance-cluster-setup
-          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
-          make install-cert-manager
-          make prepare_environment_k3d
-          make test-acceptance-api-other
-          scripts/collect-coverage.sh
+  #     - name: API Acceptance Tests
+  #       env:
+  #         REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+  #         EPINIO_TIMEOUT_MULTIPLIER: 3
+  #       run: |
+  #         rm -f /tmp/cover*
+  #         make acceptance-cluster-setup
+  #         export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+  #         make install-cert-manager
+  #         make prepare_environment_k3d
+  #         make test-acceptance-api-other
+  #         scripts/collect-coverage.sh
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: ./coverprofile.out
-          flags: acceptance-api
-          name: codecov-epinio
-          verbose: true
+  #     - name: Upload coverage to Codecov
+  #       uses: codecov/codecov-action@v3
+  #       with:
+  #         files: ./coverprofile.out
+  #         flags: acceptance-api
+  #         name: codecov-epinio
+  #         verbose: true
 
-      - name: Cleanup k3d cluster
-        if: always()
-        run: make acceptance-cluster-delete
+  #     - name: Cleanup k3d cluster
+  #       if: always()
+  #       run: make acceptance-cluster-delete
 
-      - name: Clean all
-        if: always()
-        uses: colpal/actions-clean@v1
+  #     - name: Clean all
+  #       if: always()
+  #       uses: colpal/actions-clean@v1
 
-  acceptance-api-apps:
-    needs:
-      - linter
-      - acceptance-cli-services
-    runs-on: [self-hosted, epinio]
+  # acceptance-api-apps:
+  #   needs:
+  #     - linter
+  #     - acceptance-cli-services
+  #   runs-on: [self-hosted, epinio]
 
-    env:
-      EPINIO_COVERAGE: true
+  #   env:
+  #     EPINIO_COVERAGE: true
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: recursive
+  #         fetch-depth: 0
 
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        timeout-minutes: 5
-        with:
-          cache: false
-          go-version: ${{ env.SETUP_GO_VERSION }}
+  #     - name: Setup Go
+  #       uses: actions/setup-go@v4
+  #       timeout-minutes: 5
+  #       with:
+  #         cache: false
+  #         go-version: ${{ env.SETUP_GO_VERSION }}
 
-      - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+  #     - name: Setup Ginkgo Test Framework
+  #       run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
 
-      - name: Cache Tools
-        uses: actions/cache@v3
-        with:
-          path: ${{ github.workspace }}/tools
-          key: ${{ runner.os }}-tools
+  #     - name: Cache Tools
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: ${{ github.workspace }}/tools
+  #         key: ${{ runner.os }}-tools
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Install Tools
-        run: make tools-install
+  #     - name: Install Tools
+  #       run: make tools-install
 
-      - name: Add Tools to PATH
-        run: |
-          echo "`pwd`/output/bin" >> $GITHUB_PATH
+  #     - name: Add Tools to PATH
+  #       run: |
+  #         echo "`pwd`/output/bin" >> $GITHUB_PATH
 
-      - name: API Acceptance Tests
-        env:
-          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-          EPINIO_TIMEOUT_MULTIPLIER: 3
-        run: |
-          rm -f /tmp/cover*
-          make acceptance-cluster-setup
-          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
-          make install-cert-manager
-          make prepare_environment_k3d
-          make test-acceptance-api-apps
-          scripts/collect-coverage.sh
+  #     - name: API Acceptance Tests
+  #       env:
+  #         REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+  #         EPINIO_TIMEOUT_MULTIPLIER: 3
+  #       run: |
+  #         rm -f /tmp/cover*
+  #         make acceptance-cluster-setup
+  #         export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+  #         make install-cert-manager
+  #         make prepare_environment_k3d
+  #         make test-acceptance-api-apps
+  #         scripts/collect-coverage.sh
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: ./coverprofile.out
-          flags: acceptance-api
-          name: codecov-epinio
-          verbose: true
+  #     - name: Upload coverage to Codecov
+  #       uses: codecov/codecov-action@v3
+  #       with:
+  #         files: ./coverprofile.out
+  #         flags: acceptance-api
+  #         name: codecov-epinio
+  #         verbose: true
 
-      - name: Cleanup k3d cluster
-        if: always()
-        run: make acceptance-cluster-delete
+  #     - name: Cleanup k3d cluster
+  #       if: always()
+  #       run: make acceptance-cluster-delete
 
-      - name: Clean all
-        if: always()
-        uses: colpal/actions-clean@v1
+  #     - name: Clean all
+  #       if: always()
+  #       uses: colpal/actions-clean@v1
 
+  # KEEP
   acceptance-api-services:
     needs:
       - linter
@@ -504,13 +500,10 @@ jobs:
           make test-acceptance-api-services
           scripts/collect-coverage.sh
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+      - uses: actions/upload-artifact@v2
         with:
-          files: ./coverprofile.out
-          flags: acceptance-api
-          name: codecov-epinio
-          verbose: true
+          name: acceptance-api
+          path: ./coverprofile.out
 
       - name: Cleanup k3d cluster
         if: always()
@@ -520,96 +513,116 @@ jobs:
         if: always()
         uses: colpal/actions-clean@v1
 
-  acceptance-apps:
-    needs:
-      - linter
-      - acceptance-cli
-    runs-on: [self-hosted, epinio]
+  # acceptance-apps:
+  #   needs:
+  #     - linter
+  #     - acceptance-cli
+  #   runs-on: [self-hosted, epinio]
 
-    env:
-      EPINIO_COVERAGE: true
+  #   env:
+  #     EPINIO_COVERAGE: true
+
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: recursive
+  #         fetch-depth: 0
+
+  #     - name: Setup Go
+  #       uses: actions/setup-go@v4
+  #       timeout-minutes: 5
+  #       with:
+  #         cache: false
+  #         go-version: ${{ env.SETUP_GO_VERSION }}
+
+  #     - name: Setup Ginkgo Test Framework
+  #       run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+
+  #     - name: Cache Tools
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: ${{ github.workspace }}/tools
+  #         key: ${{ runner.os }}-tools
+
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  #     - name: Install Tools
+  #       run: make tools-install
+
+  #     - name: Add Tools to PATH
+  #       run: |
+  #         echo "`pwd`/output/bin" >> $GITHUB_PATH
+
+  #     - name: Apps Acceptance Tests
+  #       env:
+  #         REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+  #         EPINIO_TIMEOUT_MULTIPLIER: 5
+  #       run: |
+  #         rm -f /tmp/cover*
+  #         make acceptance-cluster-setup
+  #         export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+  #         make install-cert-manager
+  #         make prepare_environment_k3d
+  #         make test-acceptance-apps
+  #         scripts/collect-coverage.sh
+
+  #     - name: Upload coverage to Codecov
+  #       uses: codecov/codecov-action@v3
+  #       with:
+  #         files: ./coverprofile.out
+  #         flags: acceptance-apps
+  #         name: codecov-epinio
+  #         verbose: true
+
+  #     - name: Failure Logs
+  #       if: failure()
+  #       run: |
+  #         mkdir -p tmp
+  #         kubectl get -A pod,service,ingress -o json > tmp/cluster.json
+  #         kubectl get -A events > tmp/events.log
+  #         docker logs k3d-epinio-acceptance-server-0 &> tmp/k3s.log
+  #         docker exec k3d-epinio-acceptance-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers.log
+
+  #     - name: Upload Logs
+  #       uses: actions/upload-artifact@v3
+  #       if: failure()
+  #       with:
+  #         name: acceptance-logs-${{ github.sha }}-${{ github.run_id }}
+  #         path: |
+  #           tmp/*.json
+  #           tmp/*.log
+  #         retention-days: 2
+
+  #     - name: Cleanup k3d cluster
+  #       if: always()
+  #       run: make acceptance-cluster-delete
+
+  #     - name: Clean all
+  #       if: always()
+  #       uses: colpal/actions-clean@v1
+
+  upload-coverage:
+    needs:
+      - acceptance-api-services
+      - acceptance-cli-services
+
+    runs-on: [self-hosted, epinio]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
+        uses: actions/checkout@v2
 
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        timeout-minutes: 5
-        with:
-          cache: false
-          go-version: ${{ env.SETUP_GO_VERSION }}
-
-      - name: Setup Ginkgo Test Framework
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
-
-      - name: Cache Tools
-        uses: actions/cache@v3
-        with:
-          path: ${{ github.workspace }}/tools
-          key: ${{ runner.os }}-tools
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Install Tools
-        run: make tools-install
-
-      - name: Add Tools to PATH
-        run: |
-          echo "`pwd`/output/bin" >> $GITHUB_PATH
-
-      - name: Apps Acceptance Tests
-        env:
-          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-          EPINIO_TIMEOUT_MULTIPLIER: 5
-        run: |
-          rm -f /tmp/cover*
-          make acceptance-cluster-setup
-          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
-          make install-cert-manager
-          make prepare_environment_k3d
-          make test-acceptance-apps
-          scripts/collect-coverage.sh
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: ./coverprofile.out
-          flags: acceptance-apps
           name: codecov-epinio
           verbose: true
-
-      - name: Failure Logs
-        if: failure()
-        run: |
-          mkdir -p tmp
-          kubectl get -A pod,service,ingress -o json > tmp/cluster.json
-          kubectl get -A events > tmp/events.log
-          docker logs k3d-epinio-acceptance-server-0 &> tmp/k3s.log
-          docker exec k3d-epinio-acceptance-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers.log
-
-      - name: Upload Logs
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: acceptance-logs-${{ github.sha }}-${{ github.run_id }}
-          path: |
-            tmp/*.json
-            tmp/*.log
-          retention-days: 2
-
-      - name: Cleanup k3d cluster
-        if: always()
-        run: make acceptance-cluster-delete
-
-      - name: Clean all
-        if: always()
-        uses: colpal/actions-clean@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,155 +71,148 @@ jobs:
           name: unittests
           path: ./coverprofile.out
 
-  # acceptance-cli:
-  #   needs:
-  #     - linter
-  #   runs-on: [self-hosted, epinio]
+  acceptance-cli:
+    needs:
+      - linter
+    runs-on: [self-hosted, epinio]
 
-  #   env:
-  #     EPINIO_COVERAGE: true
+    env:
+      EPINIO_COVERAGE: true
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         submodules: recursive
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
-  #     - name: Setup Go
-  #       uses: actions/setup-go@v4
-  #       timeout-minutes: 5
-  #       with:
-  #         cache: false
-  #         go-version: ${{ env.SETUP_GO_VERSION }}
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        timeout-minutes: 5
+        with:
+          cache: false
+          go-version: ${{ env.SETUP_GO_VERSION }}
 
-  #     - name: Setup Ginkgo Test Framework
-  #       run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+      - name: Setup Ginkgo Test Framework
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
 
-  #     - name: Cache Tools
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: ${{ github.workspace }}/tools
-  #         key: ${{ runner.os }}-tools
+      - name: Cache Tools
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/tools
+          key: ${{ runner.os }}-tools
 
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  #     - name: Install Tools
-  #       run: make tools-install
+      - name: Install Tools
+        run: make tools-install
 
-  #     - name: Add Tools to PATH
-  #       run: |
-  #         echo "`pwd`/output/bin" >> $GITHUB_PATH
+      - name: Add Tools to PATH
+        run: |
+          echo "`pwd`/output/bin" >> $GITHUB_PATH
 
-  #     - name: CLI Acceptance Tests
-  #       env:
-  #         REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-  #         EPINIO_TIMEOUT_MULTIPLIER: 3
-  #       run: |
-  #         rm -f /tmp/cover*
-  #         make acceptance-cluster-setup
-  #         export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
-  #         make install-cert-manager
-  #         make prepare_environment_k3d
-  #         make test-acceptance-cli-other
-  #         scripts/collect-coverage.sh
+      - name: CLI Acceptance Tests
+        env:
+          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          EPINIO_TIMEOUT_MULTIPLIER: 3
+        run: |
+          rm -f /tmp/cover*
+          make acceptance-cluster-setup
+          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+          make install-cert-manager
+          make prepare_environment_k3d
+          make test-acceptance-cli-other
+          scripts/collect-coverage.sh
 
-  #     - name: Upload coverage to Codecov
-  #       uses: codecov/codecov-action@v3
-  #       with:
-  #         files: ./coverprofile.out
-  #         flags: acceptance-cli
-  #         name: codecov-epinio
-  #         verbose: true
+      - uses: actions/upload-artifact@v3
+        with:
+          name: acceptance-cli
+          path: ./coverprofile.out
 
-  #     - name: Cleanup k3d cluster
-  #       if: always()
-  #       run: make acceptance-cluster-delete
+      - name: Cleanup k3d cluster
+        if: always()
+        run: make acceptance-cluster-delete
 
-  #     - name: Clean all
-  #       if: always()
-  #       uses: colpal/actions-clean@v1
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1
 
-  # acceptance-cli-apps:
-  #   needs:
-  #     - linter
-  #   runs-on: [self-hosted, epinio]
+  acceptance-cli-apps:
+    needs:
+      - linter
+    runs-on: [self-hosted, epinio]
 
-  #   env:
-  #     EPINIO_COVERAGE: true
+    env:
+      EPINIO_COVERAGE: true
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         submodules: recursive
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
-  #     - name: Setup Go
-  #       uses: actions/setup-go@v4
-  #       timeout-minutes: 5
-  #       with:
-  #         cache: false
-  #         go-version: ${{ env.SETUP_GO_VERSION }}
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        timeout-minutes: 5
+        with:
+          cache: false
+          go-version: ${{ env.SETUP_GO_VERSION }}
 
-  #     - name: Setup Ginkgo Test Framework
-  #       run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+      - name: Setup Ginkgo Test Framework
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
 
-  #     - name: Cache Tools
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: ${{ github.workspace }}/tools
-  #         key: ${{ runner.os }}-tools
+      - name: Cache Tools
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/tools
+          key: ${{ runner.os }}-tools
 
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  #     - name: Install Tools
-  #       run: make tools-install
+      - name: Install Tools
+        run: make tools-install
 
-  #     - name: Add Tools to PATH
-  #       run: |
-  #         echo "`pwd`/output/bin" >> $GITHUB_PATH
+      - name: Add Tools to PATH
+        run: |
+          echo "`pwd`/output/bin" >> $GITHUB_PATH
 
-  #     - name: CLI Acceptance Tests
-  #       env:
-  #         REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-  #         EPINIO_TIMEOUT_MULTIPLIER: 3
-  #       run: |
-  #         rm -f /tmp/cover*
-  #         make acceptance-cluster-setup
-  #         export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
-  #         make install-cert-manager
-  #         make prepare_environment_k3d
-  #         make test-acceptance-cli-apps
-  #         scripts/collect-coverage.sh
+      - name: CLI Acceptance Tests
+        env:
+          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          EPINIO_TIMEOUT_MULTIPLIER: 3
+        run: |
+          rm -f /tmp/cover*
+          make acceptance-cluster-setup
+          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+          make install-cert-manager
+          make prepare_environment_k3d
+          make test-acceptance-cli-apps
+          scripts/collect-coverage.sh
 
-  #     - name: Upload coverage to Codecov
-  #       uses: codecov/codecov-action@v3
-  #       with:
-  #         files: ./coverprofile.out
-  #         flags: acceptance-cli
-  #         name: codecov-epinio
-  #         verbose: true
+      - uses: actions/upload-artifact@v3
+        with:
+          name: acceptance-cli-apps
+          path: ./coverprofile.out
 
-  #     - name: Cleanup k3d cluster
-  #       if: always()
-  #       run: make acceptance-cluster-delete
+      - name: Cleanup k3d cluster
+        if: always()
+        run: make acceptance-cluster-delete
 
-  #     - name: Clean all
-  #       if: always()
-  #       uses: colpal/actions-clean@v1
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1
 
-  # KEEP
   acceptance-cli-services:
     needs:
       - linter
@@ -280,7 +273,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: acceptance-cli
+          name: acceptance-cli-services
           path: ./coverprofile.out
 
       - name: Cleanup k3d cluster
@@ -291,157 +284,150 @@ jobs:
         if: always()
         uses: colpal/actions-clean@v1
 
-  # acceptance-api:
-  #   needs:
-  #     - linter
-  #     - acceptance-api-services
-  #   runs-on: [self-hosted, epinio]
+  acceptance-api:
+    needs:
+      - linter
+      - acceptance-api-services
+    runs-on: [self-hosted, epinio]
 
-  #   env:
-  #     EPINIO_COVERAGE: true
+    env:
+      EPINIO_COVERAGE: true
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         submodules: recursive
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
-  #     - name: Setup Go
-  #       uses: actions/setup-go@v4
-  #       timeout-minutes: 5
-  #       with:
-  #         cache: false
-  #         go-version: ${{ env.SETUP_GO_VERSION }}
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        timeout-minutes: 5
+        with:
+          cache: false
+          go-version: ${{ env.SETUP_GO_VERSION }}
 
-  #     - name: Setup Ginkgo Test Framework
-  #       run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+      - name: Setup Ginkgo Test Framework
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
 
-  #     - name: Cache Tools
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: ${{ github.workspace }}/tools
-  #         key: ${{ runner.os }}-tools
+      - name: Cache Tools
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/tools
+          key: ${{ runner.os }}-tools
 
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  #     - name: Install Tools
-  #       run: make tools-install
+      - name: Install Tools
+        run: make tools-install
 
-  #     - name: Add Tools to PATH
-  #       run: |
-  #         echo "`pwd`/output/bin" >> $GITHUB_PATH
+      - name: Add Tools to PATH
+        run: |
+          echo "`pwd`/output/bin" >> $GITHUB_PATH
 
-  #     - name: API Acceptance Tests
-  #       env:
-  #         REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-  #         EPINIO_TIMEOUT_MULTIPLIER: 3
-  #       run: |
-  #         rm -f /tmp/cover*
-  #         make acceptance-cluster-setup
-  #         export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
-  #         make install-cert-manager
-  #         make prepare_environment_k3d
-  #         make test-acceptance-api-other
-  #         scripts/collect-coverage.sh
+      - name: API Acceptance Tests
+        env:
+          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          EPINIO_TIMEOUT_MULTIPLIER: 3
+        run: |
+          rm -f /tmp/cover*
+          make acceptance-cluster-setup
+          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+          make install-cert-manager
+          make prepare_environment_k3d
+          make test-acceptance-api-other
+          scripts/collect-coverage.sh
 
-  #     - name: Upload coverage to Codecov
-  #       uses: codecov/codecov-action@v3
-  #       with:
-  #         files: ./coverprofile.out
-  #         flags: acceptance-api
-  #         name: codecov-epinio
-  #         verbose: true
+      - uses: actions/upload-artifact@v3
+        with:
+          name: acceptance-api
+          path: ./coverprofile.out
 
-  #     - name: Cleanup k3d cluster
-  #       if: always()
-  #       run: make acceptance-cluster-delete
+      - name: Cleanup k3d cluster
+        if: always()
+        run: make acceptance-cluster-delete
 
-  #     - name: Clean all
-  #       if: always()
-  #       uses: colpal/actions-clean@v1
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1
 
-  # acceptance-api-apps:
-  #   needs:
-  #     - linter
-  #     - acceptance-cli-services
-  #   runs-on: [self-hosted, epinio]
+  acceptance-api-apps:
+    needs:
+      - linter
+      - acceptance-cli-services
+    runs-on: [self-hosted, epinio]
 
-  #   env:
-  #     EPINIO_COVERAGE: true
+    env:
+      EPINIO_COVERAGE: true
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         submodules: recursive
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
-  #     - name: Setup Go
-  #       uses: actions/setup-go@v4
-  #       timeout-minutes: 5
-  #       with:
-  #         cache: false
-  #         go-version: ${{ env.SETUP_GO_VERSION }}
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        timeout-minutes: 5
+        with:
+          cache: false
+          go-version: ${{ env.SETUP_GO_VERSION }}
 
-  #     - name: Setup Ginkgo Test Framework
-  #       run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+      - name: Setup Ginkgo Test Framework
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
 
-  #     - name: Cache Tools
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: ${{ github.workspace }}/tools
-  #         key: ${{ runner.os }}-tools
+      - name: Cache Tools
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/tools
+          key: ${{ runner.os }}-tools
 
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  #     - name: Install Tools
-  #       run: make tools-install
+      - name: Install Tools
+        run: make tools-install
 
-  #     - name: Add Tools to PATH
-  #       run: |
-  #         echo "`pwd`/output/bin" >> $GITHUB_PATH
+      - name: Add Tools to PATH
+        run: |
+          echo "`pwd`/output/bin" >> $GITHUB_PATH
 
-  #     - name: API Acceptance Tests
-  #       env:
-  #         REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-  #         EPINIO_TIMEOUT_MULTIPLIER: 3
-  #       run: |
-  #         rm -f /tmp/cover*
-  #         make acceptance-cluster-setup
-  #         export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
-  #         make install-cert-manager
-  #         make prepare_environment_k3d
-  #         make test-acceptance-api-apps
-  #         scripts/collect-coverage.sh
+      - name: API Acceptance Tests
+        env:
+          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          EPINIO_TIMEOUT_MULTIPLIER: 3
+        run: |
+          rm -f /tmp/cover*
+          make acceptance-cluster-setup
+          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+          make install-cert-manager
+          make prepare_environment_k3d
+          make test-acceptance-api-apps
+          scripts/collect-coverage.sh
 
-  #     - name: Upload coverage to Codecov
-  #       uses: codecov/codecov-action@v3
-  #       with:
-  #         files: ./coverprofile.out
-  #         flags: acceptance-api
-  #         name: codecov-epinio
-  #         verbose: true
+      - uses: actions/upload-artifact@v3
+        with:
+          name: acceptance-api-apps
+          path: ./coverprofile.out
 
-  #     - name: Cleanup k3d cluster
-  #       if: always()
-  #       run: make acceptance-cluster-delete
+      - name: Cleanup k3d cluster
+        if: always()
+        run: make acceptance-cluster-delete
 
-  #     - name: Clean all
-  #       if: always()
-  #       uses: colpal/actions-clean@v1
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1
 
-  # KEEP
   acceptance-api-services:
     needs:
       - linter
@@ -502,7 +488,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: acceptance-api
+          name: acceptance-api-services
           path: ./coverprofile.out
 
       - name: Cleanup k3d cluster
@@ -513,99 +499,96 @@ jobs:
         if: always()
         uses: colpal/actions-clean@v1
 
-  # acceptance-apps:
-  #   needs:
-  #     - linter
-  #     - acceptance-cli
-  #   runs-on: [self-hosted, epinio]
+  acceptance-apps:
+    needs:
+      - linter
+      - acceptance-cli
+    runs-on: [self-hosted, epinio]
 
-  #   env:
-  #     EPINIO_COVERAGE: true
+    env:
+      EPINIO_COVERAGE: true
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         submodules: recursive
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
-  #     - name: Setup Go
-  #       uses: actions/setup-go@v4
-  #       timeout-minutes: 5
-  #       with:
-  #         cache: false
-  #         go-version: ${{ env.SETUP_GO_VERSION }}
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        timeout-minutes: 5
+        with:
+          cache: false
+          go-version: ${{ env.SETUP_GO_VERSION }}
 
-  #     - name: Setup Ginkgo Test Framework
-  #       run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
+      - name: Setup Ginkgo Test Framework
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.0
 
-  #     - name: Cache Tools
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: ${{ github.workspace }}/tools
-  #         key: ${{ runner.os }}-tools
+      - name: Cache Tools
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/tools
+          key: ${{ runner.os }}-tools
 
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  #     - name: Install Tools
-  #       run: make tools-install
+      - name: Install Tools
+        run: make tools-install
 
-  #     - name: Add Tools to PATH
-  #       run: |
-  #         echo "`pwd`/output/bin" >> $GITHUB_PATH
+      - name: Add Tools to PATH
+        run: |
+          echo "`pwd`/output/bin" >> $GITHUB_PATH
 
-  #     - name: Apps Acceptance Tests
-  #       env:
-  #         REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-  #         EPINIO_TIMEOUT_MULTIPLIER: 5
-  #       run: |
-  #         rm -f /tmp/cover*
-  #         make acceptance-cluster-setup
-  #         export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
-  #         make install-cert-manager
-  #         make prepare_environment_k3d
-  #         make test-acceptance-apps
-  #         scripts/collect-coverage.sh
+      - name: Apps Acceptance Tests
+        env:
+          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          EPINIO_TIMEOUT_MULTIPLIER: 5
+        run: |
+          rm -f /tmp/cover*
+          make acceptance-cluster-setup
+          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+          make install-cert-manager
+          make prepare_environment_k3d
+          make test-acceptance-apps
+          scripts/collect-coverage.sh
 
-  #     - name: Upload coverage to Codecov
-  #       uses: codecov/codecov-action@v3
-  #       with:
-  #         files: ./coverprofile.out
-  #         flags: acceptance-apps
-  #         name: codecov-epinio
-  #         verbose: true
+      - uses: actions/upload-artifact@v3
+        with:
+          name: acceptance-apps
+          path: ./coverprofile.out
 
-  #     - name: Failure Logs
-  #       if: failure()
-  #       run: |
-  #         mkdir -p tmp
-  #         kubectl get -A pod,service,ingress -o json > tmp/cluster.json
-  #         kubectl get -A events > tmp/events.log
-  #         docker logs k3d-epinio-acceptance-server-0 &> tmp/k3s.log
-  #         docker exec k3d-epinio-acceptance-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers.log
+      - name: Failure Logs
+        if: failure()
+        run: |
+          mkdir -p tmp
+          kubectl get -A pod,service,ingress -o json > tmp/cluster.json
+          kubectl get -A events > tmp/events.log
+          docker logs k3d-epinio-acceptance-server-0 &> tmp/k3s.log
+          docker exec k3d-epinio-acceptance-server-0 sh -c 'cd /var/log/containers; grep -r "." .' > tmp/containers.log
 
-  #     - name: Upload Logs
-  #       uses: actions/upload-artifact@v3
-  #       if: failure()
-  #       with:
-  #         name: acceptance-logs-${{ github.sha }}-${{ github.run_id }}
-  #         path: |
-  #           tmp/*.json
-  #           tmp/*.log
-  #         retention-days: 2
+      - name: Upload Logs
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: acceptance-logs-${{ github.sha }}-${{ github.run_id }}
+          path: |
+            tmp/*.json
+            tmp/*.log
+          retention-days: 2
 
-  #     - name: Cleanup k3d cluster
-  #       if: always()
-  #       run: make acceptance-cluster-delete
+      - name: Cleanup k3d cluster
+        if: always()
+        run: make acceptance-cluster-delete
 
-  #     - name: Clean all
-  #       if: always()
-  #       uses: colpal/actions-clean@v1
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1
 
   upload-coverage:
     needs:
@@ -621,10 +604,34 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v3
 
-      - name: Upload coverage to Codecov
+      - name: Upload unittests coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           name: codecov-epinio
-          files: ./unittests/coverprofile.out,./acceptance-api/coverprofile.out,./acceptance-cli/coverprofile.out
-          flags: unittests,acceptance-api,acceptance-cli
+          files: ./unittests/coverprofile.out
+          flags: unittests
+          verbose: true
+
+      - name: Upload acceptance-api coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          name: codecov-epinio
+          files: ./acceptance-api/coverprofile.out,./acceptance-api-apps/coverprofile.out,./acceptance-api-services/coverprofile.out
+          flags: acceptance-api
+          verbose: true
+
+      - name: Upload acceptance-cli coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          name: codecov-epinio
+          files: ./acceptance-cli/coverprofile.out,./acceptance-cli-apps/coverprofile.out,./acceptance-cli-services/coverprofile.out
+          flags: acceptance-cli
+          verbose: true
+
+      - name: Upload acceptance-apps coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          name: codecov-epinio
+          files: ./acceptance-apps/coverprofile.out
+          flags: acceptance-apps
           verbose: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Unit Tests
         run: make test
       
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: unittests
           path: ./coverprofile.out
@@ -278,7 +278,7 @@ jobs:
           make test-acceptance-cli-services
           scripts/collect-coverage.sh
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: acceptance-cli
           path: ./coverprofile.out
@@ -500,7 +500,7 @@ jobs:
           make test-acceptance-api-services
           scripts/collect-coverage.sh
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: acceptance-api
           path: ./coverprofile.out
@@ -619,11 +619,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           name: codecov-epinio
-          files: ./acceptance-api/coverprofile.out,./acceptance-cli/coverprofile.out
+          files: ./unittests/coverprofile.out,./acceptance-api/coverprofile.out,./acceptance-cli/coverprofile.out
+          flags: unittests,acceptance-api,acceptance-cli
           verbose: true


### PR DESCRIPTION
Fixes #2308 

Moved the upload at the end of the run:

![image](https://github.com/epinio/epinio/assets/1763949/cf1d1a8a-0322-44d3-bc46-507ad8588aff)

Unfortunately I was not able to provide different flags in a single upload (I think is not possible) so I kept those uploads in the same job but in different steps.

The different coverage files are uploaded as artifacts after the test run, and then downloaded and pushed together:

![image](https://github.com/epinio/epinio/assets/1763949/b27e2664-337b-4b1a-9f8f-4ac65689d9b0)


Ref: https://about.codecov.io/blog/uploading-code-coverage-in-a-separate-job-on-github-actions/