### PR TITLE
Added more generic GET, deleted unneeded ServiceShowRequest

### DIFF
--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -101,7 +101,7 @@ type APIClient interface {
 	ServiceCatalogMatch(prefix string) (models.CatalogMatchResponse, error)
 
 	AllServices() (models.ServiceList, error)
-	ServiceShow(req *models.ServiceShowRequest, namespace string) (*models.Service, error)
+	ServiceShow(namespace, name string) (*models.Service, error)
 	ServiceCreate(req *models.ServiceCreateRequest, namespace string) error
 	ServiceBind(req *models.ServiceBindRequest, namespace, name string) error
 	ServiceUnbind(req *models.ServiceUnbindRequest, namespace, name string) error

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -112,11 +112,7 @@ func (c *EpinioClient) ServiceShow(serviceName string) error {
 
 	c.ui.Note().Msg("Showing Service...")
 
-	request := &models.ServiceShowRequest{
-		Name: serviceName,
-	}
-
-	service, err := c.API.ServiceShow(request, c.Settings.Namespace)
+	service, err := c.API.ServiceShow(c.Settings.Namespace, serviceName)
 	if err != nil {
 		return errors.Wrap(err, "service show failed")
 	}

--- a/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
+++ b/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
@@ -736,10 +736,23 @@ type FakeAPIClient struct {
 		result1 models.ServiceMatchResponse
 		result2 error
 	}
-	ServiceShowStub        func(*models.ServiceShowRequest, string) (*models.Service, error)
+	ServicePortForwardStub        func(string, string, *client.PortForwardOpts) error
+	servicePortForwardMutex       sync.RWMutex
+	servicePortForwardArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 *client.PortForwardOpts
+	}
+	servicePortForwardReturns struct {
+		result1 error
+	}
+	servicePortForwardReturnsOnCall map[int]struct {
+		result1 error
+	}
+	ServiceShowStub        func(string, string) (*models.Service, error)
 	serviceShowMutex       sync.RWMutex
 	serviceShowArgsForCall []struct {
-		arg1 *models.ServiceShowRequest
+		arg1 string
 		arg2 string
 	}
 	serviceShowReturns struct {
@@ -761,19 +774,6 @@ type FakeAPIClient struct {
 		result1 error
 	}
 	serviceUnbindReturnsOnCall map[int]struct {
-		result1 error
-	}
-	ServicePortForwardStub        func(string, string, *client.PortForwardOpts) error
-	servicePortForwardMutex       sync.RWMutex
-	servicePortForwardArgsForCall []struct {
-		arg1 string
-		arg2 string
-		arg3 *client.PortForwardOpts
-	}
-	servicePortForwardReturns struct {
-		result1 error
-	}
-	servicePortForwardReturnsOnCall map[int]struct {
 		result1 error
 	}
 	StagingCompleteStub        func(string, string) (models.Response, error)
@@ -4144,11 +4144,74 @@ func (fake *FakeAPIClient) ServiceMatchReturnsOnCall(i int, result1 models.Servi
 	}{result1, result2}
 }
 
-func (fake *FakeAPIClient) ServiceShow(arg1 *models.ServiceShowRequest, arg2 string) (*models.Service, error) {
+func (fake *FakeAPIClient) ServicePortForward(arg1 string, arg2 string, arg3 *client.PortForwardOpts) error {
+	fake.servicePortForwardMutex.Lock()
+	ret, specificReturn := fake.servicePortForwardReturnsOnCall[len(fake.servicePortForwardArgsForCall)]
+	fake.servicePortForwardArgsForCall = append(fake.servicePortForwardArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 *client.PortForwardOpts
+	}{arg1, arg2, arg3})
+	stub := fake.ServicePortForwardStub
+	fakeReturns := fake.servicePortForwardReturns
+	fake.recordInvocation("ServicePortForward", []interface{}{arg1, arg2, arg3})
+	fake.servicePortForwardMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeAPIClient) ServicePortForwardCallCount() int {
+	fake.servicePortForwardMutex.RLock()
+	defer fake.servicePortForwardMutex.RUnlock()
+	return len(fake.servicePortForwardArgsForCall)
+}
+
+func (fake *FakeAPIClient) ServicePortForwardCalls(stub func(string, string, *client.PortForwardOpts) error) {
+	fake.servicePortForwardMutex.Lock()
+	defer fake.servicePortForwardMutex.Unlock()
+	fake.ServicePortForwardStub = stub
+}
+
+func (fake *FakeAPIClient) ServicePortForwardArgsForCall(i int) (string, string, *client.PortForwardOpts) {
+	fake.servicePortForwardMutex.RLock()
+	defer fake.servicePortForwardMutex.RUnlock()
+	argsForCall := fake.servicePortForwardArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeAPIClient) ServicePortForwardReturns(result1 error) {
+	fake.servicePortForwardMutex.Lock()
+	defer fake.servicePortForwardMutex.Unlock()
+	fake.ServicePortForwardStub = nil
+	fake.servicePortForwardReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeAPIClient) ServicePortForwardReturnsOnCall(i int, result1 error) {
+	fake.servicePortForwardMutex.Lock()
+	defer fake.servicePortForwardMutex.Unlock()
+	fake.ServicePortForwardStub = nil
+	if fake.servicePortForwardReturnsOnCall == nil {
+		fake.servicePortForwardReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.servicePortForwardReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeAPIClient) ServiceShow(arg1 string, arg2 string) (*models.Service, error) {
 	fake.serviceShowMutex.Lock()
 	ret, specificReturn := fake.serviceShowReturnsOnCall[len(fake.serviceShowArgsForCall)]
 	fake.serviceShowArgsForCall = append(fake.serviceShowArgsForCall, struct {
-		arg1 *models.ServiceShowRequest
+		arg1 string
 		arg2 string
 	}{arg1, arg2})
 	stub := fake.ServiceShowStub
@@ -4170,13 +4233,13 @@ func (fake *FakeAPIClient) ServiceShowCallCount() int {
 	return len(fake.serviceShowArgsForCall)
 }
 
-func (fake *FakeAPIClient) ServiceShowCalls(stub func(*models.ServiceShowRequest, string) (*models.Service, error)) {
+func (fake *FakeAPIClient) ServiceShowCalls(stub func(string, string) (*models.Service, error)) {
 	fake.serviceShowMutex.Lock()
 	defer fake.serviceShowMutex.Unlock()
 	fake.ServiceShowStub = stub
 }
 
-func (fake *FakeAPIClient) ServiceShowArgsForCall(i int) (*models.ServiceShowRequest, string) {
+func (fake *FakeAPIClient) ServiceShowArgsForCall(i int) (string, string) {
 	fake.serviceShowMutex.RLock()
 	defer fake.serviceShowMutex.RUnlock()
 	argsForCall := fake.serviceShowArgsForCall[i]
@@ -4270,27 +4333,6 @@ func (fake *FakeAPIClient) ServiceUnbindReturnsOnCall(i int, result1 error) {
 	fake.serviceUnbindReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
-}
-
-func (fake *FakeAPIClient) ServicePortForward(arg1 string, arg2 string, arg3 *client.PortForwardOpts) error {
-	fake.servicePortForwardMutex.Lock()
-	ret, specificReturn := fake.servicePortForwardReturnsOnCall[len(fake.servicePortForwardArgsForCall)]
-	fake.servicePortForwardArgsForCall = append(fake.servicePortForwardArgsForCall, struct {
-		arg1 string
-		arg2 string
-		arg3 *client.PortForwardOpts
-	}{arg1, arg2, arg3})
-	stub := fake.ServicePortForwardStub
-	fakeReturns := fake.servicePortForwardReturns
-	fake.recordInvocation("ServicePortForward", []interface{}{arg1, arg2, arg3})
-	fake.servicePortForwardMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
 }
 
 func (fake *FakeAPIClient) StagingComplete(arg1 string, arg2 string) (models.Response, error) {
@@ -4520,6 +4562,8 @@ func (fake *FakeAPIClient) Invocations() map[string][][]interface{} {
 	defer fake.serviceListMutex.RUnlock()
 	fake.serviceMatchMutex.RLock()
 	defer fake.serviceMatchMutex.RUnlock()
+	fake.servicePortForwardMutex.RLock()
+	defer fake.servicePortForwardMutex.RUnlock()
 	fake.serviceShowMutex.RLock()
 	defer fake.serviceShowMutex.RUnlock()
 	fake.serviceUnbindMutex.RLock()

--- a/pkg/api/core/v1/client/namespaces.go
+++ b/pkg/api/core/v1/client/namespaces.go
@@ -47,9 +47,18 @@ func (c *Client) NamespaceCreate(req models.NamespaceCreateRequest) (models.Resp
 func (c *Client) NamespaceDelete(namespaces []string) (models.Response, error) {
 	resp := models.Response{}
 
-	URL := constructNamespaceBatchDeleteURL(namespaces)
+	queryParams := url.Values{}
+	for _, namespace := range namespaces {
+		queryParams.Add("namespaces[]", namespace)
+	}
 
-	data, err := c.delete(URL)
+	endpoint := fmt.Sprintf(
+		"%s?%s",
+		api.Routes.Path("NamespaceBatchDelete"),
+		queryParams.Encode(),
+	)
+
+	data, err := c.delete(endpoint)
 	if err != nil {
 		return resp, err
 	}
@@ -65,66 +74,24 @@ func (c *Client) NamespaceDelete(namespaces []string) (models.Response, error) {
 
 // NamespaceShow shows a namespace
 func (c *Client) NamespaceShow(namespace string) (models.Namespace, error) {
-	resp := models.Namespace{}
+	response := models.Namespace{}
+	endpoint := api.Routes.Path("NamespaceShow", namespace)
 
-	data, err := c.get(api.Routes.Path("NamespaceShow", namespace))
-	if err != nil {
-		return resp, err
-	}
-
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return resp, err
-	}
-
-	c.log.V(1).Info("response decoded", "response", resp)
-
-	return resp, nil
+	return Get(c, endpoint, response)
 }
 
 // NamespacesMatch returns all matching namespaces for the prefix
 func (c *Client) NamespacesMatch(prefix string) (models.NamespacesMatchResponse, error) {
-	resp := models.NamespacesMatchResponse{}
+	response := models.NamespacesMatchResponse{}
+	endpoint := api.Routes.Path("NamespacesMatch", prefix)
 
-	data, err := c.get(api.Routes.Path("NamespacesMatch", prefix))
-	if err != nil {
-		return resp, err
-	}
-
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return resp, err
-	}
-
-	c.log.V(1).Info("response decoded", "response", resp)
-
-	return resp, nil
+	return Get(c, endpoint, response)
 }
 
 // Namespaces returns a list of namespaces
 func (c *Client) Namespaces() (models.NamespaceList, error) {
-	resp := models.NamespaceList{}
+	response := models.NamespaceList{}
+	endpoint := api.Routes.Path("Namespaces")
 
-	data, err := c.get(api.Routes.Path("Namespaces"))
-	if err != nil {
-		return resp, err
-	}
-
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return resp, err
-	}
-
-	c.log.V(1).Info("response decoded", "response", resp)
-
-	return resp, nil
-}
-
-func constructNamespaceBatchDeleteURL(namespaces []string) string {
-	q := url.Values{}
-	for _, c := range namespaces {
-		q.Add("namespaces[]", c)
-	}
-	URLParams := q.Encode()
-
-	URL := api.Routes.Path("NamespaceBatchDelete")
-
-	return fmt.Sprintf("%s?%s", URL, URLParams)
+	return Get(c, endpoint, response)
 }

--- a/pkg/api/core/v1/client/namespaces_test.go
+++ b/pkg/api/core/v1/client/namespaces_test.go
@@ -1,0 +1,76 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/epinio/epinio/internal/cli/settings"
+	"github.com/epinio/epinio/pkg/api/core/v1/client"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Client Namespaces", func() {
+	Describe("Namespaces Errors", DescribeNamespacesErrors)
+})
+
+func DescribeNamespacesErrors() {
+
+	var epinioClient *client.Client
+	var statusCode int
+	var responseBody string
+
+	JustBeforeEach(func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(statusCode)
+			fmt.Fprint(w, responseBody)
+		}))
+
+		epinioClient = client.New(context.Background(), &settings.Settings{API: srv.URL})
+	})
+
+	When("a 500 status code and a JSON error was returned", func() {
+
+		BeforeEach(func() {
+			statusCode = 500
+			responseBody = `{
+					"errors": [
+						{
+							"status": 500,
+							"title": "Error title",
+							"details": "something bad happened"
+						}
+					]
+				}`
+		})
+
+		DescribeTable("the APIs are returning an error",
+			func(call func() (any, error)) {
+				_, err := call()
+				Expect(err).To(HaveOccurred())
+			},
+			Entry("namespace show", func() (any, error) {
+				return epinioClient.NamespaceShow("namespace")
+			}),
+			Entry("namespace match", func() (any, error) {
+				return epinioClient.NamespacesMatch("namespaceprefix")
+			}),
+			Entry("namespace list", func() (any, error) {
+				return epinioClient.Namespaces()
+			}),
+		)
+	})
+}

--- a/pkg/api/core/v1/client/services.go
+++ b/pkg/api/core/v1/client/services.go
@@ -23,69 +23,32 @@ import (
 )
 
 func (c *Client) ServiceCatalog() (models.CatalogServices, error) {
-	data, err := c.get(api.Routes.Path("ServiceCatalog"))
-	if err != nil {
-		return nil, err
-	}
+	response := models.CatalogServices{}
+	endpoint := api.Routes.Path("ServiceCatalog")
 
-	var resp models.CatalogServices
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return nil, err
-	}
-
-	c.log.V(1).Info("response decoded", "response", resp)
-
-	return resp, nil
+	return Get(c, endpoint, response)
 }
 
 func (c *Client) ServiceCatalogShow(serviceName string) (*models.CatalogService, error) {
-	data, err := c.get(api.Routes.Path("ServiceCatalogShow", serviceName))
-	if err != nil {
-		return nil, err
-	}
+	response := &models.CatalogService{}
+	endpoint := api.Routes.Path("ServiceCatalogShow", serviceName)
 
-	var resp models.CatalogService
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return nil, err
-	}
-
-	c.log.V(1).Info("response decoded", "response", resp)
-
-	return &resp, nil
+	return Get(c, endpoint, response)
 }
 
 // ServiceCatalogMatch returns all matching namespaces for the prefix
 func (c *Client) ServiceCatalogMatch(prefix string) (models.CatalogMatchResponse, error) {
-	resp := models.CatalogMatchResponse{}
+	response := models.CatalogMatchResponse{}
+	endpoint := api.Routes.Path("ServiceCatalogMatch", prefix)
 
-	data, err := c.get(api.Routes.Path("ServiceCatalogMatch", prefix))
-	if err != nil {
-		return resp, err
-	}
-
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return resp, err
-	}
-
-	c.log.V(1).Info("response decoded", "response", resp)
-
-	return resp, nil
+	return Get(c, endpoint, response)
 }
 
 func (c *Client) AllServices() (models.ServiceList, error) {
-	data, err := c.get(api.Routes.Path("AllServices"))
-	if err != nil {
-		return nil, err
-	}
+	response := models.ServiceList{}
+	endpoint := api.Routes.Path("AllServices")
 
-	var resp models.ServiceList
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return nil, err
-	}
-
-	c.log.V(1).Info("response decoded", "response", resp)
-
-	return resp, err
+	return Get(c, endpoint, response)
 }
 
 func (c *Client) ServiceCreate(req *models.ServiceCreateRequest, namespace string) error {
@@ -98,38 +61,19 @@ func (c *Client) ServiceCreate(req *models.ServiceCreateRequest, namespace strin
 	return err
 }
 
-func (c *Client) ServiceShow(req *models.ServiceShowRequest, namespace string) (*models.Service, error) {
-	data, err := c.get(api.Routes.Path("ServiceShow", namespace, req.Name))
-	if err != nil {
-		return nil, err
-	}
+func (c *Client) ServiceShow(namespace, name string) (*models.Service, error) {
+	response := &models.Service{}
+	endpoint := api.Routes.Path("ServiceShow", namespace, name)
 
-	var resp models.Service
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return nil, err
-	}
-
-	c.log.V(1).Info("response decoded", "response", resp)
-
-	return &resp, nil
+	return Get(c, endpoint, response)
 }
 
 // ServiceMatch returns all matching services for the prefix
 func (c *Client) ServiceMatch(namespace, prefix string) (models.ServiceMatchResponse, error) {
-	resp := models.ServiceMatchResponse{}
+	response := models.ServiceMatchResponse{}
+	endpoint := api.Routes.Path("ServiceMatch", namespace, prefix)
 
-	data, err := c.get(api.Routes.Path("ServiceMatch", namespace, prefix))
-	if err != nil {
-		return resp, err
-	}
-
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return resp, err
-	}
-
-	c.log.V(1).Info("response decoded", "response", resp)
-
-	return resp, nil
+	return Get(c, endpoint, response)
 }
 
 func (c *Client) ServiceDelete(req models.ServiceDeleteRequest, namespace string, names []string, f ErrorFunc) (models.ServiceDeleteResponse, error) {
@@ -141,9 +85,18 @@ func (c *Client) ServiceDelete(req models.ServiceDeleteRequest, namespace string
 		return resp, nil
 	}
 
-	URL := constructServiceBatchDeleteURL(namespace, names)
+	queryParams := url.Values{}
+	for _, serviceName := range names {
+		queryParams.Add("services[]", serviceName)
+	}
 
-	data, err := c.doWithCustomErrorHandling(URL, "DELETE", string(b), f)
+	endpoint := fmt.Sprintf(
+		"%s?%s",
+		api.Routes.Path("ServiceBatchDelete", namespace),
+		queryParams.Encode(),
+	)
+
+	data, err := c.doWithCustomErrorHandling(endpoint, "DELETE", string(b), f)
 	if err != nil {
 		if err.Error() != "Bad Request" {
 			return resp, err
@@ -183,49 +136,18 @@ func (c *Client) ServiceUnbind(req *models.ServiceUnbindRequest, namespace, name
 }
 
 func (c *Client) ServiceList(namespace string) (models.ServiceList, error) {
-	data, err := c.get(api.Routes.Path("ServiceList", namespace))
-	if err != nil {
-		return nil, err
-	}
+	response := models.ServiceList{}
+	endpoint := api.Routes.Path("ServiceList", namespace)
 
-	var resp models.ServiceList
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return nil, err
-	}
-
-	c.log.V(1).Info("response decoded", "response", resp)
-
-	return resp, err
+	return Get(c, endpoint, response)
 }
 
 // ServiceApps lists a map from services to bound apps, for the namespace
 func (c *Client) ServiceApps(namespace string) (models.ServiceAppsResponse, error) {
-	resp := models.ServiceAppsResponse{}
+	response := models.ServiceAppsResponse{}
+	endpoint := api.Routes.Path("ServiceApps", namespace)
 
-	data, err := c.get(api.Routes.Path("ServiceApps", namespace))
-	if err != nil {
-		return resp, err
-	}
-
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return resp, errors.Wrap(err, "response body is not JSON")
-	}
-
-	c.log.V(1).Info("response decoded", "response", resp)
-
-	return resp, nil
-}
-
-func constructServiceBatchDeleteURL(namespace string, names []string) string {
-	q := url.Values{}
-	for _, c := range names {
-		q.Add("services[]", c)
-	}
-	URLParams := q.Encode()
-
-	URL := api.Routes.Path("ServiceBatchDelete", namespace)
-
-	return fmt.Sprintf("%s?%s", URL, URLParams)
+	return Get(c, endpoint, response)
 }
 
 // ServicePortForward will forward the local traffic to a remote app

--- a/pkg/api/core/v1/client/services_test.go
+++ b/pkg/api/core/v1/client/services_test.go
@@ -1,0 +1,88 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/epinio/epinio/internal/cli/settings"
+	"github.com/epinio/epinio/pkg/api/core/v1/client"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Client Services", func() {
+	Describe("Services Errors", DescribeServicesErrors)
+})
+
+func DescribeServicesErrors() {
+
+	var epinioClient *client.Client
+	var statusCode int
+	var responseBody string
+
+	JustBeforeEach(func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(statusCode)
+			fmt.Fprint(w, responseBody)
+		}))
+
+		epinioClient = client.New(context.Background(), &settings.Settings{API: srv.URL})
+	})
+
+	When("a 500 status code and a JSON error was returned", func() {
+
+		BeforeEach(func() {
+			statusCode = 500
+			responseBody = `{
+					"errors": [
+						{
+							"status": 500,
+							"title": "Error title",
+							"details": "something bad happened"
+						}
+					]
+				}`
+		})
+
+		DescribeTable("the APIs are returning an error",
+			func(call func() (any, error)) {
+				_, err := call()
+				Expect(err).To(HaveOccurred())
+			},
+			Entry("service catalog", func() (any, error) {
+				return epinioClient.ServiceCatalog()
+			}),
+			Entry("service catalog show", func() (any, error) {
+				return epinioClient.ServiceCatalogShow("servicename")
+			}),
+			Entry("service catalog match", func() (any, error) {
+				return epinioClient.ServiceCatalogMatch("servicenameprefix")
+			}),
+			Entry("service list", func() (any, error) {
+				return epinioClient.ServiceList("namespace")
+			}),
+			Entry("service show", func() (any, error) {
+				return epinioClient.ServiceShow("namespace", "servicename")
+			}),
+			Entry("service match", func() (any, error) {
+				return epinioClient.ServiceMatch("namespace", "servicenameprefix")
+			}),
+			Entry("service apps", func() (any, error) {
+				return epinioClient.ServiceApps("namespace")
+			}),
+		)
+	})
+}

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -347,10 +347,6 @@ type ServiceUnbindRequest struct {
 	AppName string `json:"app_name,omitempty"`
 }
 
-type ServiceShowRequest struct {
-	Name string `json:"name,omitempty"`
-}
-
 type Service struct {
 	Meta                    Meta          `json:"meta,omitempty"`
 	SecretTypes             []string      `json:"secretTypes,omitempty"`


### PR DESCRIPTION
This PR moves more GET APIs to use the generic Get and adds some more tests.
While moving some of the code I've seen that the API client was implementing a ServiceShowRequest, altough it's not actually needed. It's not sent in the payload, we just need the name, like the other `get` requests.