### PR TITLE
feat: add new function to get epinio values

### DIFF
--- a/internal/services/instances.go
+++ b/internal/services/instances.go
@@ -156,7 +156,7 @@ func (s *ServiceClient) Create(ctx context.Context, namespace, name string, wait
 		return errors.Wrap(err, "error creating service secret")
 	}
 
-	catalogService.Values = concatenateCatalogServiceValues(catalogService, name)
+	catalogService.Values += concatenateCatalogServiceValues(name)
 
 	err = helm.DeployService(
 		ctx,
@@ -537,24 +537,22 @@ func convertUnstructuredListIntoHelmCharts(unstructuredList *unstructured.Unstru
 	return helmChartList, nil
 }
 
-func concatenateCatalogServiceValues(catalogService models.CatalogService, name string) string {
+func concatenateCatalogServiceValues(name string) string {
 
 	type FixedValues struct {
 		ServiceName string `json:"serviceName,omitempty"`
 	}
+
 	var fixedValues FixedValues
 	var builder strings.Builder
 
 	fixedValues.ServiceName = name
-	// Build the concatenated string
 
+	// Build the concatenated string
 	builder.WriteString("\nserviceName: ")
 	builder.WriteString(fixedValues.ServiceName)
 	builder.WriteString("\n")
 
-	// Assign the result to catalogService.Values
-	catalogService.Values += builder.String()
-
 	// Return the resulting concatenated string
-	return catalogService.Values
+	return builder.String()
 }

--- a/internal/services/instances.go
+++ b/internal/services/instances.go
@@ -156,6 +156,8 @@ func (s *ServiceClient) Create(ctx context.Context, namespace, name string, wait
 		return errors.Wrap(err, "error creating service secret")
 	}
 
+	catalogService.Values = concatenateCatalogServiceValues(catalogService, name)
+
 	err = helm.DeployService(
 		ctx,
 		helm.ServiceParameters{
@@ -533,4 +535,26 @@ func convertUnstructuredListIntoHelmCharts(unstructuredList *unstructured.Unstru
 	}
 
 	return helmChartList, nil
+}
+
+func concatenateCatalogServiceValues(catalogService models.CatalogService, name string) string {
+
+	type FixedValues struct {
+		ServiceName string `json:"serviceName,omitempty"`
+	}
+	var fixedValues FixedValues
+	var builder strings.Builder
+
+	fixedValues.ServiceName = name
+	// Build the concatenated string
+
+	builder.WriteString("\nserviceName: ")
+	builder.WriteString(fixedValues.ServiceName)
+	builder.WriteString("\n")
+
+	// Assign the result to catalogService.Values
+	catalogService.Values += builder.String()
+
+	// Return the resulting concatenated string
+	return catalogService.Values
 }


### PR DESCRIPTION
fix #2188 

This PR adds fixed values as additional values for Helm.
Currently, two values are being added: serviceName and catalogServiceName.
However, in the future, it will be possible to easily add other values.
Using the structure below:
```
type FixedValues struct {
	ServiceName        string `yaml:"serviceName,omitempty"`
	CatalogServiceName string `yaml:"catalogServiceName,omitempty"`
	OrderValue         string `yaml:"otherValue,omitempty"`
}

 ``` 
to test it, use: `"{{ .Values.serviceName }}"` end/or `"{{ .Values.catalogServiceName }}" ` in your Helm chart!
