### PR TITLE
Removed `AppImportGit` client duplication

### DIFF
--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -54,7 +54,7 @@ type APIClient interface {
 	AppUpdate(req models.ApplicationUpdateRequest, namespace string, appName string) (models.Response, error)
 	AppDelete(namespace string, names []string) (models.ApplicationDeleteResponse, error)
 	AppUpload(namespace string, name string, file client.FormFile) (models.UploadResponse, error)
-	AppImportGit(app models.AppRef, gitRef models.GitRef) (*models.ImportGitResponse, error)
+	AppImportGit(namespace string, name string, gitRef models.GitRef) (models.ImportGitResponse, error)
 	AppStage(req models.StageRequest) (*models.StageResponse, error)
 	AppDeploy(req models.DeployRequest) (*models.DeployResponse, error)
 	AppLogs(namespace, appName, stageID string, follow bool, callback func(tailer.ContainerLogLine)) error

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -162,7 +162,7 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 			return errors.New("git origin is nil")
 		}
 
-		response, err := c.API.AppImportGit(appRef, *gitOrigin)
+		response, err := c.API.AppImportGit(appRef.Namespace, appRef.Name, *gitOrigin)
 		if err != nil {
 			return errors.Wrap(err, "importing git remote")
 		}

--- a/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
+++ b/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
@@ -131,18 +131,19 @@ type FakeAPIClient struct {
 		result1 models.AppPartResponse
 		result2 error
 	}
-	AppImportGitStub        func(models.AppRef, models.GitRef) (*models.ImportGitResponse, error)
+	AppImportGitStub        func(string, string, models.GitRef) (models.ImportGitResponse, error)
 	appImportGitMutex       sync.RWMutex
 	appImportGitArgsForCall []struct {
-		arg1 models.AppRef
-		arg2 models.GitRef
+		arg1 string
+		arg2 string
+		arg3 models.GitRef
 	}
 	appImportGitReturns struct {
-		result1 *models.ImportGitResponse
+		result1 models.ImportGitResponse
 		result2 error
 	}
 	appImportGitReturnsOnCall map[int]struct {
-		result1 *models.ImportGitResponse
+		result1 models.ImportGitResponse
 		result2 error
 	}
 	AppLogsStub        func(string, string, string, bool, func(tailer.ContainerLogLine)) error
@@ -1324,19 +1325,20 @@ func (fake *FakeAPIClient) AppGetPartReturnsOnCall(i int, result1 models.AppPart
 	}{result1, result2}
 }
 
-func (fake *FakeAPIClient) AppImportGit(arg1 models.AppRef, arg2 models.GitRef) (*models.ImportGitResponse, error) {
+func (fake *FakeAPIClient) AppImportGit(arg1 string, arg2 string, arg3 models.GitRef) (models.ImportGitResponse, error) {
 	fake.appImportGitMutex.Lock()
 	ret, specificReturn := fake.appImportGitReturnsOnCall[len(fake.appImportGitArgsForCall)]
 	fake.appImportGitArgsForCall = append(fake.appImportGitArgsForCall, struct {
-		arg1 models.AppRef
-		arg2 models.GitRef
-	}{arg1, arg2})
+		arg1 string
+		arg2 string
+		arg3 models.GitRef
+	}{arg1, arg2, arg3})
 	stub := fake.AppImportGitStub
 	fakeReturns := fake.appImportGitReturns
-	fake.recordInvocation("AppImportGit", []interface{}{arg1, arg2})
+	fake.recordInvocation("AppImportGit", []interface{}{arg1, arg2, arg3})
 	fake.appImportGitMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1350,41 +1352,41 @@ func (fake *FakeAPIClient) AppImportGitCallCount() int {
 	return len(fake.appImportGitArgsForCall)
 }
 
