### PR TITLE
Add port forward for services (#2037)

### DIFF
--- a/acceptance/api/v1/service_portforward_test.go
+++ b/acceptance/api/v1/service_portforward_test.go
@@ -1,0 +1,92 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1_test
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/epinio/epinio/acceptance/helpers/catalog"
+	"github.com/epinio/epinio/acceptance/helpers/epinio"
+	"github.com/epinio/epinio/acceptance/testenv"
+	v1 "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	"github.com/gorilla/websocket"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ServicePortForward Endpoint", Label("ServicePortForward"), func() {
+	var epinioHelper epinio.Epinio
+	var namespace string
+	var catalogService models.CatalogService
+
+	Context("With ensured namespace", func() {
+		BeforeEach(func() {
+			epinioHelper = epinio.NewEpinioHelper(testenv.EpinioBinaryPath())
+			namespace = catalog.NewNamespaceName()
+			env.SetupAndTargetNamespace(namespace)
+			catalogService = catalog.CreateCatalogServiceApache()
+		})
+
+		AfterEach(func() {
+			catalog.DeleteCatalogService(catalogService.Meta.Name)
+			env.DeleteNamespace(namespace)
+		})
+
+		Context("With ensured service", func() {
+			var serviceName string
+
+			BeforeEach(func() {
+				serviceName = catalog.NewServiceName()
+				By("Deploying Apache with service", func() {
+					out, err := epinioHelper.Run("service", "create", "apache-test", serviceName, "--wait")
+					Expect(err).ToNot(HaveOccurred(), out)
+				})
+			})
+
+			AfterEach(func() {
+				catalog.DeleteService(serviceName, namespace)
+			})
+
+			It("tests the port-forward API", func() {
+				By("assemble url")
+				endpoint := fmt.Sprintf("%s%s/namespaces/%s/services/%s/portforward", serverURL, v1.WsRoot, namespace, serviceName)
+				portForwardURL, err := url.Parse(endpoint)
+				Expect(err).ToNot(HaveOccurred())
+
+				token, err := authToken()
+				Expect(err).ToNot(HaveOccurred())
+
+				values := portForwardURL.Query()
+				values.Add("authtoken", token)
+				portForwardURL.RawQuery = values.Encode()
+				portForwardURL.Scheme = "wss"
+
+				c, _, err := websocket.DefaultDialer.Dial(portForwardURL.String(), nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				req, _ := http.NewRequest(http.MethodGet, "http://localhost", nil)
+				Expect(req.Write(c.UnderlyingConn())).ToNot(HaveOccurred())
+
+				resp, err := http.ReadResponse(bufio.NewReader(c.UnderlyingConn()), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				defer c.Close()
+			})
+		})
+	})
+})

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -1979,7 +1979,7 @@ userConfig:
 		})
 	}
 
