### PR TITLE
Target workspace namespace for EKS/EC2 tests

### DIFF
--- a/acceptance/install/scenario4_test.go
+++ b/acceptance/install/scenario4_test.go
@@ -165,6 +165,13 @@ var _ = Describe("<Scenario4> EKS, epinio-ca, on S3 storage", func() {
 			}, "2m", "2s").Should(ContainSubstring("Epinio Server Version:"))
 		})
 
+		By("Targetting workspace namespace", func() {
+			Eventually(func() string {
+				out, _ := epinioHelper.Run("target", "workspace")
+				return out
+			}, "2m", "2s").Should(ContainSubstring("Namespace targeted."))
+		})
+
 		By("Creating the application", func() {
 			out, err := epinioHelper.Run("apps", "create", appName)
 			Expect(err).NotTo(HaveOccurred(), out)

--- a/acceptance/install/scenario4_test.go
+++ b/acceptance/install/scenario4_test.go
@@ -165,7 +165,7 @@ var _ = Describe("<Scenario4> EKS, epinio-ca, on S3 storage", func() {
 			}, "2m", "2s").Should(ContainSubstring("Epinio Server Version:"))
 		})
 
-		By("Targetting workspace namespace", func() {
+		By("Targeting workspace namespace", func() {
 			Eventually(func() string {
 				out, _ := epinioHelper.Run("target", "workspace")
 				return out


### PR DESCRIPTION
Fixes RKE2-EC2 workflow by targeting a default workspace namespace. This is needed because our self-hosted runner has existing `settings.yaml` with non-existing targeted ns from previous run.

Testrun https://github.com/epinio/epinio/actions/runs/5077065695/jobs/9119968996