### PR TITLE
remove remaining support for helmcontroller-based services

### DIFF
--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -2620,10 +2620,6 @@
           "type": "string",
           "x-go-name": "CatalogServiceVersion"
         },
-        "hcmanaged": {
-          "type": "boolean",
-          "x-go-name": "ManagedByHelmController"
-        },
         "internal_routes": {
           "type": "array",
           "items": {

--- a/internal/cli/usercmd/service.go
+++ b/internal/cli/usercmd/service.go
@@ -17,10 +17,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/epinio/epinio/helpers/termui"
 	"github.com/epinio/epinio/pkg/api/core/v1/client"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
-	"github.com/kyokomi/emoji"
 	"github.com/pkg/errors"
 )
 
@@ -131,17 +129,7 @@ func (c *EpinioClient) ServiceShow(serviceName string) error {
 	internalRoutes := service.InternalRoutes
 	sort.Strings(internalRoutes)
 
-	var msg *termui.Message
-	var m string
-	if service.ManagedByHelmController {
-		msg = c.ui.Exclamation()
-		m = "Managed by HelmController. Recreate to remove this dependency"
-	} else {
-		msg = c.ui.Success()
-		m = "Details:"
-	}
-
-	msg.WithTable("Key", "Value").
+	c.ui.Success().WithTable("Key", "Value").
 		WithTableRow("Name", service.Meta.Name).
 		WithTableRow("Created", service.Meta.CreatedAt.String()).
 		WithTableRow("Catalog Service", service.CatalogService).
@@ -149,7 +137,7 @@ func (c *EpinioClient) ServiceShow(serviceName string) error {
 		WithTableRow("Status", service.Status.String()).
 		WithTableRow("Used-By", strings.Join(boundApps, ", ")).
 		WithTableRow("Internal Routes", strings.Join(internalRoutes, ", ")).
-		Msg(m)
+		Msg("Details:")
 
 	if len(service.Settings) > 0 {
 		keys := []string{}
@@ -327,46 +315,20 @@ func (c *EpinioClient) ServiceList() error {
 		return nil
 	}
 
-	notes := false
-	for _, service := range services {
-		notes = notes || service.ManagedByHelmController
-	}
-
 	sort.Sort(services)
 
-	if notes {
-		msg := c.ui.Exclamation().WithTable("", "Name", "Created", "Catalog Service", "Version", "Status", "Applications")
-		for _, service := range services {
-			note := ""
-			if service.ManagedByHelmController {
-				note = emoji.Sprintf(":warning: Recreate")
-			}
-
-			msg = msg.WithTableRow(
-				note,
-				service.Meta.Name,
-				service.Meta.CreatedAt.String(),
-				service.CatalogService,
-				service.CatalogServiceVersion,
-				service.Status.String(),
-				strings.Join(service.BoundApps, ", "),
-			)
-		}
-		msg.Msg("Recreate services managed by HelmController to remove this dependency")
-	} else {
-		msg := c.ui.Success().WithTable("Name", "Created", "Catalog Service", "Version", "Status", "Applications")
-		for _, service := range services {
-			msg = msg.WithTableRow(
-				service.Meta.Name,
-				service.Meta.CreatedAt.String(),
-				service.CatalogService,
-				service.CatalogServiceVersion,
-				service.Status.String(),
-				strings.Join(service.BoundApps, ", "),
-			)
-		}
-		msg.Msg("Details:")
+	msg := c.ui.Success().WithTable("Name", "Created", "Catalog Service", "Version", "Status", "Applications")
+	for _, service := range services {
+		msg = msg.WithTableRow(
+			service.Meta.Name,
+			service.Meta.CreatedAt.String(),
+			service.CatalogService,
+			service.CatalogServiceVersion,
+			service.Status.String(),
+			strings.Join(service.BoundApps, ", "),
+		)
 	}
+	msg.Msg("Details:")
 
 	return nil
 }

--- a/internal/services/instances.go
+++ b/internal/services/instances.go
@@ -43,6 +43,9 @@ func (s *ServiceClient) Get(ctx context.Context, namespace, name string) (*model
 
 	srv, err := s.kubeClient.GetSecret(ctx, namespace, serviceName)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
 		return nil, errors.Wrap(err, "fetching the service instance")
 	}
 
@@ -226,6 +229,9 @@ func (s *ServiceClient) Delete(ctx context.Context, namespace, name string) erro
 
 	err = s.kubeClient.DeleteSecret(ctx, namespace, service)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		return errors.Wrap(err, "error deleting service secret")
 	}
 

--- a/internal/services/instances.go
+++ b/internal/services/instances.go
@@ -20,17 +20,13 @@ import (
 	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/helm"
-	"github.com/epinio/epinio/internal/helmchart"
 	"github.com/epinio/epinio/internal/names"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
-	helmapiv1 "github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1"
 	"helm.sh/helm/v3/pkg/chartutil"
 	helmdriver "helm.sh/helm/v3/pkg/storage/driver"
 	"helm.sh/helm/v3/pkg/strvals"
@@ -47,10 +43,6 @@ func (s *ServiceClient) Get(ctx context.Context, namespace, name string) (*model
 
 	srv, err := s.kubeClient.GetSecret(ctx, namespace, serviceName)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// COMPATIBILITY SUPPORT - Retry for (helm controller)-based service.
-			return s.GetForHelmController(ctx, namespace, name)
-		}
 		return nil, errors.Wrap(err, "fetching the service instance")
 	}
 
@@ -234,10 +226,6 @@ func (s *ServiceClient) Delete(ctx context.Context, namespace, name string) erro
 
 	err = s.kubeClient.DeleteSecret(ctx, namespace, service)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// COMPATIBILITY SUPPORT - Retry for (helm controller)-based service
-			return s.DeleteForHelmController(ctx, namespace, name)
-		}
 		return errors.Wrap(err, "error deleting service secret")
 	}
 
@@ -279,8 +267,7 @@ func (s *ServiceClient) DeleteAll(ctx context.Context, namespace string) error {
 		}
 	}
 
