### PR TITLE
Added unit tests to `epinio info` command

### DIFF
--- a/internal/cli/docs/generate-cli-docs.go
+++ b/internal/cli/docs/generate-cli-docs.go
@@ -28,10 +28,14 @@ import (
 func main() {
 	docDir := filepath.Join("./", os.Args[1])
 
-	cmd := cli.NewEpinioCLI()
+	cmd, err := cli.NewRootCmd()
+	if err != nil {
+		panic(err)
+	}
+
 	cmd.DisableAutoGenTag = true
 
-	err := generateCmdDoc(cmd, docDir)
+	err = generateCmdDoc(cmd, docDir)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -17,26 +17,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var ()
+// NewCmdInfo returns a new 'epinio info' command
+func NewInfoCmd(client *usercmd.EpinioClient) *cobra.Command {
+	return &cobra.Command{
+		Use:   "info",
+		Short: "Shows information about the Epinio environment",
+		Long:  "Shows status and versions for epinio's server-side components.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 
-// CmdInfo implements the command: epinio info
-var CmdInfo = &cobra.Command{
-	Use:   "info",
-	Short: "Shows information about the Epinio environment",
-	Long:  `Shows status and versions for epinio's server-side components.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
+			err := client.Info()
+			if err != nil {
+				return errors.Wrap(err, "error retrieving Epinio environment information")
+			}
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
-		err = client.Info()
-		if err != nil {
-			return errors.Wrap(err, "error retrieving Epinio environment information")
-		}
-
-		return nil
-	},
+			return nil
+		},
+	}
 }

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCmdInfo returns a new 'epinio info' command
+// NewInfoCmd returns a new 'epinio info' command
 func NewInfoCmd(client *usercmd.EpinioClient) *cobra.Command {
 	return &cobra.Command{
 		Use:   "info",

--- a/internal/cli/info_test.go
+++ b/internal/cli/info_test.go
@@ -1,0 +1,103 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"strings"
+
+	"github.com/epinio/epinio/internal/cli"
+	"github.com/epinio/epinio/internal/cli/usercmd"
+	"github.com/epinio/epinio/internal/cli/usercmd/usercmdfakes"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var _ = Describe("Command 'epinio info'", func() {
+
+	var (
+		mock    *usercmdfakes.FakeAPIClient
+		infoCmd *cobra.Command
+		output  io.ReadWriter
+	)
+
+	BeforeEach(func() {
+		epinioClient, err := usercmd.New(context.Background())
+		Expect(err).To(BeNil())
+
+		mock = &usercmdfakes.FakeAPIClient{}
+		epinioClient.API = mock
+
+		output = &bytes.Buffer{}
+		epinioClient.UI().SetOutput(output)
+
+		infoCmd = cli.NewInfoCmd(epinioClient)
+		infoCmd.SetErr(output)
+		infoCmd.SetArgs([]string{"info"})
+	})
+
+	When("the api returns a complete response", func() {
+		It("will show all the info", func() {
+			goodResponse := models.InfoResponse{
+				Version:             "v1.2.3",
+				KubeVersion:         "v1.22.33",
+				Platform:            "k8s-platform",
+				DefaultBuilderImage: "default-builder",
+			}
+			mock.InfoReturns(goodResponse, nil)
+
+			infoCmd.Execute()
+
+			out, err := ioutil.ReadAll(output)
+			Expect(err).To(BeNil())
+
+			stdout := string(out)
+			Expect(stdout).ToNot(BeEmpty())
+
+			stdout = strings.TrimSpace(stdout)
+			lines := strings.Split(stdout, "\n")
+			Expect(lines).To(HaveLen(5))
+
+			Expect(lines[0]).To(Equal("✔️  Epinio Environment"))
+			Expect(lines[1]).To(Equal("Platform: k8s-platform"))
+			Expect(lines[2]).To(Equal("Kubernetes Version: v1.22.33"))
+			Expect(lines[3]).To(Equal("Epinio Server Version: v1.2.3"))
+			Expect(lines[4]).To(Equal("Epinio Client Version: v0.0.0-dev"))
+		})
+	})
+
+	When("the api fails", func() {
+		It("will show an error", func() {
+			mock.InfoReturns(models.InfoResponse{}, errors.New("something failed"))
+
+			infoCmd.Execute()
+
+			out, err := ioutil.ReadAll(output)
+			Expect(err).To(BeNil())
+
+			stdout := string(out)
+			Expect(stdout).ToNot(BeEmpty())
+
+			stdout = strings.TrimSpace(stdout)
+			lines := strings.Split(stdout, "\n")
+			Expect(lines).To(HaveLen(1))
+
+			Expect(lines[0]).To(ContainSubstring("error retrieving Epinio environment information: something failed"))
+		})
+	})
+})

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -14,6 +14,8 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -23,6 +25,7 @@ import (
 	"github.com/epinio/epinio/helpers/termui"
 	"github.com/epinio/epinio/helpers/tracelog"
 	settings "github.com/epinio/epinio/internal/cli/settings"
+	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/epinio/epinio/internal/duration"
 	"github.com/epinio/epinio/internal/version"
 	"github.com/go-logr/stdr"
@@ -34,33 +37,20 @@ var (
 	flagSettingsFile string
 )
 
-// NewEpinioCLI returns the main `epinio` cli.
-func NewEpinioCLI() *cobra.Command {
-	return rootCmd
-}
-
-var rootCmd = &cobra.Command{
-	Args:          cobra.MaximumNArgs(0),
-	Use:           "epinio",
-	Short:         "Epinio cli",
-	Long:          `epinio cli is the official command line interface for Epinio PaaS `,
-	Version:       version.Version,
-	SilenceErrors: true,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		stdr.SetVerbosity(tracelog.TraceLevel())
-	},
-}
-
-// Execute executes the root command.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		termui.NewUI().Problem().Msg(err.Error())
-		os.Exit(-1)
+// NewRootCmd returns the rootCmd, that is the main `epinio` cli.
+func NewRootCmd() (*cobra.Command, error) {
+	rootCmd := &cobra.Command{
+		Args:          cobra.MaximumNArgs(0),
+		Use:           "epinio",
+		Short:         "Epinio cli",
+		Long:          `epinio cli is the official command line interface for Epinio PaaS `,
+		Version:       version.Version,
+		SilenceErrors: true,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			stdr.SetVerbosity(tracelog.TraceLevel())
+		},
 	}
-}
 
-func init() {
 	pf := rootCmd.PersistentFlags()
 	argToEnv := map[string]string{}
 
@@ -71,13 +61,14 @@ func init() {
 		if err != nil {
 			// Error can happen on a read-only filesystem (like the one of the epinio
 			// server Pod). User should set a location explicitly.
-			errorMsg := fmt.Sprintf("A settings file wasn't set explicitly and the default location couldn't be used: %s", err.Error())
-			panic(errorMsg)
+			return nil, fmt.Errorf("A settings file wasn't set explicitly and the default location couldn't be used: %s", err.Error())
 		}
 	}
+
 	pf.StringVarP(&flagSettingsFile, "settings-file", "", settingsLocation, "set path of settings file")
-	err = viper.BindPFlag("settings-file", pf.Lookup("settings-file"))
-	checkErr(err)
+	if err = viper.BindPFlag("settings-file", pf.Lookup("settings-file")); err != nil {
+		return nil, err
+	}
 	argToEnv["settings-file"] = "EPINIO_SETTINGS"
 
 	config.KubeConfigFlags(pf, argToEnv)
@@ -85,39 +76,67 @@ func init() {
 	duration.Flags(pf, argToEnv)
 
 	pf.IntP("verbosity", "", 0, "Only print progress messages at or above this level (0 or 1, default 0)")
-	err = viper.BindPFlag("verbosity", pf.Lookup("verbosity"))
-	checkErr(err)
+	if err = viper.BindPFlag("verbosity", pf.Lookup("verbosity")); err != nil {
+		return nil, err
+	}
 	argToEnv["verbosity"] = "VERBOSITY"
 
 	pf.BoolP("skip-ssl-verification", "", false, "Skip the verification of TLS certificates")
-	err = viper.BindPFlag("skip-ssl-verification", pf.Lookup("skip-ssl-verification"))
-	checkErr(err)
+	if err = viper.BindPFlag("skip-ssl-verification", pf.Lookup("skip-ssl-verification")); err != nil {
+		return nil, err
+	}
 	argToEnv["skip-ssl-verification"] = "SKIP_SSL_VERIFICATION"
 
 	pf.BoolP("no-colors", "", false, "Suppress colorized output")
-	err = viper.BindPFlag("no-colors", pf.Lookup("no-colors"))
-	checkErr(err)
+	if err = viper.BindPFlag("no-colors", pf.Lookup("no-colors")); err != nil {
+		return nil, err
+	}
+
 	// Environment variable EPINIO_COLORS is handled in settings/settings.go,
 	// as part of handling the settings file.
 
 	config.AddEnvToUsage(rootCmd, argToEnv)
 
-	rootCmd.AddCommand(CmdCompletion)
-	rootCmd.AddCommand(CmdSettings)
-	rootCmd.AddCommand(CmdInfo)
-	rootCmd.AddCommand(CmdClientSync)
-	rootCmd.AddCommand(CmdNamespace)
-	rootCmd.AddCommand(CmdAppPush) // shorthand access to `app push`.
-	rootCmd.AddCommand(CmdApp)
-	rootCmd.AddCommand(CmdTarget)
-	rootCmd.AddCommand(CmdConfiguration)
-	rootCmd.AddCommand(CmdServer)
-	rootCmd.AddCommand(cmdVersion)
-	rootCmd.AddCommand(CmdServices)
-	rootCmd.AddCommand(CmdLogin)
+	client, err := usercmd.New(context.Background())
+	if err != nil {
+		return nil, errors.New("error initializing cli")
+	}
+
+	rootCmd.AddCommand(
+		CmdCompletion,
+		CmdSettings,
+		NewInfoCmd(client),
+		CmdClientSync,
+		CmdNamespace,
+		CmdAppPush, // shorthand access to `app push`
+		CmdApp,
+		CmdTarget,
+		CmdConfiguration,
+		CmdServer,
+		cmdVersion,
+		CmdServices,
+		CmdLogin,
+	)
 
 	// Hidden command providing developer tools
 	rootCmd.AddCommand(CmdDebug)
+
+	return rootCmd, nil
+}
+
+// Execute executes the root command.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	rootCmd, err := NewRootCmd()
+	if err != nil {
+		termui.NewUI().Problem().Msg(err.Error())
+		os.Exit(-1)
+	}
+
+	if err := rootCmd.Execute(); err != nil {
+		termui.NewUI().Problem().Msg(err.Error())
+		os.Exit(-1)
+	}
 }
 
 var cmdVersion = &cobra.Command{

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -140,3 +140,7 @@ func NewEpinioClient(cfg *settings.Settings, apiClient APIClient) (*EpinioClient
 		Log:      logger,
 	}, nil
 }
+
+func (cli *EpinioClient) UI() *termui.UI {
+	return cli.ui
+}


### PR DESCRIPTION
This PR adds some tests to the `epinio info` cmd.

To do so I had to do a small refactoring, avoid creating the commands as global vars, but instead using constructors, to inject the needed dependency. This will be probably an enabler for other refactoring or tests where the dependencies are created inside the commands.

This is a suggested approach also from Cobra, but since they had the global var example in their README this actually was spreaded everywhere (ref: https://github.com/spf13/cobra/issues/1862).