### PR TITLE
Added generic Configuration delete

### DIFF
--- a/acceptance/appcharts_test.go
+++ b/acceptance/appcharts_test.go
@@ -103,7 +103,7 @@ var _ = Describe("apps chart", LAppchart, func() {
 			out, err := env.Epinio("", "apps", "chart", "show", "bogus")
 			Expect(err).To(HaveOccurred(), out)
 			Expect(out).To(ContainSubstring("Show application chart details"))
-			Expect(out).To(ContainSubstring("Not Found: application chart 'bogus' does not exist"))
+			Expect(out).To(ContainSubstring("application chart 'bogus' does not exist"))
 		})
 	})
 
@@ -135,7 +135,7 @@ var _ = Describe("apps chart", LAppchart, func() {
 		It("fails to sets a bogus default", func() {
 			out, err := env.Epinio("", "apps", "chart", "default", "bogus")
 			Expect(err).To(HaveOccurred(), out)
-			Expect(out).To(ContainSubstring("Not Found: application chart 'bogus' does not exist"))
+			Expect(out).To(ContainSubstring("application chart 'bogus' does not exist"))
 		})
 
 		It("unsets a default", func() {

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -405,7 +405,7 @@ var _ = Describe("Apps", LApplication, func() {
 					out, err := env.Epinio("", "app", "update", appName,
 						"--app-chart", chartName)
 					Expect(err).To(HaveOccurred(), out)
-					Expect(out).To(ContainSubstring("Bad Request: unable to change app chart of active application"))
+					Expect(out).To(ContainSubstring("unable to change app chart of active application"))
 				})
 
 				When("no workload is present", func() {

--- a/acceptance/configurations_test.go
+++ b/acceptance/configurations_test.go
@@ -611,7 +611,7 @@ var _ = Describe("Configurations", LConfiguration, func() {
 		It("doesn't unbind a service-owned configuration", func() {
 			out, err := env.Epinio("", "configuration", "unbind", config, appName)
 			Expect(err).To(HaveOccurred(), out)
-			Expect(out).To(ContainSubstring("Bad Request: Configuration '%s' belongs to service", config))
+			Expect(out).To(ContainSubstring("Configuration '%s' belongs to service", config))
 		})
 
 		It("doesn't delete a bound service-owned configuration", func() {

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -88,7 +88,7 @@ type APIClient interface {
 	AllConfigurations() (models.ConfigurationResponseList, error)
 	ConfigurationBindingCreate(req models.BindRequest, namespace string, appName string) (models.BindResponse, error)
 	ConfigurationBindingDelete(namespace string, appName string, configurationName string) (models.Response, error)
-	ConfigurationDelete(req models.ConfigurationDeleteRequest, namespace string, names []string, f epinioapi.ErrorFunc) (models.ConfigurationDeleteResponse, error)
+	ConfigurationDelete(req models.ConfigurationDeleteRequest, namespace string, names []string) (models.ConfigurationDeleteResponse, error)
 	ConfigurationCreate(req models.ConfigurationCreateRequest, namespace string) (models.Response, error)
 	ConfigurationUpdate(req models.ConfigurationUpdateRequest, namespace, name string) (models.Response, error)
 	ConfigurationShow(namespace string, name string) (models.ConfigurationResponse, error)

--- a/internal/cli/usercmd/configuration.go
+++ b/internal/cli/usercmd/configuration.go
@@ -12,13 +12,13 @@
 package usercmd
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
 	"strings"
 
-	apierrors "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/client"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -266,37 +266,36 @@ func (c *EpinioClient) DeleteConfiguration(names []string, unbind, all bool) err
 		return match.Names
 	})
 
-	_, err := c.API.ConfigurationDelete(request, c.Settings.Namespace, names,
-		func(response *http.Response, bodyBytes []byte, err error) error {
-			// nothing special for internal errors and the like
-			if response.StatusCode != http.StatusBadRequest {
-				return err
-			}
-
-			// A bad request happens when
-			//
-			// 1. the configuration is still bound to one or more applications, and the
-			//    response contains an array of their names.
-			//
-			// 2. the configuration is owned by a service and denied the request
-
-			var apiError apierrors.ErrorResponse
-			if err := json.Unmarshal(bodyBytes, &apiError); err != nil {
-				return err
-			}
-
-			// [BELONG] keep in sync with same markers in the server
-			if strings.Contains(apiError.Errors[0].Title, "belongs to service") {
-				// (2.)
-				return apiError.Errors[0]
-			}
-
-			// (1.)
-			bound = strings.Split(apiError.Errors[0].Details, ",")
-			return nil
-		})
+	_, err := c.API.ConfigurationDelete(request, c.Settings.Namespace, names)
 	if err != nil {
-		return err
+		epinioAPIError := &client.APIError{}
+		// something bad happened
+		if !errors.As(err, &epinioAPIError) {
+			return err
+		}
+
+		// the API error is something different from a bad request (500?). Do not handle.
+		if epinioAPIError.StatusCode != http.StatusBadRequest {
+			return err
+		}
+
+		// A bad request happens when
+		//
+		// 1. the configuration is still bound to one or more applications, and the
+		//    response contains an array of their names.
+		//
+		// 2. the configuration is owned by a service and denied the request
+
+		firstErr := epinioAPIError.Err.Errors[0]
+
+		// [BELONG] keep in sync with same markers in the server
+		if strings.Contains(firstErr.Title, "belongs to service") {
+			// (2.)
+			return firstErr
+		}
+
+		// (1.)
+		bound = strings.Split(firstErr.Details, ",")
 	}
 
 	if len(bound) > 0 {

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -26,6 +26,7 @@ import (
 	"github.com/epinio/epinio/helpers"
 	"github.com/epinio/epinio/helpers/termui"
 	"github.com/epinio/epinio/internal/duration"
+	"github.com/epinio/epinio/pkg/api/core/v1/client"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 )
 
@@ -117,13 +118,12 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 	}, appRef.Namespace)
 	if err != nil {
 		// try to recover if it's a response type Conflict error and not a http connection error
-		rerr, ok := err.(interface{ StatusCode() int })
-
-		if !ok {
+		epinioAPIError := &client.APIError{}
+		if !errors.As(err, &epinioAPIError) {
 			return err
 		}
 
-		if rerr.StatusCode() != http.StatusConflict {
+		if epinioAPIError.StatusCode != http.StatusConflict {
 			return err
 		}
 

--- a/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
+++ b/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
@@ -404,13 +404,12 @@ type FakeAPIClient struct {
 		result1 models.Response
 		result2 error
 	}
-	ConfigurationDeleteStub        func(models.ConfigurationDeleteRequest, string, []string, func(response *http.Response, bodyBytes []byte, err error) error) (models.ConfigurationDeleteResponse, error)
+	ConfigurationDeleteStub        func(models.ConfigurationDeleteRequest, string, []string) (models.ConfigurationDeleteResponse, error)
 	configurationDeleteMutex       sync.RWMutex
 	configurationDeleteArgsForCall []struct {
 		arg1 models.ConfigurationDeleteRequest
 		arg2 string
 		arg3 []string
-		arg4 func(response *http.Response, bodyBytes []byte, err error) error
 	}
 	configurationDeleteReturns struct {
 		result1 models.ConfigurationDeleteResponse
@@ -2576,7 +2575,7 @@ func (fake *FakeAPIClient) ConfigurationCreateReturnsOnCall(i int, result1 model
 	}{result1, result2}
 }
 
-func (fake *FakeAPIClient) ConfigurationDelete(arg1 models.ConfigurationDeleteRequest, arg2 string, arg3 []string, arg4 func(response *http.Response, bodyBytes []byte, err error) error) (models.ConfigurationDeleteResponse, error) {
+func (fake *FakeAPIClient) ConfigurationDelete(arg1 models.ConfigurationDeleteRequest, arg2 string, arg3 []string) (models.ConfigurationDeleteResponse, error) {
 	var arg3Copy []string
 	if arg3 != nil {
 		arg3Copy = make([]string, len(arg3))
@@ -2588,14 +2587,13 @@ func (fake *FakeAPIClient) ConfigurationDelete(arg1 models.ConfigurationDeleteRe
 		arg1 models.ConfigurationDeleteRequest
 		arg2 string
 		arg3 []string
-		arg4 func(response *http.Response, bodyBytes []byte, err error) error
-	}{arg1, arg2, arg3Copy, arg4})
+	}{arg1, arg2, arg3Copy})
 	stub := fake.ConfigurationDeleteStub
 	fakeReturns := fake.configurationDeleteReturns
-	fake.recordInvocation("ConfigurationDelete", []interface{}{arg1, arg2, arg3Copy, arg4})
+	fake.recordInvocation("ConfigurationDelete", []interface{}{arg1, arg2, arg3Copy})
 	fake.configurationDeleteMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -2609,17 +2607,17 @@ func (fake *FakeAPIClient) ConfigurationDeleteCallCount() int {
 	return len(fake.configurationDeleteArgsForCall)
 }
 
-func (fake *FakeAPIClient) ConfigurationDeleteCalls(stub func(models.ConfigurationDeleteRequest, string, []string, func(response *http.Response, bodyBytes []byte, err error) error) (models.ConfigurationDeleteResponse, error)) {
+func (fake *FakeAPIClient) ConfigurationDeleteCalls(stub func(models.ConfigurationDeleteRequest, string, []string) (models.ConfigurationDeleteResponse, error)) {
 	fake.configurationDeleteMutex.Lock()
 	defer fake.configurationDeleteMutex.Unlock()
 	fake.ConfigurationDeleteStub = stub
 }
 
-func (fake *FakeAPIClient) ConfigurationDeleteArgsForCall(i int) (models.ConfigurationDeleteRequest, string, []string, func(response *http.Response, bodyBytes []byte, err error) error) {
+func (fake *FakeAPIClient) ConfigurationDeleteArgsForCall(i int) (models.ConfigurationDeleteRequest, string, []string) {
 	fake.configurationDeleteMutex.RLock()
 	defer fake.configurationDeleteMutex.RUnlock()
 	argsForCall := fake.configurationDeleteArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeAPIClient) ConfigurationDeleteReturns(result1 models.ConfigurationDeleteResponse, result2 error) {


### PR DESCRIPTION
This PR add the logic of the `Delete` configurations http requests into a generic function (100% coverage for the `configurations.go` :tada: ).

This is also an opportunity to drop/remove the `doWithCustomErrorHandling`. As also stated in the comment this is used only in a couple of methods, and it can be handled in a different way.
Instead of returning `ok` just for 200 or 201 it return ok for all codes `<400`. If a logic error occurred then the function will try to unmarshal the error and return it in a custom `APIError`, containing the `StatusCode` and the unmarshalled error. If other errors occurred then it's just returned plain.

The caller can now check the error type with `errors.As(err, &epinioAPIError)` and do it's logic.

With this approach we can later refactor also the `ServiceDelete` and drop completely the `doWithCustomErrorHandling`.