-	// COMPATIBILITY SUPPORT - Remove all (helm controller)-based services too.
-	return s.DeleteAllForHelmController(ctx, namespace)
+	return nil
 }
 
 // ListAll will return all the Epinio Service instances
@@ -356,203 +343,11 @@ func (s *ServiceClient) list(ctx context.Context, namespace string) (models.Serv
 		serviceList = append(serviceList, service)
 	}
 
-	// COMPATIBILITY SUPPORT - List (helm controller)-based services too.
-	serviceListHC, err := s.listForHelmController(ctx, namespace)
-	if err != nil {
-		return nil, errors.Wrap(err, "listing the (helm controller)-based service instances")
-	}
-
-	return append(serviceList, serviceListHC...), nil
+	return serviceList, nil
 }
 
 func serviceResourceName(name string) string {
 	return names.GenerateResourceName("s", name)
-}
-
-// -----------------------------------------------------------------------------------------------
-// COMPATIBILITY SUPPORT for services from before https://github.com/epinio/epinio/issues/1704 fix
-//
-// This is essentially all of the old Get/Delete(All)/List* functions, renamed with an added
-// `HelmController` suffix. The new functions run them in appropriate places.
-//
-// NOTE that `Create` is NOT in this list. We do not create (helm controller)-based services anymore.
-//
-
-// GetForHelmController returns a Service "instance" object if one is exist, or nil otherwise.  Also
-// returns an error if one occurs.
-func (s *ServiceClient) GetForHelmController(ctx context.Context, namespace, name string) (*models.Service, error) {
-	var service models.Service
-
-	helmChartName := names.ServiceHelmChartName(name, namespace)
-	srv, err := s.helmChartsKubeClient.Namespace(helmchart.Namespace()).Get(ctx, helmChartName, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, errors.Wrap(err, "fetching the service instance")
-	}
-
-	catalogServiceName, found := srv.GetLabels()[CatalogServiceLabelKey]
-	// Helmchart is not labeled, act as if service is "not found"
-	if !found {
-		return nil, nil
-	}
-
-	catalogServiceVersion := srv.GetLabels()[CatalogServiceVersionLabelKey]
-
-	var catalogServicePrefix string
-	_, err = s.GetCatalogService(ctx, catalogServiceName)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			catalogServicePrefix = "[Missing] "
-		} else {
-			return nil, err
-		}
-	}
-
-	targetNamespace, found, err := unstructured.NestedString(srv.UnstructuredContent(), "spec", "targetNamespace")
-	if err != nil {
-		return nil, errors.Wrapf(err, "looking up targetNamespace as a string")
-	}
-	if !found {
-		return nil, errors.New("targetNamespace field not found")
-	}
-
-	secretTypes := []string{}
-	secretTypesAnnotationValue := srv.GetAnnotations()[CatalogServiceSecretTypesAnnotation]
-	if len(secretTypesAnnotationValue) > 0 {
-		secretTypes = strings.Split(secretTypesAnnotationValue, ",")
-	}
-
-	service = models.Service{
-		Meta: models.Meta{
-			Name:      name,
-			Namespace: targetNamespace,
-			CreatedAt: srv.GetCreationTimestamp(),
-		},
-		SecretTypes:             secretTypes,
-		CatalogService:          fmt.Sprintf("%s%s", catalogServicePrefix, catalogServiceName),
-		CatalogServiceVersion:   catalogServiceVersion,
-		ManagedByHelmController: true,
-	}
-
-	logger := tracelog.NewLogger().WithName("ServiceStatus")
-
-	err = setServiceStatusAndCustomValues(&service, ctx, logger, s.kubeClient,
-		targetNamespace, helmChartName,
-		nil, // no service settings -- HC -- Will be removed anyway
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &service, nil
-}
-
-// DeleteForHelmController deletes the helmcharts that matches the given service which is installed
-// on the namespace (that's the targetNamespace).
-func (s *ServiceClient) DeleteForHelmController(ctx context.Context, namespace, service string) error {
-	err := s.helmChartsKubeClient.Namespace(helmchart.Namespace()).Delete(ctx,
-		names.ServiceHelmChartName(service, namespace),
-		metav1.DeleteOptions{},
-	)
-
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
-
-	return errors.Wrap(err, "error deleting helm chart @"+namespace+"/"+service)
-}
-
-// DeleteAllForHelmController deletes all helmcharts installed on the specified namespace.  It is
-// used to cleanup before a namespace is deleted.  The targetNamespace is not the namespace where
-// the helmchart resource resides (that would be `epinio`) but the `targetNamespace` field of the
-// helmchart.
-func (s *ServiceClient) DeleteAllForHelmController(ctx context.Context, targetNamespace string) error {
-	err := s.helmChartsKubeClient.Namespace(helmchart.Namespace()).DeleteCollection(ctx,
-		metav1.DeleteOptions{},
-		metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", TargetNamespaceLabelKey, targetNamespace),
-		},
-	)
-
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
-
-	return errors.Wrap(err, "error deleting helm charts in "+targetNamespace)
-}
-
-// listForHelmController will return all the Epinio Services available in the targeted namespace.
-// If the namespace is blank it will return all the instances from all the namespaces
-func (s *ServiceClient) listForHelmController(ctx context.Context, namespace string) (models.ServiceList, error) {
-	serviceList := models.ServiceList{}
-
-	listOpts := metav1.ListOptions{}
-	if namespace == "" {
-		listOpts.LabelSelector = fmt.Sprintf("%s,%s", ServiceNameLabelKey, CatalogServiceLabelKey)
-	} else {
-		listOpts.LabelSelector = fmt.Sprintf(
-			"%s,%s,%s=%s",
-			ServiceNameLabelKey,
-			CatalogServiceLabelKey,
-			TargetNamespaceLabelKey, namespace,
-		)
-	}
-
-	unstructuredServiceList, err := s.helmChartsKubeClient.Namespace(helmchart.Namespace()).List(ctx, listOpts)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return serviceList, nil
-		}
-		return nil, errors.Wrap(err, "fetching the service instance")
-	}
-
-	helmChartList, err := convertUnstructuredListIntoHelmCharts(unstructuredServiceList)
-	if err != nil {
-		return nil, errors.Wrap(err, "error converting unstructured list to helm charts")
-	}
-
-	catalogServices, err := s.ListCatalogServices(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "error getting catalog services")
-	}
-
-	// catalogServiceNameMap is a lookup map to check the available Catalog Services
-	catalogServiceNameMap := map[string]struct{}{}
-	for _, catalogService := range catalogServices {
-		catalogServiceNameMap[catalogService.Meta.Name] = struct{}{}
-	}
-
-	for _, srv := range helmChartList {
-
-		catalogServiceName := srv.GetLabels()[CatalogServiceLabelKey]
-		if _, exists := catalogServiceNameMap[catalogServiceName]; !exists {
-			catalogServiceName = "[Missing] " + catalogServiceName
-		}
-
-		service := models.Service{
-			Meta: models.Meta{
-				Name:      srv.GetLabels()[ServiceNameLabelKey],
-				Namespace: srv.GetLabels()[TargetNamespaceLabelKey],
-				CreatedAt: srv.GetCreationTimestamp(),
-			},
-			CatalogService:          catalogServiceName,
-			CatalogServiceVersion:   srv.GetLabels()[CatalogServiceVersionLabelKey],
-			ManagedByHelmController: true,
-		}
-
-		logger := tracelog.NewLogger().WithName("ServiceStatus")
-
-		err = setServiceStatusAndCustomValues(&service, ctx, logger, s.kubeClient, srv.Spec.TargetNamespace, srv.Name, nil /* no service settings - list, and HC, to be removed */)
-		if err != nil {
-			return nil, err
-		}
-
-		serviceList = append(serviceList, service)
-	}
-
-	return serviceList, nil
 }
 
 func NewServiceStatusFromHelmRelease(status helm.ReleaseStatus) models.ServiceStatus {
@@ -564,22 +359,6 @@ func NewServiceStatusFromHelmRelease(status helm.ReleaseStatus) models.ServiceSt
 	default:
 		return models.ServiceStatusUnknown
 	}
