### PR TITLE
Update release-drafter.yml for prereleases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -40,8 +40,7 @@ exclude-labels:
 
 change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-tag-template: 'v$RESOLVED_VERSION'
-name-template: 'v$RESOLVED_VERSION'
+
 template: |
 
   # What's Changed


### PR DESCRIPTION
Removing the `$RESOLVED_VERSION` should enable also the creation of drafts for prereleases.

If not we should probably use the `$COMPLETE` var instead.