### PR TITLE
Centralized API client initialization

### DIFF
--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -349,7 +349,7 @@ var _ = Describe("Services", LService, func() {
 			By(fmt.Sprintf("%s/%s up", namespace2, service2))
 		})
 
-		FIt("list only the services in the user namespace", func() {
+		It("list only the services in the user namespace", func() {
 			By("create them in different namespaces")
 
 			// impersonate user1 and target namespace1

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -50,10 +50,10 @@ var _ = Describe("Services", LService, func() {
 		catalog.CreateCatalogService(catalogService)
 
 		catalogServiceURL = "http://" + catalogServiceHostname
-	})
 
-	AfterEach(func() {
-		catalog.DeleteCatalogService(catalogService.Meta.Name)
+		DeferCleanup(func() {
+			catalog.DeleteCatalogService(catalogService.Meta.Name)
+		})
 	})
 
 	Describe("Catalog", func() {
@@ -139,11 +139,6 @@ var _ = Describe("Services", LService, func() {
 		})
 	})
 
-	deleteServiceFromNamespace := func(namespace, service string) {
-		env.TargetNamespace(namespace)
-		env.DeleteService(service)
-	}
-
 	Describe("Show", func() {
 		var namespace, service string
 
@@ -156,12 +151,10 @@ var _ = Describe("Services", LService, func() {
 			By("create it")
 			out, err := env.Epinio("", "service", "create", catalogService.Meta.Name, service)
 			Expect(err).ToNot(HaveOccurred(), out)
-		})
 
-		AfterEach(func() {
-			By("delete it")
-			deleteServiceFromNamespace(namespace, service)
-			env.DeleteNamespace(namespace)
+			DeferCleanup(func() {
+				env.DeleteNamespace(namespace)
+			})
 		})
 
 		It("shows a service", func() {
@@ -213,12 +206,10 @@ var _ = Describe("Services", LService, func() {
 			env.SetupAndTargetNamespace(namespace)
 
 			service = catalog.NewServiceName()
-		})
 
-		AfterEach(func() {
-			By("delete it")
-			deleteServiceFromNamespace(namespace, service)
-			env.DeleteNamespace(namespace)
+			DeferCleanup(func() {
+				env.DeleteNamespace(namespace)
+			})
 		})
 
 		It("list a service", func() {
@@ -290,22 +281,18 @@ var _ = Describe("Services", LService, func() {
 			// create users with permissions in different namespaces
 			user1, password1 = env.CreateEpinioUser("user", []string{namespace1})
 			user2, password2 = env.CreateEpinioUser("user", []string{namespace2})
-		})
 
-		AfterEach(func() {
-			By("delete it")
-			deleteServiceFromNamespace(namespace1, service1)
-			deleteServiceFromNamespace(namespace2, service2)
+			DeferCleanup(func() {
+				env.DeleteNamespace(namespace1)
+				env.DeleteNamespace(namespace2)
 
-			env.DeleteNamespace(namespace1)
-			env.DeleteNamespace(namespace2)
+				// Remove transient settings
+				out, err := proc.Run("", false, "rm", "-f", tmpSettingsPath)
+				Expect(err).ToNot(HaveOccurred(), out)
 
-			// Remove transient settings
-			out, err := proc.Run("", false, "rm", "-f", tmpSettingsPath)
-			Expect(err).ToNot(HaveOccurred(), out)
-
-			env.DeleteEpinioUser(user1)
-			env.DeleteEpinioUser(user2)
+				env.DeleteEpinioUser(user1)
+				env.DeleteEpinioUser(user2)
+			})
 		})
 
 		It("list all services", func() {
@@ -362,7 +349,7 @@ var _ = Describe("Services", LService, func() {
 			By(fmt.Sprintf("%s/%s up", namespace2, service2))
 		})
 
-		It("list only the services in the user namespace", func() {
+		FIt("list only the services in the user namespace", func() {
 			By("create them in different namespaces")
 
 			// impersonate user1 and target namespace1
@@ -423,20 +410,10 @@ var _ = Describe("Services", LService, func() {
 			env.SetupAndTargetNamespace(namespace)
 
 			service = catalog.NewServiceName()
-		})
 
-		AfterEach(func() {
-			By("delete it")
-			out, err := env.Epinio("", "service", "delete", service)
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).To(ContainSubstring("Services Removed"))
-
-			Eventually(func() string {
-				out, _ := env.Epinio("", "service", "delete", service)
-				return out
-			}, "1m", "5s").Should(ContainSubstring("service '%s' does not exist", service))
-
-			env.DeleteNamespace(namespace)
+			DeferCleanup(func() {
+				env.DeleteNamespace(namespace)
+			})
 		})
 
 		It("creates a service", func() {
@@ -474,13 +451,6 @@ var _ = Describe("Services", LService, func() {
 		})
 
 		Context("command completion", func() {
-			// A service is not really required, except the outer AfterEach expects it.
-			BeforeEach(func() {
-				out, err := env.Epinio("", "service", "create", catalogService.Meta.Name, service)
-				Expect(err).ToNot(HaveOccurred(), out)
-			})
-			// Outer AfterEach removes it
-
 			It("matches empty prefix", func() {
 				out, err := env.Epinio("", "__complete", "service", "create", "")
 				Expect(err).ToNot(HaveOccurred(), out)
@@ -509,42 +479,11 @@ var _ = Describe("Services", LService, func() {
 			env.SetupAndTargetNamespace(namespace)
 
 			service = catalog.NewServiceName()
+			env.MakeServiceInstance(service, catalogService.Meta.Name)
 
-			By("create it")
-			out, err := env.Epinio("", "service", "create", catalogService.Meta.Name, service)
-			Expect(err).ToNot(HaveOccurred(), out)
-
-			By("show it")
-			out, err = env.Epinio("", "service", "show", service)
-			Expect(err).ToNot(HaveOccurred(), out)
-
-			Expect(out).To(
-				HaveATable(
-					WithHeaders("KEY", "VALUE"),
-					WithRow("Name", service),
-					WithRow("Created", WithDate()),
-					WithRow("Catalog Service", catalogService.Meta.Name),
-					WithRow("Status", "(not-ready|deployed)"),
-				),
-			)
-
-			By("wait for deployment")
-			Eventually(func() string {
-				out, _ := env.Epinio("", "service", "show", service)
-				return out
-			}, "2m", "5s").Should(
-				HaveATable(
-					WithHeaders("KEY", "VALUE"),
-					WithRow("Status", "deployed"),
-					WithRow("Internal Routes", fmt.Sprintf(`.*\.%s\.svc\.cluster\.local`, namespace)),
-				),
-			)
-
-			By(fmt.Sprintf("%s/%s up", namespace, service))
-		})
-
-		AfterEach(func() {
-			env.DeleteNamespace(namespace)
+			DeferCleanup(func() {
+				env.DeleteNamespace(namespace)
+			})
 		})
 
 		It("deletes a service", func() {
@@ -645,10 +584,10 @@ var _ = Describe("Services", LService, func() {
 						WithRow("Bound Configurations", chart+".*"),
 					),
 				)
-			})
 
-			AfterEach(func() {
-				env.DeleteNamespace(namespace)
+				DeferCleanup(func() {
+					env.DeleteNamespace(namespace)
+				})
 			})
 
 			It("fails to delete a bound service", func() {
@@ -737,8 +676,10 @@ var _ = Describe("Services", LService, func() {
 					WithRow("Status", "deployed"),
 				),
 			)
+
 		})
 
+		// [EC] we should have a look at this unbind. It should be part of a test probably
 		AfterEach(func() {
 			out, err := env.Epinio("", "service", "unbind", service, app)
 			Expect(err).ToNot(HaveOccurred(), out)
@@ -891,20 +832,10 @@ var _ = Describe("Services", LService, func() {
 					WithRow("Bound Configurations", chart+".*"),
 				),
 			)
-		})
 
-		AfterEach(func() {
-			By("delete it")
-			out, err := env.Epinio("", "service", "delete", service)
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).To(ContainSubstring("Services Removed"))
-
-			Eventually(func() string {
-				out, _ := env.Epinio("", "service", "delete", service)
-				return out
-			}, "1m", "5s").Should(ContainSubstring("service '%s' does not exist", service))
-
-			env.DeleteNamespace(namespace)
+			DeferCleanup(func() {
+				env.DeleteNamespace(namespace)
+			})
 		})
 
 		It("unbinds the service", func() {

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -12,7 +12,6 @@
 package cli
 
 import (
-	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/epinio/epinio/internal/manifest"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/pkg/errors"
@@ -86,11 +85,6 @@ var CmdAppList = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
 		all, err := cmd.Flags().GetBool("all")
 		if err != nil {
 			return errors.Wrap(err, "error reading option --all")
@@ -109,11 +103,6 @@ var CmdAppCreate = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
 
 		m, err := manifest.UpdateICE(models.ApplicationManifest{}, cmd)
 		if err != nil {
@@ -145,12 +134,7 @@ var CmdAppShow = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
-		err = client.AppShow(args[0])
+		err := client.AppShow(args[0])
 		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error showing app")
 	},
@@ -165,12 +149,7 @@ var CmdAppExport = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
-		err = client.AppExport(args[0], args[1])
+		err := client.AppExport(args[0], args[1])
 		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error exporting app")
 	},
@@ -184,11 +163,6 @@ var CmdAppLogs = &cobra.Command{
 	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
 
 		follow, err := cmd.Flags().GetBool("follow")
 		if err != nil {
@@ -223,11 +197,6 @@ var CmdAppExec = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
 		instance, err := cmd.Flags().GetString("instance")
 		if err != nil {
 			cmd.SilenceUsage = false
@@ -254,15 +223,10 @@ var CmdAppPortForward = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
 		appName := args[0]
 		ports := args[1:]
 
-		err = client.AppPortForward(cmd.Context(), appName, portForwardInstance, portForwardAddress, ports)
+		err := client.AppPortForward(cmd.Context(), appName, portForwardInstance, portForwardAddress, ports)
 		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error port forwarding to application")
 	},
@@ -278,11 +242,6 @@ var CmdAppUpdate = &cobra.Command{
 	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
 
 		m, err := manifest.UpdateICE(models.ApplicationManifest{}, cmd)
 		if err != nil {
@@ -314,12 +273,7 @@ var CmdAppManifest = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
-		err = client.AppManifest(args[0], args[1])
+		err := client.AppManifest(args[0], args[1])
 		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error getting app manifest")
 	},
@@ -334,12 +288,7 @@ var CmdAppRestart = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
-		err = client.AppRestart(args[0])
+		err := client.AppRestart(args[0])
 		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error restarting app")
 	},
@@ -353,11 +302,6 @@ var CmdAppRestage = &cobra.Command{
 	ValidArgsFunction: matchingAppsFinder,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
 
 		norestart, err := cmd.Flags().GetBool("no-restart")
 		if err != nil {

--- a/internal/cli/chart.go
+++ b/internal/cli/chart.go
@@ -12,7 +12,6 @@
 package cli
 
 import (
-	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -40,18 +39,13 @@ var CmdAppChartDefault = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
 		if len(args) == 1 {
-			err = client.ChartDefaultSet(cmd.Context(), args[0])
+			err := client.ChartDefaultSet(cmd.Context(), args[0])
 			if err != nil {
 				return errors.Wrap(err, "error setting app chart default")
 			}
 		} else {
-			err = client.ChartDefaultShow(cmd.Context())
+			err := client.ChartDefaultShow(cmd.Context())
 			if err != nil {
 				return errors.Wrap(err, "error showing app chart default")
 			}
@@ -70,12 +64,7 @@ var CmdAppChartList = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
-		err = client.ChartList(cmd.Context())
+		err := client.ChartList(cmd.Context())
 		if err != nil {
 			return errors.Wrap(err, "error listing app charts")
 		}
@@ -93,12 +82,7 @@ var CmdAppChartShow = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
-		err = client.ChartShow(cmd.Context(), args[0])
+		err := client.ChartShow(cmd.Context(), args[0])
 		if err != nil {
 			return errors.Wrap(err, "error showing app chart")
 		}

--- a/internal/cli/commons.go
+++ b/internal/cli/commons.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -63,14 +62,9 @@ func matchingConfigurationFinder(cmd *cobra.Command, args []string, toComplete s
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	app, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	app.API.DisableVersionWarning()
+	client.API.DisableVersionWarning()
 
-	matches := app.ConfigurationMatching(toComplete)
-
+	matches := client.ConfigurationMatching(toComplete)
 	return matches, cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -81,14 +75,9 @@ func matchingAppsFinder(cmd *cobra.Command, args []string, toComplete string) ([
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	app, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	app.API.DisableVersionWarning()
+	client.API.DisableVersionWarning()
 
-	matches := app.AppsMatching(toComplete)
-
+	matches := client.AppsMatching(toComplete)
 	return matches, cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -99,14 +88,9 @@ func matchingNamespaceFinder(cmd *cobra.Command, args []string, toComplete strin
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	app, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	app.API.DisableVersionWarning()
+	client.API.DisableVersionWarning()
 
-	matches := app.NamespacesMatching(toComplete)
-
+	matches := client.NamespacesMatching(toComplete)
 	return matches, cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -116,15 +100,10 @@ func matchingChartFinder(cmd *cobra.Command, args []string, toComplete string) (
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	app, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	app.API.DisableVersionWarning()
+	client.API.DisableVersionWarning()
 
 	// #args == 0: chart name.
-	matches := app.ChartMatching(toComplete)
-
+	matches := client.ChartMatching(toComplete)
 	return matches, cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -135,14 +114,9 @@ func matchingServiceFinder(cmd *cobra.Command, args []string, toComplete string)
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	app, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	app.API.DisableVersionWarning()
+	client.API.DisableVersionWarning()
 
-	matches := app.ServiceMatching(toComplete)
-
+	matches := client.ServiceMatching(toComplete)
 	return matches, cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -153,14 +127,9 @@ func matchingCatalogFinder(cmd *cobra.Command, args []string, toComplete string)
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	app, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	app.API.DisableVersionWarning()
+	client.API.DisableVersionWarning()
 
-	matches := app.CatalogMatching(toComplete)
-
+	matches := client.CatalogMatching(toComplete)
 	return matches, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/internal/cli/configuration.go
+++ b/internal/cli/configuration.go
@@ -17,7 +17,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -101,13 +100,9 @@ var CmdConfigurationDelete = &cobra.Command{
 	Long:  `Delete configurations by name.`,
 	RunE:  ConfigurationDelete,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		epinioClient, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		epinioClient.API.DisableVersionWarning()
+		client.API.DisableVersionWarning()
 
-		matches := filteredMatchingFinder(args, toComplete, epinioClient.ConfigurationMatching)
+		matches := filteredMatchingFinder(args, toComplete, client.ConfigurationMatching)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
@@ -145,12 +140,7 @@ var CmdConfigurationList = &cobra.Command{
 func ConfigurationShow(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
 
-	client, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return errors.Wrap(err, "error initializing cli")
-	}
-
-	err = client.ConfigurationDetails(args[0])
+	err := client.ConfigurationDetails(args[0])
 	if err != nil {
 		return errors.Wrap(err, "error retrieving configuration")
 	}
@@ -161,11 +151,6 @@ func ConfigurationShow(cmd *cobra.Command, args []string) error {
 // ConfigurationList is the backend of command: epinio configuration list
 func ConfigurationList(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
-
-	client, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return errors.Wrap(err, "error initializing cli")
-	}
 
 	all, err := cmd.Flags().GetBool("all")
 	if err != nil {
@@ -183,11 +168,6 @@ func ConfigurationList(cmd *cobra.Command, args []string) error {
 // ConfigurationCreate is the backend of command: epinio configuration create
 func ConfigurationCreate(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
-
-	client, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return errors.Wrap(err, "error initializing cli")
-	}
 
 	// Merge plain argument key/value data with k/v from options, i.e. files.
 	kvAssigments := args[1:]
@@ -214,11 +194,6 @@ func ConfigurationCreate(cmd *cobra.Command, args []string) error {
 // ConfigurationUpdate is the backend of command: epinio configuration update
 func ConfigurationUpdate(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
-
-	client, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return errors.Wrap(err, "error initializing cli")
-	}
 
 	// Process the --remove and --set options into operations (removals, assignments)
 
@@ -270,11 +245,6 @@ func ConfigurationDelete(cmd *cobra.Command, args []string) error {
 		return errors.New("No configurations specified for deletion")
 	}
 
-	client, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return errors.Wrap(err, "error initializing cli")
-	}
-
 	err = client.DeleteConfiguration(args, unbind, all)
 	if err != nil {
 		return errors.Wrap(err, "error deleting configuration")
@@ -287,12 +257,7 @@ func ConfigurationDelete(cmd *cobra.Command, args []string) error {
 func ConfigurationBind(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
 
-	client, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return errors.Wrap(err, "error initializing cli")
-	}
-
-	err = client.BindConfiguration(args[0], args[1])
+	err := client.BindConfiguration(args[0], args[1])
 	if err != nil {
 		return errors.Wrap(err, "error binding configuration")
 	}
@@ -304,12 +269,7 @@ func ConfigurationBind(cmd *cobra.Command, args []string) error {
 func ConfigurationUnbind(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
 
-	client, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return errors.Wrap(err, "error initializing cli")
-	}
-
-	err = client.UnbindConfiguration(args[0], args[1])
+	err := client.UnbindConfiguration(args[0], args[1])
 	if err != nil {
 		return errors.Wrap(err, "error unbinding configuration")
 	}
@@ -333,21 +293,17 @@ func findConfigurationApp(cmd *cobra.Command, args []string, toComplete string) 
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	app, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	app.API.DisableVersionWarning()
+	client.API.DisableVersionWarning()
 
 	if len(args) == 1 {
 		// #args == 1: app name.
-		matches := app.AppsMatching(toComplete)
+		matches := client.AppsMatching(toComplete)
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	// #args == 0: configuration name.
 
-	matches := app.ConfigurationMatching(toComplete)
+	matches := client.ConfigurationMatching(toComplete)
 	return matches, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -12,7 +12,6 @@
 package cli
 
 import (
-	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -24,12 +23,8 @@ var CmdAppDelete = &cobra.Command{
 	Use:   "delete NAME1 [NAME2 ...]",
 	Short: "Deletes one or more applications",
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		epinioClient, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
 
-		filteredMatches := filteredMatchingFinder(args, toComplete, epinioClient.AppsMatching)
+		filteredMatches := filteredMatchingFinder(args, toComplete, client.AppsMatching)
 		return filteredMatches, cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -45,11 +40,6 @@ var CmdAppDelete = &cobra.Command{
 		}
 		if !all && len(args) == 0 {
 			return errors.New("No applications specified for deletion")
-		}
-
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
 		}
 
 		err = client.Delete(cmd.Context(), args, all)

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -12,7 +12,6 @@
 package cli
 
 import (
-	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -41,12 +40,7 @@ var CmdEnvList = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
-		err = client.EnvList(cmd.Context(), args[0])
+		err := client.EnvList(cmd.Context(), args[0])
 		if err != nil {
 			return errors.Wrap(err, "error listing app environment")
 		}
@@ -65,13 +59,7 @@ var CmdEnvSet = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
-		err = client.EnvSet(cmd.Context(), args[0], args[1], args[2])
+		err := client.EnvSet(cmd.Context(), args[0], args[1], args[2])
 		if err != nil {
 			return errors.Wrap(err, "error setting into app environment")
 		}
@@ -88,13 +76,7 @@ var CmdEnvShow = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
-		err = client.EnvShow(cmd.Context(), args[0], args[1])
+		err := client.EnvShow(cmd.Context(), args[0], args[1])
 		if err != nil {
 			return errors.Wrap(err, "error accessing app environment")
 		}
@@ -113,12 +95,7 @@ var CmdEnvUnset = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
-		err = client.EnvUnset(cmd.Context(), args[0], args[1])
+		err := client.EnvUnset(cmd.Context(), args[0], args[1])
 		if err != nil {
 			return errors.Wrap(err, "error removing from app environment")
 		}
@@ -134,20 +111,16 @@ func matchingAppAndVarFinder(cmd *cobra.Command, args []string, toComplete strin
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	app, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	app.API.DisableVersionWarning()
+	client.API.DisableVersionWarning()
 
 	if len(args) == 1 {
 		// #args == 1: environment variable name (in application)
-		matches := app.EnvMatching(cmd.Context(), args[0], toComplete)
+		matches := client.EnvMatching(cmd.Context(), args[0], toComplete)
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	// #args == 0: application name.
-	matches := app.AppsMatching(toComplete)
+	matches := client.AppsMatching(toComplete)
 
 	return matches, cobra.ShellCompDirectiveNoFileComp
 }

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -12,7 +12,6 @@
 package cli
 
 import (
-	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/spf13/cobra"
 )
 
@@ -33,11 +32,6 @@ var CmdLogout = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return err
-		}
-
 		return client.Logout(cmd.Context())
 	},
 }
@@ -50,11 +44,6 @@ var CmdLogin = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return err
-		}
 
 		address := args[0]
 		username, err := cmd.Flags().GetString("user")

--- a/internal/cli/namespaces.go
+++ b/internal/cli/namespaces.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -61,12 +60,7 @@ var CmdNamespaceList = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
-		err = client.Namespaces()
+		err := client.Namespaces()
 		if err != nil {
 			return errors.Wrap(err, "error listing epinio-controlled namespaces")
 		}
@@ -83,12 +77,7 @@ var CmdNamespaceCreate = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
-		err = client.CreateNamespace(args[0])
+		err := client.CreateNamespace(args[0])
 		if err != nil {
 			return errors.Wrap(err, "error creating epinio-controlled namespace")
 		}
@@ -105,12 +94,7 @@ var CmdNamespaceDelete = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
-		err = client.DeleteNamespace(args, gForceFlag, gAllFlag)
+		err := client.DeleteNamespace(args, gForceFlag, gAllFlag)
 		if err != nil {
 			// Cancellation is not an "error" in deletion.
 			if !strings.Contains(err.Error(), "Cancelled") {
@@ -132,12 +116,7 @@ var CmdNamespaceShow = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
-		err = client.ShowNamespace(args[0])
+		err := client.ShowNamespace(args[0])
 		if err != nil {
 			return errors.Wrap(err, "error showing epinio-controlled namespace")
 		}

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/epinio/epinio/internal/api/v1/application"
-	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/spf13/cobra"
 )
 
@@ -46,15 +45,10 @@ func bindOption(cmd *cobra.Command) {
 			// We are responsible for splitting into segments, and expanding only the last
 			// segment.
 
-			app, err := usercmd.New(cmd.Context())
-			if err != nil {
-				return nil, cobra.ShellCompDirectiveNoFileComp
-			}
-
 			values := strings.Split(toComplete, ",")
 			if len(values) == 0 {
 				// Nothing. Report all possible matches
-				matches := app.ConfigurationMatching(toComplete)
+				matches := client.ConfigurationMatching(toComplete)
 				return matches, cobra.ShellCompDirectiveNoFileComp
 			}
 
@@ -63,7 +57,7 @@ func bindOption(cmd *cobra.Command) {
 			// expansions for that segment.
 
 			matches := []string{}
-			for _, match := range app.ConfigurationMatching(values[len(values)-1]) {
+			for _, match := range client.ConfigurationMatching(values[len(values)-1]) {
 				values[len(values)-1] = match
 				matches = append(matches, strings.Join(values, ","))
 			}

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -65,11 +65,6 @@ var CmdAppPush = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
 		// Syntax:
 		//   - push [flags] [PATH-TO-MANIFEST-FILE]
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -34,6 +34,8 @@ import (
 )
 
 var (
+	client *usercmd.EpinioClient
+
 	flagSettingsFile string
 )
 
@@ -97,7 +99,7 @@ func NewRootCmd() (*cobra.Command, error) {
 
 	config.AddEnvToUsage(rootCmd, argToEnv)
 
-	client, err := usercmd.New(context.Background())
+	client, err = usercmd.New(context.Background())
 	if err != nil {
 		return nil, errors.New("error initializing cli")
 	}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -14,7 +14,6 @@ package cli
 import (
 	"fmt"
 
-	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -54,19 +53,14 @@ var CmdServiceCatalog = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
 		if len(args) == 0 {
-			err = client.ServiceCatalog()
+			err := client.ServiceCatalog()
 			return errors.Wrap(err, "error listing Epinio catalog services")
 		}
 
 		if len(args) == 1 {
 			serviceName := args[0]
-			err = client.ServiceCatalogShow(serviceName)
+			err := client.ServiceCatalogShow(serviceName)
 			return errors.Wrap(err, fmt.Sprintf("error showing %s Epinio catalog service", serviceName))
 		}
 
@@ -87,11 +81,6 @@ var CmdServiceCreate = &cobra.Command{
 			return errors.Wrap(err, "error reading option --wait")
 		}
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
 		catalogServiceName := args[0]
 		serviceName := args[1]
 
@@ -108,14 +97,9 @@ var CmdServiceShow = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
 		serviceName := args[0]
 
-		err = client.ServiceShow(serviceName)
+		err := client.ServiceShow(serviceName)
 		return errors.Wrap(err, "error showing service")
 	},
 }
@@ -124,14 +108,10 @@ var CmdServiceDelete = &cobra.Command{
 	Use:   "delete SERVICENAME1 [SERVICENAME2 ...]",
 	Short: "Delete one or more services",
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		app, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
 
-		app.API.DisableVersionWarning()
+		client.API.DisableVersionWarning()
 
-		matches := filteredMatchingFinder(args, toComplete, app.ServiceMatching)
+		matches := filteredMatchingFinder(args, toComplete, client.ServiceMatching)
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -154,11 +134,6 @@ var CmdServiceDelete = &cobra.Command{
 			return errors.New("No services specified for deletion")
 		}
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
 		err = client.ServiceDelete(args, unbind, all)
 		return errors.Wrap(err, "error deleting service")
 	},
@@ -171,15 +146,10 @@ var CmdServiceBind = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
 		serviceName := args[0]
 		appName := args[1]
 
-		err = client.ServiceBind(serviceName, appName)
+		err := client.ServiceBind(serviceName, appName)
 		return errors.Wrap(err, "error binding service")
 	},
 }
@@ -192,15 +162,10 @@ var CmdServiceUnbind = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
 		serviceName := args[0]
 		appName := args[1]
 
-		err = client.ServiceUnbind(serviceName, appName)
+		err := client.ServiceUnbind(serviceName, appName)
 		return errors.Wrap(err, "error unbinding service")
 	},
 }
@@ -211,11 +176,6 @@ var CmdServiceList = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
 
 		all, err := cmd.Flags().GetBool("all")
 		if err != nil {
@@ -237,21 +197,17 @@ func findServiceApp(cmd *cobra.Command, args []string, toComplete string) ([]str
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	app, err := usercmd.New(cmd.Context())
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	app.API.DisableVersionWarning()
+	client.API.DisableVersionWarning()
 
 	if len(args) == 1 {
 		// #args == 1: app name.
-		matches := app.AppsMatching(toComplete)
+		matches := client.AppsMatching(toComplete)
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	// #args == 0: configuration name.
 
-	matches := app.ServiceMatching(toComplete)
+	matches := client.ServiceMatching(toComplete)
 	return matches, cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -268,15 +224,10 @@ var CmdServicePortForward = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
 		serviceName := args[0]
 		ports := args[1:]
 
-		err = client.ServicePortForward(cmd.Context(), serviceName, servicePortForwardAddress, ports)
+		err := client.ServicePortForward(cmd.Context(), serviceName, servicePortForwardAddress, ports)
 		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error port forwarding to service")
 	},

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -12,7 +12,6 @@
 package cli
 
 import (
-	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -28,17 +27,12 @@ var CmdTarget = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := usercmd.New(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error initializing cli")
-		}
-
 		namespace := ""
 		if len(args) > 0 {
 			namespace = args[0]
 		}
 
-		err = client.Target(namespace)
+		err := client.Target(namespace)
 		if err != nil {
 			return errors.Wrap(err, "failed to set target")
 		}

--- a/internal/cli/usercmd/login.go
+++ b/internal/cli/usercmd/login.go
@@ -89,6 +89,7 @@ func (c *EpinioClient) Login(ctx context.Context, username, password, address st
 		if err != nil {
 			return err
 		}
+		client.API.DisableVersionWarning()
 
 		// we don't need anything, just checking if the namespace exist and we have permissions
 		_, err = client.API.NamespaceShow(updatedSettings.Namespace)


### PR DESCRIPTION
While working on https://github.com/epinio/epinio/issues/2317 I'had the need to centralize the API client, in order to use and setup the headers only once.

This PR centralize its creation in a single place, having it as a global variable, accessible to every command.

It also fixes a couple of flaky tests.

Further fix #2315