### PR TITLE
Simplification of DeployApp

### DIFF
--- a/internal/api/v1/application/deploy.go
+++ b/internal/api/v1/application/deploy.go
@@ -92,9 +92,14 @@ func Deploy(c *gin.Context) apierror.APIErrors {
 		return apierr
 	}
 
-	routes, apierr := deploy.DeployApp(ctx, cluster, req.App, username, req.Stage.ID, &req.Origin, nil)
+	routes, apierr := deploy.DeployApp(ctx, cluster, req.App, username, req.Stage.ID)
 	if apierr != nil {
 		return apierr
+	}
+
+	err = application.SetOrigin(ctx, cluster, req.App, req.Origin)
+	if err != nil {
+		return apierror.InternalError(err, "saving the app origin")
 	}
 
 	response.OKReturn(c, models.DeployResponse{

--- a/internal/api/v1/application/restart.go
+++ b/internal/api/v1/application/restart.go
@@ -14,7 +14,6 @@ package application
 import (
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/deploy"
@@ -76,8 +75,7 @@ func Restart(c *gin.Context) apierror.APIErrors {
 		}
 	}
 
-	nano := time.Now().UnixNano()
-	_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, username, "", nil, &nano)
+	_, apierr := deploy.DeployAppWithRestart(ctx, cluster, app.Meta, username, "")
 	if apierr != nil {
 		return apierr
 	}

--- a/internal/api/v1/application/update.go
+++ b/internal/api/v1/application/update.go
@@ -265,7 +265,7 @@ func Update(c *gin.Context) apierror.APIErrors { // nolint:gocyclo // simplifica
 	if app.Workload != nil || desired > 0 {
 		log.Info("updating app -- redeploy")
 
-		_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, username, "", nil, nil)
+		_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, username, "")
 		if apierr != nil {
 			return apierr
 		}

--- a/internal/api/v1/configuration/replace.go
+++ b/internal/api/v1/configuration/replace.go
@@ -12,8 +12,6 @@
 package configuration
 
 import (
-	"time"
-
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/deploy"
 	"github.com/epinio/epinio/internal/api/v1/response"
@@ -82,8 +80,7 @@ func Replace(c *gin.Context) apierror.APIErrors { // nolint:gocyclo // simplific
 				// references/uses changed, i.e. the configuration. We still have to
 				// trigger the restart somehow, so that the pod mounting the
 				// configuration remounts it for the new/changed keys.
-				nano := time.Now().UnixNano()
-				_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, username, "", nil, &nano)
+				_, apierr := deploy.DeployAppWithRestart(ctx, cluster, app.Meta, username, "")
 				if apierr != nil {
 					return apierr
 				}

--- a/internal/api/v1/configuration/update.go
+++ b/internal/api/v1/configuration/update.go
@@ -12,8 +12,6 @@
 package configuration
 
 import (
-	"time"
-
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/deploy"
 	"github.com/epinio/epinio/internal/api/v1/response"
@@ -86,8 +84,7 @@ func Update(c *gin.Context) apierror.APIErrors { // nolint:gocyclo // simplifica
 			// references/uses changed, i.e. the configuration. We still have to
 			// trigger the restart somehow, so that the pod mounting the
 			// configuration remounts it for the new/changed keys.
-			nano := time.Now().UnixNano()
-			_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, username, "", nil, &nano)
+			_, apierr := deploy.DeployAppWithRestart(ctx, cluster, app.Meta, username, "")
 			if apierr != nil {
 				return apierr
 			}

--- a/internal/api/v1/configurationbinding/create.go
+++ b/internal/api/v1/configurationbinding/create.go
@@ -149,7 +149,7 @@ func CreateConfigurationBinding(
 
 		// Update the workload, if there is any.
 		if app.Workload != nil {
-			_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, requestctx.User(ctx).Username, "", nil, nil)
+			_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, requestctx.User(ctx).Username, "")
 			if apierr != nil {
 				return nil, apierr
 			}

--- a/internal/api/v1/configurationbinding/deletebinding.go
+++ b/internal/api/v1/configurationbinding/deletebinding.go
@@ -36,7 +36,7 @@ func DeleteBinding(ctx context.Context, cluster *kubernetes.Cluster, namespace, 
 	}
 
 	if app.Workload != nil {
-		_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, username, "", nil, nil)
+		_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, username, "")
 		if apierr != nil {
 			return apierr
 		}

--- a/internal/api/v1/deploy/deploy.go
+++ b/internal/api/v1/deploy/deploy.go
@@ -42,7 +42,7 @@ func DeployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppR
 
 // DeployAppWithRestart is the same as DeployApp but it will also force Helm to perform a restart of the deployment
 func DeployAppWithRestart(ctx context.Context, cluster *kubernetes.Cluster, app models.AppRef, username, expectedStageID string) ([]string, apierror.APIErrors) {
-	return deployApp(ctx, cluster, app, username, expectedStageID, false)
+	return deployApp(ctx, cluster, app, username, expectedStageID, true)
 }
 
 func deployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppRef, username, expectedStageID string, restart bool) ([]string, apierror.APIErrors) {

--- a/internal/api/v1/deploy/deploy.go
+++ b/internal/api/v1/deploy/deploy.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -32,11 +33,19 @@ import (
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 )
 
-// DeployApp deploys the referenced application via helm, based on the state held by CRD
-// and associated secrets. It is the backend for the API deploypoint, as well as all the
-// mutating endpoints, i.e. configuration and app changes (bindings, environment,
-// scaling).
-func DeployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppRef, username, expectedStageID string, origin *models.ApplicationOrigin, start *int64) ([]string, apierror.APIErrors) {
+// DeployApp deploys the referenced application via helm, based on the state held by CRD and associated secrets.
+// It is the backend for the API deploypoint, as well as all the mutating endpoints,
+// i.e. configuration and app changes (bindings, environment, scaling).
+func DeployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppRef, username, expectedStageID string) ([]string, apierror.APIErrors) {
+	return deployApp(ctx, cluster, app, username, expectedStageID, false)
+}
+
+// DeployAppWithRestart is the same as DeployApp but it will also force Helm to perform a restart of the deployment
+func DeployAppWithRestart(ctx context.Context, cluster *kubernetes.Cluster, app models.AppRef, username, expectedStageID string) ([]string, apierror.APIErrors) {
+	return deployApp(ctx, cluster, app, username, expectedStageID, false)
+}
+
+func deployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppRef, username, expectedStageID string, restart bool) ([]string, apierror.APIErrors) {
 	log := requestctx.Logger(ctx)
 
 	appObj, err := application.Lookup(ctx, cluster, app.Namespace, app.Name)
@@ -118,6 +127,12 @@ func DeployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppR
 	}
 	maplog.Info("domain map end")
 
