### PR TITLE
Added proper status check for Service deployments

### DIFF
--- a/acceptance/configurations_test.go
+++ b/acceptance/configurations_test.go
@@ -517,8 +517,16 @@ var _ = Describe("Configurations", LConfiguration, func() {
 
 			By("make service instance: " + service)
 			// catalogService.Meta.Name
-			out, err := env.Epinio("", "service", "create", "mysql-dev", service, "--wait")
+			out, err := env.Epinio("", "service", "create", "mysql-dev", service)
 			Expect(err).ToNot(HaveOccurred(), out)
+
+			By("wait for deployment")
+			Eventually(func() string {
+				out, _ := env.Epinio("", "service", "show", service)
+				return out
+			}, ServiceDeployTimeout, ServiceDeployPollingInterval).Should(
+				HaveATable(WithRow("Status", "deployed")),
+			)
 
 			appName = catalog.NewAppName()
 			By("make app: " + appName)

--- a/acceptance/configurations_test.go
+++ b/acceptance/configurations_test.go
@@ -34,10 +34,10 @@ var _ = Describe("Configurations", LConfiguration, func() {
 		configurationName1 = catalog.NewConfigurationName()
 		configurationName2 = catalog.NewConfigurationName()
 		env.SetupAndTargetNamespace(namespace)
-	})
 
-	AfterEach(func() {
-		env.DeleteNamespace(namespace)
+		DeferCleanup(func() {
+			env.DeleteNamespace(namespace)
+		})
 	})
 
 	Describe("configuration list", func() {
@@ -45,11 +45,6 @@ var _ = Describe("Configurations", LConfiguration, func() {
 		BeforeEach(func() {
 			env.MakeConfiguration(configurationName1)
 			env.MakeConfiguration(configurationName2)
-		})
-
-		AfterEach(func() {
-			env.CleanupConfiguration(configurationName1)
-			env.CleanupConfiguration(configurationName2)
 		})
 
 		It("shows all created configurations", func() {
@@ -94,19 +89,11 @@ var _ = Describe("Configurations", LConfiguration, func() {
 			env.SetupAndTargetNamespace(namespace2)
 			env.MakeConfiguration(configuration1) // separate from namespace1.configuration1
 			env.MakeConfiguration(configuration2)
-		})
 
-		AfterEach(func() {
-			env.TargetNamespace(namespace2)
-			env.DeleteConfigurations(configuration1)
-			env.DeleteConfigurations(configuration2)
-
-			env.TargetNamespace(namespace1)
-			env.DeleteApp(app1)
-			env.DeleteConfigurations(configuration1)
-
-			env.DeleteNamespace(namespace1)
-			env.DeleteNamespace(namespace2)
+			DeferCleanup(func() {
+				env.DeleteNamespace(namespace1)
+				env.DeleteNamespace(namespace2)
+			})
 		})
 
 		It("lists all configurations belonging to all namespaces", func() {
@@ -129,10 +116,6 @@ var _ = Describe("Configurations", LConfiguration, func() {
 	Describe("configuration create", func() {
 		// Note: Configurations provision instantly.
 		// No testing of wait/don't wait required.
-
-		AfterEach(func() {
-			env.CleanupConfiguration(configurationName1)
-		})
 
 		It("creates a configuration", func() {
 			env.MakeConfiguration(configurationName1)
@@ -187,20 +170,23 @@ var _ = Describe("Configurations", LConfiguration, func() {
 		})
 
 		Describe("directory", func() {
-			BeforeEach(func() {
-				err := os.MkdirAll("DIR", 0755)
-				Expect(err).ToNot(HaveOccurred())
-			})
+			var tmpDir string
+			var mkdirErr error
 
-			AfterEach(func() {
-				err := os.RemoveAll("DIR")
-				Expect(err).ToNot(HaveOccurred())
+			BeforeEach(func() {
+				tmpDir, mkdirErr = os.MkdirTemp("", "epinio-config")
+				Expect(mkdirErr).ToNot(HaveOccurred())
+
+				DeferCleanup(func() {
+					err := os.RemoveAll(tmpDir)
+					Expect(err).ToNot(HaveOccurred())
+				})
 			})
 
 			It("fails for a directory", func() {
-				out, err := env.Epinio("", "configuration", "create", "foo", "--from-file", "DIR")
+				out, err := env.Epinio("", "configuration", "create", "foo", "--from-file", tmpDir)
 				Expect(err).To(HaveOccurred(), out)
-				Expect(out).To(ContainSubstring("filesystem error: read DIR: is a directory"))
+				Expect(out).To(ContainSubstring("filesystem error: read %s: is a directory", tmpDir))
 			})
 		})
 	})
@@ -307,11 +293,6 @@ var _ = Describe("Configurations", LConfiguration, func() {
 			env.MakeContainerImageApp(appName, 1, containerImageURL)
 		})
 
-		AfterEach(func() {
-			env.CleanupApp(appName)
-			env.CleanupConfiguration(configurationName1)
-		})
-
 		It("binds a configuration to the application deployment", func() {
 			env.BindAppConfiguration(appName, configurationName1, namespace)
 		})
@@ -361,11 +342,6 @@ var _ = Describe("Configurations", LConfiguration, func() {
 			env.BindAppConfiguration(appName, configurationName1, namespace)
 		})
 
-		AfterEach(func() {
-			env.CleanupApp(appName)
-			env.CleanupConfiguration(configurationName1)
-		})
-
 		It("unbinds a configuration from the application deployment", func() {
 			env.UnbindAppConfiguration(appName, configurationName1, namespace)
 		})
@@ -405,9 +381,6 @@ var _ = Describe("Configurations", LConfiguration, func() {
 	})
 
 	Describe("configuration show", func() {
-		AfterEach(func() {
-			env.CleanupConfiguration(configurationName1)
-		})
 
 		It("it shows configuration details", func() {
 			env.MakeConfiguration(configurationName1)
@@ -488,12 +461,6 @@ var _ = Describe("Configurations", LConfiguration, func() {
 			)
 		})
 
-		AfterEach(func() {
-			env.TargetNamespace(namespace)
-			env.DeleteApp(appName)
-			env.CleanupConfiguration(configurationName1)
-		})
-
 		It("it edits the configuration, and restarts the app", func() {
 			// edit the configuration ...
 
@@ -550,14 +517,8 @@ var _ = Describe("Configurations", LConfiguration, func() {
 
 			By("make service instance: " + service)
 			// catalogService.Meta.Name
-			out, err := env.Epinio("", "service", "create", "mysql-dev", service)
+			out, err := env.Epinio("", "service", "create", "mysql-dev", service, "--wait")
 			Expect(err).ToNot(HaveOccurred(), out)
-
-			By("wait for deployment")
-			Eventually(func() string {
-				out, _ := env.Epinio("", "service", "show", service)
-				return out
-			}, "2m", "5s").Should(HaveATable(WithRow("Status", "deployed")))
 
 			appName = catalog.NewAppName()
 			By("make app: " + appName)
@@ -585,29 +546,6 @@ var _ = Describe("Configurations", LConfiguration, func() {
 			By("done before")
 		})
 
-		AfterEach(func() {
-			env.TargetNamespace(namespace)
-
-			By("remove app: " + appName)
-			env.DeleteApp(appName)
-
-			// The preceding removed the service/config binding as well, allowing us to
-			// remove the service and its configs without care.
-
-			By("remove service instance: " + service)
-
-			out, err := env.Epinio("", "service", "delete", service)
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).To(ContainSubstring("Services Removed"))
-
-			Eventually(func() string {
-				out, _ := env.Epinio("", "service", "delete", service)
-				return out
-			}, "1m", "5s").Should(ContainSubstring("service '%s' does not exist", service))
-
-			By("done after")
-		})
-
 		It("doesn't unbind a service-owned configuration", func() {
 			out, err := env.Epinio("", "configuration", "unbind", config, appName)
 			Expect(err).To(HaveOccurred(), out)
@@ -625,7 +563,6 @@ var _ = Describe("Configurations", LConfiguration, func() {
 
 			out, err := env.Epinio("", "service", "unbind", service, appName)
 			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).ToNot(ContainSubstring("Available Commands:")) // Command should exist
 
 			By("wait for unbound")
 			Eventually(func() string {
@@ -636,6 +573,44 @@ var _ = Describe("Configurations", LConfiguration, func() {
 			out, err = env.Epinio("", "configuration", "delete", config)
 			Expect(err).To(HaveOccurred(), out)
 			Expect(out).To(ContainSubstring("Configuration '%s' belongs to service", config))
+		})
+
+		It("deletes a service-owned configuration after service deletion", func() {
+			By("unbind service: " + appName)
+
+			out, err := env.Epinio("", "service", "unbind", service, appName)
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			By("wait for unbound")
+			Eventually(func() string {
+				out, _ := env.Epinio("", "app", "show", appName)
+				return out
+			}, "2m", "5s").ShouldNot(HaveATable(WithRow("Bound Configurations", config)))
+
+			out, err = env.Epinio("", "configuration", "delete", config)
+			Expect(err).To(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("Configuration '%s' belongs to service", config))
+
+			By("remove app: " + appName)
+			env.DeleteApp(appName)
+
+			// The preceding removed the service/config binding as well, allowing us to
+			// remove the service and its configs without care.
+
+			By("remove service instance: " + service)
+
+			out, err = env.Epinio("", "service", "delete", service)
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("Services Removed"))
+
+			Eventually(func() string {
+				out, _ := env.Epinio("", "service", "delete", service)
+				return out
+			}, "1m", "5s").Should(ContainSubstring("service '%s' does not exist", service))
+
+			By("done after")
+
+			env.CleanupConfiguration(configurationName1)
 		})
 	})
 

--- a/acceptance/helpers/catalog/misc.go
+++ b/acceptance/helpers/catalog/misc.go
@@ -44,10 +44,10 @@ func NginxCatalogService(name string) models.CatalogService {
 		},
 		Values: values,
 		Settings: map[string]models.ChartSetting{
-			"ingress.enabled": models.ChartSetting{
+			"ingress.enabled": {
 				Type: "bool",
 			},
-			"ingress.hostname": models.ChartSetting{
+			"ingress.hostname": {
 				Type: "string",
 			},
 		},

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -172,13 +172,10 @@ var _ = Describe("Services", LService, func() {
 
 		It("shows a service", func() {
 			By("show it")
-			Eventually(func() string {
-				out, err := env.Epinio("", "service", "show", service)
-				Expect(err).ToNot(HaveOccurred(), out)
-				Expect(out).To(ContainSubstring("Showing Service"))
-
-				return out
-			}, "2m", "5s").Should(
+			out, err := env.Epinio("", "service", "show", service)
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("Showing Service"))
+			Expect(out).To(
 				HaveATable(
 					WithHeaders("KEY", "VALUE"),
 					WithRow("Name", service),
@@ -765,13 +762,12 @@ var _ = Describe("Services", LService, func() {
 			Eventually(func() string {
 				out, _ := env.Epinio("", "service", "show", service)
 				return out
-			}, ServiceDeployTimeout, ServiceDeployPollingInterval).
-				Should(
-					HaveATable(
-						WithRow("Status", "deployed"),
-						WithRow("Status", "deployed"),
-					),
-				)
+			}, ServiceDeployTimeout, ServiceDeployPollingInterval).Should(
+				HaveATable(
+					WithHeaders("KEY", "VALUE"),
+					WithRow("Status", "deployed"),
+				),
+			)
 
 			By("bind it")
 			out, err = env.Epinio("", "service", "bind", service, app)
@@ -890,12 +886,9 @@ var _ = Describe("Services", LService, func() {
 			)
 			Expect(err).ToNot(HaveOccurred(), out)
 
-			// wait for the service to be ready
-			Eventually(func() int {
-				resp, err := http.Get(catalogServiceURL)
-				Expect(err).ToNot(HaveOccurred())
-				return resp.StatusCode
-			}, "1m", "1s").Should(Equal(http.StatusOK))
+			resp, err := http.Get(catalogServiceURL)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		})
 
 		randomPort := func() string {

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -36,11 +36,16 @@ import (
 const mysqlVersion = "8.0.31" // Doesn't change too often
 
 var _ = Describe("Services", LService, func() {
+	var namespace string
+
 	var catalogService models.CatalogService
 	var catalogServiceURL string
 	var catalogServiceHostname string
 
 	BeforeEach(func() {
+		namespace = catalog.NewNamespaceName()
+		env.SetupAndTargetNamespace(namespace)
+
 		settings, err := env.GetSettingsFrom(testenv.EpinioYAML())
 		Expect(err).ToNot(HaveOccurred())
 
@@ -53,6 +58,7 @@ var _ = Describe("Services", LService, func() {
 
 		DeferCleanup(func() {
 			catalog.DeleteCatalogService(catalogService.Meta.Name)
+			env.DeleteNamespace(namespace)
 		})
 	})
 
@@ -150,21 +156,14 @@ var _ = Describe("Services", LService, func() {
 	})
 
 	Describe("Show", func() {
-		var namespace, service string
+		var service string
 
 		BeforeEach(func() {
-			namespace = catalog.NewNamespaceName()
-			env.SetupAndTargetNamespace(namespace)
-
 			service = catalog.NewServiceName()
 
 			By("create it")
-			out, err := env.Epinio("", "service", "create", catalogService.Meta.Name, service)
+			out, err := env.Epinio("", "service", "create", catalogService.Meta.Name, service, "--wait")
 			Expect(err).ToNot(HaveOccurred(), out)
-
-			DeferCleanup(func() {
-				env.DeleteNamespace(namespace)
-			})
 		})
 
 		It("shows a service", func() {
@@ -209,20 +208,10 @@ var _ = Describe("Services", LService, func() {
 	})
 
 	Describe("List", func() {
-		var namespace, service string
-
-		BeforeEach(func() {
-			namespace = catalog.NewNamespaceName()
-			env.SetupAndTargetNamespace(namespace)
-
-			service = catalog.NewServiceName()
-
-			DeferCleanup(func() {
-				env.DeleteNamespace(namespace)
-			})
-		})
 
 		It("list a service", func() {
+			service := catalog.NewServiceName()
+
 			By("create it")
 			out, err := env.Epinio("", "service", "create", catalogService.Meta.Name, service)
 			Expect(err).ToNot(HaveOccurred(), out)
@@ -237,7 +226,7 @@ var _ = Describe("Services", LService, func() {
 			Expect(out).To(
 				HaveATable(
 					WithHeaders("NAME", "CREATED", "CATALOG SERVICE", "VERSION", "STATUS", "APPLICATIONS"),
-					WithRow(service, WithDate(), catalogService.Meta.Name, catalogService.AppVersion, "(not-ready|deployed)", ""),
+					WithRow(service, WithDate(), catalogService.Meta.Name, catalogService.AppVersion, "(unknown|not-ready|deployed)", ""),
 				),
 			)
 
@@ -309,12 +298,12 @@ var _ = Describe("Services", LService, func() {
 			By("create them in different namespaces")
 			// create service1 in namespace1
 			env.TargetNamespace(namespace1)
-			out, err := env.Epinio("", "service", "create", catalogService.Meta.Name, service1)
+			out, err := env.Epinio("", "service", "create", catalogService.Meta.Name, service1, "--wait")
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			// create service2 in namespace2
 			env.TargetNamespace(namespace2)
-			out, err = env.Epinio("", "service", "create", catalogService.Meta.Name, service2)
+			out, err = env.Epinio("", "service", "create", catalogService.Meta.Name, service2, "--wait")
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			// show all the services (we are admin, good to go)
@@ -327,36 +316,10 @@ var _ = Describe("Services", LService, func() {
 			Expect(out).To(
 				HaveATable(
 					WithHeaders("NAMESPACE", "NAME", "CREATED", "CATALOG SERVICE", "VERSION", "STATUS", "APPLICATION"),
-					WithRow(namespace1, service1, WithDate(), catalogService.Meta.Name, catalogService.AppVersion, "(not-ready|deployed)", ""),
-					WithRow(namespace2, service2, WithDate(), catalogService.Meta.Name, catalogService.AppVersion, "(not-ready|deployed)", ""),
-				),
-			)
-
-			By("wait for deployment of " + service1)
-			Eventually(func() string {
-				out, _ := env.Epinio("", "service", "list", "--all")
-				return out
-			}, "2m", "5s").Should(
-				HaveATable(
-					WithHeaders("NAMESPACE", "NAME", "CREATED", "CATALOG SERVICE", "VERSION", "STATUS", "APPLICATION"),
 					WithRow(namespace1, service1, WithDate(), catalogService.Meta.Name, catalogService.AppVersion, "deployed", ""),
-				),
-			)
-
-			By(fmt.Sprintf("%s/%s up", namespace1, service1))
-
-			By("wait for deployment of " + service2)
-			Eventually(func() string {
-				out, _ := env.Epinio("", "service", "list", "--all")
-				return out
-			}, "2m", "5s").Should(
-				HaveATable(
-					WithHeaders("NAMESPACE", "NAME", "CREATED", "CATALOG SERVICE", "VERSION", "STATUS", "APPLICATION"),
 					WithRow(namespace2, service2, WithDate(), catalogService.Meta.Name, catalogService.AppVersion, "deployed", ""),
 				),
 			)
-
-			By(fmt.Sprintf("%s/%s up", namespace2, service2))
 		})
 
 		It("list only the services in the user namespace", func() {
@@ -366,7 +329,7 @@ var _ = Describe("Services", LService, func() {
 			updateSettings(user1, password1, namespace1)
 
 			// create service1 in namespace1
-			out, err := env.Epinio("", "service", "create", catalogService.Meta.Name, service1, "--settings-file", tmpSettingsPath)
+			out, err := env.Epinio("", "service", "create", catalogService.Meta.Name, service1, "--settings-file", tmpSettingsPath, "--wait")
 			Expect(err).ToNot(HaveOccurred(), out, tmpSettingsPath)
 
 			// impersonate user2
@@ -374,7 +337,7 @@ var _ = Describe("Services", LService, func() {
 
 			// create service2 in namespace2
 			env.TargetNamespace(namespace2)
-			out, err = env.Epinio("", "service", "create", catalogService.Meta.Name, service2, "--settings-file", tmpSettingsPath)
+			out, err = env.Epinio("", "service", "create", catalogService.Meta.Name, service2, "--settings-file", tmpSettingsPath, "--wait")
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			// show only owned namespaces (we are user2, only namespace2)
@@ -397,36 +360,48 @@ var _ = Describe("Services", LService, func() {
 				),
 			)
 
-			By("wait for deployment")
-			Eventually(func() string {
-				out, _ := env.Epinio("", "service", "list", "--all", "--settings-file", tmpSettingsPath)
-				return out
-			}, "2m", "5s").Should(
+			By("verify service deployment")
+			out, err = env.Epinio("", "service", "list", "--all", "--settings-file", tmpSettingsPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(
 				HaveATable(
 					WithHeaders("NAMESPACE", "NAME", "CREATED", "CATALOG SERVICE", "VERSION", "STATUS", "APPLICATION"),
 					WithRow(namespace2, service2, WithDate(), catalogService.Meta.Name, catalogService.AppVersion, "deployed", ""),
 				),
 			)
 
-			By(fmt.Sprintf("%s/%s up", namespace2, service2))
 		})
 	})
 
 	Describe("Create", func() {
-		var namespace, service string
 
-		BeforeEach(func() {
-			namespace = catalog.NewNamespaceName()
-			env.SetupAndTargetNamespace(namespace)
+		It("creates a service waiting for completion", func() {
+			service := catalog.NewServiceName()
 
-			service = catalog.NewServiceName()
+			By("create it")
+			out, err := env.Epinio("", "service", "create", catalogService.Meta.Name, service, "--wait")
+			Expect(err).ToNot(HaveOccurred(), out)
 
-			DeferCleanup(func() {
-				env.DeleteNamespace(namespace)
-			})
+			By("show it")
+			out, err = env.Epinio("", "service", "show", service)
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			Expect(out).To(
+				HaveATable(
+					WithHeaders("KEY", "VALUE"),
+					WithRow("Name", service),
+					WithRow("Created", WithDate()),
+					WithRow("Catalog Service", catalogService.Meta.Name),
+					WithRow("Status", "deployed"),
+				),
+			)
+
+			By(fmt.Sprintf("%s/%s up", namespace, service))
 		})
 
 		It("creates a service", func() {
+			service := catalog.NewServiceName()
+
 			By("create it")
 			out, err := env.Epinio("", "service", "create", catalogService.Meta.Name, service)
 			Expect(err).ToNot(HaveOccurred(), out)
@@ -441,7 +416,7 @@ var _ = Describe("Services", LService, func() {
 					WithRow("Name", service),
 					WithRow("Created", WithDate()),
 					WithRow("Catalog Service", catalogService.Meta.Name),
-					WithRow("Status", "(not-ready|deployed)"),
+					WithRow("Status", "(unknown|not-ready|deployed)"),
 				),
 			)
 
@@ -482,18 +457,11 @@ var _ = Describe("Services", LService, func() {
 	})
 
 	Describe("Delete", func() {
-		var namespace, service string
+		var service string
 
 		BeforeEach(func() {
-			namespace = catalog.NewNamespaceName()
-			env.SetupAndTargetNamespace(namespace)
-
 			service = catalog.NewServiceName()
 			env.MakeServiceInstance(service, catalogService.Meta.Name)
-
-			DeferCleanup(func() {
-				env.DeleteNamespace(namespace)
-			})
 		})
 
 		It("deletes a service", func() {
@@ -550,54 +518,28 @@ var _ = Describe("Services", LService, func() {
 		})
 
 		When("bound to an app", func() {
-			var namespace, service, app, containerImageURL, chart string
+			var app, containerImageURL, chart string
 
 			BeforeEach(func() {
 				containerImageURL = "splatform/sample-app"
-
-				namespace = catalog.NewNamespaceName()
-				env.SetupAndTargetNamespace(namespace)
-
-				service = catalog.NewServiceName()
-				chart = names.ServiceReleaseName(service)
-
-				By("create it")
-				out, err := env.Epinio("", "service", "create", "mysql-dev", service)
-				Expect(err).ToNot(HaveOccurred(), out)
 
 				By("create app")
 				app = catalog.NewAppName()
 				env.MakeContainerImageApp(app, 1, containerImageURL)
 
-				By("wait for deployment")
-				Eventually(func() string {
-					out, _ := env.Epinio("", "service", "show", service)
-					return out
-				}, "2m", "5s").Should(
-					HaveATable(
-						WithHeaders("KEY", "VALUE"),
-						WithRow("Status", "deployed"),
-					),
-				)
-
 				By("bind it")
-				out, err = env.Epinio("", "service", "bind", service, app)
+				out, err := env.Epinio("", "service", "bind", service, app)
 				Expect(err).ToNot(HaveOccurred(), out)
 
 				By("verify binding")
 				appShowOut, err := env.Epinio("", "app", "show", app)
 				Expect(err).ToNot(HaveOccurred())
-
 				Expect(appShowOut).To(
 					HaveATable(
 						WithHeaders("KEY", "VALUE"),
 						WithRow("Bound Configurations", chart+".*"),
 					),
 				)
-
-				DeferCleanup(func() {
-					env.DeleteNamespace(namespace)
-				})
 			})
 
 			It("fails to delete a bound service", func() {
@@ -657,36 +599,21 @@ var _ = Describe("Services", LService, func() {
 	})
 
 	Describe("Bind", func() {
-		var namespace, service, app, containerImageURL, chart string
+		var service, app, containerImageURL, chart string
 
 		BeforeEach(func() {
 			containerImageURL = "splatform/sample-app"
-
-			namespace = catalog.NewNamespaceName()
-			env.SetupAndTargetNamespace(namespace)
 
 			service = catalog.NewServiceName()
 			chart = names.ServiceReleaseName(service)
 
 			By("create it")
-			out, err := env.Epinio("", "service", "create", "mysql-dev", service)
+			out, err := env.Epinio("", "service", "create", "mysql-dev", service, "--wait")
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			By("create app")
 			app = catalog.NewAppName()
 			env.MakeContainerImageApp(app, 1, containerImageURL)
-
-			By("wait for deployment")
-			Eventually(func() string {
-				out, _ := env.Epinio("", "service", "show", service)
-				return out
-			}, "2m", "5s").Should(
-				HaveATable(
-					WithHeaders("KEY", "VALUE"),
-					WithRow("Status", "deployed"),
-				),
-			)
-
 		})
 
 		// [EC] we should have a look at this unbind. It should be part of a test probably
@@ -714,8 +641,6 @@ var _ = Describe("Services", LService, func() {
 				out, _ := env.Epinio("", "service", "delete", service)
 				return out
 			}, "1m", "5s").Should(ContainSubstring("service '%s' does not exist", service))
-
-			env.DeleteNamespace(namespace)
 		})
 
 		It("binds the service", func() {
@@ -799,30 +724,26 @@ var _ = Describe("Services", LService, func() {
 	})
 
 	Describe("Unbind", func() {
-		var namespace, service, app, containerImageURL, chart string
+		var service, app, containerImageURL, chart string
 
 		BeforeEach(func() {
 			containerImageURL = "splatform/sample-app"
-
-			namespace = catalog.NewNamespaceName()
-			env.SetupAndTargetNamespace(namespace)
 
 			service = catalog.NewServiceName()
 			chart = names.ServiceReleaseName(service)
 
 			By("create it")
-			out, err := env.Epinio("", "service", "create", "mysql-dev", service)
+			out, err := env.Epinio("", "service", "create", "mysql-dev", service, "--wait")
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			By("create app")
 			app = catalog.NewAppName()
 			env.MakeContainerImageApp(app, 1, containerImageURL)
 
-			By("wait for deployment")
-			Eventually(func() string {
-				out, _ := env.Epinio("", "service", "show", service)
-				return out
-			}, "2m", "5s").Should(
+			By("verify service deployment")
+			out, err = env.Epinio("", "service", "show", service)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(
 				HaveATable(
 					WithHeaders("KEY", "VALUE"),
 					WithRow("Status", "deployed"),
@@ -842,10 +763,6 @@ var _ = Describe("Services", LService, func() {
 					WithRow("Bound Configurations", chart+".*"),
 				),
 			)
-
-			DeferCleanup(func() {
-				env.DeleteNamespace(namespace)
-			})
 		})
 
 		It("unbinds the service", func() {
@@ -937,18 +854,17 @@ var _ = Describe("Services", LService, func() {
 	})
 
 	Describe("Port-forward", func() {
-		var namespace, serviceName string
+		var serviceName string
 
 		BeforeEach(func() {
-			namespace = catalog.NewNamespaceName()
-			env.SetupAndTargetNamespace(namespace)
-
 			serviceName = catalog.NewServiceName()
 
 			out, err := env.Epinio("", "service", "create",
 				catalogService.Meta.Name, serviceName,
 				"--chart-value", "ingress.enabled=true",
-				"--chart-value", "ingress.hostname="+catalogServiceHostname)
+				"--chart-value", "ingress.hostname="+catalogServiceHostname,
+				"--wait",
+			)
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			// wait for the service to be ready
@@ -957,11 +873,6 @@ var _ = Describe("Services", LService, func() {
 				Expect(err).ToNot(HaveOccurred())
 				return resp.StatusCode
 			}, "1m", "1s").Should(Equal(http.StatusOK))
-
-			DeferCleanup(func() {
-				catalog.DeleteService(serviceName, namespace)
-				env.DeleteNamespace(namespace)
-			})
 		})
 
 		randomPort := func() string {

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -758,7 +758,7 @@ var _ = Describe("Services", LService, func() {
 			env.MakeContainerImageApp(app, 1, containerImageURL)
 
 			By("verify service deployment")
-			out, err = env.Epinio("", "service", "show", service)
+			out, err := env.Epinio("", "service", "show", service)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).To(
 				HaveATable(

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -135,7 +135,8 @@ func (c *SynchronizedClient) UpgradeChart(ctx context.Context, spec *hc.ChartSpe
 	return c.helmClient.UpgradeChart(ctx, spec, opts)
 }
 
-func (c *SynchronizedClient) GetReleaseStatus(name string) (*release.Release, error) {
+// Status implements the 'helm status' command, with the ShowResources flag enabled
+func (c *SynchronizedClient) Status(name string) (*release.Release, error) {
 	concreteHelmClient, ok := c.helmClient.(*hc.HelmClient)
 	if !ok {
 		return nil, fmt.Errorf("helm client is not of the right type. Expected *hc.HelmClient but got %T", c.helmClient)
@@ -143,5 +144,5 @@ func (c *SynchronizedClient) GetReleaseStatus(name string) (*release.Release, er
 
 	statusAction := action.NewStatus(concreteHelmClient.ActionConfig)
 	statusAction.ShowResources = true
-	return statusAction.Run("epinio")
+	return statusAction.Run(name)
 }

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -8,14 +8,14 @@ import (
 	hc "github.com/mittwald/go-helm-client"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/release"
+	helmrelease "helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/repo"
 )
 
 var _ hc.Client = (*SynchronizedClient)(nil)
 
 // InstallOrUpgradeChart implements helmclient.Client
-func (c *SynchronizedClient) InstallOrUpgradeChart(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*release.Release, error) {
+func (c *SynchronizedClient) InstallOrUpgradeChart(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*helmrelease.Release, error) {
 	anyMutex, _ := c.mutexMap.LoadOrStore(spec.ReleaseName, &sync.Mutex{})
 	if m, ok := anyMutex.(*sync.Mutex); ok {
 		m.Lock()
@@ -47,7 +47,7 @@ func (c *SynchronizedClient) GetChart(chartName string, chartPathOptions *action
 }
 
 // GetRelease implements helmclient.Client
-func (c *SynchronizedClient) GetRelease(name string) (*release.Release, error) {
+func (c *SynchronizedClient) GetRelease(name string) (*helmrelease.Release, error) {
 	return c.helmClient.GetRelease(name)
 }
 
@@ -57,7 +57,7 @@ func (c *SynchronizedClient) GetReleaseValues(name string, allValues bool) (map[
 }
 
 // InstallChart implements helmclient.Client
-func (c *SynchronizedClient) InstallChart(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*release.Release, error) {
+func (c *SynchronizedClient) InstallChart(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*helmrelease.Release, error) {
 	anyMutex, _ := c.mutexMap.LoadOrStore(spec.ReleaseName, &sync.Mutex{})
 	if m, ok := anyMutex.(*sync.Mutex); ok {
 		m.Lock()
@@ -73,17 +73,17 @@ func (c *SynchronizedClient) LintChart(spec *hc.ChartSpec) error {
 }
 
 // ListDeployedReleases implements helmclient.Client
-func (c *SynchronizedClient) ListDeployedReleases() ([]*release.Release, error) {
+func (c *SynchronizedClient) ListDeployedReleases() ([]*helmrelease.Release, error) {
 	return c.helmClient.ListDeployedReleases()
 }
 
 // ListReleaseHistory implements helmclient.Client
-func (c *SynchronizedClient) ListReleaseHistory(name string, max int) ([]*release.Release, error) {
+func (c *SynchronizedClient) ListReleaseHistory(name string, max int) ([]*helmrelease.Release, error) {
 	return c.helmClient.ListReleaseHistory(name, max)
 }
 
 // ListReleasesByStateMask implements helmclient.Client
-func (c *SynchronizedClient) ListReleasesByStateMask(actions action.ListStates) ([]*release.Release, error) {
+func (c *SynchronizedClient) ListReleasesByStateMask(actions action.ListStates) ([]*helmrelease.Release, error) {
 	return c.helmClient.ListReleasesByStateMask(actions)
 }
 
@@ -125,7 +125,7 @@ func (c *SynchronizedClient) UpdateChartRepos() error {
 }
 
 // UpgradeChart implements helmclient.Client
-func (c *SynchronizedClient) UpgradeChart(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*release.Release, error) {
+func (c *SynchronizedClient) UpgradeChart(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*helmrelease.Release, error) {
 	anyMutex, _ := c.mutexMap.LoadOrStore(spec.ReleaseName, &sync.Mutex{})
 	if m, ok := anyMutex.(*sync.Mutex); ok {
 		m.Lock()
@@ -136,7 +136,7 @@ func (c *SynchronizedClient) UpgradeChart(ctx context.Context, spec *hc.ChartSpe
 }
 
 // Status implements the 'helm status' command, with the ShowResources flag enabled
-func (c *SynchronizedClient) Status(name string) (*release.Release, error) {
+func (c *SynchronizedClient) Status(name string) (*helmrelease.Release, error) {
 	concreteHelmClient, ok := c.helmClient.(*hc.HelmClient)
 	if !ok {
 		return nil, fmt.Errorf("helm client is not of the right type. Expected *hc.HelmClient but got %T", c.helmClient)

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -2,13 +2,13 @@ package helm
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	hc "github.com/mittwald/go-helm-client"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
-	helmrelease "helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/repo"
 )
 
@@ -47,7 +47,7 @@ func (c *SynchronizedClient) GetChart(chartName string, chartPathOptions *action
 }
 
 // GetRelease implements helmclient.Client
-func (c *SynchronizedClient) GetRelease(name string) (*helmrelease.Release, error) {
+func (c *SynchronizedClient) GetRelease(name string) (*release.Release, error) {
 	return c.helmClient.GetRelease(name)
 }
 
@@ -57,7 +57,7 @@ func (c *SynchronizedClient) GetReleaseValues(name string, allValues bool) (map[
 }
 
 // InstallChart implements helmclient.Client
-func (c *SynchronizedClient) InstallChart(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*helmrelease.Release, error) {
+func (c *SynchronizedClient) InstallChart(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*release.Release, error) {
 	anyMutex, _ := c.mutexMap.LoadOrStore(spec.ReleaseName, &sync.Mutex{})
 	if m, ok := anyMutex.(*sync.Mutex); ok {
 		m.Lock()
@@ -73,17 +73,17 @@ func (c *SynchronizedClient) LintChart(spec *hc.ChartSpec) error {
 }
 
 // ListDeployedReleases implements helmclient.Client
-func (c *SynchronizedClient) ListDeployedReleases() ([]*helmrelease.Release, error) {
+func (c *SynchronizedClient) ListDeployedReleases() ([]*release.Release, error) {
 	return c.helmClient.ListDeployedReleases()
 }
 
 // ListReleaseHistory implements helmclient.Client
-func (c *SynchronizedClient) ListReleaseHistory(name string, max int) ([]*helmrelease.Release, error) {
+func (c *SynchronizedClient) ListReleaseHistory(name string, max int) ([]*release.Release, error) {
 	return c.helmClient.ListReleaseHistory(name, max)
 }
 
 // ListReleasesByStateMask implements helmclient.Client
-func (c *SynchronizedClient) ListReleasesByStateMask(actions action.ListStates) ([]*helmrelease.Release, error) {
+func (c *SynchronizedClient) ListReleasesByStateMask(actions action.ListStates) ([]*release.Release, error) {
 	return c.helmClient.ListReleasesByStateMask(actions)
 }
 
@@ -125,7 +125,7 @@ func (c *SynchronizedClient) UpdateChartRepos() error {
 }
 
 // UpgradeChart implements helmclient.Client
-func (c *SynchronizedClient) UpgradeChart(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*helmrelease.Release, error) {
+func (c *SynchronizedClient) UpgradeChart(ctx context.Context, spec *hc.ChartSpec, opts *hc.GenericHelmOptions) (*release.Release, error) {
 	anyMutex, _ := c.mutexMap.LoadOrStore(spec.ReleaseName, &sync.Mutex{})
 	if m, ok := anyMutex.(*sync.Mutex); ok {
 		m.Lock()
@@ -133,4 +133,15 @@ func (c *SynchronizedClient) UpgradeChart(ctx context.Context, spec *hc.ChartSpe
 	}
 
 	return c.helmClient.UpgradeChart(ctx, spec, opts)
+}
+
+func (c *SynchronizedClient) GetReleaseStatus(name string) (*release.Release, error) {
+	concreteHelmClient, ok := c.helmClient.(*hc.HelmClient)
+	if !ok {
+		return nil, fmt.Errorf("helm client is not of the right type. Expected *hc.HelmClient but got %T", c.helmClient)
+	}
+
+	statusAction := action.NewStatus(concreteHelmClient.ActionConfig)
+	statusAction.ShowResources = true
+	return statusAction.Run("epinio")
 }

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -412,7 +412,7 @@ const (
 
 // Status will check for the readyness of the release returning an internal status instead of
 // the Helm release status (https://github.com/helm/helm/blob/main/pkg/release/status.go).
-// Helm is not checking for the actual status of the release and also if the resources are still
+// Helm is not checking for the actual status of the release and even if the resources are still
 // in deployment they will be marked as "deployed"
 func Status(ctx context.Context, logger logr.Logger, cluster *kubernetes.Cluster, namespace, releaseName string) (ReleaseStatus, error) {
 	helmClient, err := GetHelmClient(cluster.RestConfig, logger, namespace)

--- a/internal/services/instances.go
+++ b/internal/services/instances.go
@@ -216,6 +216,8 @@ func (s *ServiceClient) Create(ctx context.Context, namespace, name string,
 		}
 	}
 
+	err = helm.GetStatus(requestctx.Logger(ctx), s.kubeClient, "epinio", "epinio")
+
 	return errors.Wrap(err, "error deploying service helm chart")
 }
 

--- a/internal/services/instances.go
+++ b/internal/services/instances.go
@@ -104,7 +104,7 @@ func (s *ServiceClient) Get(ctx context.Context, namespace, name string) (*model
 		}
 	}
 
-	service.Status = models.NewServiceStatusFromHelmRelease(serviceStatus)
+	service.Status = NewServiceStatusFromHelmRelease(serviceStatus)
 
 	return &service, nil
 }
@@ -215,8 +215,6 @@ func (s *ServiceClient) Create(ctx context.Context, namespace, name string,
 			return errors.Wrap(errb, "error deploying service helm chart while undoing the secret")
 		}
 	}
-
-	err = helm.GetStatus(requestctx.Logger(ctx), s.kubeClient, "epinio", "epinio")
 
 	return errors.Wrap(err, "error deploying service helm chart")
 }
@@ -351,7 +349,7 @@ func (s *ServiceClient) list(ctx context.Context, namespace string) (models.Serv
 			}
 		}
 
-		service.Status = models.NewServiceStatusFromHelmRelease(serviceStatus)
+		service.Status = NewServiceStatusFromHelmRelease(serviceStatus)
 
 		serviceList = append(serviceList, service)
 	}
@@ -446,7 +444,7 @@ func (s *ServiceClient) GetForHelmController(ctx context.Context, namespace, nam
 		}
 	}
 
-	service.Status = models.NewServiceStatusFromHelmRelease(serviceStatus)
+	service.Status = NewServiceStatusFromHelmRelease(serviceStatus)
 
 	return &service, nil
 }
@@ -554,12 +552,23 @@ func (s *ServiceClient) listForHelmController(ctx context.Context, namespace str
 			}
 		}
 
-		service.Status = models.NewServiceStatusFromHelmRelease(serviceStatus)
+		service.Status = NewServiceStatusFromHelmRelease(serviceStatus)
 
 		serviceList = append(serviceList, service)
 	}
 
 	return serviceList, nil
+}
+
+func NewServiceStatusFromHelmRelease(status helm.ReleaseStatus) models.ServiceStatus {
+	switch status {
+	case helm.StatusReady:
+		return models.ServiceStatusDeployed
+	case helm.StatusNotReady:
+		return models.ServiceStatusNotReady
+	default:
+		return models.ServiceStatusUnknown
+	}
 }
 
 func convertUnstructuredListIntoHelmCharts(unstructuredList *unstructured.UnstructuredList) ([]helmapiv1.HelmChart, error) {

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/epinio/epinio/helpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	helmrelease "helm.sh/helm/v3/pkg/release"
 )
 
 // Note: Meta is an extension of `ConfigurationRef` later in the file. Users of
@@ -379,15 +377,6 @@ const (
 	ServiceStatusNotReady ServiceStatus = "not-ready"
 	ServiceStatusUnknown  ServiceStatus = "unknown"
 )
-
-func NewServiceStatusFromHelmRelease(status helmrelease.Status) ServiceStatus {
-	switch status {
-	case helmrelease.StatusDeployed:
-		return ServiceStatusDeployed
-	default:
-		return ServiceStatusNotReady
-	}
-}
 
 func (s ServiceStatus) String() string { return string(s) }
 


### PR DESCRIPTION
This PR adds a proper status check for the Service deployments.

From the mittwald client I had to get the underlying Helm client, to run the `helm status` command with the `ShowResources` flag enabled.

This will return an `helm.Release` with the resources involved. Then thanks to the `kube.ReadyChecker` ([see](https://github.com/helm/helm/blob/main/pkg/kube/ready.go#L77-L82)) we are able to check if all the resources are in a ready state.

I had to move the `NewServiceStatusFromHelmRelease` because of a cycle dependency.