### PR TITLE
Updated `bci/bci-micro` image

### DIFF
--- a/images/unpacker-Dockerfile
+++ b/images/unpacker-Dockerfile
@@ -12,7 +12,7 @@
 FROM registry.suse.com/bci/bci-base AS stage
 RUN zypper refresh && zypper --non-interactive  install -f tar gzip unzip bzip2 xz findutils
 
-FROM registry.suse.com/bci/bci-micro:15.4.21.1
+FROM registry.suse.com/bci/bci-micro:15.5.9.1
 COPY --from=stage /bin/tar       /bin/tar
 COPY --from=stage /usr/bin/unzip /usr/bin/unzip
 COPY --from=stage /bin/gzip      /bin/gzip


### PR DESCRIPTION
After updating to the latest SP4 (`15.4.21.1` - https://github.com/epinio/epinio/pull/2398) dependabot tried to upload to the latest SP5 (https://github.com/epinio/epinio/pull/2399)

It should be ok for us to go from SP4 to SP5.

Ref: https://registry.suse.com/bci/bci-micro-15sp5/index.html