+	var start *int64
+	if restart {
+		now := time.Now().UnixNano()
+		start = &now
+	}
+
 	deployParams := helm.ChartParameters{
 		Context:        ctx,
 		Cluster:        cluster,
@@ -154,16 +169,6 @@ func DeployApp(ctx context.Context, cluster *kubernetes.Cluster, app models.AppR
 		if err := application.Unstage(ctx, cluster, app, stageID); err != nil {
 			return nil, apierror.InternalError(err)
 		}
-	}
-
-	if origin != nil {
-		err = application.SetOrigin(ctx, cluster,
-			models.NewAppRef(app.Name, app.Namespace), *origin)
-		if err != nil {
-			return nil, apierror.InternalError(err, "saving the app origin")
-		}
-
-		log.Info("saved app origin", "namespace", app.Namespace, "app", app.Name, "origin", *origin)
 	}
 
 	return routes, nil

--- a/internal/api/v1/env/set.go
+++ b/internal/api/v1/env/set.go
@@ -61,7 +61,7 @@ func Set(c *gin.Context) apierror.APIErrors {
 	}
 
 	if app.Workload != nil {
-		_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, username, "", nil, nil)
+		_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, username, "")
 		if apierr != nil {
 			return apierr
 		}

--- a/internal/api/v1/env/unset.go
+++ b/internal/api/v1/env/unset.go
@@ -55,7 +55,7 @@ func Unset(c *gin.Context) apierror.APIErrors {
 	}
 
 	if app.Workload != nil {
-		_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, username, "", nil, nil)
+		_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, username, "")
 		if apierr != nil {
 			return apierr
 		}


### PR DESCRIPTION
While investigating issue https://github.com/epinio/epinio/issues/2360 I've seen that the two last arguments of the `DeployApp` were not really used, and a bit obscure. The `start` was not clear, and I initially that that was needed for some benchmarks, while reading the Helm doc regarding the deploy parameters it was needed to force a restart.

To simplify the function I've added a `DeployAppWithRestart` function, and I moved the origin update in the only part where it was actually used.

Also the `expectedStageID` is used only for a check in a single place, but moving it it was a bit more "difficult", so I left it for another refactoring.