### PR TITLE
Removed Kubernetes API access from `settings update-ca` command

### DIFF
--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -18,6 +18,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
@@ -307,8 +308,10 @@ var _ = Describe("Services", LService, func() {
 
 			// create temp settings that we can use to switch users
 			tmpSettingsPath = catalog.NewTmpName("tmpEpinio") + `.yaml`
-			out, err := env.Epinio("", "settings", "update-ca", "--settings-file", tmpSettingsPath)
-			Expect(err).ToNot(HaveOccurred(), out)
+			data, err := os.ReadFile(testenv.EpinioYAML())
+			Expect(err).ToNot(HaveOccurred())
+			err = os.WriteFile(tmpSettingsPath, data, 0644)
+			Expect(err).ToNot(HaveOccurred())
 
 			// create users with permissions in different namespaces
 			user1, password1 = env.CreateEpinioUser("user", []string{namespace1})

--- a/acceptance/settings_test.go
+++ b/acceptance/settings_test.go
@@ -159,7 +159,10 @@ var _ = Describe("Settings", LMisc, func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newSettings.Certs).To(BeEmpty())
 
-			out, err := env.Epinio("", "settings", "update-ca", "--settings-file", tmpSettingsPath)
+			out, err := env.Epinio("", "info", "--settings-file", tmpSettingsPath)
+			Expect(err).To(HaveOccurred(), out)
+
+			out, err = env.Epinio("", "settings", "update-ca", "--settings-file", tmpSettingsPath)
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(ContainSubstring(`Updating CA in the stored credentials`))
 

--- a/acceptance/settings_test.go
+++ b/acceptance/settings_test.go
@@ -140,23 +140,33 @@ var _ = Describe("Settings", LMisc, func() {
 	Describe("UpdateCA", func() {
 		oldSettingsPath := testenv.EpinioYAML()
 
-		It("regenerates certs and credentials", func() {
-			// Get back the certs and credentials
-			// Note that `namespace`, as a purely local setting, is not restored
-
-			out, err := env.Epinio("", "settings", "update-ca", "--settings-file", tmpSettingsPath)
+		It("regenerates the certificate", func() {
+			// create a copy of the original settings
+			data, err := os.ReadFile(oldSettingsPath)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(ContainSubstring(`Updating CA in the stored credentials`))
-
-			oldSettings, err := env.GetSettingsFrom(oldSettingsPath)
+			err = os.WriteFile(tmpSettingsPath, data, 0644)
 			Expect(err).ToNot(HaveOccurred())
 
+			// delete the certificate from the new settings
 			newSettings, err := env.GetSettingsFrom(tmpSettingsPath)
 			Expect(err).ToNot(HaveOccurred())
+			newSettings.Certs = ""
+			err = newSettings.Save()
+			Expect(err).ToNot(HaveOccurred())
 
-			Expect(newSettings.API).To(Equal(oldSettings.API))
-			Expect(newSettings.WSS).To(Equal(oldSettings.WSS))
-			Expect(newSettings.Certs).To(Equal(oldSettings.Certs))
+			// check that the new settings are saved without the certificate
+			newSettings, err = env.GetSettingsFrom(tmpSettingsPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(newSettings.Certs).To(BeEmpty())
+
+			out, err := env.Epinio("", "settings", "update-ca", "--settings-file", tmpSettingsPath)
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring(`Updating CA in the stored credentials`))
+
+			// check that the new settings now have the certificate
+			newSettings, err = env.GetSettingsFrom(tmpSettingsPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(newSettings.Certs).ToNot(BeEmpty())
 		})
 	})
 

--- a/acceptance/testenv/env.go
+++ b/acceptance/testenv/env.go
@@ -26,5 +26,4 @@ func SetupEnv() {
 	if os.Getenv("EPINIO_BINARY_PATH") == "" {
 		os.Setenv("EPINIO_BINARY_PATH", fmt.Sprintf("./dist/%s", ServerBinaryName()))
 	}
-	os.Setenv("SKIP_SSL_VERIFICATION", "true")
 }

--- a/internal/cli/admincmd/settings.go
+++ b/internal/cli/admincmd/settings.go
@@ -15,15 +15,16 @@ package admincmd
 
 import (
 	"context"
-	"fmt"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"net/url"
+	"strings"
 
 	"github.com/epinio/epinio/helpers"
-	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/helpers/termui"
 	"github.com/epinio/epinio/helpers/tracelog"
 	"github.com/epinio/epinio/internal/cli/settings"
-	"github.com/epinio/epinio/internal/duration"
-	"github.com/epinio/epinio/internal/helmchart"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -74,16 +75,13 @@ func (a *Admin) SettingsUpdateCA(ctx context.Context) error {
 
 	details.Info("retrieving server locations")
 
-	api, wss, err := getAPI(ctx, details)
-	if err != nil {
-		a.ui.Exclamation().Msg(err.Error())
-		return nil
-	}
+	api := a.Settings.API
+	wss := a.Settings.WSS
 
 	details.Info("retrieved server locations", "api", api, "wss", wss)
 	details.Info("retrieving certs")
 
-	certs, err := getCerts(ctx, details)
+	certs, err := encodeCertificate(api)
 	if err != nil {
 		a.ui.Exclamation().Msg(err.Error())
 		return nil
@@ -91,8 +89,6 @@ func (a *Admin) SettingsUpdateCA(ctx context.Context) error {
 
 	details.Info("retrieved certs", "certs", certs)
 
-	a.Settings.API = api
-	a.Settings.WSS = wss
 	a.Settings.Certs = certs
 
 	details.Info("saving",
@@ -115,92 +111,63 @@ func (a *Admin) SettingsUpdateCA(ctx context.Context) error {
 	return nil
 }
 
-func getAPI(ctx context.Context, log logr.Logger) (string, string, error) {
-	// This is called only by the admin command `settings update-ca`
-	// which has to talk to the cluster to retrieve the
-	// information. This is allowed.
+func encodeCertificate(address string) (string, error) {
+	var builder strings.Builder
 
-	cluster, err := kubernetes.GetCluster(ctx)
+	cert, err := checkCA(address)
 	if err != nil {
-		return "", "", err
+		// something bad happened while checking the certificates
+		if cert == nil {
+			return "", errors.Wrap(err, "error while checking CA")
+		}
+		// add the untrusted certificate
+		pemCert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+		builder.Write(pemCert)
+	} else {
+		// and regularly trusted certs go directly into the result
+		// This was missing in PR #1964, and demonstrated as bug with issue #2003
+		pemCert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+		builder.Write(pemCert)
 	}
 
-	log.Info("got cluster")
-
-	epinioURL, epinioWsURL, err := getEpinioURL(ctx, cluster)
-	if err != nil {
-		return "", "", errors.Wrap(err, "failed to resolve epinio api host")
-	}
-
-	return epinioURL, epinioWsURL, err
+	return builder.String(), nil
 }
 
-func getCerts(ctx context.Context, log logr.Logger) (string, error) {
-	// This is called only by the admin command `settings update-ca`
-	// which has to talk to the cluster to retrieve the
-	// information. This is allowed.
-
-	// Save the  CA cert into the settings. The regular client
-	// will then extend the Cert pool with the same, so that it
-	// can cerify the server cert.
-
-	cluster, err := kubernetes.GetCluster(ctx)
+// checkCA will check if the address has a trusted certificate.
+// If not trusted it returns the untrusted certificate and an error, otherwise if trusted then no error will be returned
+func checkCA(address string) (*x509.Certificate, error) {
+	parsedURL, err := url.Parse(address)
 	if err != nil {
-		return "", err
+		return nil, errors.New("error parsing the address")
 	}
 
-	log.Info("got cluster")
+	port := parsedURL.Port()
+	if port == "" {
+		port = "443"
+	}
 
-	// Waiting for the secret is better than simply trying to get
-	// it. This way we automatically handle the case where we try
-	// to pull data from a secret still under construction by some
-	// other part of the system.
-
-	// See the `auth.createCertificate` template for the created
-	// Certs, and epinio.go `apply` for the call to
-	// `auth.createCertificate`, which determines the secret's
-	// name we are using here
-
-	secret, err := cluster.WaitForSecret(ctx,
-		helmchart.Namespace(),
-		helmchart.EpinioCertificateName+"-tls",
-		duration.ToConfigurationSecret(),
-	)
-
+	tlsConfig := &tls.Config{InsecureSkipVerify: true} // nolint:gosec // We need to check the validity
+	conn, err := tls.Dial("tcp", parsedURL.Hostname()+":"+port, tlsConfig)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get API CA cert secret")
+		return nil, errors.Wrap(err, "error while dialing the server")
+	}
+	defer conn.Close()
+
+	certs := conn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		return nil, errors.New("no certificates to verify")
 	}
 
-	log.Info("got secret", "secret", helmchart.EpinioCertificateName+"-tls")
-
-	return string(secret.Data["tls.crt"]), nil
-}
-
-// getEpinioURL finds the URL's for epinio from the cluster
-func getEpinioURL(ctx context.Context, cluster *kubernetes.Cluster) (string, string, error) {
-	// Get the ingress
-	ingresses, err := cluster.ListIngress(ctx, helmchart.Namespace(), "app.kubernetes.io/name=epinio")
-	if err != nil {
-		return "", "", errors.Wrap(err, "failed to list ingresses for epinio api server")
+	// check if at least one certificate in the chain is valid
+	for _, cert := range certs {
+		_, err = cert.Verify(x509.VerifyOptions{})
+		// if it's valid we are good to go
+		if err == nil {
+			return cert, nil
+		}
 	}
 
-	if len(ingresses.Items) < 1 {
-		return "", "", errors.New("epinio api ingress not found")
-	}
-
-	if len(ingresses.Items) > 1 {
-		return "", "", errors.New("more than one epinio api ingress found")
-	}
-
-	if len(ingresses.Items[0].Spec.Rules) < 1 {
-		return "", "", errors.New("epinio api ingress has no rules")
-	}
-
-	if len(ingresses.Items[0].Spec.Rules) > 1 {
-		return "", "", errors.New("epinio api ingress has more than on rule")
-	}
-
-	host := ingresses.Items[0].Spec.Rules[0].Host
-
-	return fmt.Sprintf("%s://%s", epinioAPIProtocol, host), fmt.Sprintf("%s://%s", epinioWSProtocol, host), nil
+	// if none of the certificates are valid, return the leaf cert with its error
+	_, err = certs[0].Verify(x509.VerifyOptions{})
+	return certs[0], err
 }

--- a/internal/cli/admincmd/settings.go
+++ b/internal/cli/admincmd/settings.go
@@ -73,6 +73,10 @@ func (a *Admin) SettingsUpdateCA(ctx context.Context) error {
 		WithStringValue("Settings", helpers.AbsPath(a.Settings.Location)).
 		Msg("Updating CA in the stored credentials from the current cluster")
 
+	if a.Settings.Location == "" {
+		return errors.New("settings file not found")
+	}
+
 	details.Info("retrieving server locations")
 
 	api := a.Settings.API


### PR DESCRIPTION
The `epinio` cli should be used without having access to the Kubernetes cluster or the kube API.

The only user command that was left with this access was the `settings update-ca`, looking for the Ingress, Secret and storing the certificate in the settings. This is not needed because the certificate can be loaded directly from the provided address.

This PR is getting the certificate with the same copy/pasted func used by the `login` command, removing some logic and checks (we are always trusting the certificate in this case, and we are checking just the Epinio url, so no need to loop for different addresses).

Tested also locally (messing up the cert in the settings). It was correctly updated.

The `admincmd` and `usercmd` package are now obsolete and could be merged.  
I will leave this for another PR to avoid confusion.