### PR TITLE
Added generic POST/PATCH with tests in configuration API

### DIFF
--- a/pkg/api/core/v1/client/configurations.go
+++ b/pkg/api/core/v1/client/configurations.go
@@ -32,33 +32,18 @@ func (c *Client) Configurations(namespace string) (models.ConfigurationResponseL
 
 // AllConfigurations returns a list of all configurations, across all namespaces
 func (c *Client) AllConfigurations() (models.ConfigurationResponseList, error) {
-	v := models.ConfigurationResponseList{}
+	response := models.ConfigurationResponseList{}
 	endpoint := api.Routes.Path("AllConfigurations")
 
-	return Get(c, endpoint, v)
+	return Get(c, endpoint, response)
 }
 
 // ConfigurationBindingCreate creates a binding from an app to a configurationclass
-func (c *Client) ConfigurationBindingCreate(req models.BindRequest, namespace string, appName string) (models.BindResponse, error) {
-	resp := models.BindResponse{}
+func (c *Client) ConfigurationBindingCreate(request models.BindRequest, namespace string, appName string) (models.BindResponse, error) {
+	response := models.BindResponse{}
+	endpoint := api.Routes.Path("ConfigurationBindingCreate", namespace, appName)
 
-	b, err := json.Marshal(req)
-	if err != nil {
-		return resp, nil
-	}
-
-	data, err := c.post(api.Routes.Path("ConfigurationBindingCreate", namespace, appName), string(b))
-	if err != nil {
-		return resp, err
-	}
-
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return resp, errors.Wrap(err, "response body is not JSON")
-	}
-
-	c.log.V(1).Info("response decoded", "response", resp)
-
-	return resp, nil
+	return Post(c, endpoint, request, response)
 }
 
 // ConfigurationBindingDelete deletes a binding from an app to a configurationclass
@@ -110,57 +95,19 @@ func (c *Client) ConfigurationDelete(req models.ConfigurationDeleteRequest, name
 }
 
 // ConfigurationCreate creates a configuration by invoking the associated API endpoint
-func (c *Client) ConfigurationCreate(req models.ConfigurationCreateRequest, namespace string) (models.Response, error) {
-	resp := models.Response{}
+func (c *Client) ConfigurationCreate(request models.ConfigurationCreateRequest, namespace string) (models.Response, error) {
+	response := models.Response{}
+	endpoint := api.Routes.Path("ConfigurationCreate", namespace)
 
-	c.log.V(5).WithValues("request", req, "namespace", namespace).Info("requesting ConfigurationCreate")
-
-	b, err := json.Marshal(req)
-	if err != nil {
-		return resp, nil
-	}
-
-	data, err := c.post(api.Routes.Path("ConfigurationCreate", namespace), string(b))
-	if err != nil {
-		return resp, err
-	}
-
-	c.log.V(5).WithValues("response", req, "namespace", namespace).Info("received ConfigurationCreate")
-
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return resp, errors.Wrap(err, "response body is not JSON")
-	}
-
-	c.log.V(1).Info("response decoded", "response", resp)
-
-	return resp, nil
+	return Post(c, endpoint, request, response)
 }
 
 // ConfigurationUpdate updates a configuration by invoking the associated API endpoint
-func (c *Client) ConfigurationUpdate(req models.ConfigurationUpdateRequest, namespace, name string) (models.Response, error) {
-	resp := models.Response{}
+func (c *Client) ConfigurationUpdate(request models.ConfigurationUpdateRequest, namespace, name string) (models.Response, error) {
+	response := models.Response{}
+	endpoint := api.Routes.Path("ConfigurationUpdate", namespace, name)
 
-	c.log.V(5).WithValues("request", req, "namespace", namespace, "configuration", name).Info("requesting ConfigurationUpdate")
-
-	b, err := json.Marshal(req)
-	if err != nil {
-		return resp, nil
-	}
-
-	data, err := c.patch(api.Routes.Path("ConfigurationUpdate", namespace, name), string(b))
-	if err != nil {
-		return resp, err
-	}
-
-	c.log.V(5).WithValues("response", req, "namespace", namespace, "configuration", name).Info("received ConfigurationUpdate")
-
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return resp, errors.Wrap(err, "response body is not JSON")
-	}
-
-	c.log.V(1).Info("response decoded", "response", resp)
-
-	return resp, nil
+	return Post(c, endpoint, request, response)
 }
 
 // ConfigurationShow shows a configuration

--- a/pkg/api/core/v1/client/configurations.go
+++ b/pkg/api/core/v1/client/configurations.go
@@ -107,7 +107,7 @@ func (c *Client) ConfigurationUpdate(request models.ConfigurationUpdateRequest, 
 	response := models.Response{}
 	endpoint := api.Routes.Path("ConfigurationUpdate", namespace, name)
 
-	return Post(c, endpoint, request, response)
+	return Patch(c, endpoint, request, response)
 }
 
 // ConfigurationShow shows a configuration

--- a/pkg/api/core/v1/client/configurations_test.go
+++ b/pkg/api/core/v1/client/configurations_test.go
@@ -40,93 +40,73 @@ var _ = Describe("Client Configurations", func() {
 	})
 
 	Describe("getting a configuration list", func() {
-		When("a 200 status code occurred with empty response", func() {
+		Context("with a 200 status code", func() {
 
 			BeforeEach(func() {
 				statusCode = 200
-				responseBody = `[]`
 			})
 
-			It("gets an empty list", func() {
-				configs, err := epinioClient.Configurations("namespace-foo")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(configs).To(Equal(models.ConfigurationResponseList{}))
-			})
-		})
+			When("returns an empty response", func() {
+				It("gets an empty list", func() {
+					responseBody = `[]`
 
-		When("a 200 status code occurred but no JSON was returned", func() {
-
-			BeforeEach(func() {
-				statusCode = 200
-				responseBody = `<html>borken</html>`
+					configs, err := epinioClient.Configurations("namespace-foo")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(configs).To(Equal(models.ConfigurationResponseList{}))
+				})
 			})
 
-			It("returns an error", func() {
-				_, err := epinioClient.Configurations("namespace-foo")
-				Expect(err).To(HaveOccurred())
-			})
-		})
+			When("no JSON was returned", func() {
+				It("returns an error", func() {
+					responseBody = `<html>borken</html>`
 
-		When("a 200 status code occurred with a valid JSON", func() {
-
-			BeforeEach(func() {
-				statusCode = 200
-				responseBody = `[{},{}]`
+					_, err := epinioClient.Configurations("namespace-foo")
+					Expect(err).To(HaveOccurred())
+				})
 			})
 
-			It("returns some configurations", func() {
-				configs, err := epinioClient.Configurations("namespace-foo")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(configs).To(HaveLen(2))
+			When("a valid JSON is returned", func() {
+				It("returns some configurations", func() {
+					responseBody = `[{},{}]`
 
-				resp := []models.ConfigurationResponse{
-					{Meta: models.ConfigurationRef{}, Configuration: models.ConfigurationShowResponse{}},
-					{Meta: models.ConfigurationRef{}, Configuration: models.ConfigurationShowResponse{}},
-				}
-				Expect(configs).To(Equal(models.ConfigurationResponseList(resp)))
+					configs, err := epinioClient.Configurations("namespace-foo")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(configs).To(HaveLen(2))
+
+					resp := []models.ConfigurationResponse{
+						{Meta: models.ConfigurationRef{}, Configuration: models.ConfigurationShowResponse{}},
+						{Meta: models.ConfigurationRef{}, Configuration: models.ConfigurationShowResponse{}},
+					}
+					Expect(configs).To(Equal(models.ConfigurationResponseList(resp)))
+				})
 			})
 		})
 	})
 
 	Describe("creating a configuration", func() {
-		When("a 200 status code occurred with empty response", func() {
+		Context("with a 200 status code", func() {
 
 			BeforeEach(func() {
 				statusCode = 200
-				responseBody = `{"status":"ok"}`
 			})
 
-			It("gets an empty list", func() {
-				resp, err := epinioClient.ConfigurationCreate(models.ConfigurationCreateRequest{}, "namespace-foo")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(resp).To(Equal(models.ResponseOK))
-			})
-		})
+			When("returns a valid response", func() {
+				It("gets a successful response", func() {
+					responseBody = `{"status":"ok"}`
 
-		When("a 200 status code occurred but no JSON was returned", func() {
-
-			BeforeEach(func() {
-				statusCode = 200
-				responseBody = `<html>borken</html>`
+					resp, err := epinioClient.ConfigurationCreate(models.ConfigurationCreateRequest{}, "namespace-foo")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(resp).To(Equal(models.ResponseOK))
+				})
 			})
 
-			It("returns an error", func() {
-				_, err := epinioClient.ConfigurationCreate(models.ConfigurationCreateRequest{}, "namespace-foo")
-				Expect(err).To(HaveOccurred())
-			})
-		})
+			When("no JSON was returned", func() {
+				It("returns an error", func() {
+					responseBody = `<html>borken</html>`
 
-		When("a 200 status code occurred with a valid JSON", func() {
-
-			BeforeEach(func() {
-				statusCode = 200
-				responseBody = `{"status":"ok"}`
-			})
-
-			It("returns some configurations", func() {
-				resp, err := epinioClient.ConfigurationCreate(models.ConfigurationCreateRequest{}, "namespace-foo")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(resp).To(Equal(models.ResponseOK))
+					_, err := epinioClient.ConfigurationCreate(models.ConfigurationCreateRequest{}, "namespace-foo")
+					Expect(err).To(HaveOccurred())
+				})
 			})
 		})
 	})

--- a/pkg/api/core/v1/client/configurations_test.go
+++ b/pkg/api/core/v1/client/configurations_test.go
@@ -88,6 +88,49 @@ var _ = Describe("Client Configurations", func() {
 		})
 	})
 
+	Describe("creating a configuration", func() {
+		When("a 200 status code occurred with empty response", func() {
+
+			BeforeEach(func() {
+				statusCode = 200
+				responseBody = `{"status":"ok"}`
+			})
+
+			It("gets an empty list", func() {
+				resp, err := epinioClient.ConfigurationCreate(models.ConfigurationCreateRequest{}, "namespace-foo")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp).To(Equal(models.ResponseOK))
+			})
+		})
+
+		When("a 200 status code occurred but no JSON was returned", func() {
+
+			BeforeEach(func() {
+				statusCode = 200
+				responseBody = `<html>borken</html>`
+			})
+
+			It("returns an error", func() {
+				_, err := epinioClient.ConfigurationCreate(models.ConfigurationCreateRequest{}, "namespace-foo")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		When("a 200 status code occurred with a valid JSON", func() {
+
+			BeforeEach(func() {
+				statusCode = 200
+				responseBody = `{"status":"ok"}`
+			})
+
+			It("returns some configurations", func() {
+				resp, err := epinioClient.ConfigurationCreate(models.ConfigurationCreateRequest{}, "namespace-foo")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp).To(Equal(models.ResponseOK))
+			})
+		})
+	})
+
 	When("a 500 status code and a JSON error was returned", func() {
 
 		BeforeEach(func() {
@@ -108,11 +151,30 @@ var _ = Describe("Client Configurations", func() {
 				_, err := call()
 				Expect(err).To(HaveOccurred())
 			},
-			Entry("configuration", func() (any, error) { return epinioClient.Configurations("namespace") }),
-			Entry("all configurations", func() (any, error) { return epinioClient.AllConfigurations() }),
-			Entry("configuration show", func() (any, error) { return epinioClient.ConfigurationShow("namespace", "config") }),
-			Entry("configuration apps", func() (any, error) { return epinioClient.ConfigurationApps("namespace") }),
-			Entry("configuration match", func() (any, error) { return epinioClient.ConfigurationMatch("namespace", "prefix") }),
+			Entry("configuration", func() (any, error) {
+				return epinioClient.Configurations("namespace")
+			}),
+			Entry("all configurations", func() (any, error) {
+				return epinioClient.AllConfigurations()
+			}),
+			Entry("configurations binding", func() (any, error) {
+				return epinioClient.ConfigurationBindingCreate(models.BindRequest{}, "namespace", "app")
+			}),
+			Entry("configuration create", func() (any, error) {
+				return epinioClient.ConfigurationCreate(models.ConfigurationCreateRequest{}, "namespace")
+			}),
+			Entry("configuration update", func() (any, error) {
+				return epinioClient.ConfigurationUpdate(models.ConfigurationUpdateRequest{}, "namespace", "prefix")
+			}),
+			Entry("configuration show", func() (any, error) {
+				return epinioClient.ConfigurationShow("namespace", "config")
+			}),
+			Entry("configuration apps", func() (any, error) {
+				return epinioClient.ConfigurationApps("namespace")
+			}),
+			Entry("configuration match", func() (any, error) {
+				return epinioClient.ConfigurationMatch("namespace", "prefix")
+			}),
 		)
 	})
 })


### PR DESCRIPTION
Added a generic `Post[T]`, `Patch[T]` and `Do[T]` to centralize duplicated code and added some tests.

Same as `Get[T]`: https://github.com/epinio/epinio/pull/2347