### PR TITLE
Added optional `restart` field to `AppUpdate` API

### DIFF
--- a/acceptance/api/v1/application_export_test.go
+++ b/acceptance/api/v1/application_export_test.go
@@ -105,7 +105,7 @@ namespace: %s
 
 		By(string(bodyBytes))
 		By(expecting)
-		Expect(string(bodyBytes)).To(Equal(expecting))
+		Expect(string(bodyBytes)).To(Equal(expecting), string(bodyBytes))
 	})
 
 	It("returns a 404 when the namespace does not exist", func() {

--- a/acceptance/api/v1/application_update_test.go
+++ b/acceptance/api/v1/application_update_test.go
@@ -137,6 +137,8 @@ var _ = Describe("AppUpdate Endpoint", LApplication, func() {
 		}
 
 		checkIngresses := func(appName, namespaceName string, routesStr ...string) {
+			GinkgoHelper()
+
 			routeObjects := []routes.Route{}
 			for _, route := range routesStr {
 				routeObjects = append(routeObjects, routes.FromString(route))
@@ -169,6 +171,8 @@ var _ = Describe("AppUpdate Endpoint", LApplication, func() {
 		// has a corresponding secret. routes are used to wait until all
 		// certificates are created.
 		checkSecretsForCerts := func(appName, namespaceName string, routes ...string) {
+			GinkgoHelper()
+
 			Eventually(func() int {
 				out, err := proc.Kubectl("get", "certificates",
 					"-n", namespaceName,
@@ -195,6 +199,8 @@ var _ = Describe("AppUpdate Endpoint", LApplication, func() {
 		}
 
 		checkRoutesOnApp := func(appName, namespaceName string, routes ...string) {
+			GinkgoHelper()
+
 			out, err := proc.Kubectl("get", "apps", "-n", namespaceName, appName, "-o", "jsonpath={.spec.routes[*]}")
 			Expect(err).ToNot(HaveOccurred(), out)
 			appRoutes := deleteEmpty(strings.Split(strings.TrimSpace(out), " "))

--- a/acceptance/api/v1/application_validate_cv_test.go
+++ b/acceptance/api/v1/application_validate_cv_test.go
@@ -28,6 +28,7 @@ var _ = Describe("AppValidateCV Endpoint", LApplication, func() {
 		tempFile  string
 		namespace string
 		appName   string
+		restart   bool
 	)
 
 	BeforeEach(func() {
@@ -90,14 +91,17 @@ var _ = Describe("AppValidateCV Endpoint", LApplication, func() {
 
 	It("returns ok for good chart values", func() {
 		// unknowntype, badminton, maxbad - bad spec, no good values
-		request := models.ApplicationUpdateRequest{Settings: models.ChartValueSettings{
-			"fake":  "true",
-			"foo":   "bar",
-			"bar":   "sna",
-			"floof": "3.1415926535",
-			"fox":   "99",
-			"cat":   "0.31415926535",
-		}}
+		request := models.ApplicationUpdateRequest{
+			Restart: &restart,
+			Settings: models.ChartValueSettings{
+				"fake":  "true",
+				"foo":   "bar",
+				"bar":   "sna",
+				"floof": "3.1415926535",
+				"fox":   "99",
+				"cat":   "0.31415926535",
+			},
+		}
 		bodyBytes, statusCode := appUpdate(namespace, appName, toJSON(request))
 		ExpectResponseToBeOK(bodyBytes, statusCode)
 
@@ -106,9 +110,12 @@ var _ = Describe("AppValidateCV Endpoint", LApplication, func() {
 	})
 
 	It("fails for an unknown field", func() {
-		request := models.ApplicationUpdateRequest{Settings: models.ChartValueSettings{
-			"bogus": "x",
-		}}
+		request := models.ApplicationUpdateRequest{
+			Restart: &restart,
+			Settings: models.ChartValueSettings{
+				"bogus": "x",
+			},
+		}
 		bodyBytes, statusCode := appUpdate(namespace, appName, toJSON(request))
 		ExpectResponseToBeOK(bodyBytes, statusCode)
 
@@ -117,9 +124,12 @@ var _ = Describe("AppValidateCV Endpoint", LApplication, func() {
 	})
 
 	It("fails for an unknown field type", func() {
-		request := models.ApplicationUpdateRequest{Settings: models.ChartValueSettings{
-			"unknowntype": "x",
-		}}
+		request := models.ApplicationUpdateRequest{
+			Restart: &restart,
+			Settings: models.ChartValueSettings{
+				"unknowntype": "x",
+			},
+		}
 		bodyBytes, statusCode := appUpdate(namespace, appName, toJSON(request))
 		ExpectResponseToBeOK(bodyBytes, statusCode)
 
@@ -128,9 +138,12 @@ var _ = Describe("AppValidateCV Endpoint", LApplication, func() {
 	})
 
 	It("fails for an integer field with a bad minimum", func() {
-		request := models.ApplicationUpdateRequest{Settings: models.ChartValueSettings{
-			"badminton": "0",
-		}}
+		request := models.ApplicationUpdateRequest{
+			Restart: &restart,
+			Settings: models.ChartValueSettings{
+				"badminton": "0",
+			},
+		}
 		bodyBytes, statusCode := appUpdate(namespace, appName, toJSON(request))
 		ExpectResponseToBeOK(bodyBytes, statusCode)
 
@@ -139,9 +152,12 @@ var _ = Describe("AppValidateCV Endpoint", LApplication, func() {
 	})
 
 	It("fails for an integer field with a bad maximum", func() {
-		request := models.ApplicationUpdateRequest{Settings: models.ChartValueSettings{
-			"maxbad": "0",
-		}}
+		request := models.ApplicationUpdateRequest{
+			Restart: &restart,
+			Settings: models.ChartValueSettings{
+				"maxbad": "0",
+			},
+		}
 		bodyBytes, statusCode := appUpdate(namespace, appName, toJSON(request))
 		ExpectResponseToBeOK(bodyBytes, statusCode)
 
@@ -150,9 +166,12 @@ var _ = Describe("AppValidateCV Endpoint", LApplication, func() {
 	})
 
 	It("fails for a value out of range (< min)", func() {
-		request := models.ApplicationUpdateRequest{Settings: models.ChartValueSettings{
-			"floof": "-2",
-		}}
+		request := models.ApplicationUpdateRequest{
+			Restart: &restart,
+			Settings: models.ChartValueSettings{
+				"floof": "-2",
+			},
+		}
 		bodyBytes, statusCode := appUpdate(namespace, appName, toJSON(request))
 		ExpectResponseToBeOK(bodyBytes, statusCode)
 
@@ -161,9 +180,12 @@ var _ = Describe("AppValidateCV Endpoint", LApplication, func() {
 	})
 
 	It("fails for a value out of range (> max)", func() {
-		request := models.ApplicationUpdateRequest{Settings: models.ChartValueSettings{
-			"fox": "1000",
-		}}
+		request := models.ApplicationUpdateRequest{
+			Restart: &restart,
+			Settings: models.ChartValueSettings{
+				"fox": "1000",
+			},
+		}
 		bodyBytes, statusCode := appUpdate(namespace, appName, toJSON(request))
 		ExpectResponseToBeOK(bodyBytes, statusCode)
 
@@ -172,9 +194,12 @@ var _ = Describe("AppValidateCV Endpoint", LApplication, func() {
 	})
 
 	It("fails for a value out of range (not in enum)", func() {
-		request := models.ApplicationUpdateRequest{Settings: models.ChartValueSettings{
-			"bar": "fox",
-		}}
+		request := models.ApplicationUpdateRequest{
+			Restart: &restart,
+			Settings: models.ChartValueSettings{
+				"bar": "fox",
+			},
+		}
 		bodyBytes, statusCode := appUpdate(namespace, appName, toJSON(request))
 		ExpectResponseToBeOK(bodyBytes, statusCode)
 
@@ -183,9 +208,12 @@ var _ = Describe("AppValidateCV Endpoint", LApplication, func() {
 	})
 
 	It("fails for a non-integer value where integer required", func() {
-		request := models.ApplicationUpdateRequest{Settings: models.ChartValueSettings{
-			"fox": "hound",
-		}}
+		request := models.ApplicationUpdateRequest{
+			Restart: &restart,
+			Settings: models.ChartValueSettings{
+				"fox": "hound",
+			},
+		}
 		bodyBytes, statusCode := appUpdate(namespace, appName, toJSON(request))
 		ExpectResponseToBeOK(bodyBytes, statusCode)
 
@@ -194,9 +222,12 @@ var _ = Describe("AppValidateCV Endpoint", LApplication, func() {
 	})
 
 	It("fails for a non-numeric value where numeric required", func() {
-		request := models.ApplicationUpdateRequest{Settings: models.ChartValueSettings{
-			"cat": "dog",
-		}}
+		request := models.ApplicationUpdateRequest{
+			Restart: &restart,
+			Settings: models.ChartValueSettings{
+				"cat": "dog",
+			},
+		}
 		bodyBytes, statusCode := appUpdate(namespace, appName, toJSON(request))
 		ExpectResponseToBeOK(bodyBytes, statusCode)
 
@@ -205,9 +236,12 @@ var _ = Describe("AppValidateCV Endpoint", LApplication, func() {
 	})
 
 	It("fails for a non-boolean value where boolean required", func() {
-		request := models.ApplicationUpdateRequest{Settings: models.ChartValueSettings{
-			"fake": "news",
-		}}
+		request := models.ApplicationUpdateRequest{
+			Restart: &restart,
+			Settings: models.ChartValueSettings{
+				"fake": "news",
+			},
+		}
 		bodyBytes, statusCode := appUpdate(namespace, appName, toJSON(request))
 		ExpectResponseToBeOK(bodyBytes, statusCode)
 

--- a/acceptance/api/v1/helpers_api_test.go
+++ b/acceptance/api/v1/helpers_api_test.go
@@ -107,7 +107,7 @@ func makeEndpoint(path string) string {
 func ExpectResponseToBeOK(bodyBytes []byte, statusCode int) {
 	GinkgoHelper()
 
-	Expect(statusCode).To(Equal(http.StatusOK))
+	Expect(statusCode).To(Equal(http.StatusOK), string(bodyBytes))
 
 	response := fromJSON[models.Response](bodyBytes)
 	Expect(response).To(Equal(models.ResponseOK))

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -783,6 +783,10 @@ var _ = Describe("Apps", LApplication, func() {
 			tmpDir, err = os.MkdirTemp("", "epinio-failing-app")
 			Expect(err).ToNot(HaveOccurred())
 
+			DeferCleanup(func() {
+				os.RemoveAll(tmpDir)
+			})
+
 			err = os.WriteFile(path.Join(tmpDir, "empty"), []byte(""), 0644)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -813,10 +817,6 @@ var _ = Describe("Apps", LApplication, func() {
 
 				return status["type"]
 			}, 3*time.Minute, 3*time.Second).Should(BeEquivalentTo("Failed"))
-
-			DeferCleanup(func() {
-				os.RemoveAll(tmpDir)
-			})
 		})
 
 		It("succeeds when re-pushing a fix", func() {

--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -1712,7 +1712,7 @@
       "title": "App has all the application's properties, for at rest (Configuration), and active (Workload).",
       "properties": {
         "configuration": {
-          "$ref": "#/definitions/ApplicationUpdateRequest"
+          "$ref": "#/definitions/ApplicationConfiguration"
         },
         "deployment": {
           "$ref": "#/definitions/AppDeployment"
@@ -1885,6 +1885,42 @@
       },
       "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
     },
+    "ApplicationConfiguration": {
+      "description": "ApplicationConfiguration is the part of the manifest describing the configuration of the application",
+      "type": "object",
+      "properties": {
+        "appchart": {
+          "type": "string",
+          "x-go-name": "AppChart"
+        },
+        "configurations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Configurations"
+        },
+        "environment": {
+          "$ref": "#/definitions/EnvVariableMap"
+        },
+        "instances": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "Instances"
+        },
+        "routes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Routes"
+        },
+        "settings": {
+          "$ref": "#/definitions/ChartValueSettings"
+        }
+      },
+      "x-go-package": "github.com/epinio/epinio/pkg/api/core/v1/models"
+    },
     "ApplicationCreateRequest": {
       "description": "ApplicationCreateRequest represents and contains the data needed to\ncreate an application (at rest), possibly with presets (configurations)",
       "type": "object",
@@ -1981,6 +2017,10 @@
           "type": "integer",
           "format": "int32",
           "x-go-name": "Instances"
+        },
+        "restart": {
+          "type": "boolean",
+          "x-go-name": "Restart"
         },
         "routes": {
           "type": "array",

--- a/internal/api/v1/application/part.go
+++ b/internal/api/v1/application/part.go
@@ -334,13 +334,11 @@ func fetchAppValues(c *gin.Context, logger logr.Logger, cluster *kubernetes.Clus
 
 func fetchAppManifest(c *gin.Context, app *models.App) apierror.APIErrors {
 	m := models.ApplicationManifest{
-		ApplicationCreateRequest: models.ApplicationCreateRequest{
-			Name:          app.Meta.Name,
-			Configuration: app.Configuration,
-		},
-		Namespace: app.Meta.Namespace,
-		Origin:    app.Origin,
-		Staging:   app.Staging,
+		Name:          app.Meta.Name,
+		Configuration: app.Configuration,
+		Namespace:     app.Meta.Namespace,
+		Origin:        app.Origin,
+		Staging:       app.Staging,
 	}
 
 	response.OKYaml(c, m)

--- a/internal/api/v1/application/restart.go
+++ b/internal/api/v1/application/restart.go
@@ -46,8 +46,8 @@ func Restart(c *gin.Context) apierror.APIErrors {
 		return apierror.AppIsNotKnown(appName)
 	}
 
-	if app.Workload == nil {
-		return apierror.NewAPIError("No restart possible for an application without workload", http.StatusBadRequest)
+	if app.Configuration.Instances == nil || *app.Configuration.Instances == 0 {
+		return apierror.NewAPIError("No restart possible for an application with no instances", http.StatusBadRequest)
 	}
 
 	if !strings.Contains(app.ImageURL, app.StageID) {

--- a/internal/api/v1/application/update.go
+++ b/internal/api/v1/application/update.go
@@ -197,9 +197,9 @@ func Update(c *gin.Context) apierror.APIErrors { // nolint:gocyclo // simplifica
 		}
 	}
 
-	// backward compatibility: if no flag provided then restart the app, this time failing for no workload, or any other wrong update
+	// backward compatibility: if no flag provided then restart the app
 	restart := updateRequest.Restart == nil || *updateRequest.Restart
-	if restart {
+	if app.Workload != nil && restart {
 		log.Info("updating app -- restarting")
 
 		_, apierr := deploy.DeployApp(ctx, cluster, app.Meta, username, "")

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -119,7 +119,8 @@ var CmdAppCreate = &cobra.Command{
 			return err
 		}
 
-		err = client.AppCreate(args[0], m.Configuration)
+		updateRequest := models.NewApplicationUpdateRequest(m)
+		err = client.AppCreate(args[0], updateRequest)
 		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error creating app")
 	},
@@ -258,7 +259,17 @@ var CmdAppUpdate = &cobra.Command{
 			return errors.Wrap(err, "unable to update domains")
 		}
 
-		err = client.AppUpdate(args[0], m.Configuration)
+		manifestConfig := m.Configuration
+		updateRequest := models.ApplicationUpdateRequest{
+			Instances:      manifestConfig.Instances,
+			Configurations: manifestConfig.Configurations,
+			Environment:    manifestConfig.Environment,
+			Routes:         manifestConfig.Routes,
+			AppChart:       manifestConfig.AppChart,
+			Settings:       manifestConfig.Settings,
+		}
+
+		err = client.AppUpdate(args[0], updateRequest)
 		// Note: errors.Wrap (nil, "...") == nil
 		return errors.Wrap(err, "error updating the app")
 	},

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/epinio/epinio/internal/manifest"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/pkg/errors"
@@ -124,11 +123,7 @@ var CmdAppPush = &cobra.Command{
 			}
 		}
 
-		params := usercmd.PushParams{
-			ApplicationManifest: m,
-		}
-
-		err = client.Push(cmd.Context(), params)
+		err = client.Push(cmd.Context(), m)
 		if err != nil {
 			return errors.Wrap(err, "error pushing app to server")
 		}

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -131,6 +131,10 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 		c.ui.Normal().Msg("Application exists, updating ...")
 		details.Info("app exists conflict")
 
+		// do not restart during a push
+		restart := false
+		params.Configuration.Restart = &restart
+
 		_, err := c.API.AppUpdate(params.Configuration, appRef.Namespace, appRef.Name)
 		if err != nil {
 			return err

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -136,7 +136,6 @@ func (c *EpinioClient) Push(ctx context.Context, manifest models.ApplicationMani
 		restart := false
 		updateRequest.Restart = &restart
 
-		updateRequest := models.NewApplicationUpdateRequest(manifest)
 		_, err := c.API.AppUpdate(updateRequest, appRef.Namespace, appRef.Name)
 		if err != nil {
 			return err

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -36,10 +36,6 @@ var _ = Describe("Manifest", func() {
 				m, err := manifest.Get("missing.yml")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(m).To(Equal(models.ApplicationManifest{
-					ApplicationCreateRequest: models.ApplicationCreateRequest{
-						Name:          "",
-						Configuration: models.ApplicationUpdateRequest{},
-					},
 					Self: "<<Defaults>>",
 					Origin: models.ApplicationOrigin{
 						Kind:      models.OriginPath,
@@ -121,17 +117,15 @@ configuration:
 				Expect(err).ToNot(HaveOccurred())
 				var instances int32 = 2
 				Expect(m).To(Equal(models.ApplicationManifest{
-					ApplicationCreateRequest: models.ApplicationCreateRequest{
-						Name: "foo",
-						Configuration: models.ApplicationUpdateRequest{
-							Instances: &instances,
-							Configurations: []string{
-								"bar",
-							},
-							Environment: models.EnvVariableMap{
-								"DOGMA": "no",
-								"CREDO": "up",
-							},
+					Name: "foo",
+					Configuration: models.ApplicationConfiguration{
+						Instances: &instances,
+						Configurations: []string{
+							"bar",
+						},
+						Environment: models.EnvVariableMap{
+							"DOGMA": "no",
+							"CREDO": "up",
 						},
 					},
 					Self: path.Join(workdir, "goodyaml.yml"),

--- a/pkg/api/core/v1/models/app.go
+++ b/pkg/api/core/v1/models/app.go
@@ -96,7 +96,7 @@ type GitRef struct {
 // It is used in the CLI and API responses.
 type App struct {
 	Meta          AppRef                   `json:"meta"`
-	Configuration ApplicationUpdateRequest `json:"configuration"`
+	Configuration ApplicationConfiguration `json:"configuration"`
 	Origin        ApplicationOrigin        `json:"origin"`
 	Workload      *AppDeployment           `json:"deployment,omitempty"`
 	Staging       ApplicationStage         `json:"staging,omitempty"`

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -189,6 +189,7 @@ type ApplicationCreateRequest struct {
 // Note: Instances is a pointer to give us a nil value separate from
 // actual integers, as means of communicating `default`/`no change`.
 type ApplicationUpdateRequest struct {
+	Restart        *bool              `json:"restart,omitempty"`
 	Instances      *int32             `json:"instances"          yaml:"instances,omitempty"`
 	Configurations []string           `json:"configurations"     yaml:"configurations,omitempty"`
 	Environment    EnvVariableMap     `json:"environment"        yaml:"environment,omitempty"`

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -109,11 +109,12 @@ type BindResponse struct {
 // plus some auxiliary data never (un)marshalled. Namely, the file's location, and origin
 // type tag.
 type ApplicationManifest struct {
-	ApplicationCreateRequest `yaml:",inline"`
-	Self                     string            `yaml:"-"` // Hidden from yaml. The file's location.
-	Origin                   ApplicationOrigin `yaml:"origin,omitempty"`
-	Staging                  ApplicationStage  `yaml:"staging,omitempty"`
-	Namespace                string            `yaml:"namespace,omitempty"`
+	Name          string                   `yaml:"name,omitempty"`
+	Configuration ApplicationConfiguration `yaml:"configuration"`
+	Self          string                   `yaml:"-"` // Hidden from yaml. The file's location.
+	Origin        ApplicationOrigin        `yaml:"origin,omitempty"`
+	Staging       ApplicationStage         `yaml:"staging,omitempty"`
+	Namespace     string                   `yaml:"namespace,omitempty"`
 }
 
 // ApplicationStage is the part of the manifest holding information
@@ -121,6 +122,16 @@ type ApplicationManifest struct {
 // only the reference to the Paketo builder image to use.
 type ApplicationStage struct {
 	Builder string `yaml:"builder,omitempty" json:"builder,omitempty"`
+}
+
+// ApplicationConfiguration is the part of the manifest describing the configuration of the application
+type ApplicationConfiguration struct {
+	Instances      *int32             `json:"instances"          yaml:"instances,omitempty"`
+	Configurations []string           `json:"configurations"     yaml:"configurations,omitempty"`
+	Environment    EnvVariableMap     `json:"environment"        yaml:"environment,omitempty"`
+	Routes         []string           `json:"routes"             yaml:"routes,omitempty"`
+	AppChart       string             `json:"appchart,omitempty" yaml:"appchart,omitempty"`
+	Settings       ChartValueSettings `json:"settings,omitempty" yaml:"settings,omitempty"`
 }
 
 // ApplicationOrigin is the part of the manifest describing the origin of the application
@@ -196,6 +207,18 @@ type ApplicationUpdateRequest struct {
 	Routes         []string           `json:"routes"             yaml:"routes,omitempty"`
 	AppChart       string             `json:"appchart,omitempty" yaml:"appchart,omitempty"`
 	Settings       ChartValueSettings `json:"settings,omitempty" yaml:"settings,omitempty"`
+}
+
+func NewApplicationUpdateRequest(manifest ApplicationManifest) ApplicationUpdateRequest {
+	manifestConfig := manifest.Configuration
+	return ApplicationUpdateRequest{
+		Instances:      manifestConfig.Instances,
+		Configurations: manifestConfig.Configurations,
+		Environment:    manifestConfig.Environment,
+		Routes:         manifestConfig.Routes,
+		AppChart:       manifestConfig.AppChart,
+		Settings:       manifestConfig.Settings,
+	}
 }
 
 type ImportGitResponse struct {


### PR DESCRIPTION
This PR fix #2363 but it will need some work from the UI, to pass the same `restart: false` flag during the `push`.

After a lot of thoughts the problem was related to an unwanted call to the `DeployApp`, after an `UpdateApp`.

The problem is that if the DeployApp will fail, then the Update will fail as well, and no updated sources are going to be uploaded to try to fix the issue.
To fix this keeping the old behavior for backward compatibility and also to keep the same restart during the `epinio app update` command a new optional `restart` flag can be provided, to force the not-restart (by default it's true).

Changes to the `models.Manifest` struct was needed, because it was using internally the same `models.ApplicationUpdateRequest` as a `Configuration`. While containing the same fields (until now) these two struct are conceptually different, and they could/should be different.  A new similar `ApplicationConfiguration` struct was added, to avoid having the `Restart` flag in the Manifest.