-	var _ = Describe("Custom chart-value", func() {
+	var _ = Describe("Custom chart-value", Label("appListeningPort"), func() {
 		var (
 			namespace string
 			appName   string

--- a/acceptance/helpers/catalog/misc.go
+++ b/acceptance/helpers/catalog/misc.go
@@ -52,6 +52,28 @@ func CreateCatalogServiceNginx() models.CatalogService {
 	return catalogService
 }
 
+func ApacheCatalogService(name string) models.CatalogService {
+	return models.CatalogService{
+		Meta: models.MetaLite{
+			Name: name,
+		},
+		HelmChart: "apache",
+		HelmRepo: models.HelmRepo{
+			Name: "",
+			URL:  "https://charts.bitnami.com/bitnami",
+		},
+		Values: "{'service': {'type': 'ClusterIP'}}",
+	}
+}
+
+func CreateCatalogServiceApache() models.CatalogService {
+	catalogService := ApacheCatalogService("apache-test")
+
+	CreateCatalogService(catalogService)
+
+	return catalogService
+}
+
 func CreateCatalogService(catalogService models.CatalogService) {
 	CreateCatalogServiceInNamespace("epinio", catalogService)
 }

--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -1634,6 +1634,34 @@
         }
       }
     },
+    "/namespaces/{Namespace}/services/{Service}/portforward": {
+      "get": {
+        "tags": [
+          "service"
+        ],
+        "summary": "Get a shell to the `Service` in the `Namespace`.",
+        "operationId": "ServicePortForward",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "Namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "Service",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ServicePortForwardResponse"
+          }
+        }
+      }
+    },
     "/namespaces/{Namespace}/staging/{StageID}/complete": {
       "get": {
         "tags": [
@@ -3103,6 +3131,9 @@
       "schema": {
         "$ref": "#/definitions/Response"
       }
+    },
+    "ServicePortForwardResponse": {
+      "description": ""
     },
     "StagingCompleteResponse": {
       "description": "",

--- a/internal/api/v1/docs/service.go
+++ b/internal/api/v1/docs/service.go
@@ -236,3 +236,14 @@ type ServiceUnbindResponse struct {
 	// in: body
 	Body models.Response
 }
+
+// swagger:parameters ServicePortForward
+type ServicePortForwardParam struct {
+	// in: path
+	Namespace string
+	// in: path
+	Service string
+}
+
+// swagger:response ServicePortForwardResponse
+type ServicePortForwardResponse struct{}

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -191,10 +191,11 @@ var Routes = routes.NamedRoutes{
 }
 
 var WsRoutes = routes.NamedRoutes{
-	"AppExec":        get("/namespaces/:namespace/applications/:app/exec", errorHandler(application.Exec)),
-	"AppPortForward": get("/namespaces/:namespace/applications/:app/portforward", errorHandler(application.PortForward)),
-	"AppLogs":        get("/namespaces/:namespace/applications/:app/logs", application.Logs),
-	"StagingLogs":    get("/namespaces/:namespace/staging/:stage_id/logs", application.Logs),
+	"AppExec":            get("/namespaces/:namespace/applications/:app/exec", errorHandler(application.Exec)),
+	"AppPortForward":     get("/namespaces/:namespace/applications/:app/portforward", errorHandler(application.PortForward)),
+	"AppLogs":            get("/namespaces/:namespace/applications/:app/logs", application.Logs),
+	"ServicePortForward": get("/namespaces/:namespace/services/:service/portforward", errorHandler(service.PortForward)),
+	"StagingLogs":        get("/namespaces/:namespace/staging/:stage_id/logs", application.Logs),
 }
 
 // Lemon extends the specified router with the methods and urls

--- a/internal/api/v1/service/portforward.go
+++ b/internal/api/v1/service/portforward.go
@@ -1,0 +1,73 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/internal/api/v1/proxy"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
+	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{} // use default option
+
+func PortForward(c *gin.Context) apierror.APIErrors {
+	ctx := c.Request.Context()
+	logger := requestctx.Logger(ctx).WithName("PortForward")
+	namespace := c.Param("namespace")
+	serviceName := c.Param("service")
+
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	service, apiErr := GetService(ctx, cluster, logger, namespace, serviceName)
+	if apiErr != nil {
+		return apiErr
+	}
+
+	if service == nil {
+		return apierror.ServiceIsNotKnown(serviceName)
+	}
+
+	wconn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		logger.Error(err, "failed to upgrade")
+		return apierror.InternalError(err)
+	}
+	defer wconn.Close()
+
+	conn := wconn.UnderlyingConn()
+
+	msg := fmt.Sprintf("upgraded connection [%s] - service routes [%s]", conn.RemoteAddr().String(), strings.Join(service.InternalRoutes, ", "))
+	logger.V(1).Info(msg)
+
+	if len(service.InternalRoutes) == 0 {
+		return apierror.NewInternalError("no internal service routes available")
+	}
+
+	tcpProxy, err := proxy.NewTCPProxy(c, conn, service.InternalRoutes[0])
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+	if err := tcpProxy.Start(); err != nil {
+		return apierror.InternalError(err)
+	}
+
+	return nil
+}

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -108,6 +108,7 @@ type APIClient interface {
 	ServiceDelete(req models.ServiceDeleteRequest, namespace string, names []string, f epinioapi.ErrorFunc) (models.ServiceDeleteResponse, error)
 	ServiceList(namespace string) (models.ServiceList, error)
 	ServiceMatch(namespace, prefix string) (models.ServiceMatchResponse, error)
+	ServicePortForward(namespace string, serviceName string, opts *epinioapi.PortForwardOpts) error
 
 	// application charts
 	ChartList() ([]models.AppChart, error)

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -12,12 +12,14 @@
 package usercmd
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"sort"
 	"strings"
 
 	"github.com/epinio/epinio/helpers/termui"
+	"github.com/epinio/epinio/pkg/api/core/v1/client"
 	apierrors "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/kyokomi/emoji"
@@ -431,4 +433,23 @@ func (c *EpinioClient) CatalogMatching(prefix string) []string {
 
 	log.Info("matches", "found", result)
 	return result
+}
+
+func (c *EpinioClient) ServicePortForward(ctx context.Context, serviceName string, address, ports []string) error {
+	log := c.Log.WithName("ServicePortForward")
+	log.Info("start")
+	defer log.Info("return")
+
+	msg := c.ui.Note().
+		WithStringValue("Namespace", c.Settings.Namespace).
+		WithStringValue("Service", serviceName)
+
+	msg.Msg("Executing port forwarding")
+
+	if err := c.TargetOk(); err != nil {
+		return err
+	}
+
+	opts := client.NewPortForwardOpts(address, ports)
+	return c.API.ServicePortForward(c.Settings.Namespace, serviceName, opts)
 }

--- a/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
+++ b/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
@@ -763,6 +763,19 @@ type FakeAPIClient struct {
 	serviceUnbindReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ServicePortForwardStub        func(string, string, *client.PortForwardOpts) error
+	servicePortForwardMutex       sync.RWMutex
+	servicePortForwardArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 *client.PortForwardOpts
+	}
+	servicePortForwardReturns struct {
+		result1 error
+	}
+	servicePortForwardReturnsOnCall map[int]struct {
+		result1 error
+	}
 	StagingCompleteStub        func(string, string) (models.Response, error)
 	stagingCompleteMutex       sync.RWMutex
 	stagingCompleteArgsForCall []struct {
@@ -4257,6 +4270,27 @@ func (fake *FakeAPIClient) ServiceUnbindReturnsOnCall(i int, result1 error) {
 	fake.serviceUnbindReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeAPIClient) ServicePortForward(arg1 string, arg2 string, arg3 *client.PortForwardOpts) error {
+	fake.servicePortForwardMutex.Lock()
+	ret, specificReturn := fake.servicePortForwardReturnsOnCall[len(fake.servicePortForwardArgsForCall)]
+	fake.servicePortForwardArgsForCall = append(fake.servicePortForwardArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 *client.PortForwardOpts
+	}{arg1, arg2, arg3})
+	stub := fake.ServicePortForwardStub
+	fakeReturns := fake.servicePortForwardReturns
+	fake.recordInvocation("ServicePortForward", []interface{}{arg1, arg2, arg3})
+	fake.servicePortForwardMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
 }
 
 func (fake *FakeAPIClient) StagingComplete(arg1 string, arg2 string) (models.Response, error) {

--- a/pkg/api/core/v1/client/portforwarder.go
+++ b/pkg/api/core/v1/client/portforwarder.go
@@ -1,0 +1,218 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"strconv"
+
+	. "github.com/epinio/epinio/internal/api/v1/proxy"
+	"github.com/gorilla/websocket"
+)
+
+type ServicePortForwarder struct {
+	Client             *Client
+	Endpoint           string
+	ListeningAddresses []ListenAddress
+	Ports              []ForwardedPort
+	StopChan           <-chan struct{}
+}
+
+func NewServicePortForwarder(client *Client, endpoint string, addresses []string, ports []string, stopChan <-chan struct{}) (*ServicePortForwarder, error) {
+	if len(addresses) == 0 {
+		return nil, errors.New("you must specify at least 1 address")
+	}
+	parsedAddresses, err := ParseAddresses(addresses)
+	if err != nil {
+		return nil, err
+	}
+	if len(ports) == 0 {
+		return nil, errors.New("you must specify at least 1 port")
+	}
+	parsedPorts, err := ParsePorts(ports)
+	if err != nil {
+		return nil, err
+	}
+	return &ServicePortForwarder{
+		Client:             client,
+		Endpoint:           endpoint,
+		ListeningAddresses: parsedAddresses,
+		Ports:              parsedPorts,
+		StopChan:           stopChan,
+	}, nil
+}
+
+func (pf *ServicePortForwarder) ForwardPorts() error {
+	var err error
+
+	listenSuccess := false
+	for i := range pf.Ports {
+		port := &pf.Ports[i]
+		err = pf.listenOnPort(port)
+		switch {
+		case err == nil:
+			listenSuccess = true
+		default:
+			pf.Client.log.V(1).Info("Unable to listen on port %d: %v\n", port.Local)
+			return err
+		}
+	}
+
+	if !listenSuccess {
+		return fmt.Errorf("unable to listen on any of the requested ports: %v", pf.Ports)
+	}
+
+	// wait for interrupt or conn closure
+	<-pf.StopChan
+	pf.Client.log.V(1).Info("lost connection to pod")
+
+	return nil
+}
+
+func (pf *ServicePortForwarder) listenOnPort(port *ForwardedPort) error {
+	var errors []error
+	failCounters := make(map[string]int, 2)
+	successCounters := make(map[string]int, 2)
+	for _, addr := range pf.ListeningAddresses {
+		err := pf.listenOnPortAndAddress(port, addr.Protocol, addr.Address)
+		if err != nil {
+			errors = append(errors, err)
+			failCounters[addr.FailureMode]++
+		} else {
+			successCounters[addr.FailureMode]++
+		}
+	}
+	if successCounters["all"] == 0 && failCounters["all"] > 0 {
+		return fmt.Errorf("%s: %v", "Listeners failed to create with the following errors", errors)
+	}
+	if failCounters["any"] > 0 {
+		return fmt.Errorf("%s: %v", "Listeners failed to create with the following errors", errors)
+	}
+	return nil
+}
+
+func (pf *ServicePortForwarder) listenOnPortAndAddress(port *ForwardedPort, protocol string, address string) error {
+	listener, err := pf.getListener(protocol, address, port)
+	if err != nil {
+		return err
+	}
+	go func() {
+		if err = pf.waitForConnection(listener, *port); err != nil {
+			return
+		}
+	}()
+	return err
+}
+
+func (pf *ServicePortForwarder) getListener(protocol string, hostname string, port *ForwardedPort) (net.Listener, error) {
+	listener, err := net.Listen(protocol, net.JoinHostPort(hostname, strconv.Itoa(int(port.Local))))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create listener: Error %s", err)
+	}
+	listenerAddress := listener.Addr().String()
+	host, localPort, _ := net.SplitHostPort(listenerAddress)
+	localPortUInt, err := strconv.ParseUint(localPort, 10, 16)
+
+	if err != nil {
+		errStr := fmt.Sprintf("error parsing local port: %s from %s (%s)", err, listenerAddress, host)
+		return nil, fmt.Errorf(errStr)
+	}
+	port.Local = uint16(localPortUInt)
+	pf.Client.log.V(1).Info("Forwarding from %s -> %d\n", net.JoinHostPort(hostname, strconv.Itoa(int(localPortUInt))), port.Remote)
+
+	return listener, nil
+}
+
+func (pf *ServicePortForwarder) waitForConnection(listener net.Listener, port ForwardedPort) error {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			pf.Client.log.V(1).Info("error accepting connection on port %d: %v", port.Local, err)
+			return err
+		} else {
+			defer listener.Close()
+		}
+
+		go func() {
+			if err = pf.handleConnection(conn); err != nil {
+				return
+			}
+		}()
+	}
+}
+
+func (pf *ServicePortForwarder) handleConnection(localConn net.Conn) error {
+	defer localConn.Close()
+
+	portForwardURL, err := url.Parse(pf.Endpoint)
+	if err != nil {
+		pf.Client.log.V(1).Error(err, "error parsing endpoint")
+		return err
+	}
+
+	if err := pf.Client.addAuthTokenToURL(portForwardURL); err != nil {
+		pf.Client.log.V(1).Error(err, "error adding auth token to URL")
+		return err
+	}
+
+	portForwardURL.Scheme = "wss"
+
+	c, _, err := websocket.DefaultDialer.Dial(portForwardURL.String(), nil)
+	if err != nil {
+		pf.Client.log.V(1).Error(err, "error dialing")
+		return err
+	}
+	if c != nil {
+		defer c.Close()
+	}
+
+	upgradedConnection := c.UnderlyingConn()
+	defer upgradedConnection.Close()
+
+	localError := make(chan error)
+	remoteDone := make(chan struct{})
+
+	go func() {
+		// Copy from the remote side to the local port.
+		if _, err := io.Copy(localConn, upgradedConnection); err != nil && !errors.Is(err, net.ErrClosed) {
+			pf.Client.log.V(1).Error(err, "error copying from upgradedConnection to local connection")
+			localError <- err
+		}
+
+		// inform the select below that the remote copy is done
+		close(remoteDone)
+	}()
+
+	go func() {
+		// Copy from the local port to the remote side.
+		if _, err := io.Copy(upgradedConnection, localConn); err != nil && !errors.Is(err, net.ErrClosed) {
+			pf.Client.log.V(1).Error(err, "error copying from local connection to UpgradedConnection")
+			// break out of the select below without waiting for the other copy to finish
+			localError <- err
+		}
+	}()
+
+	// wait for either a local->remote error or for copying from remote->local to finish
+	select {
+	case <-remoteDone:
+		break
+	case err := <-localError:
+		pf.Client.log.Error(err, "closed ServicePortForwarder for connection", upgradedConnection.RemoteAddr().String())
+		return err
+	}
+
+	return nil
+}

--- a/pkg/api/core/v1/client/services.go
+++ b/pkg/api/core/v1/client/services.go
@@ -227,3 +227,14 @@ func constructServiceBatchDeleteURL(namespace string, names []string) string {
 
 	return fmt.Sprintf("%s?%s", URL, URLParams)
 }
+
+// ServicePortForward will forward the local traffic to a remote app
+func (c *Client) ServicePortForward(namespace string, serviceName string, opts *PortForwardOpts) error {
+	endpoint := fmt.Sprintf("%s%s/%s", c.Settings.API, api.WsRoot, api.WsRoutes.Path("ServicePortForward", namespace, serviceName))
+
+	if fw, err := NewServicePortForwarder(c, endpoint, opts.Address, opts.Ports, opts.StopChannel); err != nil {
+		return err
+	} else {
+		return fw.ForwardPorts()
+	}
+}


### PR DESCRIPTION
Epinio services can now be accessed from the host by executing:

epinio service port-forward SERVICENAME [LOCAL_PORT] [...[LOCAL_PORT_N]] [flags]

Issue: https://github.com/epinio/epinio/issues/2037