### PR TITLE
Fixed wrong client initialization

### DIFF
--- a/internal/cli/clientsync.go
+++ b/internal/cli/clientsync.go
@@ -12,13 +12,12 @@
 package cli
 
 import (
-	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 // NewClientSyncCmd implements the command: epinio client-sync
-func NewClientSyncCmd(client *usercmd.EpinioClient) *cobra.Command {
+func NewClientSyncCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "client-sync",
 		Short: "Downloads a client binary matching the currently logged server",

--- a/internal/cli/clientsync_test.go
+++ b/internal/cli/clientsync_test.go
@@ -61,7 +61,8 @@ var _ = Describe("Command 'epinio client-sync'", func() {
 		mockUpdater = &selfupdaterfakes.FakeUpdater{}
 		epinioClient.Updater = mockUpdater
 
-		clientSyncCmd = cli.NewClientSyncCmd(epinioClient)
+		clientSyncCmd = cli.NewClientSyncCmd()
+		cli.SetClient(epinioClient)
 		clientSyncCmd.SetErr(output)
 		clientSyncCmd.SetArgs([]string{"client-sync"})
 	})

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -12,13 +12,12 @@
 package cli
 
 import (
-	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 // NewInfoCmd returns a new 'epinio info' command
-func NewInfoCmd(client *usercmd.EpinioClient) *cobra.Command {
+func NewInfoCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "info",
 		Short: "Shows information about the Epinio environment",

--- a/internal/cli/info_test.go
+++ b/internal/cli/info_test.go
@@ -46,7 +46,8 @@ var _ = Describe("Command 'epinio info'", func() {
 		output = &bytes.Buffer{}
 		epinioClient.UI().SetOutput(output)
 
-		infoCmd = cli.NewInfoCmd(epinioClient)
+		infoCmd = cli.NewInfoCmd()
+		cli.SetClient(epinioClient)
 		infoCmd.SetErr(output)
 		infoCmd.SetArgs([]string{"info"})
 	})


### PR DESCRIPTION
Flags are parsed not during the creation of the command but just before the `Run`.

It means that the client initialized at the beginning was not looking for the settings in the specified location but always in the default one. This PR moves the initialization in the `PersistentPreRunE` (run before every command) for all the commands.