### PR TITLE
Add region flag for eksctl-0.148.0 workaround

### DIFF
--- a/.github/workflows/eks.yml
+++ b/.github/workflows/eks.yml
@@ -141,9 +141,14 @@ jobs:
           # Get AWS Account ID
           AWS_ACCOUNT_ID=$(aws sts get-caller-identity | jq -r '.Account')
           # Assign OIDC provider to the cluster
-          eksctl utils associate-iam-oidc-provider --cluster=epinio-ci$id --approve
+          eksctl utils associate-iam-oidc-provider \
+            --region=${{ env.EKS_REGION }} \
+            --cluster=epinio-ci$id \
+            --approve
           # Assign existing policy Amazon_EBS_CSI_Driver to the cluster's serviceAccount via a new Role
-          eksctl create iamserviceaccount --cluster=epinio-ci$id \
+          eksctl create iamserviceaccount \
+            --region=${{ env.EKS_REGION }} \
+            --cluster=epinio-ci$id \
             --name=ebs-csi-controller-sa \
             --namespace=kube-system \
             --attach-policy-arn=arn:aws:iam::$AWS_ACCOUNT_ID:policy/Amazon_EBS_CSI_Driver \
@@ -151,7 +156,9 @@ jobs:
             --role-only \
             --role-name=AmazonEKS_epinio-ci$id-EBS_CSI_DriverRole
           # Install the driver addon and use the Role
-          eksctl create addon --name=aws-ebs-csi-driver \
+          eksctl create addon \
+            --region=${{ env.EKS_REGION }} \
+            --name=aws-ebs-csi-driver \
             --cluster=epinio-ci$id \
             --service-account-role-arn=arn:aws:iam::$AWS_ACCOUNT_ID:role/AmazonEKS_epinio-ci$id-EBS_CSI_DriverRole \
             --force


### PR DESCRIPTION
EKS-CI fails within "Configure EKS EBS CSI storage" - where eksctl relies on AWS_REGION envvar, which was working up to eksctl-0.147.0, but is broken for current 0.148.0.
Fix for https://github.com/weaveworks/eksctl/issues/6774. While the workaround for ekstcl not reading AWS_REGION from env can stay, since the flag uses the var from github env.