### PR TITLE
Removed old http `do` func

### DIFF
--- a/pkg/api/core/v1/client/http_test.go
+++ b/pkg/api/core/v1/client/http_test.go
@@ -32,6 +32,8 @@ var _ = Describe("Client HTTP", func() {
 
 	JustBeforeEach(func() {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer GinkgoRecover()
+
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprint(w, responseBody)
 


### PR DESCRIPTION
This PR removes the old `do` http func to avoid other replication. After this we will need just to make the last few `POST` request use the common client logic.

This removes part of now unused code, and increase a bit the coverage.