### PR TITLE
Show custom values for service instances

### DIFF
--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -1707,7 +1707,7 @@
   },
   "definitions": {
     "App": {
-      "description": "The main structure has identifying information.\nIt is used in the CLI and API responses.\nIf an error is hit while constructing the app object, the Error attribute\nwill be set to that.",
+      "description": "The main structure has identifying information.\nIt is used in the CLI and API responses.",
       "type": "object",
       "title": "App has all the application's properties, for at rest (Configuration), and active (Workload).",
       "properties": {
@@ -2640,6 +2640,9 @@
             "type": "string"
           },
           "x-go-name": "SecretTypes"
+        },
+        "settings": {
+          "$ref": "#/definitions/ChartValueSettings"
         },
         "status": {
           "$ref": "#/definitions/ServiceStatus"

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -151,6 +151,24 @@ func (c *EpinioClient) ServiceShow(serviceName string) error {
 		WithTableRow("Internal Routes", strings.Join(internalRoutes, ", ")).
 		Msg(m)
 
+	if len(service.Settings) > 0 {
+		keys := []string{}
+		for key := range service.Settings {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		msg := c.ui.Success().WithTable("Key", "Value")
+
+		for _, key := range keys {
+			msg = msg.WithTableRow(key, service.Settings[key])
+		}
+
+		msg.Msg("Settings")
+	} else {
+		c.ui.Exclamation().Msg("No settings")
+	}
+
 	return nil
 }
 

--- a/internal/services/instances.go
+++ b/internal/services/instances.go
@@ -622,8 +622,9 @@ func setServiceStatusAndCustomValues(service *models.Service,
 		return errors.Wrap(err, "finding helm release status")
 	}
 
-	serviceStatus, err := helm.Status(ctx, logger, cluster, namespace, releaseName,
-		serviceRelease)
+	service.Status = models.ServiceStatusUnknown
+
+	serviceStatus, err := helm.Status(ctx, logger, cluster, serviceRelease)
 	if err != nil {
 		return errors.Wrap(err, "calculating helm release status")
 	}

--- a/internal/services/instances.go
+++ b/internal/services/instances.go
@@ -616,7 +616,7 @@ func setServiceStatusAndCustomValues(service *models.Service,
 
 	if err != nil {
 		if errors.Is(err, helmdriver.ErrReleaseNotFound) {
-			service.Status = "Not Ready" // The installation job is still running?
+			service.Status = models.ServiceStatusNotReady // The installation job is still running?
 			return nil
 		}
 		return errors.Wrap(err, "finding helm release status")

--- a/internal/services/instances.go
+++ b/internal/services/instances.go
@@ -98,9 +98,13 @@ func (s *ServiceClient) Get(ctx context.Context, namespace, name string) (*model
 
 	logger := tracelog.NewLogger().WithName("ServiceStatus")
 
+	var settings map[string]models.ChartSetting
+	if catalogEntry != nil {
+		settings = catalogEntry.Settings
+	}
+
 	err = setServiceStatusAndCustomValues(&service, ctx, logger, s.kubeClient,
-		namespace, names.ServiceReleaseName(name),
-		catalogEntry.Settings)
+		namespace, names.ServiceReleaseName(name), settings)
 
 	return &service, err
 }

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -348,14 +348,15 @@ type ServiceUnbindRequest struct {
 }
 
 type Service struct {
-	Meta                    Meta          `json:"meta,omitempty"`
-	SecretTypes             []string      `json:"secretTypes,omitempty"`
-	CatalogService          string        `json:"catalog_service,omitempty"`
-	CatalogServiceVersion   string        `json:"catalog_service_version,omitempty"`
-	Status                  ServiceStatus `json:"status,omitempty"`
-	BoundApps               []string      `json:"boundapps"`
-	ManagedByHelmController bool          `json:"hcmanaged"`
-	InternalRoutes          []string      `json:"internal_routes,omitempty"`
+	Meta                    Meta               `json:"meta,omitempty"`
+	SecretTypes             []string           `json:"secretTypes,omitempty"`
+	CatalogService          string             `json:"catalog_service,omitempty"`
+	CatalogServiceVersion   string             `json:"catalog_service_version,omitempty"`
+	Status                  ServiceStatus      `json:"status,omitempty"`
+	BoundApps               []string           `json:"boundapps"`
+	ManagedByHelmController bool               `json:"hcmanaged"`
+	InternalRoutes          []string           `json:"internal_routes,omitempty"`
+	Settings                ChartValueSettings `json:"settings,omitempty"`
 }
 
 func (s Service) Namespace() string {


### PR DESCRIPTION
fix #2402

- [x] moved service status calc into helper function
- [x] separated retrieval of helm release from status calculations
- [x] implement retrieval of custom values from release
- [x] extend instance model to carry custom values
- [x] extend client service show to show the custom values
- [x] extend and/or update service tests
