### PR TITLE
Added error check for release deletion

### DIFF
--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -116,15 +116,7 @@ func RemoveService(logger logr.Logger, cluster *kubernetes.Cluster, app models.A
 	}
 
 	err = client.UninstallReleaseByName(names.ServiceReleaseName(app.Name))
-
-	// Ignore errors. The release may not be present. For example due to an aborted
-	// deployment. Note that a multitude of different errors was seen for essentially the same
-	// thing, depending on exact timing of deletion to partial creation. Just ignoring a
-	// specific one is fraught. Report, in case we were to generous and debugging is required.
-	if err != nil {
-		logger.Info("release deletion issue", "error", err)
-	}
-	return nil
+	return errors.Wrap(err, "deleting release")
 }
 
 func DeployService(ctx context.Context, parameters ServiceParameters) error {


### PR DESCRIPTION
Fix #2194

When a release deletion fails we get in an inconsistent state because we are removing anyway the service.

It's probably better to return the error and let the operator trying to understand what's going on.