-}
-
-func convertUnstructuredListIntoHelmCharts(unstructuredList *unstructured.UnstructuredList) ([]helmapiv1.HelmChart, error) {
-	helmChartList := []helmapiv1.HelmChart{}
-
-	for _, srv := range unstructuredList.Items {
-		helmChart := helmapiv1.HelmChart{}
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(srv.Object, &helmChart)
-		if err != nil {
-			return nil, errors.Wrap(err, "error converting helmchart")
-		}
-
-		helmChartList = append(helmChartList, helmChart)
-	}
-
-	return helmChartList, nil
 }
 
 func getEpinioValues(serviceName, catalogServiceName string) (string, error) {

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -354,15 +354,14 @@ type ServiceUnbindRequest struct {
 }
 
 type Service struct {
-	Meta                    Meta               `json:"meta,omitempty"`
-	SecretTypes             []string           `json:"secretTypes,omitempty"`
-	CatalogService          string             `json:"catalog_service,omitempty"`
-	CatalogServiceVersion   string             `json:"catalog_service_version,omitempty"`
-	Status                  ServiceStatus      `json:"status,omitempty"`
-	BoundApps               []string           `json:"boundapps"`
-	ManagedByHelmController bool               `json:"hcmanaged"`
-	InternalRoutes          []string           `json:"internal_routes,omitempty"`
-	Settings                ChartValueSettings `json:"settings,omitempty"`
+	Meta                  Meta               `json:"meta,omitempty"`
+	SecretTypes           []string           `json:"secretTypes,omitempty"`
+	CatalogService        string             `json:"catalog_service,omitempty"`
+	CatalogServiceVersion string             `json:"catalog_service_version,omitempty"`
+	Status                ServiceStatus      `json:"status,omitempty"`
+	BoundApps             []string           `json:"boundapps"`
+	InternalRoutes        []string           `json:"internal_routes,omitempty"`
+	Settings              ChartValueSettings `json:"settings,omitempty"`
 }
 
 func (s Service) Namespace() string {


### PR DESCRIPTION
fix #2452

note: service model field `hcmanaged` is kept for unknown clients using it. It will simply never be `true` any longer.

@richard-cox Does the Web UI use this field ?
The CLI used it to highlight these old-style services when showing service details and lists, and nag the user about converting them to the new style (i.e. delete and re-create).
