### PR TITLE
Enable default serviceaccount to use the regcred secret

### DIFF
--- a/.github/workflows/rke2-lh-ec2.yml
+++ b/.github/workflows/rke2-lh-ec2.yml
@@ -244,8 +244,8 @@ jobs:
       - name: Installation Acceptance Tests
         env:
           REGEX: Scenario4
-          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          REGISTRY_USERNAME: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
           AWS_ZONE_ID: ${{ secrets.AWS_ZONE_ID }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/upgrade-bound.yml
+++ b/.github/workflows/upgrade-bound.yml
@@ -78,8 +78,8 @@ jobs:
 
       - name: Deploy k3d cluster with latest release of Epinio
         env:
-          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          REGISTRY_USERNAME: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
         run: |
           make acceptance-cluster-setup
           export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig

--- a/.github/workflows/upgrade-bound.yml
+++ b/.github/workflows/upgrade-bound.yml
@@ -77,6 +77,9 @@ jobs:
           echo "`pwd`/output/bin" >> $GITHUB_PATH    
 
       - name: Deploy k3d cluster with latest release of Epinio
+        env:
+          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           make acceptance-cluster-setup
           export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -78,8 +78,8 @@ jobs:
 
       - name: Deploy k3d cluster with latest release of Epinio
         env:
-          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          REGISTRY_USERNAME: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
         run: |
           make acceptance-cluster-setup
           export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -77,6 +77,9 @@ jobs:
           echo "`pwd`/output/bin" >> $GITHUB_PATH    
 
       - name: Deploy k3d cluster with latest release of Epinio
+        env:
+          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           make acceptance-cluster-setup
           export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ acceptance-cluster-delete-kind:
 	kind delete cluster --name epinio-acceptance
 
 acceptance-cluster-setup:
-	@./scripts/acceptance-cluster-setup.sh
+	./scripts/acceptance-cluster-setup.sh
 
 acceptance-cluster-setup-kind:
 	@./scripts/acceptance-cluster-setup-kind.sh
@@ -224,7 +224,7 @@ uninstall-upgrade-responder:
 	helm uninstall -n epinio upgrade-responder --wait || true
 
 prepare_environment_k3d: build-linux-amd64 build-images
-	@./scripts/prepare-environment-k3d.sh
+	./scripts/prepare-environment-k3d.sh
 
 unprepare_environment_k3d:
 	kubectl delete --ignore-not-found=true secret regcred

--- a/acceptance/testenv/registry.go
+++ b/acceptance/testenv/registry.go
@@ -33,10 +33,13 @@ func RegistryPassword() string {
 func CreateRegistrySecret() {
 	if RegistryUsername() != "" && RegistryPassword() != "" {
 		fmt.Printf("Creating image pull secret for Dockerhub on node %d\n", GinkgoParallelProcess())
+		_, _ = proc.Kubectl("create", "namespace", "epinio")
 		_, _ = proc.Kubectl("create", "secret", "docker-registry", "regcred",
+			"--namespace", "epinio",
 			"--docker-server", "https://index.docker.io/v1/",
 			"--docker-username", RegistryUsername(),
 			"--docker-password", RegistryPassword(),
 		)
+		_, _ = proc.Kubectl("patch", "serviceaccount", "-n", "epinio", "default", "-p", `{"imagePullSecrets": [{"name": "regcred"}]}`)
 	}
 }

--- a/scripts/acceptance-cluster-setup.sh
+++ b/scripts/acceptance-cluster-setup.sh
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -ex
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 NETWORK_NAME=epinio-acceptance

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -37,12 +37,15 @@ function check_dependency {
 }
 
 function create_docker_pull_secret {
-	if [[ "$REGISTRY_USERNAME" != "" && "$REGISTRY_PASSWORD" != "" && ! $(kubectl get secret regcred > /dev/null 2>&1) ]];
+	if [[ "$REGISTRY_USERNAME" != "" && "$REGISTRY_PASSWORD" != "" && ! $(kubectl get secret -n epinio regcred > /dev/null 2>&1) ]];
 	then
+		kubectl create namespace epinio
 		kubectl create secret docker-registry regcred \
+			--namespace epinio \
 			--docker-server https://index.docker.io/v1/ \
 			--docker-username $REGISTRY_USERNAME \
 			--docker-password $REGISTRY_PASSWORD
+		kubectl patch serviceaccount -n epinio default -p '{"imagePullSecrets": [{"name": "regcred"}]}'
 	fi
 }
 

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -ex
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 


### PR DESCRIPTION
This is about setting up default SA to use the existing `regcred` secret for dockerhub registries for pulling images.

It may help when CI reach public dockerhub rate-limit.

- [x] Needs to be tested first (any install test and upgrade).
* Upgrade test: https://github.com/epinio/epinio/actions/runs/5257824919
* Install test RKE-CI: https://github.com/epinio/epinio/actions/runs/5257843879

~But seems the `REGISTRY_USERNAME|PASSWORD` vars are not set in CI.~ addressed with this PR

- [ ] TODO retest CI
* Upgrade test
* Upgrade test with bound service
* Install test RKE-CI
* Install test RKE2-EC2-CI