### PR TITLE
Refactor of HTTP client with handlers, and AppGetPart

### DIFF
--- a/internal/api/v1/application/part.go
+++ b/internal/api/v1/application/part.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -143,11 +142,7 @@ func fetchAppChart(c *gin.Context, ctx context.Context, logger logr.Logger, clus
 
 			logger.Info("input", "chart archive", "returning file")
 
-			c.DataFromReader(http.StatusOK, contentLength, contentType, bufio.NewReader(file),
-				map[string]string{
-					"X-Content-Length": strconv.FormatInt(contentLength, 10),
-				})
-
+			c.DataFromReader(http.StatusOK, contentLength, contentType, bufio.NewReader(file), nil)
 			return nil
 		}
 	}
@@ -170,9 +165,8 @@ func fetchAppChart(c *gin.Context, ctx context.Context, logger logr.Logger, clus
 		"origin", c.Request.URL.String(),
 		"returning", fmt.Sprintf("%d bytes %s as is", contentLength, contentType),
 	)
-	c.DataFromReader(http.StatusOK, contentLength, contentType, reader, map[string]string{
-		"X-Content-Length": strconv.FormatInt(contentLength, 10),
-	})
+
+	c.DataFromReader(http.StatusOK, contentLength, contentType, reader, nil)
 	return nil
 }
 
@@ -212,10 +206,7 @@ func fetchAppImage(c *gin.Context, ctx context.Context, logger logr.Logger, clus
 		return apierror.NewInternalError("failed to get file info", "error", err.Error())
 	}
 
