### PR TITLE
Added CA certs in validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.11.2
 	k8s.io/api v0.26.3
-	k8s.io/apiextensions-apiserver v0.26.3
 	k8s.io/apimachinery v0.26.3
 	k8s.io/apiserver v0.26.3
 	k8s.io/client-go v0.26.3
@@ -66,7 +65,15 @@ require (
 	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d
 )
 
-require github.com/go-jose/go-jose/v3 v3.0.0 // indirect
+require (
+	github.com/buildpacks/libcnb v1.18.0 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
+	github.com/heroku/color v0.0.6 // indirect
+	github.com/mattn/go-shellwords v1.0.12 // indirect
+	github.com/paketo-buildpacks/libpak v1.49.0 // indirect
+	github.com/pelletier/go-toml v1.9.5 // indirect
+	k8s.io/apiextensions-apiserver v0.26.3 // indirect
+)
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
@@ -173,6 +180,7 @@ require (
 	github.com/nwaples/rardecode v1.1.3 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc2 // indirect
+	github.com/paketo-buildpacks/ca-certificates v1.0.1
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,7 @@ github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
@@ -142,6 +143,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZkEHchZRSq9OQbsSzIT/OrI8YFFmRIng=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembjv71DPz3uX/V/6MMlSyD9JBQ6kQ=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
+github.com/buildpacks/libcnb v1.18.0 h1:Q7I+HjQ1Cq02/AqhTOrzecuNESip9xE2axckxnymYLQ=
+github.com/buildpacks/libcnb v1.18.0/go.mod h1:yzAQd//jyUXVx6Z/F0cKk/hrl49QZq1OE/hP5+/ZPuQ=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/bwesterb/go-ristretto v1.2.1/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
@@ -515,6 +518,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/heroku/color v0.0.6 h1:UTFFMrmMLFcL3OweqP1lAdp8i1y/9oHqkeHjQ/b/Ny0=
+github.com/heroku/color v0.0.6/go.mod h1:ZBvOcx7cTF2QKOv4LbmoBtNl5uB17qWxGuzZrsi1wLU=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -644,6 +649,7 @@ github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kN
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
@@ -664,6 +670,9 @@ github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.15/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
@@ -763,6 +772,8 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.27.1 h1:rfztXRbg6nv/5f+Raen9RcGoSecHIFgBBLQK3Wdj754=
 github.com/onsi/gomega v1.27.1/go.mod h1:aHX5xOykVYzWOV4WqQy0sy8BQptgukenXpCXfadcIAw=
@@ -773,12 +784,19 @@ github.com/opencontainers/image-spec v1.1.0-rc2/go.mod h1:3OVijpioIKYWTqjiG0zfF6
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.0.3-0.20180606204148-bd9c31933947/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/oschwald/maxminddb-golang v1.8.0/go.mod h1:RXZtst0N6+FY/3qCNmZMBApR19cdQj43/NM9VkrNAis=
+github.com/paketo-buildpacks/ca-certificates v1.0.1 h1:JOUHDmC8AB/ElGnKN6b5ifggmyJSqEexTEiY5a0Qu1U=
+github.com/paketo-buildpacks/ca-certificates v1.0.1/go.mod h1:lZIlfeMrz8QHCyZG912Tv0n+KNOtuHs0W/z7A5oRkZ4=
+github.com/paketo-buildpacks/libpak v1.49.0 h1:Yf3wt1RBb5Psjmc1X7joMal/tL15kSl8lz07Rfh48m4=
+github.com/paketo-buildpacks/libpak v1.49.0/go.mod h1:8vMe0mZNZj1vqngvtH6KCrs98mL+KW9mTymOb5PE6pw=
 github.com/panjf2000/ants/v2 v2.7.1 h1:qBy5lfSdbxvrR0yUnZfaEDjf0FlCw4ufsbcsxmE7r+M=
 github.com/panjf2000/ants/v2 v2.7.1/go.mod h1:KIBmYG9QQX5U2qzFP/yQJaq/nSb6rahS9iEHkrCMgM8=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChlfo5C6hzIHwPqfFE=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
+github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
@@ -863,6 +881,7 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/schollz/progressbar/v3 v3.13.1 h1:o8rySDYiQ59Mwzy2FELeHY5ZARXZTVJC7iHD6PEFUiE=
 github.com/schollz/progressbar/v3 v3.13.1/go.mod h1:xvrbki8kfT1fzWzBT/UZd9L6GA+jdL7HAgq2RFnO6fQ=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
+github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
@@ -1122,6 +1141,7 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=

--- a/helpers/cahash/cahash.go
+++ b/helpers/cahash/cahash.go
@@ -12,16 +12,11 @@
 package cahash
 
 import (
-	"crypto/sha1" // nolint:gosec // Required by subject hash specification
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/asn1"
-	"encoding/binary"
 	"encoding/pem"
 	"fmt"
-	"regexp"
-	"strings"
 
+	"github.com/paketo-buildpacks/ca-certificates/cacerts"
 	"github.com/pkg/errors"
 )
 
@@ -33,7 +28,7 @@ func GenerateHash(certRaw []byte) (string, error) {
 		return "", fmt.Errorf("failed to decode certificate\n%w", err)
 	}
 
-	hash, err := SubjectNameHash(cert)
+	hash, err := cacerts.SubjectNameHash(cert)
 	if err != nil {
 		return "", fmt.Errorf("failed compute subject name hash for cert\n%w", err)
 	}
@@ -44,7 +39,8 @@ func GenerateHash(certRaw []byte) (string, error) {
 
 // -----------------------------------------------------------------------------------
 // See gh:paketo-buildpacks/ca-certificates (cacerts/certs.go) for the original code.
-
+// https://github.com/paketo-buildpacks/ca-certificates
+//
 // Iterates over pem blocks until a valid certificate is found or no other PEM blocks exist.
 func DecodeOneCert(raw []byte) (*x509.Certificate, error) {
 	byteData := raw
@@ -63,84 +59,4 @@ func DecodeOneCert(raw []byte) (*x509.Certificate, error) {
 	}
 
 	return nil, errors.New("failed find PEM data")
-}
-
-// SubjectNameHash is a reimplementation of the X509_subject_name_hash
-// in openssl. It computes the SHA-1 of the canonical encoding of the
-// certificate's subject name and returns the 32-bit integer
-// represented by the first four bytes of the hash using little-endian
-// byte order.
-func SubjectNameHash(cert *x509.Certificate) (uint32, error) {
-	name, err := CanonicalName(cert.RawSubject)
-	if err != nil {
-		return 0, fmt.Errorf("failed to compute canonical subject name\n%w", err)
-	}
-	hasher := sha1.New() // nolint:gosec // Required by subject hash specification
-	_, err = hasher.Write(name)
-	if err != nil {
-		return 0, fmt.Errorf("failed to compute sha1sum of canonical subject name\n%w", err)
-	}
-	sum := hasher.Sum(nil)
-	return binary.LittleEndian.Uint32(sum[:4]), nil
-}
-
-// canonicalSET holds a of canonicalATVs. Suffix SET ensures it is
-// marshaled as a set rather than a sequence by asn1.Marshal.
-type canonicalSET []canonicalATV
-
-// canonicalATV is similar to pkix.AttributeTypeAndValue but includes
-// tag to ensure all values are marshaled as ASN.1, UTF8String values
-type canonicalATV struct {
-	Type  asn1.ObjectIdentifier
-	Value string `asn1:"utf8"`
-}
-
-// CanonicalName accepts a DER encoded subject name and returns a
-// "Canonical Encoding" matching that returned by the x509_name_canon
-// function in openssl. All string values are transformed with
-// CanonicalString and UTF8 encoded and the leading SEQ header is
-// removed.
-//
-// For more information see
-// https://stackoverflow.com/questions/34095440/hash-algorithm-for-certificate-crl-directory.
-func CanonicalName(name []byte) ([]byte, error) {
-	var origSeq pkix.RDNSequence
-	_, err := asn1.Unmarshal(name, &origSeq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse subject name\n%w", err)
-	}
-	var result []byte
-	for _, origSet := range origSeq {
-		var canonSet canonicalSET
-		for _, origATV := range origSet {
-			origVal, ok := origATV.Value.(string)
-			if !ok {
-				return nil, errors.New("got unexpected non-string value")
-			}
-			canonSet = append(canonSet, canonicalATV{
-				Type:  origATV.Type,
-				Value: CanonicalString(origVal),
-			})
-		}
-		setBytes, err := asn1.Marshal(canonSet)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal canonical name\n%w", err)
-		}
-		result = append(result, setBytes...)
-	}
-	return result, nil
-}
-
-// CanonicalString transforms the given string. All leading and
-// trailing whitespace is trimmed where whitespace is defined as a
-// space, formfeed, tab, newline, carriage return, or vertical tab
-// character. Any remaining sequence of one or more consecutive
-// whitespace characters in replaced with a single ' '.
-//
-// This is a reimplementation of the asn1_string_canon in openssl
-func CanonicalString(s string) string {
-	s = strings.TrimLeft(s, " \f\t\n\v")
-	s = strings.TrimRight(s, " \f\t\n\v")
-	s = strings.ToLower(s)
-	return string(regexp.MustCompile(`[[:space:]]+`).ReplaceAll([]byte(s), []byte(" ")))
 }

--- a/helpers/cahash/cahash.go
+++ b/helpers/cahash/cahash.go
@@ -45,14 +45,13 @@ func GenerateHash(certRaw []byte) (string, error) {
 // -----------------------------------------------------------------------------------
 // See gh:paketo-buildpacks/ca-certificates (cacerts/certs.go) for the original code.
 
-// Iterates over pem blocks until a non-CA certificate if found or no other PEM
-// blocks exist.
+// Iterates over pem blocks until a valid certificate is found or no other PEM blocks exist.
 func DecodeOneCert(raw []byte) (*x509.Certificate, error) {
 	byteData := raw
 	for len(byteData) > 0 {
 		block, rest := pem.Decode(byteData)
 		if block == nil {
-			return nil, errors.New("failed find PEM data")
+			return nil, errors.New("failed decoding PEM data")
 		}
 
 		cert, err := x509.ParseCertificate(block.Bytes)
@@ -60,10 +59,7 @@ func DecodeOneCert(raw []byte) (*x509.Certificate, error) {
 			byteData = rest
 			continue // pem block is not a cert? (e.g. maybe it was a dh_params block)
 		}
-		if !cert.IsCA {
-			return cert, nil
-		}
-		byteData = rest
+		return cert, nil
 	}
 
 	return nil, errors.New("failed find PEM data")

--- a/helpers/cahash/cahash_test.go
+++ b/helpers/cahash/cahash_test.go
@@ -13,14 +13,119 @@ package cahash_test
 
 import (
 	"github.com/epinio/epinio/helpers/cahash"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("CA Hash CanonicalString", func() {
-	It("properly transforms the string", func() {
-		r := cahash.CanonicalString(" \f\n \v\thello      \t \f \n \v  world\t \v\n \f ")
-		Expect(r).To(Equal("hello world"))
+var _ = Describe("GenerateHash", func() {
+
+	When("cert is from a CA", func() {
+		It("will be decoded ok", func() {
+			hash, err := cahash.GenerateHash([]byte(caCrt))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).ToNot(BeNil())
+			Expect(hash).To(Equal("4a2d0bdb"))
+		})
 	})
+
+	When("cert has CA:TRUE in Key Usage", func() {
+		It("will be decoded ok", func() {
+			hash, err := cahash.GenerateHash([]byte(ca2Crt))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).ToNot(BeNil())
+			Expect(hash).To(Equal("bb7fe9fe"))
+		})
+	})
+
+	When("cert is not a CA certificate", func() {
+		It("will be decoded ok", func() {
+			hash, err := cahash.GenerateHash([]byte(tlsCert))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).ToNot(BeNil())
+			Expect(hash).To(Equal("eea339da"))
+		})
+	})
+
+	When("PEM data does not contain a certificate", func() {
+		It("returns an error", func() {
+			hash, err := cahash.GenerateHash([]byte(dhParams))
+			Expect(err).To(HaveOccurred())
+			Expect(hash).To(Equal(""))
+		})
+	})
+
+	When("byte data are not PEM encoded", func() {
+		It("returns an error", func() {
+			hash, err := cahash.GenerateHash([]byte("jnhsdjknjsdk"))
+			Expect(err).To(HaveOccurred())
+			Expect(hash).To(Equal(""))
+		})
+	})
+
 })
+
+var (
+	caCrt = `-----BEGIN CERTIFICATE-----
+MIIBaDCCAQ6gAwIBAgIQfKPL2KSrus0tgwC+yXWCCjAKBggqhkjOPQQDAjAUMRIw
+EAYDVQQDEwllcGluaW8tY2EwHhcNMjMwNTI5MDk0MDEyWhcNMjMwODI3MDk0MDEy
+WjAUMRIwEAYDVQQDEwllcGluaW8tY2EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC
+AATAGx1D7ouV5MHIUWFwP9yaH4uu65kGP9F9wLden/6Kt5OLOA2R5D8IMSYfg5A2
+M+QsXBNefq/nYylMxwrAglC4o0IwQDAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/
+BAUwAwEB/zAdBgNVHQ4EFgQUoAS25Dc5P4gvlo5GJ7gTi0MNrmMwCgYIKoZIzj0E
+AwIDSAAwRQIgLqCFhVfWJb9pRTNRYTpJ0VHi1YIuhbzKKt/PMUN5N4ECIQDhTYcX
+MoTdO/129uqhd26+7dODT6zSF2sBYGS17IvdmA==
+-----END CERTIFICATE-----
+`
+
+	ca2Crt = `-----BEGIN CERTIFICATE-----
+MIIE1zCCA7+gAwIBAgIUSDJy88GCPAKMX961dozA/Fk56ocwDQYJKoZIhvcNAQEL
+BQAwgZoxCzAJBgNVBAYTAkNaMQ4wDAYDVQQIDAVDemVjaDEQMA4GA1UEBwwHUHJh
+Z3VlcjENMAsGA1UECgwEU1VTRTEPMA0GA1UECwwGZXBpbmlvMScwJQYDVQQDDB50
+aC1yZWdpc3RyeS5jaS5lcGluaW8uc3VzZS5kZXYxIDAeBgkqhkiG9w0BCQEWEXRo
+ZWhlamlrQHN1c2UuY29tMB4XDTIzMDUyOTA5Mjc1OVoXDTMzMDUyNjA5Mjc1OVow
+gZoxCzAJBgNVBAYTAkNaMQ4wDAYDVQQIDAVDemVjaDEQMA4GA1UEBwwHUHJhZ3Vl
+cjENMAsGA1UECgwEU1VTRTEPMA0GA1UECwwGZXBpbmlvMScwJQYDVQQDDB50aC1y
+ZWdpc3RyeS5jaS5lcGluaW8uc3VzZS5kZXYxIDAeBgkqhkiG9w0BCQEWEXRoZWhl
+amlrQHN1c2UuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr9Es
+UywTXXGPQ1H57SxIX/JzqgBnwPtqZlRFss7bddGO/oJtIhu806tcn60pVcYtfJa4
+xiz/tCw2YB8LoJNjMO56zSU74t+IJu367jwA0KC88Ym5RjUoZX0QC5xQYQv5dVig
+TgZHyxc3Pp3Gq3+eHX5tEBKqnzHuYM3fHcbzBvtZ/mcBWo4NK+S0y/787Y3GzfmP
+PsUDcSVs/zcWD538JGbjVca/HYXaFon6oy44l3ZcFN6IiUZis1rTDLDMuD7IT+36
+NZu4oGk53xmVQv8sa/JEFtPAqvKLk2dhSBpIym6lKMr+vrLBAaIavjacaAwAkvII
+MSU5SxZ29RhXUfinJQIDAQABo4IBETCCAQ0wgcQGA1UdIwSBvDCBuaGBoKSBnTCB
+mjELMAkGA1UEBhMCQ1oxDjAMBgNVBAgMBUN6ZWNoMRAwDgYDVQQHDAdQcmFndWVy
+MQ0wCwYDVQQKDARTVVNFMQ8wDQYDVQQLDAZlcGluaW8xJzAlBgNVBAMMHnRoLXJl
+Z2lzdHJ5LmNpLmVwaW5pby5zdXNlLmRldjEgMB4GCSqGSIb3DQEJARYRdGhlaGVq
+aWtAc3VzZS5jb22CFEgycvPBgjwCjF/etXaMwPxZOeqHMAwGA1UdEwQFMAMBAf8w
+CwYDVR0PBAQDAgTwMCkGA1UdEQQiMCCCHnRoLXJlZ2lzdHJ5LmNpLmVwaW5pby5z
+dXNlLmRldjANBgkqhkiG9w0BAQsFAAOCAQEAAa4GsrbdvNKsDUTEy2EQIUPlLcJt
+cKnJNByDuvVsObN9/o161OlqIo7pPq02xsrbSWTECtaPbKs4JAw3l8jTu7seQ92p
+bikAGrN4jbMHkLzoltdGQ6wI/qAaEJ18vSAnvHLE0mClC8/UX45oteMO9y0oOPMf
+amYOhy46EVjwhMQDbMGVtqLDTYV4Wh/FOlf0k0SNS/0YwA03EvMlVV6YuCe15NA/
+KsBNWqAwpXLT7hnbs318Tq1MpUnS7SGWS+NQO8lA8FWz8QxEn/hQnXkQZ1xhVJ3Q
+gTx1164+0b5waF86X3PQEVSM4qCNnNBS6CB6kJNGzjE6Ulx+D6HVpOwj0A==
+-----END CERTIFICATE-----`
+
+	tlsCert = `-----BEGIN CERTIFICATE-----
+MIICVjCCAfugAwIBAgIQb+dL7bataJBnRIpe6Y51UjAKBggqhkjOPQQDAjAUMRIw
+EAYDVQQDEwllcGluaW8tY2EwHhcNMjMwNTI5MDk0MDE3WhcNMjMwODI3MDk0MDE3
+WjAAMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1M3KAUzBqUVWxggg
+e6XsThNt6gYzlgnMUdHtza/TsBaDEJznI8u8/ppL+tp58IB6UFGHXkJfZHYMhDb8
+xSc4031RevF7W7Y1rKmoFQekN2HWJM2WazWiznar5b+MrYo7CIhFVH4lui1cqBEL
+YIJPPOtEU+E9DROWzSsobmlDfbTSys9suVNTKE9orrU7t6tpvZ3dy6OdQyrxeggF
+Gzr+Xe+sGab7+bEwCG0DjHQ1ap1gV730DJah/mIZr+MzVbysCZH54gM1zgUV/5LA
+qnEvia6h6QG8jjV1QZSyXCqUJXeYnijs/h5R6ck4jfST1CzyNJg2R5KEjpfmpF08
+ruxc5QIDAQABo3gwdjAOBgNVHQ8BAf8EBAMCBaAwDAYDVR0TAQH/BAIwADAfBgNV
+HSMEGDAWgBSgBLbkNzk/iC+WjkYnuBOLQw2uYzA1BgNVHREBAf8EKzApgiFyZWdp
+c3RyeS5lcGluaW8uc3ZjLmNsdXN0ZXIubG9jYWyHBH8AAAEwCgYIKoZIzj0EAwID
+SQAwRgIhAJhtbr9lMKsgwK7L6jOU5VTc065YrDoEj6/xs9UCdhPCAiEAptsuBGMb
+bwsBe8AtriDRezWjmgfs01ScAQkgipp7/HQ=
+-----END CERTIFICATE-----
+`
+
+	dhParams = `-----BEGIN DH PARAMETERS-----
+MIGHAoGBANclzZUHl2R0NYH5D4cIHcfM8ATuk75NeO2iaV3FhcAAfs9ljlOuJaVn
+UDH9qdl9A4YrDi3VPm55r/YHA4v3wx42Xaq4YfbljeGOKfT6HuhIVS9/n3ZjwNFe
+2IAJeiV4VCRAmjVrgZcUodpEK+jEH4tULNS3NO3p6BbvU/6gyCQLAgEC
+-----END DH PARAMETERS-----`
+)

--- a/helpers/cahash/suite_test.go
+++ b/helpers/cahash/suite_test.go
@@ -20,5 +20,5 @@ import (
 
 func TestEpinio(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, " CA hash suite")
+	RunSpecs(t, "CA hash suite")
 }


### PR DESCRIPTION
This PR removes the check/filter for CA certificates introduced in https://github.com/epinio/epinio/pull/1082

It also use directly the paketo functions instead of copying them.