### PR TITLE
fix mishandling of env assignments with spaces in var name and/or value

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -105,6 +105,7 @@ var _ = Describe("Apps", LApplication, func() {
 					"--env", "CREDO=up",
 					"--env", "DOGMA=no",
 					"--env", "COMPLEX=-X foo=bar",
+					"--env", "COMPLEXB=-Xbab -Xaba",
 				)
 				Expect(err).ToNot(HaveOccurred(), out)
 				Expect(out).To(ContainSubstring("Ok"))
@@ -125,6 +126,7 @@ var _ = Describe("Apps", LApplication, func() {
 						WithRow("Bound Configurations", configurationName),
 						WithRow("Environment", ""),
 						WithRow("- COMPLEX", "-X foo=bar"),
+						WithRow("- COMPLEXB", "-Xbab -Xaba"),
 						WithRow("- CREDO", "up"),
 						WithRow("- DOGMA", "no"),
 					),

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -197,7 +197,12 @@ var _ = Describe("Apps", LApplication, func() {
 
 			It("creates the workload", func() {
 				appDir := "../assets/sample-app"
-				out, err := env.EpinioPush(appDir, appName, "--name", appName)
+				out, err := env.EpinioPush(appDir, appName, "--name", appName,
+					"--env", "CREDO=up",
+					"--env", "DOGMA=no",
+					"--env", "COMPLEX=-X foo=bar",
+					"--env", "COMPLEXB=-Xbab -Xaba",
+				)
 				Expect(err).ToNot(HaveOccurred(), out)
 				Expect(out).To(ContainSubstring("App is online"))
 			})


### PR DESCRIPTION
ref #2468 

Importing fix from https://github.com/epinio/helm-charts/pull/477
