### PR TITLE
Added `--header/-H` flag to CLI

### DIFF
--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -12,6 +12,9 @@
 package cli
 
 import (
+	"strings"
+
+	epinioapi "github.com/epinio/epinio/pkg/api/core/v1/client"
 	"github.com/spf13/cobra"
 )
 
@@ -69,6 +72,14 @@ var CmdLogin = &cobra.Command{
 		prompt, err := cmd.Flags().GetBool("prompt")
 		if err != nil {
 			return err
+		}
+
+		apiClient, ok := client.API.(*epinioapi.Client)
+		if ok {
+			for _, h := range flagHeaders {
+				keyVal := strings.Split(h, ":")
+				apiClient.SetHeader(keyVal[0], keyVal[1])
+			}
 		}
 
 		if oidc {

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -12,9 +12,6 @@
 package cli
 
 import (
-	"strings"
-
-	epinioapi "github.com/epinio/epinio/pkg/api/core/v1/client"
 	"github.com/spf13/cobra"
 )
 
@@ -72,14 +69,6 @@ var CmdLogin = &cobra.Command{
 		prompt, err := cmd.Flags().GetBool("prompt")
 		if err != nil {
 			return err
-		}
-
-		apiClient, ok := client.API.(*epinioapi.Client)
-		if ok {
-			for _, h := range flagHeaders {
-				keyVal := strings.Split(h, ":")
-				apiClient.SetHeader(keyVal[0], keyVal[1])
-			}
 		}
 
 		if oidc {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -37,6 +37,7 @@ var (
 	client *usercmd.EpinioClient
 
 	flagSettingsFile string
+	flagHeaders      []string
 )
 
 // NewRootCmd returns the rootCmd, that is the main `epinio` cli.
@@ -77,19 +78,24 @@ func NewRootCmd() (*cobra.Command, error) {
 	tracelog.LoggerFlags(pf, argToEnv)
 	duration.Flags(pf, argToEnv)
 
-	pf.IntP("verbosity", "", 0, "Only print progress messages at or above this level (0 or 1, default 0)")
+	pf.Int("verbosity", 0, "Only print progress messages at or above this level (0 or 1, default 0)")
 	if err = viper.BindPFlag("verbosity", pf.Lookup("verbosity")); err != nil {
 		return nil, err
 	}
 	argToEnv["verbosity"] = "VERBOSITY"
 
-	pf.BoolP("skip-ssl-verification", "", false, "Skip the verification of TLS certificates")
+	pf.Bool("skip-ssl-verification", false, "Skip the verification of TLS certificates")
 	if err = viper.BindPFlag("skip-ssl-verification", pf.Lookup("skip-ssl-verification")); err != nil {
 		return nil, err
 	}
 	argToEnv["skip-ssl-verification"] = "SKIP_SSL_VERIFICATION"
 
-	pf.BoolP("no-colors", "", false, "Suppress colorized output")
+	pf.StringSliceVarP("header", "H", flagHeaders, "Skip the verification of TLS certificates")
+	if err = viper.BindPFlag("header", pf.Lookup("header")); err != nil {
+		return nil, err
+	}
+
+	pf.Bool("no-colors", false, "Suppress colorized output")
 	if err = viper.BindPFlag("no-colors", pf.Lookup("no-colors")); err != nil {
 		return nil, err
 	}

--- a/pkg/api/core/v1/client/apps.go
+++ b/pkg/api/core/v1/client/apps.go
@@ -161,11 +161,9 @@ func (c *Client) AppGetPart(namespace, appName, part, destinationPath string) er
 	uri := fmt.Sprintf("%s%s/%s", c.Settings.API, api.Root, endpoint)
 	c.log.Info(fmt.Sprintf("%s %s", method, uri))
 
-	reqLog := requestLogger(c.log, method, uri, requestBody)
-
 	request, err := http.NewRequest(method, uri, strings.NewReader(requestBody))
 	if err != nil {
-		reqLog.V(1).Error(err, "cannot build request")
+		c.log.V(1).Error(err, "cannot build request")
 		return err
 	}
 
@@ -173,6 +171,12 @@ func (c *Client) AppGetPart(namespace, appName, part, destinationPath string) er
 	if err != nil {
 		return errors.Wrap(err, "handling oauth2 request")
 	}
+
+	for key, value := range c.customHeaders {
+		request.Header.Set(key, value)
+	}
+
+	reqLog := requestLogger(c.log, request, requestBody)
 
 	response, err := c.HttpClient.Do(request)
 	if err != nil {

--- a/pkg/api/core/v1/client/client.go
+++ b/pkg/api/core/v1/client/client.go
@@ -31,6 +31,7 @@ type Client struct {
 	log              logr.Logger
 	Settings         *epiniosettings.Settings
 	HttpClient       *http.Client
+	customHeaders    map[string]string
 	noVersionWarning bool
 }
 
@@ -70,8 +71,15 @@ func New(ctx context.Context, settings *epiniosettings.Settings) *Client {
 	}
 
 	return &Client{
-		log:        log,
-		Settings:   settings,
-		HttpClient: oauth2.NewClient(ctx, tokenSource),
+		log:           log,
+		Settings:      settings,
+		HttpClient:    oauth2.NewClient(ctx, tokenSource),
+		customHeaders: make(map[string]string),
+	}
+}
+
+func (c *Client) SetHeader(key, value string) {
+	if c.customHeaders != nil {
+		c.customHeaders[key] = value
 	}
 }

--- a/pkg/api/core/v1/client/http.go
+++ b/pkg/api/core/v1/client/http.go
@@ -128,6 +128,10 @@ func (c *Client) upload(endpoint string, path string) ([]byte, error) {
 		return []byte{}, err
 	}
 
+	for key, value := range c.customHeaders {
+		request.Header.Add(key, value)
+	}
+
 	response, err := c.HttpClient.Do(request)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to POST to upload")
@@ -190,6 +194,10 @@ func (c *Client) do(endpoint, method, requestBody string) ([]byte, error) {
 	err = c.handleAuthorization(request)
 	if err != nil {
 		return []byte{}, err
+	}
+
+	for key, value := range c.customHeaders {
+		request.Header.Add(key, value)
 	}
 
 	response, err := c.HttpClient.Do(request)
@@ -266,6 +274,10 @@ func (c *Client) doWithCustomErrorHandling(endpoint, method, requestBody string,
 	err = c.handleAuthorization(request)
 	if err != nil {
 		return []byte{}, err
+	}
+
+	for key, value := range c.customHeaders {
+		request.Header.Add(key, value)
 	}
 
 	response, err := c.HttpClient.Do(request)

--- a/pkg/api/core/v1/client/http_test.go
+++ b/pkg/api/core/v1/client/http_test.go
@@ -42,9 +42,7 @@ var _ = Describe("Client HTTP", func() {
 	})
 
 	Describe("executing a request", func() {
-
 		When("custom headers are set", func() {
-
 			It("gets the additional headers", func() {
 				responseBody = `{"status":"ok"}`
 
@@ -68,7 +66,6 @@ var _ = Describe("Client HTTP", func() {
 		})
 
 		When("no custom headers are set", func() {
-
 			It("gets no additional headers", func() {
 				responseBody = `{"status":"ok"}`
 
@@ -87,7 +84,5 @@ var _ = Describe("Client HTTP", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
-
 	})
-
 })

--- a/pkg/api/core/v1/client/http_test.go
+++ b/pkg/api/core/v1/client/http_test.go
@@ -1,0 +1,93 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/epinio/epinio/internal/cli/settings"
+	"github.com/epinio/epinio/pkg/api/core/v1/client"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Client HTTP", func() {
+
+	var epinioClient *client.Client
+	var responseBody string
+	var requestInterceptor func(r *http.Request)
+
+	JustBeforeEach(func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, responseBody)
+
+			requestInterceptor(r)
+		}))
+
+		epinioClient = client.New(context.Background(), &settings.Settings{API: srv.URL})
+	})
+
+	Describe("executing a request", func() {
+
+		When("custom headers are set", func() {
+
+			It("gets the additional headers", func() {
+				responseBody = `{"status":"ok"}`
+
+				epinioClient.SetHeader("x-custom-header-1", "custom header 1")
+				epinioClient.SetHeader("x-custom-header-2", "custom header 2")
+
+				// check that Header foo is set
+				requestInterceptor = func(r *http.Request) {
+					customHeader1 := r.Header.Get("x-custom-header-1")
+					Expect(customHeader1).NotTo(BeEmpty())
+					Expect(customHeader1).To(Equal("custom header 1"))
+
+					customHeader2 := r.Header.Get("x-custom-header-2")
+					Expect(customHeader2).NotTo(BeEmpty())
+					Expect(customHeader2).To(Equal("custom header 2"))
+				}
+
+				_, err := client.Do(epinioClient, "any", http.MethodGet, nil, &models.Response{})
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		When("no custom headers are set", func() {
+
+			It("gets no additional headers", func() {
+				responseBody = `{"status":"ok"}`
+
+				// check that Header foo is set
+				requestInterceptor = func(r *http.Request) {
+					Expect(r.Header).To(HaveLen(2))
+
+					standardHeader1 := r.Header.Get("Accept-Encoding")
+					Expect(standardHeader1).NotTo(BeEmpty())
+
+					standardHeader2 := r.Header.Get("User-Agent")
+					Expect(standardHeader2).NotTo(BeEmpty())
+				}
+
+				_, err := client.Do(epinioClient, "any", http.MethodGet, nil, &models.Response{})
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+	})
+
+})


### PR DESCRIPTION
This PR adds a new `--header/-H` flag that can be used to provide/overwrite custom headers to the Epinio CLI.

It could fix the #2317.