### PR TITLE
Fixed passing CI when `codecov` upload fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -613,6 +613,7 @@ jobs:
           files: ./unittests/coverprofile.out
           flags: unittests
           verbose: true
+          fail_ci_if_error: true
 
       - name: Upload acceptance-api coverage to Codecov
         uses: codecov/codecov-action@v3
@@ -621,6 +622,7 @@ jobs:
           files: ./acceptance-api/coverprofile.out,./acceptance-api-apps/coverprofile.out,./acceptance-api-services/coverprofile.out
           flags: acceptance-api
           verbose: true
+          fail_ci_if_error: true
 
       - name: Upload acceptance-cli coverage to Codecov
         uses: codecov/codecov-action@v3
@@ -629,6 +631,7 @@ jobs:
           files: ./acceptance-cli/coverprofile.out,./acceptance-cli-apps/coverprofile.out,./acceptance-cli-services/coverprofile.out
           flags: acceptance-cli
           verbose: true
+          fail_ci_if_error: true
 
       - name: Upload acceptance-apps coverage to Codecov
         uses: codecov/codecov-action@v3
@@ -637,3 +640,4 @@ jobs:
           files: ./acceptance-apps/coverprofile.out
           flags: acceptance-apps
           verbose: true
+          fail_ci_if_error: true


### PR DESCRIPTION
There were some code coverage reports missing due to silent failures of the codecov actions.

This run succeded, but the CI was green: https://github.com/epinio/epinio/actions/runs/5123706518/jobs/9217088520

```
[2023-05-30T18:04:09.448Z] ['info'] Pinging Codecov: https://codecov.io/upload/v4?package=github-action-3.1.4-uploader-0.5.0&token=*******&branch=main&build=5123706518&build_url=https%3A%2F%2Fgithub.com%2Fepinio%2Fepinio%2Factions%2Fruns%2F5123706518%2Fjobs%2F9217088520&commit=2240f783f44018a16eb85bfbdb096c16bc2dbc70&job=CI&pr=&service=github-actions&slug=epinio%2Fepinio&name=codecov-epinio&tag=&flags=unittests&parent=
[2023-05-30T18:04:09.448Z] ['verbose'] Passed token was 0 characters long
[2023-05-30T18:04:09.448Z] ['verbose'] https://codecov.io/upload/v4?package=github-action-3.1.4-uploader-0.5.0&branch=main&build=5123706518&build_url=https%3A%2F%2Fgithub.com%2Fepinio%2Fepinio%2Factions%2Fruns%2F5123706518%2Fjobs%2F9217088520&commit=2240f783f44018a16eb85bfbdb096c16bc2dbc70&job=CI&pr=&service=github-actions&slug=epinio%2Fepinio&name=codecov-epinio&tag=&flags=unittests&parent=
        Content-Type: 'text/plain'
        Content-Encoding: 'gzip'
        X-Reduced-Redundancy: 'false'
[2023-05-30T18:04:09.731Z] ['error'] There was an error running the uploader: Error uploading to https://codecov.io: Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
[2023-05-30T18:04:09.733Z] ['verbose'] The error stack is: Error: Error uploading to https://codecov.io: Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
    at main (/snapshot/repo/dist/src/index.js)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
[2023-05-30T18:04:09.734Z] ['verbose'] End of uploader: 1173 milliseconds
```

Investigating a bit this seems the expected default behaviour.

Since in our workflow the upload is done in a separate final step we can retry this manually if it fails.

Setting the `fail_ci_if_error` value to `true` will enable the failure of the CI.

---

Relevant Codecov issues:

- https://github.com/codecov/codecov-action/issues/917
- https://github.com/codecov/codecov-action/issues/926

