### PR TITLE
ci: add automation to generate README.md for tests

### DIFF
--- a/.github/workflows/update-tests-description.yaml
+++ b/.github/workflows/update-tests-description.yaml
@@ -1,0 +1,40 @@
+name: Update tests description
+
+on:
+  schedule:
+    - cron: 0 23 * * *
+  workflow_dispatch:
+
+jobs:
+  update-tests-description:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          # A token is needed to be able to push on main, maybe this can be changed later
+          # with another GHA or with some webhook?
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate tests description file
+        id: readme_generator
+        run: |
+          # Generate checksum of current file
+          FILE="acceptance/README.md"
+          OLD_CHK=$(sha512sum ${FILE} 2>/dev/null) || true
+
+          # Create new file
+          make generate-acceptance-readme
+
+          # Generate checksum of new file
+          NEW_CHK=$(sha512sum ${FILE} 2>/dev/null) || true
+
+          # Compare checksum and set generate value if needed
+          if [[ "${NEW_CHK}" != "${OLD_CHK}" ]]; then
+            echo "generate=needed" >> ${GITHUB_OUTPUT}
+          fi
+      - uses: EndBug/add-and-commit@v9
+        if: steps.readme_generator.outputs.generate == 'needed'
+        with:
+          default_author: github_actions
+          message: 'ci: update tests/README.md file'
+          add: 'acceptance/README.md'

--- a/Makefile
+++ b/Makefile
@@ -235,3 +235,7 @@ prepare_environment_k3d: build-linux-amd64 build-images
 unprepare_environment_k3d:
 	kubectl delete --ignore-not-found=true secret regcred
 	helm uninstall epinio -n epinio --wait || true
+
+# Generate tests description file
+generate-acceptance-readme:
+	@./scripts/generate-readme acceptance > acceptance/README.md

--- a/scripts/generate-readme
+++ b/scripts/generate-readme
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Execute script on all directories
+for DIR in $(find $1 -type d); do
+  if [[ -d ${DIR} ]]; then
+    VALUE=$(scripts/generate-tests-description ${DIR})
+    if [[ -n "${VALUE}" ]]; then
+      echo -e "# Tests description for ${DIR#./}\n"
+      echo -e "${VALUE}\n"
+    fi
+  fi
+done
+
+# Done!
+exit 0

--- a/scripts/generate-tests-description
+++ b/scripts/generate-tests-description
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Small script to generated README.sh file to add a
+# basic test documentation based on the code.
+# It uses Describe/It/By syntax to extract kindof
+# useful informations.
+#
+# It currently supports these frameworks/languages:
+# - Ginkgo(Gomega)/Go
+# - Cypress/Typescript
+
+function abort() {
+  echo "$1" >&2
+  exit 1
+}
+
+# Variables
+DIR=$1
+EXT="*_test.go *.spec.ts"
+
+# Go to directory if it exists, otherwise exit
+[[ ! -d ${DIR:=$PWD} ]] && abort "Directory '${DIR}' does not exist!"
+pushd ${DIR} >/dev/null
+
+# Loop on each test file
+for TST_FILE in $(ls ${EXT} 2>/dev/null); do
+  # Set regex/fields depending of language
+  if [[ "${TST_FILE##*.}" == "go" ]]; then
+    REGEX="^[[:space:]]*(Context|It|By)|^.*=.*(Describe)"
+    FIELDS="\1\2"
+  elif [[ "${TST_FILE##*.}" == "ts" ]]; then
+    REGEX="^[[:space:]]*(describe|it|by)"
+    FIELDS="\1"
+  fi
+
+  # Extact the informations
+  TXT=$(
+    grep -h -E "${REGEX}" ${TST_FILE} \
+      | tr -d "('\"" \
+      | sed -E \
+            -e "s/${REGEX}/${FIELDS}: /" \
+            -e 's/,[[:space:]]*(func|Label).*//' \
+            -e 's/,[[:space:]]*\)[[:space:]]*=>[[:space:]]*\{//' \
+            -e 's/\{[[:space:]]*tags:.*\}//' \
+            -e 's/\)$//' \
+            -e 's/,[[:space:]]*$//' \
+            -e 's/^[Dd]escribe:/- **Describe:**/' \
+            -e 's/^[Cc]ontext:/\t- **Context:**/' \
+            -e 's/^[Ii]t:/\t\t- **It:**/' \
+            -e 's/^[Bb]y:/\t\t\t-  **By:**/'
+  )
+
+  # If empty
+  [[ -z "${TXT}" ]] && TXT="*No test defined!*"
+
+  # Show all informations (with tabs size set to 2)
+  echo -e "## \`${TST_FILE}\`\n\n${TXT}\n" | expand -t2
+done
+
+# Go back to the previous directory
+popd >/dev/null
+
+# Done!
+exit 0


### PR DESCRIPTION
This is to have an automated list of QA/integration tests.

It's already done in Elemental project. Not something perfect but could be useful to have a limited QA doc.
It's clearly not perfect and should be improved. The idea is to re-write the script in Go at some point an use it as a library.