### PR TITLE
Remove `upload` httpclient duplication

### DIFF
--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/cli/settings"
 	"github.com/epinio/epinio/internal/selfupdater"
+	"github.com/epinio/epinio/pkg/api/core/v1/client"
 	epinioapi "github.com/epinio/epinio/pkg/api/core/v1/client"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/pkg/errors"
@@ -52,7 +53,7 @@ type APIClient interface {
 	AppShow(namespace string, appName string) (models.App, error)
 	AppUpdate(req models.ApplicationUpdateRequest, namespace string, appName string) (models.Response, error)
 	AppDelete(namespace string, names []string) (models.ApplicationDeleteResponse, error)
-	AppUpload(namespace string, name string, tarball string) (models.UploadResponse, error)
+	AppUpload(namespace string, name string, file client.FormFile) (models.UploadResponse, error)
 	AppImportGit(app models.AppRef, gitRef models.GitRef) (*models.ImportGitResponse, error)
 	AppStage(req models.StageRequest) (*models.StageResponse, error)
 	AppDeploy(req models.DeployRequest) (*models.DeployResponse, error)

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -44,7 +44,7 @@ type EpinioClient struct {
 
 //counterfeiter:generate . APIClient
 type APIClient interface {
-	AuthToken() (string, error)
+	AuthToken() (models.AuthTokenResponse, error)
 
 	// app
 	AppCreate(req models.ApplicationCreateRequest, namespace string) (models.Response, error)

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
 
@@ -148,37 +149,11 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 	case models.OriginNone:
 		return fmt.Errorf("%s", "No application origin")
 	case models.OriginPath:
-		c.ui.Normal().Msg("Collecting the application sources ...")
-
-		tmpDir, tarball, err := helpers.Tar(source)
-		defer func() {
-			if tmpDir != "" {
-				_ = os.RemoveAll(tmpDir)
-			}
-		}()
+		uploadedSourceBlobID, err := c.uploadSources(log, appRef, source)
 		if err != nil {
 			return err
 		}
-
-		c.ui.Normal().Msg("Uploading application code ...")
-
-		details.Info("upload code")
-
-		// open the tarball
-		file, err := os.Open(tarball)
-		if err != nil {
-			return errors.Wrap(err, "failed to open tarball")
-		}
-		defer file.Close()
-
-		upload, err := c.API.AppUpload(appRef.Namespace, appRef.Name, file)
-		if err != nil {
-			return err
-		}
-		log.V(3).Info("upload response", "response", upload)
-
-		blobUID = upload.BlobUID
-
+		blobUID = uploadedSourceBlobID
 	case models.OriginGit:
 		c.ui.Normal().Msg("Importing the application sources from Git ...")
 
@@ -270,6 +245,39 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 
 	c.reportOK(appRef, params.Staging.Builder, routes)
 	return nil
+}
+
+func (c *EpinioClient) uploadSources(log logr.Logger, appRef models.AppRef, source string) (string, error) {
+	c.ui.Normal().Msg("Collecting the application sources ...")
+
+	tmpDir, tarball, err := helpers.Tar(source)
+	defer func() {
+		if tmpDir != "" {
+			_ = os.RemoveAll(tmpDir)
+		}
+	}()
+	if err != nil {
+		return "", err
+	}
+
+	c.ui.Normal().Msg("Uploading application code ...")
+
+	log.V(1).Info("upload code")
+
+	// open the tarball
+	file, err := os.Open(tarball)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to open tarball")
+	}
+	defer file.Close()
+
+	upload, err := c.API.AppUpload(appRef.Namespace, appRef.Name, file)
+	if err != nil {
+		return "", err
+	}
+	log.V(3).Info("upload response", "response", upload)
+
+	return upload.BlobUID, nil
 }
 
 func (c *EpinioClient) stageLogs(appRef models.AppRef, stageID string) {

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -163,7 +163,15 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 		c.ui.Normal().Msg("Uploading application code ...")
 
 		details.Info("upload code")
-		upload, err := c.API.AppUpload(appRef.Namespace, appRef.Name, tarball)
+
+		// open the tarball
+		file, err := os.Open(tarball)
+		if err != nil {
+			return errors.Wrap(err, "failed to open tarball")
+		}
+		defer file.Close()
+
+		upload, err := c.API.AppUpload(appRef.Namespace, appRef.Name, file)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
+++ b/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
@@ -257,12 +257,12 @@ type FakeAPIClient struct {
 		result1 models.Response
 		result2 error
 	}
-	AppUploadStub        func(string, string, string) (models.UploadResponse, error)
+	AppUploadStub        func(string, string, client.FormFile) (models.UploadResponse, error)
 	appUploadMutex       sync.RWMutex
 	appUploadArgsForCall []struct {
 		arg1 string
 		arg2 string
-		arg3 string
+		arg3 client.FormFile
 	}
 	appUploadReturns struct {
 		result1 models.UploadResponse
@@ -1907,13 +1907,13 @@ func (fake *FakeAPIClient) AppUpdateReturnsOnCall(i int, result1 models.Response
 	}{result1, result2}
 }
 
-func (fake *FakeAPIClient) AppUpload(arg1 string, arg2 string, arg3 string) (models.UploadResponse, error) {
+func (fake *FakeAPIClient) AppUpload(arg1 string, arg2 string, arg3 client.FormFile) (models.UploadResponse, error) {
 	fake.appUploadMutex.Lock()
 	ret, specificReturn := fake.appUploadReturnsOnCall[len(fake.appUploadArgsForCall)]
 	fake.appUploadArgsForCall = append(fake.appUploadArgsForCall, struct {
 		arg1 string
 		arg2 string
-		arg3 string
+		arg3 client.FormFile
 	}{arg1, arg2, arg3})
 	stub := fake.AppUploadStub
 	fakeReturns := fake.appUploadReturns
@@ -1934,13 +1934,13 @@ func (fake *FakeAPIClient) AppUploadCallCount() int {
 	return len(fake.appUploadArgsForCall)
 }
 
-func (fake *FakeAPIClient) AppUploadCalls(stub func(string, string, string) (models.UploadResponse, error)) {
+func (fake *FakeAPIClient) AppUploadCalls(stub func(string, string, client.FormFile) (models.UploadResponse, error)) {
 	fake.appUploadMutex.Lock()
 	defer fake.appUploadMutex.Unlock()
 	fake.AppUploadStub = stub
 }
 
-func (fake *FakeAPIClient) AppUploadArgsForCall(i int) (string, string, string) {
+func (fake *FakeAPIClient) AppUploadArgsForCall(i int) (string, string, client.FormFile) {
 	fake.appUploadMutex.RLock()
 	defer fake.appUploadMutex.RUnlock()
 	argsForCall := fake.appUploadArgsForCall[i]

--- a/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
+++ b/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
@@ -299,16 +299,16 @@ type FakeAPIClient struct {
 		result1 models.AppList
 		result2 error
 	}
-	AuthTokenStub        func() (string, error)
+	AuthTokenStub        func() (models.AuthTokenResponse, error)
 	authTokenMutex       sync.RWMutex
 	authTokenArgsForCall []struct {
 	}
 	authTokenReturns struct {
-		result1 string
+		result1 models.AuthTokenResponse
 		result2 error
 	}
 	authTokenReturnsOnCall map[int]struct {
-		result1 string
+		result1 models.AuthTokenResponse
 		result2 error
 	}
 	ChartListStub        func() ([]models.AppChart, error)
@@ -2102,7 +2102,7 @@ func (fake *FakeAPIClient) AppsReturnsOnCall(i int, result1 models.AppList, resu
 	}{result1, result2}
 }
 
-func (fake *FakeAPIClient) AuthToken() (string, error) {
+func (fake *FakeAPIClient) AuthToken() (models.AuthTokenResponse, error) {
 	fake.authTokenMutex.Lock()
 	ret, specificReturn := fake.authTokenReturnsOnCall[len(fake.authTokenArgsForCall)]
 	fake.authTokenArgsForCall = append(fake.authTokenArgsForCall, struct {
@@ -2126,34 +2126,34 @@ func (fake *FakeAPIClient) AuthTokenCallCount() int {
 	return len(fake.authTokenArgsForCall)
 }
 
-func (fake *FakeAPIClient) AuthTokenCalls(stub func() (string, error)) {
+func (fake *FakeAPIClient) AuthTokenCalls(stub func() (models.AuthTokenResponse, error)) {
 	fake.authTokenMutex.Lock()
 	defer fake.authTokenMutex.Unlock()
 	fake.AuthTokenStub = stub
 }
 
-func (fake *FakeAPIClient) AuthTokenReturns(result1 string, result2 error) {
+func (fake *FakeAPIClient) AuthTokenReturns(result1 models.AuthTokenResponse, result2 error) {
 	fake.authTokenMutex.Lock()
 	defer fake.authTokenMutex.Unlock()
 	fake.AuthTokenStub = nil
 	fake.authTokenReturns = struct {
-		result1 string
+		result1 models.AuthTokenResponse
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeAPIClient) AuthTokenReturnsOnCall(i int, result1 string, result2 error) {
+func (fake *FakeAPIClient) AuthTokenReturnsOnCall(i int, result1 models.AuthTokenResponse, result2 error) {
 	fake.authTokenMutex.Lock()
 	defer fake.authTokenMutex.Unlock()
 	fake.AuthTokenStub = nil
 	if fake.authTokenReturnsOnCall == nil {
 		fake.authTokenReturnsOnCall = make(map[int]struct {
-			result1 string
+			result1 models.AuthTokenResponse
 			result2 error
 		})
 	}
 	fake.authTokenReturnsOnCall[i] = struct {
-		result1 string
+		result1 models.AuthTokenResponse
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/api/core/v1/client/apps.go
+++ b/pkg/api/core/v1/client/apps.go
@@ -152,16 +152,9 @@ func (c *Client) AppDelete(namespace string, names []string) (models.Application
 }
 
 // AppUpload uploads a tarball for the named app, which is later used in staging
-func (c *Client) AppUpload(namespace string, name string, tarball string) (models.UploadResponse, error) {
+func (c *Client) AppUpload(namespace string, name string, file FormFile) (models.UploadResponse, error) {
 	response := models.UploadResponse{}
 	endpoint := api.Routes.Path("AppUpload", namespace, name)
-
-	// open the tarball
-	file, err := os.Open(tarball)
-	if err != nil {
-		return response, errors.Wrap(err, "failed to open tarball")
-	}
-	defer file.Close()
 
 	requestHandler := NewFileUploadRequestHandler(file)
 	responseHandler := NewJSONResponseHandler(c.log, response)

--- a/pkg/api/core/v1/client/apps_test.go
+++ b/pkg/api/core/v1/client/apps_test.go
@@ -103,6 +103,9 @@ func DescribeAppsErrors() {
 			Entry("app running", func() (any, error) {
 				return epinioClient.AppRunning(models.AppRef{})
 			}),
+			Entry("authtoken", func() (any, error) {
+				return epinioClient.AuthToken()
+			}),
 		)
 	})
 }

--- a/pkg/api/core/v1/client/apps_test.go
+++ b/pkg/api/core/v1/client/apps_test.go
@@ -14,6 +14,7 @@ package client_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 
@@ -67,6 +68,9 @@ func DescribeAppsErrors() {
 			Entry("app create", func() (any, error) {
 				return epinioClient.AppCreate(models.ApplicationCreateRequest{}, "namespace")
 			}),
+			Entry("app get part", func() (any, error) {
+				return epinioClient.AppGetPart("namespace", "appname", "values")
+			}),
 			Entry("apps", func() (any, error) {
 				return epinioClient.Apps("namespace")
 			}),
@@ -107,5 +111,24 @@ func DescribeAppsErrors() {
 				return epinioClient.AuthToken()
 			}),
 		)
+	})
+
+	When("the app part return something", func() {
+
+		BeforeEach(func() {
+			statusCode = 200
+			responseBody = `randomdatabytes`
+		})
+
+		It("get the response", func() {
+			response, err := epinioClient.AppGetPart("namespace", "appname", "part")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+
+			b, err := io.ReadAll(response.Data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(b).To(Equal([]byte("randomdatabytes")))
+			Expect(response.ContentLength).To(BeEquivalentTo(len("randomdatabytes")))
+		})
 	})
 }

--- a/pkg/api/core/v1/client/apps_test.go
+++ b/pkg/api/core/v1/client/apps_test.go
@@ -82,6 +82,9 @@ func DescribeAppsErrors() {
 			Entry("app delete", func() (any, error) {
 				return epinioClient.AppDelete("namespace", []string{"appname"})
 			}),
+			Entry("app upload", func() (any, error) {
+				return epinioClient.AppUpload("namespace", "appname", nil)
+			}),
 			Entry("app match", func() (any, error) {
 				return epinioClient.AppMatch("namespace", "appprefix")
 			}),

--- a/pkg/api/core/v1/client/http.go
+++ b/pkg/api/core/v1/client/http.go
@@ -19,7 +19,6 @@ import (
 	"log"
 	"mime/multipart"
 	"net/http"
-	"os"
 	"path/filepath"
 
 	"github.com/epinio/epinio/helpers/termui"
@@ -75,70 +74,6 @@ func Patch[T any](c *Client, endpoint string, request any, response T) (T, error
 
 func Delete[T any](c *Client, endpoint string, request any, response T) (T, error) {
 	return Do(c, endpoint, http.MethodDelete, request, response)
-}
-
-// upload the given path as param "file" in a multipart form
-func (c *Client) upload(endpoint string, path string) ([]byte, error) {
-	uri := fmt.Sprintf("%s%s/%s", c.Settings.API, api.Root, endpoint)
-
-	// open the tarball
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to open tarball")
-	}
-	defer file.Close()
-
-	// create multipart form
-	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
-	part, err := writer.CreateFormFile("file", filepath.Base(file.Name()))
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create multiform part")
-	}
-
-	_, err = io.Copy(part, file)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to write to multiform part")
-	}
-
-	err = writer.Close()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to close multiform")
-	}
-
-	// make the request
-	request, err := http.NewRequest("POST", uri, body)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to build request")
-	}
-
-	request.Header.Add("Content-Type", writer.FormDataContentType())
-
-	err = c.handleAuthorization(request)
-	if err != nil {
-		return []byte{}, err
-	}
-
-	for key, value := range c.customHeaders {
-		request.Header.Set(key, value)
-	}
-
-	response, err := c.HttpClient.Do(request)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to POST to upload")
-	}
-
-	if response.StatusCode >= http.StatusBadRequest {
-		return nil, handleError(c.log, response)
-	}
-
-	defer response.Body.Close()
-
-	bodyBytes, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, errors.Wrap(err, "reading response")
-	}
-	return bodyBytes, nil
 }
 
 // Do will execute a common JSON http request, marshalling the provided body, and unmarshalling the httpResponse into the response struct
@@ -235,25 +170,35 @@ func NewJSONRequestHandler(body any) RequestHandler {
 	}
 }
 
+// FormFile is a file that can be used with the FileUpload request handler
+type FormFile interface {
+	io.Reader
+	Name() string
+}
+
 // NewFileUploadRequestHandler creates a multipart/form-data request to upload the provided file
-func NewFileUploadRequestHandler(file *os.File) RequestHandler {
+func NewFileUploadRequestHandler(file FormFile) RequestHandler {
 	return func(method, url string) (*http.Request, error) {
+		if file == nil {
+			return nil, errors.New("cannot create multipart form without file")
+		}
+
 		// create multipart form
 		body := &bytes.Buffer{}
 		writer := multipart.NewWriter(body)
 		part, err := writer.CreateFormFile("file", filepath.Base(file.Name()))
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create multiform part")
+			return nil, errors.Wrap(err, "failed to create multipart form")
 		}
 
 		_, err = io.Copy(part, file)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to write to multiform part")
+			return nil, errors.Wrap(err, "failed to write to multipart form")
 		}
 
 		err = writer.Close()
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to close multiform")
+			return nil, errors.Wrap(err, "failed to close multipart")
 		}
 
 		// make the request


### PR DESCRIPTION
This PR adds the `NewFileUploadRequestHandler` that will be used by the `AppUpload` API. In this way we can remove one more duplication of the HTTP client in the `upload` method.

After this the only left duplicated code is in the `AppImportGit` API, because it's doing an `application/x-www-form-urlencoded` request.

This PR adds a couple of test, and a small func to avoid the linters complaining about a too long func.
