### PR TITLE
CI Remove Settings key if not present in existing service CRD

### DIFF
--- a/acceptance/helpers/catalog/misc.go
+++ b/acceptance/helpers/catalog/misc.go
@@ -124,6 +124,15 @@ func SampleServiceTmpFile(namespace string, catalogService models.CatalogService
 		},
 	}
 
+	// Check if the installed Epinio version has compatible CRD deployed
+	out, err := proc.Kubectl("get", "crd", "services.application.epinio.io", "-o", `jsonpath='{..properties.settings}'`)
+	Expect(err).ToNot(HaveOccurred(), out)
+
+	// Delete the Spec.Settings key if the kubectl output is empty - the CRD is not compatible then
+	if string(out) == "''" {
+		srv.Spec.Settings = nil
+	}
+
 	if len(catalogService.SecretTypes) > 0 {
 		srv.ObjectMeta.Annotations = map[string]string{
 			services.CatalogServiceSecretTypesAnnotation: strings.Join(catalogService.SecretTypes, ","),

--- a/acceptance/install/suite_test.go
+++ b/acceptance/install/suite_test.go
@@ -153,6 +153,13 @@ func UpgradeSequence(epinioHelper epinio.Epinio, domain string) {
 		})
 
 		By("Upgrading actual", func() {
+			// Update CRDs prior the upgrade
+			out, err := proc.Kubectl("apply",
+				"-f", "https://raw.githubusercontent.com/epinio/helm-charts/main/chart/epinio/crds/app-crd.yaml",
+				"-f", "https://raw.githubusercontent.com/epinio/helm-charts/main/chart/epinio/crds/appcharts-crd.yaml",
+				"-f", "https://raw.githubusercontent.com/epinio/helm-charts/main/chart/epinio/crds/service-crd.yaml",
+			)
+			Expect(err).ToNot(HaveOccurred(), out)
 			// Upgrade to current as found in checkout
 			epinioHelper.Upgrade()
 		})


### PR DESCRIPTION
ref. https://github.com/epinio/epinio/issues/2418

The code is working but I believe it could be done better.

Anyway the code won't be needed once v1.9.0 is released as the service settings values will be available in the services CRD by default.

Also not sure if the code for updating CRDs is needed because we don't test the service value functionality when the settings key is getting removed.

Testruns:
* GKE https://github.com/epinio/epinio/actions/runs/5445933360/jobs/9906044849
* RKE https://github.com/epinio/epinio/actions/runs/5446193581/jobs/9906646810