-func (fake *FakeAPIClient) AppImportGitCalls(stub func(models.AppRef, models.GitRef) (*models.ImportGitResponse, error)) {
+func (fake *FakeAPIClient) AppImportGitCalls(stub func(string, string, models.GitRef) (models.ImportGitResponse, error)) {
 	fake.appImportGitMutex.Lock()
 	defer fake.appImportGitMutex.Unlock()
 	fake.AppImportGitStub = stub
 }
 
-func (fake *FakeAPIClient) AppImportGitArgsForCall(i int) (models.AppRef, models.GitRef) {
+func (fake *FakeAPIClient) AppImportGitArgsForCall(i int) (string, string, models.GitRef) {
 	fake.appImportGitMutex.RLock()
 	defer fake.appImportGitMutex.RUnlock()
 	argsForCall := fake.appImportGitArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeAPIClient) AppImportGitReturns(result1 *models.ImportGitResponse, result2 error) {
+func (fake *FakeAPIClient) AppImportGitReturns(result1 models.ImportGitResponse, result2 error) {
 	fake.appImportGitMutex.Lock()
 	defer fake.appImportGitMutex.Unlock()
 	fake.AppImportGitStub = nil
 	fake.appImportGitReturns = struct {
-		result1 *models.ImportGitResponse
+		result1 models.ImportGitResponse
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeAPIClient) AppImportGitReturnsOnCall(i int, result1 *models.ImportGitResponse, result2 error) {
+func (fake *FakeAPIClient) AppImportGitReturnsOnCall(i int, result1 models.ImportGitResponse, result2 error) {
 	fake.appImportGitMutex.Lock()
 	defer fake.appImportGitMutex.Unlock()
 	fake.AppImportGitStub = nil
 	if fake.appImportGitReturnsOnCall == nil {
 		fake.appImportGitReturnsOnCall = make(map[int]struct {
-			result1 *models.ImportGitResponse
+			result1 models.ImportGitResponse
 			result2 error
 		})
 	}
 	fake.appImportGitReturnsOnCall[i] = struct {
-		result1 *models.ImportGitResponse
+		result1 models.ImportGitResponse
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/api/core/v1/client/apps_test.go
+++ b/pkg/api/core/v1/client/apps_test.go
@@ -89,6 +89,9 @@ func DescribeAppsErrors() {
 			Entry("app upload", func() (any, error) {
 				return epinioClient.AppUpload("namespace", "appname", nil)
 			}),
+			Entry("app import git", func() (any, error) {
+				return epinioClient.AppImportGit("namespace", "appname", models.GitRef{})
+			}),
 			Entry("app match", func() (any, error) {
 				return epinioClient.AppMatch("namespace", "appprefix")
 			}),

--- a/pkg/api/core/v1/client/http.go
+++ b/pkg/api/core/v1/client/http.go
@@ -19,7 +19,10 @@ import (
 	"log"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/epinio/epinio/helpers/termui"
 	api "github.com/epinio/epinio/internal/api/v1"
@@ -208,6 +211,23 @@ func NewFileUploadRequestHandler(file FormFile) RequestHandler {
 		}
 
 		request.Header.Add("Content-Type", writer.FormDataContentType())
+
+		return request, nil
+	}
+}
+
+// NewFormURLEncodedRequestHandler creates a application/x-www-form-urlencoded request encoding the provided data
+func NewFormURLEncodedRequestHandler(data url.Values) RequestHandler {
+	return func(method, url string) (*http.Request, error) {
+		encodedData := data.Encode()
+
+		request, err := http.NewRequest(method, url, strings.NewReader(encodedData))
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to build request")
+		}
+
+		request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		request.Header.Add("Content-Length", strconv.Itoa(len(encodedData)))
 
 		return request, nil
 	}


### PR DESCRIPTION
This PR removes the last http client duplication, adding a RequestHandler for the `application/x-www-form-urlencoded`, that can be used from the AppImportGit API.

It also changes the signature to have the same structure of the other APIs.