### PR TITLE
Added support for Git configurations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -191,6 +191,7 @@ jobs:
           REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           EPINIO_TIMEOUT_MULTIPLIER: 3
+          PRIVATE_REPO_IMPORT_PAT: ${{ secrets.PRIVATE_REPO_IMPORT_PAT }}
         run: |
           rm -f /tmp/cov*
           make acceptance-cluster-setup

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -337,7 +337,7 @@ var _ = Describe("Apps", LApplication, func() {
 				Expect(out).To(ContainSubstring("authentication required"))
 			})
 
-			It("pushes the app providing a token", func() {
+			It("pushes the app when providing a proper token", func() {
 				tmpTokenDir, err := os.MkdirTemp("", "tmp-token-dir")
 				Expect(err).ToNot(HaveOccurred())
 

--- a/helpers/kubernetes/cluster.go
+++ b/helpers/kubernetes/cluster.go
@@ -48,11 +48,12 @@ const (
 )
 
 var (
-	EpinioNamespaceLabelKey     = "app.kubernetes.io/component"
-	EpinioNamespaceLabelValue   = "epinio-namespace"
-	EpinioAPISecretLabelKey     = fmt.Sprintf("%s/%s", APISGroupName, "api-user-credentials")
-	EpinioAPISecretLabelValue   = "true"
-	EpinioAPISecretRoleLabelKey = fmt.Sprintf("%s/%s", APISGroupName, "role")
+	EpinioNamespaceLabelKey         = "app.kubernetes.io/component"
+	EpinioNamespaceLabelValue       = "epinio-namespace"
+	EpinioAPISecretLabelKey         = fmt.Sprintf("%s/%s", APISGroupName, "api-user-credentials")
+	EpinioAPISecretLabelValue       = "true"
+	EpinioAPIGitCredentialsLabelKey = fmt.Sprintf("%s/%s", APISGroupName, "api-git-credentials")
+	EpinioAPISecretRoleLabelKey     = fmt.Sprintf("%s/%s", APISGroupName, "role")
 )
 
 // Memoization of GetCluster

--- a/internal/api/v1/application/importgit.go
+++ b/internal/api/v1/application/importgit.go
@@ -223,7 +223,7 @@ var (
 // checkoutRepository will clone the repository and it will checkout the revision
 // It will also try to find the matching branch/reference, and if found this will be returned
 func checkoutRepository(ctx context.Context, log logr.Logger, gitRepo, url, revision string, gitconfig *gitbridge.Configuration) (*plumbing.Reference, error) {
-	cloneOptions := &git.CloneOptions{URL: url}
+	cloneOptions := git.CloneOptions{URL: url}
 	cloneOptions = loadCloneOptions(cloneOptions, gitconfig)
 
 	if revision == "" {
@@ -244,7 +244,7 @@ func checkoutRepository(ctx context.Context, log logr.Logger, gitRepo, url, revi
 
 	// we are left we the full clone option
 	log.Info("importgit, cloning plain", "url", url)
-	repo, err := git.PlainCloneContext(ctx, gitRepo, false, cloneOptions)
+	repo, err := git.PlainCloneContext(ctx, gitRepo, false, &cloneOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -279,8 +279,8 @@ func checkoutRepository(ctx context.Context, log logr.Logger, gitRepo, url, revi
 	return ref, nil
 }
 
-func loadCloneOptions(opts *git.CloneOptions, config *gitbridge.Configuration) *git.CloneOptions {
-	if config == nil || opts == nil {
+func loadCloneOptions(opts git.CloneOptions, config *gitbridge.Configuration) git.CloneOptions {
+	if config == nil {
 		return opts
 	}
 
@@ -300,10 +300,10 @@ func loadCloneOptions(opts *git.CloneOptions, config *gitbridge.Configuration) *
 	return opts
 }
 
-func shallowCheckout(ctx context.Context, gitRepo string, opts *git.CloneOptions) (*plumbing.Reference, error) {
+func shallowCheckout(ctx context.Context, gitRepo string, opts git.CloneOptions) (*plumbing.Reference, error) {
 	opts.Depth = 1
 
-	repo, err := git.PlainCloneContext(ctx, gitRepo, false, opts)
+	repo, err := git.PlainCloneContext(ctx, gitRepo, false, &opts)
 	if err != nil {
 		return nil, err
 	}
@@ -311,12 +311,12 @@ func shallowCheckout(ctx context.Context, gitRepo string, opts *git.CloneOptions
 	return repo.Head()
 }
 
-func branchCheckout(ctx context.Context, gitRepo, revision string, opts *git.CloneOptions) (*plumbing.Reference, error) {
+func branchCheckout(ctx context.Context, gitRepo, revision string, opts git.CloneOptions) (*plumbing.Reference, error) {
 	opts.Depth = 1
 	opts.SingleBranch = true
 	opts.ReferenceName = plumbing.NewBranchReferenceName(revision)
 
-	repo, err := git.PlainCloneContext(ctx, gitRepo, false, opts)
+	repo, err := git.PlainCloneContext(ctx, gitRepo, false, &opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/v1/application/importgit.go
+++ b/internal/api/v1/application/importgit.go
@@ -85,11 +85,13 @@ import (
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-logr/logr"
 
 	"github.com/epinio/epinio/helpers"
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
+	gitbridge "github.com/epinio/epinio/internal/bridge/git"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/helmchart"
 	"github.com/epinio/epinio/internal/s3manager"
@@ -115,17 +117,39 @@ func ImportGit(c *gin.Context) apierror.APIErrors {
 		return errGitURL
 	}
 
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		return apierror.InternalError(err, "failed to get access to a kube client")
+	}
+
+	gitManager, err := gitbridge.NewManager(log, cluster.Kubectl.CoreV1().Secrets(helmchart.Namespace()))
+	if err != nil {
+		return apierror.InternalError(err, "creating git configuration manager")
+	}
+
 	gitRepo, err := os.MkdirTemp("", "epinio-app")
 	if err != nil {
 		return apierror.InternalError(err, "can't create temp directory")
 	}
 	defer os.RemoveAll(gitRepo)
 
-	// clone/fetch/checkout
-	ref, err := checkoutRepository(ctx, log, gitRepo, giturl, revision)
+	gitConfig, err := gitManager.FindConfiguration(giturl)
 	if err != nil {
-		return apierror.InternalError(err,
-			fmt.Sprintf("cloning the git repository: %s @ %s", giturl, revision))
+		errMsg := fmt.Sprintf("finding git configuration for gitURL [%s]", giturl)
+		return apierror.InternalError(err, errMsg)
+	}
+
+	if gitConfig != nil {
+		log.Info("loaded git config", "gitConfig", gitConfig.ID)
+	} else {
+		log.Info("git config not found for giturl", "giturl", giturl)
+	}
+
+	// clone/fetch/checkout
+	ref, err := checkoutRepository(ctx, log, gitRepo, giturl, revision, gitConfig)
+	if err != nil {
+		errMsg := fmt.Sprintf("cloning the git repository: %s @ %s", giturl, revision)
+		return apierror.InternalError(err, errMsg)
 	}
 
 	var branch string
@@ -147,10 +171,6 @@ func ImportGit(c *gin.Context) apierror.APIErrors {
 	}
 
 	// Upload to S3
-	cluster, err := kubernetes.GetCluster(ctx)
-	if err != nil {
-		return apierror.InternalError(err, "failed to get access to a kube client")
-	}
 	connectionDetails, err := s3manager.GetConnectionDetails(ctx, cluster, helmchart.Namespace(), "epinio-s3-connection-details")
 	if err != nil {
 		return apierror.InternalError(err, "fetching the S3 connection details from the Kubernetes secret")
@@ -202,14 +222,17 @@ var (
 
 // checkoutRepository will clone the repository and it will checkout the revision
 // It will also try to find the matching branch/reference, and if found this will be returned
-func checkoutRepository(ctx context.Context, log logr.Logger, gitRepo, url, revision string) (*plumbing.Reference, error) {
+func checkoutRepository(ctx context.Context, log logr.Logger, gitRepo, url, revision string, gitconfig *gitbridge.Configuration) (*plumbing.Reference, error) {
+	cloneOptions := &git.CloneOptions{URL: url}
+	cloneOptions = loadCloneOptions(cloneOptions, gitconfig)
+
 	if revision == "" {
 		// Input A: repository, no revision.
 		log.Info("importgit, cloning simple", "url", url)
-		return shallowCheckout(ctx, gitRepo, url)
+		return shallowCheckout(ctx, gitRepo, cloneOptions)
 	}
 
-	ref, err := branchCheckout(ctx, gitRepo, url, revision)
+	ref, err := branchCheckout(ctx, gitRepo, revision, cloneOptions)
 	// it was a branch, and everything went fine
 	if err == nil {
 		return ref, nil
@@ -221,7 +244,7 @@ func checkoutRepository(ctx context.Context, log logr.Logger, gitRepo, url, revi
 
 	// we are left we the full clone option
 	log.Info("importgit, cloning plain", "url", url)
-	repo, err := git.PlainCloneContext(ctx, gitRepo, false, &git.CloneOptions{URL: url})
+	repo, err := git.PlainCloneContext(ctx, gitRepo, false, cloneOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -256,11 +279,31 @@ func checkoutRepository(ctx context.Context, log logr.Logger, gitRepo, url, revi
 	return ref, nil
 }
 
-func shallowCheckout(ctx context.Context, gitRepo, url string) (*plumbing.Reference, error) {
-	repo, err := git.PlainCloneContext(ctx, gitRepo, false, &git.CloneOptions{
-		URL:   url,
-		Depth: 1,
-	})
+func loadCloneOptions(opts *git.CloneOptions, config *gitbridge.Configuration) *git.CloneOptions {
+	if config == nil || opts == nil {
+		return opts
+	}
+
+	opts.InsecureSkipTLS = config.SkipSSL
+
+	if config.Username != "" && config.Password != "" {
+		opts.Auth = &http.BasicAuth{
+			Username: config.Username,
+			Password: config.Password,
+		}
+	}
+
+	if len(config.Certificate) > 0 {
+		opts.CABundle = config.Certificate
+	}
+
+	return opts
+}
+
+func shallowCheckout(ctx context.Context, gitRepo string, opts *git.CloneOptions) (*plumbing.Reference, error) {
+	opts.Depth = 1
+
+	repo, err := git.PlainCloneContext(ctx, gitRepo, false, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -268,18 +311,17 @@ func shallowCheckout(ctx context.Context, gitRepo, url string) (*plumbing.Refere
 	return repo.Head()
 }
 
-func branchCheckout(ctx context.Context, gitRepo, url, revision string) (*plumbing.Reference, error) {
-	repo, err := git.PlainCloneContext(ctx, gitRepo, false, &git.CloneOptions{
-		URL:           url,
-		SingleBranch:  true,
-		ReferenceName: plumbing.NewBranchReferenceName(revision),
-		Depth:         1,
-	})
-	if err == nil {
-		return repo.Head()
+func branchCheckout(ctx context.Context, gitRepo, revision string, opts *git.CloneOptions) (*plumbing.Reference, error) {
+	opts.Depth = 1
+	opts.SingleBranch = true
+	opts.ReferenceName = plumbing.NewBranchReferenceName(revision)
+
+	repo, err := git.PlainCloneContext(ctx, gitRepo, false, opts)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, err
+	return repo.Head()
 }
 
 // findReferenceForRevision will loop through all the available refs (branches, tags, ...) and it will try

--- a/internal/bridge/git/git.go
+++ b/internal/bridge/git/git.go
@@ -48,8 +48,7 @@ type Configuration struct {
 	URL      string
 	Provider models.GitProvider
 	// Username and Password are used to perform a BasicAuth.
-	// For Github the username is the one used to generate the PAT token.
-	// For Gitlab it can be anything (see https://gitlab.com/gitlab-org/gitlab/-/issues/212953).
+	// For Github/Gitlab the username can be anything (see https://gitlab.com/gitlab-org/gitlab/-/issues/212953).
 	Username string
 	// The Personal Access Token
 	Password string

--- a/internal/bridge/git/git.go
+++ b/internal/bridge/git/git.go
@@ -1,0 +1,247 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/internal/helmchart"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type SecretLister interface {
+	List(ctx context.Context, opts metav1.ListOptions) (*v1.SecretList, error)
+}
+
+type Manager struct {
+	logger         logr.Logger
+	SecretLister   SecretLister
+	Configurations []Configuration
+}
+
+// Configuration is used to setup a Git requests to a git provider.
+// The only required field is the URL, needed to check the specific instance to apply the configuration.
+// If also the UserOrg and/or the Repository are specified then the most specific configuration will be used.
+type Configuration struct {
+	// ID of the configuration (it maps to the kubernetes secret)
+	ID string
+	// URL is the full url (schema/host/port) used to match a particular instance
+	URL      string
+	Provider models.GitProvider
+	// Username and Password are used to perform a BasicAuth.
+	// For Github the username is the one used to generate the PAT token.
+	// For Gitlab it can be anything (see https://gitlab.com/gitlab-org/gitlab/-/issues/212953).
+	Username string
+	// The Personal Access Token
+	Password string
+	// UserOrg is used to specify the username/organization/project
+	UserOrg string
+	// Repository is used to specify the exact repository
+	Repository  string
+	SkipSSL     bool
+	Certificate []byte
+}
+
+func NewManager(logger logr.Logger, secretLoader SecretLister) (*Manager, error) {
+	logger = logger.WithName("GitManager")
+
+	secretSelector := labels.Set(map[string]string{
+		kubernetes.EpinioAPIGitCredentialsLabelKey: "true",
+	}).AsSelector().String()
+
+	secretList, err := secretLoader.List(context.Background(), metav1.ListOptions{LabelSelector: secretSelector})
+	if err != nil {
+		return nil, err
+	}
+	configurations := NewConfigurationsFromSecrets(secretList.Items)
+
+	configIDs := []string{}
+	for _, config := range configurations {
+		configIDs = append(configIDs, config.ID)
+	}
+
+	// Sort the configurations to fetch always the same, in case of multiple matches.
+	// This will help in case of errors because in case of multiple configurations always the same will be chosen.
+	// Having instead a different one everytime could cause sporadic errors.
+	sort.Slice(configurations, func(i, j int) bool {
+		return configurations[i].ID < configurations[j].ID
+	})
+
+	logger.V(1).Info(fmt.Sprintf("found %d git configurations [%s]", len(configurations), strings.Join(configIDs, ", ")))
+
+	return &Manager{
+		logger:         logger,
+		SecretLister:   secretLoader,
+		Configurations: configurations,
+	}, nil
+}
+
+func NewConfigurationsFromSecrets(secrets []v1.Secret) []Configuration {
+	configs := make([]Configuration, 0, len(secrets))
+
+	for _, sec := range secrets {
+		config := &Configuration{
+			ID:          string(sec.Name),
+			URL:         string(sec.Data["url"]),
+			Username:    string(sec.Data["username"]),
+			Password:    string(sec.Data["password"]),
+			UserOrg:     string(sec.Data["userOrg"]),
+			Repository:  string(sec.Data["repo"]),
+			Certificate: sec.Data["certificate"],
+		}
+
+		// the func is always returning a provider, if err a models.ProviderUnknown
+		config.Provider, _ = models.GitProviderFromString(string(sec.Data["provider"]))
+
+		skipSSLVal, found := sec.Data["skipSSL"]
+		// if not found skipSSL is false, otherwise it needs to be "true"
+		if found && strings.ToLower(string(skipSSLVal)) == "true" {
+			config.SkipSSL = true
+		}
+
+		configs = append(configs, *config)
+	}
+
+	return configs
+}
+
+func NewSecretFromConfiguration(config Configuration) v1.Secret {
+	// helper to set the value in the map, if present
+	setValue := func(m map[string][]byte, key, value string) map[string][]byte {
+		if len(value) > 0 {
+			m[key] = []byte(value)
+		}
+		return m
+	}
+
+	dataMap := make(map[string][]byte)
+
+	dataMap = setValue(dataMap, "url", string(config.URL))
+	dataMap = setValue(dataMap, "provider", string(config.Provider))
+	dataMap = setValue(dataMap, "username", string(config.Username))
+	dataMap = setValue(dataMap, "password", string(config.Password))
+	dataMap = setValue(dataMap, "userOrg", string(config.UserOrg))
+	dataMap = setValue(dataMap, "repo", string(config.Repository))
+	dataMap = setValue(dataMap, "certificate", string(config.Certificate))
+
+	if config.SkipSSL {
+		dataMap = setValue(dataMap, "skipSSL", "true")
+	} else {
+		dataMap = setValue(dataMap, "skipSSL", "false")
+	}
+
+	return v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.ID,
+			Namespace: helmchart.Namespace(),
+			Labels: map[string]string{
+				kubernetes.EpinioAPIGitCredentialsLabelKey: "true",
+			},
+		},
+		Data: dataMap,
+	}
+}
+
+// FindConfiguration will load the most specific Configuration for the provided gitUrl.
+// A gitURL is a full git repo url like 'https://github.com/username/repo'
+func (m *Manager) FindConfiguration(gitURL string) (*Configuration, error) {
+
+	// We could have multiple configurations that are valid for a specific provider
+	// and we need to find the most specific one.
+	availableConfigurations := map[string][]Configuration{}
+
+	gitInfo, err := newGitRepoInfoFromURL(gitURL)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, config := range m.Configurations {
+		// create the key for this config
+		configMapKey := config.URL
+		if config.UserOrg != "" {
+			configMapKey = fmt.Sprintf("%s/%s", config.URL, config.UserOrg)
+		}
+		if config.Repository != "" {
+			configMapKey = fmt.Sprintf("%s/%s/%s", config.URL, config.UserOrg, config.Repository)
+		}
+
+		// append the config to the available configurations
+		configsForKey, found := availableConfigurations[configMapKey]
+		if !found {
+			configsForKey = []Configuration{}
+		}
+		availableConfigurations[configMapKey] = append(configsForKey, config)
+	}
+
+	// now we need to check if there is a configuration available for the specific repo,
+	// or for the userOrg, or at least for the provider.
+	// I.e. if we have a config for the 'https://github.com/username/repo' we should return it,
+	// otherwise we could return the more generic config for the 'https://github.com/username'
+	// or the global 'https://github.com' configuration
+
+	toMatch := fmt.Sprintf("%s/%s/%s", gitInfo.URL, gitInfo.UserOrg, gitInfo.Repository)
+	if userOrgRepoConfigs, found := availableConfigurations[toMatch]; found {
+		return &userOrgRepoConfigs[0], nil
+	}
+
+	toMatch = fmt.Sprintf("%s/%s", gitInfo.URL, gitInfo.UserOrg)
+	if userOrgRepoConfigs, found := availableConfigurations[toMatch]; found {
+		return &userOrgRepoConfigs[0], nil
+	}
+
+	if userOrgRepoConfigs, found := availableConfigurations[gitInfo.URL]; found {
+		return &userOrgRepoConfigs[0], nil
+	}
+
+	return nil, nil
+}
+
+type gitRepoInfo struct {
+	URL        string
+	UserOrg    string
+	Repository string
+}
+
+// newGitRepoInfoFromURL will create a gitRepoInfo from the full git URL
+func newGitRepoInfoFromURL(gitURL string) (*gitRepoInfo, error) {
+	url, err := url.Parse(gitURL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parsing gitURL [%s]", gitURL)
+	}
+
+	// gitRepoHost has the host of the gitURL, i.e.: https://github.com
+	gitRepoHost := fmt.Sprintf("%s://%s", url.Scheme, url.Host)
+
+	path := strings.TrimPrefix(url.Path, "/")
+	orgRepoPath := strings.Split(path, "/")
+
+	info := &gitRepoInfo{
+		URL:     gitRepoHost,
+		UserOrg: orgRepoPath[0],
+	}
+
+	if len(orgRepoPath) > 1 {
+		info.Repository = orgRepoPath[1]
+	}
+
+	return info, nil
+}

--- a/internal/bridge/git/git.go
+++ b/internal/bridge/git/git.go
@@ -38,9 +38,9 @@ type Manager struct {
 	Configurations []Configuration
 }
 
-// Configuration is used to setup a Git requests to a git provider.
+// Configuration is used to customize the Git requests for a  specific git provider.
 // The only required field is the URL, needed to check the specific instance to apply the configuration.
-// If also the UserOrg and/or the Repository are specified then the most specific configuration will be used.
+// If the UserOrg and/or the Repository are also specified then the most specific configuration will be used.
 type Configuration struct {
 	// ID of the configuration (it maps to the kubernetes secret)
 	ID string

--- a/internal/bridge/git/git_suite_test.go
+++ b/internal/bridge/git/git_suite_test.go
@@ -1,0 +1,24 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGit(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Git Suite")
+}

--- a/internal/bridge/git/git_test.go
+++ b/internal/bridge/git/git_test.go
@@ -1,0 +1,325 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git_test
+
+import (
+	"context"
+	"math/rand"
+
+	"github.com/epinio/epinio/internal/bridge/git"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type mockSecretLister struct {
+	list *v1.SecretList
+	err  error
+}
+
+func (m *mockSecretLister) List(ctx context.Context, opts metav1.ListOptions) (*v1.SecretList, error) {
+	return m.list, m.err
+}
+
+var _ = Describe("Manager", func() {
+	Describe("NewManager", func() {
+		When("multiple secrets are found", func() {
+			It("returns the configurations in the same order", func() {
+				secrets := []v1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: "ccc"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "aaa"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "ddd"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "bbb"}},
+				}
+
+				rand.Shuffle(len(secrets), func(i, j int) {
+					secrets[i], secrets[j] = secrets[j], secrets[i]
+				})
+
+				mockSecretLister := &mockSecretLister{list: &v1.SecretList{Items: secrets}}
+
+				gitManager, err := git.NewManager(logr.Discard(), mockSecretLister)
+				Expect(err).To(BeNil())
+
+				Expect(gitManager.Configurations[0].ID).To(Equal("aaa"))
+				Expect(gitManager.Configurations[1].ID).To(Equal("bbb"))
+				Expect(gitManager.Configurations[2].ID).To(Equal("ccc"))
+				Expect(gitManager.Configurations[3].ID).To(Equal("ddd"))
+			})
+		})
+	})
+
+	Describe("FindConfiguration", func() {
+		When("configurations are empty", func() {
+			It("returns no configuration", func() {
+				manager := &git.Manager{Configurations: []git.Configuration{}}
+
+				config, err := manager.FindConfiguration("https://github.com/username/repo")
+				Expect(config).To(BeNil())
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("configurations are not matching", func() {
+			It("returns no configuration", func() {
+				configs := []git.Configuration{
+					newConfiguration("another", "https://another.com", "", ""),
+					newConfiguration("gitlab", "https://gitlab.com", "", ""),
+					newConfiguration("github-username-repo2", "https://github.com", "username", "repo2"),
+					newConfiguration("github-username2", "https://github.com", "username2", ""),
+				}
+
+				manager := &git.Manager{Configurations: configs}
+
+				config, err := manager.FindConfiguration("https://github.com/username/repo")
+				Expect(config).To(BeNil())
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("a configuration for a whole provider is matching", func() {
+			It("returns the provider configuration", func() {
+				configs := []git.Configuration{
+					newConfiguration("another", "https://another.com", "", ""),
+					newConfiguration("gitlab", "https://gitlab.com", "", ""),
+					newConfiguration("github", "https://github.com", "", ""),
+					newConfiguration("github-username-repo2", "https://github.com", "username", "repo2"),
+					newConfiguration("github-username2", "https://github.com", "username2", ""),
+				}
+
+				manager := &git.Manager{Configurations: configs}
+
+				config, err := manager.FindConfiguration("https://github.com/username/repo")
+				Expect(config).ToNot(BeNil())
+				Expect(err).To(BeNil())
+				Expect(config.ID).To(Equal("github"))
+			})
+		})
+
+		When("a configuration for the org is matching", func() {
+			It("returns the org configuration", func() {
+				configs := []git.Configuration{
+					newConfiguration("another", "https://another.com", "", ""),
+					newConfiguration("gitlab", "https://gitlab.com", "", ""),
+					newConfiguration("github", "https://github.com", "", ""),
+					newConfiguration("github-username-repo2", "https://github.com", "username", "repo2"),
+					newConfiguration("github-username", "https://github.com", "username", ""),
+					newConfiguration("github-username2", "https://github.com", "username2", ""),
+				}
+
+				manager := &git.Manager{Configurations: configs}
+
+				config, err := manager.FindConfiguration("https://github.com/username/repo")
+				Expect(config).ToNot(BeNil())
+				Expect(err).To(BeNil())
+				Expect(config.ID).To(Equal("github-username"))
+			})
+		})
+
+		When("a configuration for a repo exists", func() {
+			It("returns the specific configuration", func() {
+				configs := []git.Configuration{
+					newConfiguration("another", "https://another.com", "", ""),
+					newConfiguration("gitlab", "https://gitlab.com", "", ""),
+					newConfiguration("github", "https://github.com", "", ""),
+					newConfiguration("github-username-repo", "https://github.com", "username", "repo"),
+					newConfiguration("github-username-repo2", "https://github.com", "username", "repo2"),
+					newConfiguration("github-username", "https://github.com", "username", ""),
+					newConfiguration("github-username2", "https://github.com", "username2", ""),
+				}
+
+				manager := &git.Manager{Configurations: configs}
+
+				config, err := manager.FindConfiguration("https://github.com/username/repo2")
+				Expect(config).ToNot(BeNil())
+				Expect(err).To(BeNil())
+				Expect(config.ID).To(Equal("github-username-repo2"))
+			})
+		})
+
+		When("multiple org and repo configurations matches", func() {
+			It("returns the most specific one", func() {
+				configs := []git.Configuration{
+					newConfiguration("another", "https://another.com", "", ""),
+					newConfiguration("gitlab", "https://gitlab.com", "", ""),
+					newConfiguration("github", "https://github.com", "", ""),
+					newConfiguration("github-username-repo", "https://github.com", "username", "repo"),
+					newConfiguration("github-username-repo2", "https://github.com", "username", "repo2"),
+					newConfiguration("github-username", "https://github.com", "username", ""),
+					newConfiguration("github-username2", "https://github.com", "username2", ""),
+				}
+
+				manager := &git.Manager{Configurations: configs}
+
+				config, err := manager.FindConfiguration("https://github.com/username/repo2")
+				Expect(config).ToNot(BeNil())
+				Expect(err).To(BeNil())
+				Expect(config.ID).To(Equal("github-username-repo2"))
+			})
+		})
+
+		When("multiple specific configurations matches", func() {
+			It("returns the first one, ordered by ID", func() {
+				configs := []git.Configuration{
+					newConfiguration("github-username-repo-1", "https://github.com", "username", "repo"),
+					newConfiguration("github-username-repo-2", "https://github.com", "username", "repo"),
+					newConfiguration("github-username-repo-3", "https://github.com", "username", "repo"),
+				}
+
+				manager := &git.Manager{Configurations: configs}
+
+				config, err := manager.FindConfiguration("https://github.com/username/repo")
+				Expect(config).ToNot(BeNil())
+				Expect(err).To(BeNil())
+				Expect(config.ID).To(Equal("github-username-repo-1"))
+			})
+		})
+	})
+
+	Describe("NewSecretFromConfiguration", func() {
+		When("some secrets exists", func() {
+			It("returns the expected configurations", func() {
+				configs := git.NewConfigurationsFromSecrets([]v1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "my-config"},
+						Data: map[string][]byte{
+							"url":         []byte("giturl"),
+							"provider":    []byte("github"),
+							"username":    []byte("myuser"),
+							"password":    []byte("mypass"),
+							"userOrg":     []byte("myuserorg"),
+							"repo":        []byte("myrepo"),
+							"skipSSL":     []byte("true"),
+							"certificate": []byte("----CERT----"),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "my-config-skipssl-false"},
+						Data: map[string][]byte{
+							"skipSSL": []byte("false"),
+						},
+					},
+
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "my-config-skipssl-anything"},
+						Data: map[string][]byte{
+							"skipSSL": []byte("anything"),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "my-config-provider-unknown"},
+						Data: map[string][]byte{
+							"provider": []byte("sdjnksd"),
+						},
+					},
+				})
+
+				Expect(configs).ToNot(BeNil())
+				Expect(configs).To(HaveLen(4))
+
+				Expect(configs[0].ID).To(Equal("my-config"))
+				Expect(configs[0].Provider).To(Equal(models.ProviderGithub))
+				Expect(configs[0].Username).To(Equal("myuser"))
+				Expect(configs[0].Password).To(Equal("mypass"))
+				Expect(configs[0].UserOrg).To(Equal("myuserorg"))
+				Expect(configs[0].Repository).To(Equal("myrepo"))
+				Expect(configs[0].SkipSSL).To(BeTrue())
+				Expect(configs[0].Certificate).To(Equal([]byte("----CERT----")))
+
+				Expect(configs[1].ID).To(Equal("my-config-skipssl-false"))
+				Expect(configs[1].SkipSSL).To(BeFalse())
+
+				Expect(configs[2].ID).To(Equal("my-config-skipssl-anything"))
+				Expect(configs[2].SkipSSL).To(BeFalse())
+
+				Expect(configs[3].ID).To(Equal("my-config-provider-unknown"))
+				Expect(configs[3].Provider).To(Equal(models.ProviderUnknown))
+			})
+		})
+	})
+
+	Describe("NewSecretFromConfiguration and NewSecretFromConfiguration", func() {
+		When("some secrets exists and they are encoded to configs", func() {
+			It("will return the same secrets", func() {
+				originalSecrets := []v1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "my-config"},
+						Data: map[string][]byte{
+							"url":         []byte("giturl"),
+							"provider":    []byte("github"),
+							"username":    []byte("myuser"),
+							"password":    []byte("mypass"),
+							"userOrg":     []byte("myuserorg"),
+							"repo":        []byte("myrepo"),
+							"skipSSL":     []byte("true"),
+							"certificate": []byte("----CERT----"),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "my-config-skipssl-false"},
+						Data: map[string][]byte{
+							"skipSSL": []byte("false"),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "my-config-skipssl-anything"},
+						Data: map[string][]byte{
+							"skipSSL": []byte("anything"),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "my-config-provider-unknown"},
+						Data: map[string][]byte{
+							"provider": []byte("sdjnksd"),
+						},
+					},
+				}
+
+				configs := git.NewConfigurationsFromSecrets(originalSecrets)
+
+				secrets := []v1.Secret{}
+				for _, conf := range configs {
+					secrets = append(secrets, git.NewSecretFromConfiguration(conf))
+				}
+
+				Expect(secrets).ToNot(BeNil())
+				Expect(secrets).To(HaveLen(4))
+
+				Expect(secrets[0].Data).To(Equal(originalSecrets[0].Data))
+				Expect(secrets[1].Data).To(Equal(map[string][]byte{
+					"provider": []byte("unknown"),
+					"skipSSL":  []byte("false"),
+				}))
+				Expect(secrets[2].Data).To(Equal(map[string][]byte{
+					"provider": []byte("unknown"),
+					"skipSSL":  []byte("false"),
+				}))
+				Expect(secrets[3].Data).To(Equal(map[string][]byte{
+					"provider": []byte("unknown"),
+					"skipSSL":  []byte("false"),
+				}))
+			})
+		})
+	})
+})
+
+func newConfiguration(ID, url, userOrg, repo string) git.Configuration {
+	return git.Configuration{
+		ID:         ID,
+		URL:        url,
+		UserOrg:    userOrg,
+		Repository: repo,
+	}
+}


### PR DESCRIPTION
This PR adds the support for Git configurations.

A Git configuration can be used to provide some particular options to a Git instance/provider. It's a secret that holds some information that will be used during the cloning of a repository, such as the `username` and `password` to clone private repositories, the `skipSSL` option to skip the ssl verification of the host, or the `certificate` to load private certificates.

For Github and Gitlab the username is not actually used (but it needs to be provided), and the password is the token (see [issue](https://gitlab.com/gitlab-org/gitlab/-/issues/212953)).

A configuration is a struct holding this informations:

```go
type Configuration struct {
	// ID of the configuration (it maps to the kubernetes secret)
	ID string
	// URL is the full url (schema/host/port) used to match a particular instance
	URL      string
	Provider models.GitProvider
	// Username and Password are used to perform a BasicAuth.
	// For Github/Gitlab the username can be anything (see https://gitlab.com/gitlab-org/gitlab/-/issues/212953).
	Username string
	// The Personal Access Token
	Password string
	// UserOrg is used to specify the username/organization/project
	UserOrg string
	// Repository is used to specify the exact repository
	Repository  string
	SkipSSL     bool
	Certificate []byte
}
```

The only required information is the URL. It should be something like `https://github.com`. A configuration with only this info will apply to the all repositories of `https://github.com`. Otherwise if you want to restrict the configuration to be applied only to a particular organization/project you can specify also the `UserOrg` value. And if you would like to use it only for a specific repo then you can use the `Repository` as well.

If multiple configurations are found then the most specific will be applied.

The secret containing the data needs to have the label ` epinio.io/api-git-credentials: "true"`, and the following fields are available:

```yaml
  url: https://github.com
  provider: github
  username: "myuser" 
  password: "abcde12345" 
  userOrg: epinio 
  repo: helm-charts 
  skipSSL: true 
  certificate: |
    -----BEGIN CERTIFICATE-----
    MIIBaTCCAQ+gAwIBAgIRAN4tvwEOKogvOzT/KccL8t8wCgYIKoZIzj0EAwIwFDES
    ***************
    -----END CERTIFICATE-----
```

Example:

```yaml
apiVersion: v1 
kind: Secret 
type: Opaque 
metadata: 
  labels: 
    epinio.io/api-git-credentials: "true" 
  name: my-github-token 
  namespace: epinio 
stringData:
  url: https://github.com
  provider: github
  username: "myuser" 
  password: "abcde12345" 
  userOrg: epinio 
  repo: helm-charts 
  skipSSL: true 
  certificate: |
    -----BEGIN CERTIFICATE-----
    MIIBaTCCAQ+gAwIBAgIRAN4tvwEOKogvOzT/KccL8t8wCgYIKoZIzj0EAwIwFDES
    ***************
    -----END CERTIFICATE-----
```

Note:
the Git manager was put under the `internal/bridge/git` package. Since the `internal` folder is containing everything maybe it's worth to restructure a bit the organization moving all the "external" clients/managers in this folder (s3, helm, upgraderesponder, and maybe something else).