### PR TITLE
small cleanup of API helpers

### DIFF
--- a/acceptance/api/v1/application_show_test.go
+++ b/acceptance/api/v1/application_show_test.go
@@ -47,7 +47,7 @@ var _ = Describe("AppShow Endpoint", LApplication, func() {
 		env.MakeContainerImageApp(app, 1, containerImageURL)
 		defer env.DeleteApp(app)
 
-		appObj := appFromAPI(namespace, app)
+		appObj := appShow(namespace, app)
 		Expect(appObj.Workload.Status).To(Equal("1/1"))
 		createdAt, err := time.Parse(time.RFC3339, appObj.Workload.CreatedAt)
 		Expect(err).ToNot(HaveOccurred())
@@ -77,7 +77,7 @@ var _ = Describe("AppShow Endpoint", LApplication, func() {
 			"--", "bin/sh", "-c", "yes > /dev/null 2> /dev/null &")
 		Expect(err).ToNot(HaveOccurred(), out)
 		Eventually(func() int64 {
-			appObj := appFromAPI(namespace, app)
+			appObj := appShow(namespace, app)
 			return appObj.Workload.Replicas[replica.Name].MilliCPUs
 		}, "240s", "1s").Should(BeNumerically(">=", 900))
 		// Kill the "yes" process to bring CPU down again
@@ -92,12 +92,12 @@ var _ = Describe("AppShow Endpoint", LApplication, func() {
 			"--", "bin/bash", "-c", "cat <( </dev/zero head -c 50m) <(sleep 180) | tail")
 		Expect(err).ToNot(HaveOccurred(), out)
 		Eventually(func() int64 {
-			appObj := appFromAPI(namespace, app)
+			appObj := appShow(namespace, app)
 			return appObj.Workload.Replicas[replica.Name].MemoryBytes
 		}, "240s", "1s").Should(BeNumerically(">=", 0))
 
 		Consistently(func() int32 {
-			appObj := appFromAPI(namespace, app)
+			appObj := appShow(namespace, app)
 			return appObj.Workload.Replicas[replica.Name].Restarts
 		}, "10s", "1s").Should(BeNumerically("==", 0))
 
@@ -108,7 +108,7 @@ var _ = Describe("AppShow Endpoint", LApplication, func() {
 		Expect(err).ToNot(HaveOccurred(), out)
 
 		Eventually(func() int32 {
-			appObj := appFromAPI(namespace, app)
+			appObj := appShow(namespace, app)
 			return appObj.Workload.Replicas[replica.Name].Restarts
 		}, "15s", "1s").Should(BeNumerically("==", 1))
 	})

--- a/acceptance/api/v1/application_stage_test.go
+++ b/acceptance/api/v1/application_stage_test.go
@@ -44,8 +44,9 @@ var _ = Describe("AppStage Endpoint", LApplication, func() {
 		appName = catalog.NewAppName()
 
 		By("creating application resource first")
-		_, err := createApplication(appName, namespace, nil)
-		Expect(err).ToNot(HaveOccurred())
+		appCreateRequest := models.ApplicationCreateRequest{Name: appName}
+		bodyBytes, statusCode := appCreate(namespace, toJSON(appCreateRequest))
+		Expect(statusCode).To(Equal(http.StatusCreated), string(bodyBytes))
 	})
 
 	AfterEach(func() {
@@ -60,8 +61,9 @@ var _ = Describe("AppStage Endpoint", LApplication, func() {
 			appName2 = catalog.NewAppName()
 
 			By("creating the other application resource first")
-			_, err := createApplication(appName2, namespace, nil)
-			Expect(err).ToNot(HaveOccurred())
+			appCreateRequest := models.ApplicationCreateRequest{Name: appName2}
+			_, statusCode := appCreate(namespace, toJSON(appCreateRequest))
+			Expect(statusCode).To(Equal(http.StatusCreated))
 
 			By("uploading the code of the other")
 			uploadResponse2 = uploadApplication(appName2, namespace)
@@ -274,7 +276,7 @@ var _ = Describe("AppStage Endpoint", LApplication, func() {
 			By("confirming at highlevel")
 			// Highlevel check and confirmation
 			Eventually(func() string {
-				return appFromAPI(namespace, appName).Workload.Status
+				return appShow(namespace, appName).Workload.Status
 			}, "5m").Should(Equal("1/1"))
 		})
 
@@ -346,7 +348,7 @@ var _ = Describe("AppStage Endpoint", LApplication, func() {
 			By("confirming at highlevel")
 			// Highlevel check and confirmation
 			Eventually(func() string {
-				return appFromAPI(namespace, appName).Workload.Status
+				return appShow(namespace, appName).Workload.Status
 			}, "5m").Should(Equal("1/1"))
 		})
 	})

--- a/acceptance/api/v1/helpers_api_test.go
+++ b/acceptance/api/v1/helpers_api_test.go
@@ -1,0 +1,92 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	v1 "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func appShow(namespace, app string) models.App {
+	GinkgoHelper()
+
+	endpoint := makeEndpoint(v1.Routes.Path("AppShow", namespace, app))
+	response, err := env.Curl(http.MethodGet, endpoint, nil)
+
+	Expect(err).ToNot(HaveOccurred())
+	Expect(response).ToNot(BeNil())
+	defer response.Body.Close()
+
+	Expect(response.StatusCode).To(Equal(http.StatusOK))
+	bodyBytes, err := io.ReadAll(response.Body)
+	Expect(err).ToNot(HaveOccurred())
+
+	var responseApp models.App
+	err = json.Unmarshal(bodyBytes, &responseApp)
+	Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+	Expect(responseApp.Meta.Name).To(Equal(app))
+	Expect(responseApp.Meta.Namespace).To(Equal(namespace))
+
+	return responseApp
+}
+
+func appCreate(namespace string, body io.Reader) ([]byte, int) {
+	GinkgoHelper()
+
+	endpoint := makeEndpoint(v1.Routes.Path("AppCreate", namespace))
+
+	response, err := env.Curl(http.MethodPost, endpoint, body)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(response).ToNot(BeNil())
+	defer response.Body.Close()
+
+	bodyBytes, err := io.ReadAll(response.Body)
+	Expect(err).ToNot(HaveOccurred())
+
+	return bodyBytes, response.StatusCode
+}
+
+func appUpdate(namespace, app string, body io.Reader) ([]byte, int) {
+	GinkgoHelper()
+
+	endpoint := makeEndpoint(v1.Routes.Path("AppUpdate", namespace, app))
+	response, err := env.Curl(http.MethodPatch, endpoint, body)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(response).ToNot(BeNil())
+	defer response.Body.Close()
+
+	bodyBytes, err := io.ReadAll(response.Body)
+	Expect(err).ToNot(HaveOccurred())
+
+	return bodyBytes, response.StatusCode
+}
+
+func toJSON(request any) io.Reader {
+	GinkgoHelper()
+
+	b, err := json.Marshal(request)
+	Expect(err).ToNot(HaveOccurred())
+	return bytes.NewReader(b)
+}
+
+func makeEndpoint(path string) string {
+	return fmt.Sprintf("%s%s/%s", serverURL, v1.Root, path)
+}


### PR DESCRIPTION
This PR moves and refactor some of the API helpers from `acceptance/api/v1/helpers_test.go` in their own file `acceptance/api/v1/helpers_api_test.go`.

Names are now matching the APIs that they are calling (i.e.: `appCreate` or `appShow`), and they are now accepting an `io.Reader`. This is useful to test the API against unexpected JSON (or even not JSON body).

For example there was the `updateAppInstancesNAN` func that was messing the body with
```go
// Hack to make the Instances value non-number
data = []byte(strings.Replace(string(data), "314", `"thisisnotanumber"`, 1))
```

and now this test can be done just providing the unwanted JSON:
```go
request := map[string]string{"instances": "not-a-number"}
updateResponseBody, status := appUpdate(namespace, app, toJSON(request))
```
