### PR TITLE
Support array index syntax and deeper object nesting for custom values of services.

### DIFF
--- a/acceptance/helpers/catalog/misc.go
+++ b/acceptance/helpers/catalog/misc.go
@@ -56,6 +56,9 @@ func NginxCatalogService(name string) models.CatalogService {
 			"other.sequence": {
 				Type: "string",
 			},
+			"nesting": {
+				Type: "map",
+			},
 		},
 	}
 }

--- a/acceptance/helpers/catalog/misc.go
+++ b/acceptance/helpers/catalog/misc.go
@@ -50,6 +50,12 @@ func NginxCatalogService(name string) models.CatalogService {
 			"ingress.hostname": {
 				Type: "string",
 			},
+			"sequence": {
+				Type: "string",
+			},
+			"other.sequence": {
+				Type: "string",
+			},
 		},
 	}
 }

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -190,6 +190,9 @@ var _ = Describe("Services", LService, func() {
 					catalogService.Meta.Name, serviceName,
 					"--chart-value", "ingress.enabled=true",
 					"--chart-value", "ingress.hostname="+serviceHostname,
+					"--chart-value", "sequence[0]=alpha",
+					"--chart-value", "sequence[1]=omega",
+					"--chart-value", "other[0].sequence=delta",
 					"--wait",
 				)
 				Expect(err).ToNot(HaveOccurred(), out)
@@ -207,6 +210,8 @@ var _ = Describe("Services", LService, func() {
 						WithHeaders("KEY", "VALUE"),
 						WithRow("ingress.enabled", "true"),
 						WithRow("ingress.hostname", serviceHostname),
+						WithRow("sequence", `\[alpha omega\]`),
+						WithRow("other", `\[map\[sequence:delta\]\]`),
 					),
 				)
 			})

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -210,10 +210,10 @@ var _ = Describe("Services", LService, func() {
 					HaveATable(
 						WithHeaders("KEY", "VALUE"),
 						WithRow("ingress.enabled", "true"),
-						WithRow("ingress.hostname", serviceHostname),
-						WithRow("nesting", `map\[here:map\[hello:world\]\]`),
-						WithRow("other", `\[map\[sequence:delta\]\]`),
-						WithRow("sequence", `\[alpha omega\]`),
+						WithRow("ingress.hostname", `"`+serviceHostname+`"`),
+						WithRow("nesting", `{"here":{"hello":"world"}}`),
+						WithRow("other", `\[{"sequence":"delta"}\]`),
+						WithRow("sequence", `\["alpha","omega"\]`),
 					),
 				)
 			})

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -193,6 +193,7 @@ var _ = Describe("Services", LService, func() {
 					"--chart-value", "sequence[0]=alpha",
 					"--chart-value", "sequence[1]=omega",
 					"--chart-value", "other[0].sequence=delta",
+					"--chart-value", "nesting.here.hello=world",
 					"--wait",
 				)
 				Expect(err).ToNot(HaveOccurred(), out)
@@ -210,8 +211,9 @@ var _ = Describe("Services", LService, func() {
 						WithHeaders("KEY", "VALUE"),
 						WithRow("ingress.enabled", "true"),
 						WithRow("ingress.hostname", serviceHostname),
-						WithRow("sequence", `\[alpha omega\]`),
+						WithRow("nesting", `map\[here:map\[hello:world\]\]`),
 						WithRow("other", `\[map\[sequence:delta\]\]`),
+						WithRow("sequence", `\[alpha omega\]`),
 					),
 				)
 			})

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -70,7 +70,32 @@ func ValidateCV(cv models.ChartValueSettings, decl map[string]models.ChartSettin
 
 		spec, found := decl[keybase]
 		if !found {
-			issues = append(issues, fmt.Errorf(`Setting "%s": Not known`, keybase))
+			// Shorten the key incrementally to see if a prefix exists and is a map.
+
+			nestedmap := false
+			pieces := strings.Split(keybase, ".")
+			pieces = pieces[0 : len(pieces)-1]
+
+			for len(pieces) > 0 {
+				prefix := strings.Join(pieces, ".")
+
+				spec, found := decl[prefix]
+				if found && spec.Type == "map" {
+					nestedmap = true
+					break
+				}
+
+				pieces = pieces[0 : len(pieces)-1]
+			}
+
+			if !nestedmap {
+				issues = append(issues, fmt.Errorf(`Setting "%s": Not known`, keybase))
+			}
+			continue
+		}
+
+		// Maps are not checked deeper.
+		if spec.Type == "map" {
 			continue
 		}
 

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -56,17 +56,28 @@ func ValidateCV(cv models.ChartValueSettings, decl map[string]models.ChartSettin
 
 	var issues []error
 
+	// Pattern to strip array index syntax from the actual key to determine the underlying base
+	// setting to check against. Note that this handles inner array syntax too.
+	//
+	// Examples:	                               KEY                           KEYBASE
+	//   --set 'keycloak.ingress.hosts[0]=auth1' ~ 'keycloak.ingress.hosts[0]' ~ 'keycloak.ingress.hosts'
+	//   --set 'servers[0].port=80'              ~ 'servers[0].port'           ~ 'servers.port'
+
+	rex := regexp.MustCompile(`\[[^]]\]`)
+
 	for key, value := range cv {
-		spec, found := decl[key]
+		keybase := rex.ReplaceAllString(key, "")
+
+		spec, found := decl[keybase]
 		if !found {
-			issues = append(issues, fmt.Errorf(`Setting "%s": Not known`, key))
+			issues = append(issues, fmt.Errorf(`Setting "%s": Not known`, keybase))
 			continue
 		}
 
 		// Note: The interface{} result for the properly typed value is ignored here. We do
 		// not care about the value, just that it is ok.
 
-		_, err := helm.ValidateField(key, value, spec)
+		_, err := helm.ValidateField(keybase, value, spec)
 		if err != nil {
 			issues = append(issues, err)
 		}

--- a/internal/cli/usercmd/settings.go
+++ b/internal/cli/usercmd/settings.go
@@ -52,6 +52,9 @@ func settingToString(spec models.ChartSetting) string {
 	if spec.Type == "bool" {
 		return ""
 	}
+	if spec.Type == "map" {
+		return ""
+	}
 	if spec.Type == "string" {
 		if len(spec.Enum) > 0 {
 			return strings.Join(spec.Enum, ", ")

--- a/internal/services/instances.go
+++ b/internal/services/instances.go
@@ -13,6 +13,7 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -471,13 +472,21 @@ func setServiceStatusAndCustomValues(service *models.Service,
 func getValue(values chartutil.Values, key string, maybetable bool) (string, error) {
 	value, err := values.PathValue(key)
 	if err == nil {
-		valueAsString := fmt.Sprintf("%v", value)
+		data, err := json.Marshal(value)
+		if err != nil {
+			return "", err
+		}
+		valueAsString := string(data)
 		return valueAsString, nil
 	}
 	if maybetable {
 		tvalue, terr := values.Table(key)
 		if terr == nil {
-			valueAsString := fmt.Sprintf("%v", tvalue)
+			data, err := json.Marshal(tvalue)
+			if err != nil {
+				return "", err
+			}
+			valueAsString := string(data)
 			return valueAsString, nil
 		}
 	}

--- a/internal/services/instances.go
+++ b/internal/services/instances.go
@@ -439,6 +439,24 @@ func setServiceStatusAndCustomValues(service *models.Service,
 			if err != nil {
 				// Not found - This custom value was not customized by the user.
 				// That is ok. Nothing to report.
+				// Actually, it may be customized using array syntax.
+				// Then it is not a pure nested map anymore. Trial this out.
+				// Done by checking shorter keys, starting from the longest.
+
+				pieces := strings.Split(key, ".")
+				pieces = pieces[0 : len(pieces)-1]
+
+				for len(pieces) > 0 {
+					key := strings.Join(pieces, ".")
+					customValue, err := configValues.PathValue(key)
+					if err == nil {
+						customValueAsString := fmt.Sprintf("%v", customValue)
+						customized[key] = customValueAsString
+						break
+					}
+					pieces = pieces[0 : len(pieces)-1]
+				}
+
 				continue
 			}
 			customValueAsString := fmt.Sprintf("%v", customValue)


### PR DESCRIPTION
fix #2401

also fixes an issue with deleting a partially created service (kube secret, no helm release) exposed during testing.

### Testing

1. Make a copy of one of the services in the catalog, and add the settings below to its CR. Or just modify one of the entries by adding the settings to the CR. Then deploy E with the new or modified service. __Note__: The chosen settings have nothing to do with the settings of the services. That is ok. It means that playing with them will not affect service deployment.
2. Create service instances with various forms of custom values. See below for possibilities to test
3. Use `epinio service show ...` to see the custom values set on creation are returned/shown, and the correct.
4. The command `helm get values ...` can also be used show the full set of values. This has to be pointed at the helm release underlying the service. Note further that all our bitnami services will have a very large `extraDeploy` field in the returned values to confuse things. The customized settings should be at the end, after it.

```
 settings:
    "frobni.blag":
      type: string
```

  - `-v frobni.blag=foo`

    Regular setting, supported before the change, still supported.

  - `-v 'frobni.blag[0]=foo' -v 'frobni.blag[1]=bar'`

    Make `blag` an array holding `foo` and `bar`.

  - `-v 'frobni[0].blag=foo' -v 'frobni[1].blag=bar'`

    Make `frobni`! an array of maps. Each contains a `blag=...` assignment.

  - `-v 'frobni.blag[0]=foo' -v 'frobni[0].blag=bar'`

    __Mismatch__ :boom: First option sets `frobni` to type map, second option then tries to use `frobni` as type array.
    This fails, and leaves a partially created service instance behind (secret, but not helm release).
    __Note__ The first commits of the PR ensure that such a partial service can be deleted again!

:warning: Attention :warning: 

  - `-v 'frobni.blag={foo,bar}'`

    This syntax for array values, while supported by `helm`, is __not__ supported by E. The issue is that the `Cobra` package we use for command line processing does its own handling of the `,` character for list-type flags, which `-v` is. This interferes with what we would have liked to have here.