### PR TITLE
Fixed wrong `upgrade responder` configuration

### DIFF
--- a/scripts/upgrade-responder-release-update.sh
+++ b/scripts/upgrade-responder-release-update.sh
@@ -44,7 +44,7 @@ function UpgradeResponderResponseJSON
   fi
 
   cat /tmp/epinio_releases.json | \
-  jq '.[] | {
+  jq '.[] | select(.draft | not) | {
     Name: (.name | split(" ")[0]),
     ReleaseDate: .published_at,
     MinUpgradableVersion: "",


### PR DESCRIPTION
The Upgrade Responder instance was not starting because of a `null` `ReleaseDate` in the configuration.

This was generated because the usage of the authenticated Github APIs will return the draft as well.

This PR fixes this, filtering the draft releases.