### PR TITLE
Bump goreleaser version

### DIFF
--- a/.github/workflows/release-qa.yml
+++ b/.github/workflows/release-qa.yml
@@ -66,7 +66,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
-          version: 1.11.4
+          version: 1.18.2
           args: release --skip-announce --skip-validate --config .goreleaser-qa.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -67,7 +67,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
-          version: 1.11.4
+          version: 1.18.2
           args: release --rm-dist --skip-publish --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
-          version: 1.11.4
+          version: 1.18.2
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Goreleaser version bumped to the latest to get the ${digest} variable introduced in [v1.13](https://github.com/goreleaser/goreleaser/pull/3540).