### PR TITLE
Meaningful error message when starting service port-forwarding

### DIFF
--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -447,6 +447,14 @@ func (c *EpinioClient) ServicePortForward(ctx context.Context, serviceName strin
 		return err
 	}
 
+	/*
+		We use ServiceList API to check if we can establish a connection with the Epinio backend service.
+	*/
+	_, err := c.API.ServiceList(c.Settings.Namespace)
+	if err != nil {
+		return errors.Wrap(err, "Cannot establish a connection with Epinio server")
+	}
+
 	opts := client.NewPortForwardOpts(address, ports)
 	return c.API.ServicePortForward(c.Settings.Namespace, serviceName, opts)
 }


### PR DESCRIPTION
Display error message for service port-forwarding if the user is logged out
    
Message displayed if the backend is down or if the client is not authenticated:
    
    "Cannot establish a connection with Epinio. Check both if Epinio is up
    and if the client is logged in."

Related to: https://github.com/epinio/epinio/issues/2365
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>