### PR TITLE
Skip cleanup for non-scheduled run

### DIFF
--- a/.github/workflows/clientsync.yml
+++ b/.github/workflows/clientsync.yml
@@ -103,5 +103,5 @@ jobs:
         run: make acceptance-cluster-delete
 
       - name: Clean all
-        if: always()
+        if: ${{ github.event_name == 'schedule' }}
         uses: colpal/actions-clean@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,7 +139,7 @@ jobs:
         run: make acceptance-cluster-delete
 
       - name: Clean all
-        if: always()
+        if: ${{ github.event_name == 'schedule' }}
         uses: colpal/actions-clean@v1
 
   acceptance-cli-apps:
@@ -210,7 +210,7 @@ jobs:
         run: make acceptance-cluster-delete
 
       - name: Clean all
-        if: always()
+        if: ${{ github.event_name == 'schedule' }}
         uses: colpal/actions-clean@v1
 
   acceptance-cli-services:
@@ -281,7 +281,7 @@ jobs:
         run: make acceptance-cluster-delete
 
       - name: Clean all
-        if: always()
+        if: ${{ github.event_name == 'schedule' }}
         uses: colpal/actions-clean@v1
 
   acceptance-api:
@@ -353,7 +353,7 @@ jobs:
         run: make acceptance-cluster-delete
 
       - name: Clean all
-        if: always()
+        if: ${{ github.event_name == 'schedule' }}
         uses: colpal/actions-clean@v1
 
   acceptance-api-apps:
@@ -425,7 +425,7 @@ jobs:
         run: make acceptance-cluster-delete
 
       - name: Clean all
-        if: always()
+        if: ${{ github.event_name == 'schedule' }}
         uses: colpal/actions-clean@v1
 
   acceptance-api-services:
@@ -496,7 +496,7 @@ jobs:
         run: make acceptance-cluster-delete
 
       - name: Clean all
-        if: always()
+        if: ${{ github.event_name == 'schedule' }}
         uses: colpal/actions-clean@v1
 
   acceptance-apps:
@@ -587,7 +587,7 @@ jobs:
         run: make acceptance-cluster-delete
 
       - name: Clean all
-        if: always()
+        if: ${{ github.event_name == 'schedule' }}
         uses: colpal/actions-clean@v1
 
   upload-coverage:

--- a/.github/workflows/rke-upgrade.yml
+++ b/.github/workflows/rke-upgrade.yml
@@ -176,5 +176,5 @@ jobs:
 
       # Only on RKE, as it uses a self-hosted runner
       - name: Clean all
-        if: always()
+        if: ${{ github.event_name == 'schedule' }}
         uses: colpal/actions-clean@v1

--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -156,5 +156,5 @@ jobs:
 
       # Only on RKE, as it uses a self-hosted runner
       - name: Clean all
-        if: always()
+        if: ${{ github.event_name == 'schedule' }}
         uses: colpal/actions-clean@v1

--- a/.github/workflows/rke2-lh-ec2.yml
+++ b/.github/workflows/rke2-lh-ec2.yml
@@ -272,5 +272,5 @@ jobs:
 
       # Only on RKE, as it uses a self-hosted runner
       - name: Clean all
-        if: always()
+        if: ${{ github.event_name == 'schedule' }}
         uses: colpal/actions-clean@v1

--- a/.github/workflows/upgrade-bound.yml
+++ b/.github/workflows/upgrade-bound.yml
@@ -102,5 +102,5 @@ jobs:
         run: make acceptance-cluster-delete
 
       - name: Clean all
-        if: always()
+        if: ${{ github.event_name == 'schedule' }}
         uses: colpal/actions-clean@v1

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -102,5 +102,5 @@ jobs:
         run: make acceptance-cluster-delete
 
       - name: Clean all
-        if: always()
+        if: ${{ github.event_name == 'schedule' }}
         uses: colpal/actions-clean@v1


### PR DESCRIPTION
The cleanup will remove all the containers, also the mirror registry that we are using to cache the pull of our images.

To avoid this we can cleanup only at night during the scheduled workflows.