### PR TITLE
Added git URL and git provider validation

### DIFF
--- a/acceptance/api/v1/helpers_api_test.go
+++ b/acceptance/api/v1/helpers_api_test.go
@@ -30,18 +30,11 @@ func appShow(namespace, app string) models.App {
 	GinkgoHelper()
 
 	endpoint := makeEndpoint(v1.Routes.Path("AppShow", namespace, app))
-	response, err := env.Curl(http.MethodGet, endpoint, nil)
-
-	Expect(err).ToNot(HaveOccurred())
-	Expect(response).ToNot(BeNil())
-	defer response.Body.Close()
-
-	Expect(response.StatusCode).To(Equal(http.StatusOK))
-	bodyBytes, err := io.ReadAll(response.Body)
-	Expect(err).ToNot(HaveOccurred())
+	bodyBytes, statusCode := curl(http.MethodGet, endpoint, nil)
+	Expect(statusCode).To(Equal(http.StatusOK))
 
 	var responseApp models.App
-	err = json.Unmarshal(bodyBytes, &responseApp)
+	err := json.Unmarshal(bodyBytes, &responseApp)
 	Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
 	Expect(responseApp.Meta.Name).To(Equal(app))
 	Expect(responseApp.Meta.Namespace).To(Equal(namespace))
@@ -53,38 +46,34 @@ func appCreate(namespace string, body io.Reader) ([]byte, int) {
 	GinkgoHelper()
 
 	endpoint := makeEndpoint(v1.Routes.Path("AppCreate", namespace))
-
-	response, err := env.Curl(http.MethodPost, endpoint, body)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(response).ToNot(BeNil())
-	defer response.Body.Close()
-
-	bodyBytes, err := io.ReadAll(response.Body)
-	Expect(err).ToNot(HaveOccurred())
-
-	return bodyBytes, response.StatusCode
+	return curl(http.MethodPost, endpoint, body)
 }
 
 func appUpdate(namespace, app string, body io.Reader) ([]byte, int) {
 	GinkgoHelper()
 
 	endpoint := makeEndpoint(v1.Routes.Path("AppUpdate", namespace, app))
-	response, err := env.Curl(http.MethodPatch, endpoint, body)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(response).ToNot(BeNil())
-	defer response.Body.Close()
-
-	bodyBytes, err := io.ReadAll(response.Body)
-	Expect(err).ToNot(HaveOccurred())
-
-	return bodyBytes, response.StatusCode
+	return curl(http.MethodPatch, endpoint, body)
 }
 
 func appValidateCV(namespace, app string) ([]byte, int) {
 	GinkgoHelper()
 
 	endpoint := makeEndpoint(v1.Routes.Path("AppValidateCV", namespace, app))
-	response, err := env.Curl(http.MethodGet, endpoint, nil)
+	return curl(http.MethodGet, endpoint, nil)
+}
+
+func appDeploy(namespace, app string, body io.Reader) ([]byte, int) {
+	GinkgoHelper()
+
+	endpoint := makeEndpoint(v1.Routes.Path("AppDeploy", namespace, app))
+	return curl(http.MethodPost, endpoint, body)
+}
+
+func curl(method, endpoint string, body io.Reader) ([]byte, int) {
+	GinkgoHelper()
+
+	response, err := env.Curl(method, endpoint, body)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(response).ToNot(BeNil())
 	defer response.Body.Close()
@@ -101,6 +90,16 @@ func toJSON(request any) io.Reader {
 	b, err := json.Marshal(request)
 	Expect(err).ToNot(HaveOccurred())
 	return bytes.NewReader(b)
+}
+
+func fromJSON[T any](bodyBytes []byte) T {
+	GinkgoHelper()
+
+	t := new(T)
+	err := json.Unmarshal(bodyBytes, t)
+	Expect(err).ToNot(HaveOccurred())
+
+	return *t
 }
 
 func makeEndpoint(path string) string {
@@ -123,16 +122,6 @@ func ExpectBadRequestError(bodyBytes []byte, statusCode int, expectedErrorMsg st
 
 	Expect(statusCode).To(Equal(http.StatusBadRequest))
 
-	errorResponse := toError(bodyBytes)
+	errorResponse := fromJSON[apierrors.ErrorResponse](bodyBytes)
 	Expect(errorResponse.Errors[0].Title).To(Equal(expectedErrorMsg))
-}
-
-func toError(bodyBytes []byte) apierrors.ErrorResponse {
-	GinkgoHelper()
-
-	var errorResponse apierrors.ErrorResponse
-	err := json.Unmarshal(bodyBytes, &errorResponse)
-	Expect(err).ToNot(HaveOccurred())
-
-	return errorResponse
 }

--- a/acceptance/api/v1/helpers_api_test.go
+++ b/acceptance/api/v1/helpers_api_test.go
@@ -33,9 +33,7 @@ func appShow(namespace, app string) models.App {
 	bodyBytes, statusCode := curl(http.MethodGet, endpoint, nil)
 	Expect(statusCode).To(Equal(http.StatusOK))
 
-	var responseApp models.App
-	err := json.Unmarshal(bodyBytes, &responseApp)
-	Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+	responseApp := fromJSON[models.App](bodyBytes)
 	Expect(responseApp.Meta.Name).To(Equal(app))
 	Expect(responseApp.Meta.Namespace).To(Equal(namespace))
 
@@ -111,9 +109,7 @@ func ExpectResponseToBeOK(bodyBytes []byte, statusCode int) {
 
 	Expect(statusCode).To(Equal(http.StatusOK))
 
-	response := models.Response{}
-	err := json.Unmarshal(bodyBytes, &response)
-	Expect(err).ToNot(HaveOccurred())
+	response := fromJSON[models.Response](bodyBytes)
 	Expect(response).To(Equal(models.ResponseOK))
 }
 

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -226,6 +226,16 @@ var _ = Describe("Apps", LApplication, func() {
 			Expect(out).To(ContainSubstring("Bad --git-provider `bogus`"))
 		})
 
+		FIt("rejects a bad provider specification for a wrong git url", func() {
+			out, err := env.Epinio("", "push",
+				"--name", appName,
+				"--git", wordpress,
+				"--git-provider", "gitlab")
+			Expect(err).To(HaveOccurred(), out)
+
+			Expect(out).To(ContainSubstring("git url and provider mismatch"))
+		})
+
 		It("rejects a bad specification", func() {
 			out, err := env.Epinio("", "push",
 				"--name", appName,

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Apps", LApplication, func() {
 			Expect(out).To(ContainSubstring("Bad --git-provider `bogus`"))
 		})
 
-		FIt("rejects a bad provider specification for a wrong git url", func() {
+		It("rejects a bad provider specification for a wrong git url", func() {
 			out, err := env.Epinio("", "push",
 				"--name", appName,
 				"--git", wordpress,

--- a/internal/api/v1/application/deploy.go
+++ b/internal/api/v1/application/deploy.go
@@ -54,9 +54,13 @@ func Deploy(c *gin.Context) apierror.APIErrors {
 
 	// validate provider reference, if actually present (git origin, and specified)
 	if req.Origin.Git != nil && req.Origin.Git.Provider != "" {
-		_, err := models.GitProviderFromString(string(req.Origin.Git.Provider))
-		if err != nil {
-			return apierror.NewBadRequestErrorf("bad git provider `%s`", req.Origin.Git.Provider)
+		provider := req.Origin.Git.Provider
+		if _, err := models.GitProviderFromString(string(provider)); err != nil {
+			return apierror.NewBadRequestErrorf("bad git provider `%s`", provider)
+		}
+
+		if err := provider.ValidateURL(req.Origin.Git.URL); err != nil {
+			return apierror.NewBadRequestErrorf("validating git url: `%s`", err.Error())
 		}
 	}
 

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -162,6 +162,17 @@ func (c *EpinioClient) Push(ctx context.Context, params PushParams) error { // n
 			return errors.New("git origin is nil")
 		}
 
+		// validate provider reference, if actually present (git origin, and specified)
+		if gitOrigin.Provider != "" {
+			if _, err := models.GitProviderFromString(string(gitOrigin.Provider)); err != nil {
+				return errors.Wrapf(err, "bad git provider `%s`", gitOrigin.Provider)
+			}
+
+			if err := gitOrigin.Provider.ValidateURL(gitOrigin.URL); err != nil {
+				return errors.Wrap(err, "validating git url")
+			}
+		}
+
 		response, err := c.API.AppImportGit(appRef.Namespace, appRef.Name, *gitOrigin)
 		if err != nil {
 			return errors.Wrap(err, "importing git remote")

--- a/pkg/api/core/v1/models/app.go
+++ b/pkg/api/core/v1/models/app.go
@@ -71,6 +71,8 @@ func (p GitProvider) ValidateURL(gitURL string) error {
 		return fmt.Errorf("parsing git url `%s`", gitURL)
 	}
 
+	// The only assumption that we can do is that if the host is known (github or gitlab) then we know the provider,
+	// otherwise we cannot be sure about it, and we need to trust the user.
 	if (u.Host == "github.com" && p != ProviderGithub) ||
 		(u.Host == "gitlab.com" && p != ProviderGitlab) {
 		return fmt.Errorf("git url and provider mismatch `%s - %s`", gitURL, p)

--- a/pkg/api/core/v1/models/app.go
+++ b/pkg/api/core/v1/models/app.go
@@ -13,6 +13,8 @@ package models
 
 import (
 	"errors"
+	"fmt"
+	"net/url"
 
 	"github.com/epinio/epinio/internal/names"
 )
@@ -60,6 +62,21 @@ func GitProviderFromString(provider string) (GitProvider, error) {
 		}
 	}
 	return ProviderUnknown, errors.New("unknown provider")
+}
+
+func (p GitProvider) ValidateURL(gitURL string) error {
+	// check provider URL
+	u, err := url.Parse(gitURL)
+	if err != nil {
+		return fmt.Errorf("parsing git url `%s`", gitURL)
+	}
+
+	if (u.Host == "github.com" && p != ProviderGithub) ||
+		(u.Host == "gitlab.com" && p != ProviderGitlab) {
+		return fmt.Errorf("git url and provider mismatch `%s - %s`", gitURL, p)
+	}
+
+	return nil
 }
 
 type ApplicationStatus string

--- a/pkg/api/core/v1/models/app_test.go
+++ b/pkg/api/core/v1/models/app_test.go
@@ -1,0 +1,87 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models_test
+
+import (
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GitProvider", func() {
+	It("correctly converts a right provider from a correct string", func() {
+		provider, err := models.GitProviderFromString("github")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(provider).To(Equal(models.ProviderGithub))
+
+		provider, err = models.GitProviderFromString("gitlab")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(provider).To(Equal(models.ProviderGitlab))
+
+		provider, err = models.GitProviderFromString("github_enterprise")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(provider).To(Equal(models.ProviderGithubEnterprise))
+
+		provider, err = models.GitProviderFromString("gitlab_enterprise")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(provider).To(Equal(models.ProviderGitlabEnterprise))
+
+		provider, err = models.GitProviderFromString("git")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(provider).To(Equal(models.ProviderGit))
+	})
+
+	It("fails for an unknown provider string", func() {
+		provider, err := models.GitProviderFromString("bogus")
+		Expect(err).To(HaveOccurred())
+		Expect(provider).To(Equal(models.ProviderUnknown))
+	})
+
+	It("has the right number of valid providers", func() {
+		// This test will fail when we update the length of the valid providers.
+		// This will remind us to update the tests, or the code, if needed.
+		Expect(len(models.ValidProviders)).To(Equal(5))
+	})
+
+	It("does not fail for the right git URL, or unknown", func() {
+		err := models.ProviderGithub.ValidateURL("https://github.com/user/repo")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = models.ProviderGithub.ValidateURL("https://myprivate.github.com")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = models.ProviderGitlab.ValidateURL("https://gitlab.com/user/repo")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = models.ProviderGitlab.ValidateURL("https://myprivate.gitlab.com")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("fails parsing an incorrect git URL", func() {
+		err := models.ProviderGit.ValidateURL("h://user:abc{DEf1=ghi@e")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("fails for a mismatched provider and git URL", func() {
+		err := models.ProviderGit.ValidateURL("https://github.com")
+		Expect(err).To(HaveOccurred())
+
+		err = models.ProviderGitlab.ValidateURL("https://github.com")
+		Expect(err).To(HaveOccurred())
+
+		err = models.ProviderGit.ValidateURL("https://gitlab.com")
+		Expect(err).To(HaveOccurred())
+
+		err = models.ProviderGithub.ValidateURL("https://gitlab.com")
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
This PR adds a validation for the provided Git url and the Git provider.

The only assumption that we can do is that a `github.com` or `gitlab.com` repo should be only from a `github` or `gitlab` provider. For other cases we need to trust the user, because a github/gitlab instance could have a different url.