-	c.DataFromReader(http.StatusOK, fileInfo.Size(), "application/x-tar", bufio.NewReader(file), map[string]string{
-		"X-Content-Length": strconv.FormatInt(fileInfo.Size(), 10),
-	})
-
+	c.DataFromReader(http.StatusOK, fileInfo.Size(), "application/x-tar", bufio.NewReader(file), nil)
 	return nil
 }
 

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -288,6 +288,7 @@ func (c *EpinioClient) getPartAndWriteFile(appName, part, destinationPath string
 	if err != nil {
 		return err
 	}
+	defer partResponse.Data.Close()
 
 	// Create the file
 	out, err := os.Create(destinationPath)

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -265,43 +265,30 @@ func (c *EpinioClient) AppExport(appName string, directory string) error {
 
 	fmt.Println()
 
-	partResponse, err := c.API.AppGetPart(c.Settings.Namespace, appName, "values")
-	if err != nil {
-		return err
-	}
-	err = writeOut(partResponse, filepath.Join(directory, "values.yaml"), "values")
+	err = c.getPartAndWriteFile(appName, "values", filepath.Join(directory, "values.yaml"))
 	if err != nil {
 		return err
 	}
 
-	partResponse, err = c.API.AppGetPart(c.Settings.Namespace, appName, "chart")
-	if err != nil {
-		return err
-	}
-	err = writeOut(partResponse, filepath.Join(directory, "app-chart.tar.gz"), "chart")
+	err = c.getPartAndWriteFile(appName, "chart", filepath.Join(directory, "app-chart.tar.gz"))
 	if err != nil {
 		return err
 	}
 
-	fmt.Println("fetching image")
-
-	partResponse, err = c.API.AppGetPart(c.Settings.Namespace, appName, "image")
+	err = c.getPartAndWriteFile(appName, "image", filepath.Join(directory, "app-image.tar"))
 	if err != nil {
 		return err
 	}
-	fmt.Println("writing image")
-
-	err = writeOut(partResponse, filepath.Join(directory, "app-image.tar"), "image")
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("DONE image")
 
 	return nil
 }
 
-func writeOut(partResponse models.AppPartResponse, destinationPath, part string) error {
+func (c *EpinioClient) getPartAndWriteFile(appName, part, destinationPath string) error {
+	partResponse, err := c.API.AppGetPart(c.Settings.Namespace, appName, part)
+	if err != nil {
+		return err
+	}
+
 	// Create the file
 	out, err := os.Create(destinationPath)
 	if err != nil {
@@ -336,13 +323,9 @@ func (c *EpinioClient) AppManifest(appName, manifestPath string) error {
 		return err
 	}
 
-	details.Info("show application")
+	details.Info("save application manifest")
 
-	partResponse, err := c.API.AppGetPart(c.Settings.Namespace, appName, "manifest")
-	if err != nil {
-		return err
-	}
-	err = writeOut(partResponse, manifestPath, "manifest")
+	err := c.getPartAndWriteFile(appName, "manifest", manifestPath)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -278,19 +278,25 @@ func (c *EpinioClient) AppExport(appName string, directory string) error {
 	if err != nil {
 		return err
 	}
-	err = writeOut(partResponse, filepath.Join(directory, "app-chart.tar.gz"), "values")
+	err = writeOut(partResponse, filepath.Join(directory, "app-chart.tar.gz"), "chart")
 	if err != nil {
 		return err
 	}
+
+	fmt.Println("fetching image")
 
 	partResponse, err = c.API.AppGetPart(c.Settings.Namespace, appName, "image")
 	if err != nil {
 		return err
 	}
-	err = writeOut(partResponse, filepath.Join(directory, "app-image.tar"), "values")
+	fmt.Println("writing image")
+
+	err = writeOut(partResponse, filepath.Join(directory, "app-image.tar"), "image")
 	if err != nil {
 		return err
 	}
+
+	fmt.Println("DONE image")
 
 	return nil
 }

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -62,7 +62,7 @@ type APIClient interface {
 	AppExec(ctx context.Context, namespace string, appName, instance string, tty kubectlterm.TTY) error
 	AppPortForward(namespace string, appName, instance string, opts *epinioapi.PortForwardOpts) error
 	AppRestart(namespace string, appName string) (models.Response, error)
-	AppGetPart(namespace, appName, part, destinationPath string) error
+	AppGetPart(namespace, appName, part string) (models.AppPartResponse, error)
 	AppMatch(namespace, prefix string) (models.AppMatchResponse, error)
 	AppValidateCV(namespace string, name string) (models.Response, error)
 

--- a/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
+++ b/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
@@ -116,19 +116,20 @@ type FakeAPIClient struct {
 	appExecReturnsOnCall map[int]struct {
 		result1 error
 	}
-	AppGetPartStub        func(string, string, string, string) error
+	AppGetPartStub        func(string, string, string) (models.AppPartResponse, error)
 	appGetPartMutex       sync.RWMutex
 	appGetPartArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
-		arg4 string
 	}
 	appGetPartReturns struct {
-		result1 error
+		result1 models.AppPartResponse
+		result2 error
 	}
 	appGetPartReturnsOnCall map[int]struct {
-		result1 error
+		result1 models.AppPartResponse
+		result2 error
 	}
 	AppImportGitStub        func(models.AppRef, models.GitRef) (*models.ImportGitResponse, error)
 	appImportGitMutex       sync.RWMutex
@@ -1257,26 +1258,25 @@ func (fake *FakeAPIClient) AppExecReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeAPIClient) AppGetPart(arg1 string, arg2 string, arg3 string, arg4 string) error {
+func (fake *FakeAPIClient) AppGetPart(arg1 string, arg2 string, arg3 string) (models.AppPartResponse, error) {
 	fake.appGetPartMutex.Lock()
 	ret, specificReturn := fake.appGetPartReturnsOnCall[len(fake.appGetPartArgsForCall)]
 	fake.appGetPartArgsForCall = append(fake.appGetPartArgsForCall, struct {
 		arg1 string
 		arg2 string
 		arg3 string
-		arg4 string
-	}{arg1, arg2, arg3, arg4})
+	}{arg1, arg2, arg3})
 	stub := fake.AppGetPartStub
 	fakeReturns := fake.appGetPartReturns
-	fake.recordInvocation("AppGetPart", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("AppGetPart", []interface{}{arg1, arg2, arg3})
 	fake.appGetPartMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeAPIClient) AppGetPartCallCount() int {
@@ -1285,40 +1285,43 @@ func (fake *FakeAPIClient) AppGetPartCallCount() int {
 	return len(fake.appGetPartArgsForCall)
 }
 
-func (fake *FakeAPIClient) AppGetPartCalls(stub func(string, string, string, string) error) {
+func (fake *FakeAPIClient) AppGetPartCalls(stub func(string, string, string) (models.AppPartResponse, error)) {
 	fake.appGetPartMutex.Lock()
 	defer fake.appGetPartMutex.Unlock()
 	fake.AppGetPartStub = stub
 }
 
-func (fake *FakeAPIClient) AppGetPartArgsForCall(i int) (string, string, string, string) {
+func (fake *FakeAPIClient) AppGetPartArgsForCall(i int) (string, string, string) {
 	fake.appGetPartMutex.RLock()
 	defer fake.appGetPartMutex.RUnlock()
 	argsForCall := fake.appGetPartArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeAPIClient) AppGetPartReturns(result1 error) {
+func (fake *FakeAPIClient) AppGetPartReturns(result1 models.AppPartResponse, result2 error) {
 	fake.appGetPartMutex.Lock()
 	defer fake.appGetPartMutex.Unlock()
 	fake.AppGetPartStub = nil
 	fake.appGetPartReturns = struct {
-		result1 error
-	}{result1}
+		result1 models.AppPartResponse
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeAPIClient) AppGetPartReturnsOnCall(i int, result1 error) {
+func (fake *FakeAPIClient) AppGetPartReturnsOnCall(i int, result1 models.AppPartResponse, result2 error) {
 	fake.appGetPartMutex.Lock()
 	defer fake.appGetPartMutex.Unlock()
 	fake.AppGetPartStub = nil
 	if fake.appGetPartReturnsOnCall == nil {
 		fake.appGetPartReturnsOnCall = make(map[int]struct {
-			result1 error
+			result1 models.AppPartResponse
+			result2 error
 		})
 	}
 	fake.appGetPartReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
+		result1 models.AppPartResponse
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeAPIClient) AppImportGit(arg1 models.AppRef, arg2 models.GitRef) (*models.ImportGitResponse, error) {

--- a/pkg/api/core/v1/client/apps.go
+++ b/pkg/api/core/v1/client/apps.go
@@ -140,17 +140,9 @@ func (c *Client) AppGetPart(namespace, appName, part string) (models.AppPartResp
 		return response, handleError(c.log, httpResponse)
 	}
 
-	contentLength := httpResponse.ContentLength
-	if httpResponse.Header.Get("X-Content-Length") != "" {
-		xContentLength, err := strconv.ParseInt(httpResponse.Header.Get("X-Content-Length"), 10, 64)
-		if err == nil {
-			contentLength = xContentLength
-		}
-	}
-
 	return models.AppPartResponse{
 		Data:          httpResponse.Body,
-		ContentLength: contentLength,
+		ContentLength: httpResponse.ContentLength,
 	}, nil
 }
 

--- a/pkg/api/core/v1/client/apps.go
+++ b/pkg/api/core/v1/client/apps.go
@@ -36,7 +36,6 @@ import (
 	"github.com/epinio/epinio/helpers/kubernetes/tailer"
 	api "github.com/epinio/epinio/internal/api/v1"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
-	progressbar "github.com/schollz/progressbar/v3"
 	kubectlterm "k8s.io/kubectl/pkg/util/term"
 )
 
@@ -103,80 +102,56 @@ func (c *Client) AppShow(namespace string, appName string) (models.App, error) {
 }
 
 // AppGetPart retrieves part of an app (values.yaml, chart, image)
-func (c *Client) AppGetPart(namespace, appName, part, destinationPath string) error {
+func (c *Client) AppGetPart(namespace, appName, part string) (models.AppPartResponse, error) {
+	response := models.AppPartResponse{}
 
-	endpoint := api.Routes.Path("AppPart", namespace, appName, part)
-	requestBody := ""
-	method := "GET"
+	partURL := fmt.Sprintf(
+		"%s%s/%s",
+		c.Settings.API,
+		api.Root,
+		api.Routes.Path("AppPart", namespace, appName, part),
+	)
 
-	// inlined c.get/c.do to the where the response is handled.
-	uri := fmt.Sprintf("%s%s/%s", c.Settings.API, api.Root, endpoint)
-	c.log.Info(fmt.Sprintf("%s %s", method, uri))
-
-	request, err := http.NewRequest(method, uri, strings.NewReader(requestBody))
+	request, err := http.NewRequest(http.MethodGet, partURL, nil)
 	if err != nil {
 		c.log.V(1).Error(err, "cannot build request")
-		return err
+		return response, err
 	}
 
 	err = c.handleAuthorization(request)
 	if err != nil {
-		return errors.Wrap(err, "handling oauth2 request")
+		return response, errors.Wrap(err, "handling oauth2 request")
 	}
 
 	for key, value := range c.customHeaders {
 		request.Header.Set(key, value)
 	}
 
-	reqLog := requestLogger(c.log, request, requestBody)
+	reqLog := requestLogger(c.log, request, "")
 
-	response, err := c.HttpClient.Do(request)
+	httpResponse, err := c.HttpClient.Do(request)
 	if err != nil {
-		reqLog.V(1).Error(err, "request failed")
-		castedErr, ok := err.(*url.Error)
-		if !ok {
-			return errors.New("couldn't cast request Error!")
-		}
-		if castedErr.Timeout() {
-			return errors.New("request cancelled or timed out")
-		}
-
-		return errors.Wrap(err, "making the request")
+		return response, errors.Wrap(err, "making the request")
 	}
-
-	if response.StatusCode != http.StatusOK {
-		return handleError(c.log, response)
-	}
-
-	defer response.Body.Close()
 	reqLog.V(1).Info("request finished")
 
-	// Create the file
-	out, err := os.Create(destinationPath)
-	if err != nil {
-		return err
+	// the server returned an error
+	if httpResponse.StatusCode >= http.StatusBadRequest {
+		return response, handleError(c.log, httpResponse)
 	}
-	defer out.Close()
 
-	contentLength := response.ContentLength
-	if response.Header.Get("X-Content-Length") != "" {
-		xContentLength, err := strconv.ParseInt(response.Header.Get("X-Content-Length"), 10, 64)
+	contentLength := httpResponse.ContentLength
+	if httpResponse.Header.Get("X-Content-Length") != "" {
+		xContentLength, err := strconv.ParseInt(httpResponse.Header.Get("X-Content-Length"), 10, 64)
 		if err == nil {
 			contentLength = xContentLength
 		}
 	}
 
-	bar := progressbar.DefaultBytes(
-		contentLength,
-		fmt.Sprintf("Downloading app %s to '%s'", part, destinationPath),
-	)
-
-	// copy response body to file
-	_, err = io.Copy(io.MultiWriter(out, bar), response.Body)
-
-	c.log.V(1).Info("response stored")
-
-	return err
+	return models.AppPartResponse{
+		Data:          httpResponse.Body,
+		ContentLength: contentLength,
+	}, nil
 }
 
 // AppUpdate updates an app

--- a/pkg/api/core/v1/client/apps.go
+++ b/pkg/api/core/v1/client/apps.go
@@ -106,7 +106,7 @@ func (c *Client) AppGetPart(namespace, appName, part string) (models.AppPartResp
 	response := models.AppPartResponse{}
 	endpoint := api.Routes.Path("AppPart", namespace, appName, part)
 
-	httpResponse, err := DoRaw(c, endpoint, http.MethodGet, nil)
+	httpResponse, err := c.Do(endpoint, http.MethodGet, nil)
 	if err != nil {
 		return response, errors.Wrap(err, "executing AppPart request")
 	}

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -19,6 +19,7 @@ package models
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/epinio/epinio/helpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -168,6 +169,11 @@ func (o *ApplicationOrigin) String() string {
 		// Nothing
 	}
 	return "<<undefined>>"
+}
+
+type AppPartResponse struct {
+	Data          io.ReadCloser
+	ContentLength int64
 }
 
 // ApplicationCreateRequest represents and contains the data needed to


### PR DESCRIPTION
This PR removes the duplicated http request code from the AppGetPart API. It also removes the `X-Content-Length` custom header that is not actually needed (not sure why it wasn't working at the beginning).

To do so the `getPartAndWriteFile` func was created, to centralize the `get and write to file` logic.
Now the API returns a `models.AppPartResponse`, leaving to the caller the responsability to handle the body, and knowing where to write the file.

The most "interesting" refactor was done in the client itself. The problem with this call is that it was not a standard JSON request, so it was not receiving a JSON response that was going to be unmarshalled. To make it possible I had to make the client a bit more customizable, and so I've added to func:

```go
// RequestHandler is a method that will return a *http.Request from a method and url
type RequestHandler func(method, url string) (*http.Request, error)

// ResponseHandler is a method that will handle a *http.Response to return a typed struct
type ResponseHandler[T any] func(httpResponse *http.Response) (T, error)
```

So the http client will use those to know how to prepare the request, and how to handle the response.

For example the `NewJSONRequestHandler` is usually used, and it will JSON marshal the provided body into the request. Same for the `NewJSONResponseHandler`.

On the other hand the `NewHTTPRequestHandler` and the `NewHTTPResponseHandler` are a "passthrough" with plain HTTP request and response, and they for example are used in the `AppGetPart` api:

```go
// Do will execute a plain http request, returning the *http.Response
func (c *Client) Do(endpoint string, method string, body io.Reader) (*http.Response, error) {
	requestHandler := NewHTTPRequestHandler(body)
	responseHandler := NewHTTPResponseHandler()
	return DoWithHandlers(c, endpoint, method, requestHandler, responseHandler)
}
```

```go
// AppGetPart retrieves part of an app (values.yaml, chart, image)
func (c *Client) AppGetPart(namespace, appName, part string) (models.AppPartResponse, error) {
	response := models.AppPartResponse{}
	endpoint := api.Routes.Path("AppPart", namespace, appName, part)

	httpResponse, err := c.Do(endpoint, http.MethodGet, nil)
	if err != nil {
		return response, errors.Wrap(err, "executing AppPart request")
	}

	return models.AppPartResponse{
		Data:          httpResponse.Body,
		ContentLength: httpResponse.ContentLength,
	}, nil
}
```

With this approach all the common logic is centralized into the `DoWithHandlers` func, that will take care of the authentication, versionCheck, customHeaders and so on.