### PR TITLE
Enabled redirection of trace output to arbitrary file

### DIFF
--- a/helpers/tracelog/logger.go
+++ b/helpers/tracelog/logger.go
@@ -58,7 +58,7 @@ func LoggerFlags(pf *flag.FlagSet, argToEnv map[string]string) {
 	}
 	argToEnv["trace-file"] = "TRACE_FILE"
 
-	pf.String("trace-output", "text", "(TRACE_OUTPUT) logs output format [text,json]")
+	pf.String("trace-output", "text", "Sets trace output format [text,json]")
 	err = viper.BindPFlag("trace-output", pf.Lookup("trace-output"))
 	if err != nil {
 		log.Fatal(err)

--- a/helpers/tracelog/logger.go
+++ b/helpers/tracelog/logger.go
@@ -95,11 +95,18 @@ func NewStdrLogger() logr.Logger {
 // Zap does not have named levels that are more verbose than DebugLevel, but it's possible to fake it.
 //
 // https://github.com/go-logr/zapr#increasing-verbosity
+
 func NewZapLogger() logr.Logger {
 	var logger logr.Logger
 
+	level := TraceLevel()
+	// Prevent wrap around in zap internals
+	if level > 128 {
+		level = 128
+	}
+
 	zc := zap.NewProductionConfig()
-	zc.Level = zap.NewAtomicLevelAt(zapcore.Level(TraceLevel() * -1))
+	zc.Level = zap.NewAtomicLevelAt(zapcore.Level(level * -1))
 
 	traceFilePath := TraceFile()
 	if traceFilePath != "" {

--- a/helpers/tracelog/logger.go
+++ b/helpers/tracelog/logger.go
@@ -59,7 +59,7 @@ func LoggerFlags(pf *flag.FlagSet, argToEnv map[string]string) {
 	argToEnv["trace-file"] = "TRACE_FILE"
 
 	pf.String("trace-output", "text", "(TRACE_OUTPUT) logs output format [text,json]")
-	err = viper.BindPFlag("trace-output", flags.Lookup("trace-output"))
+	err = viper.BindPFlag("trace-output", pf.Lookup("trace-output"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/helpers/tracelog/logger.go
+++ b/helpers/tracelog/logger.go
@@ -57,6 +57,13 @@ func LoggerFlags(pf *flag.FlagSet, argToEnv map[string]string) {
 		log.Fatal(err)
 	}
 	argToEnv["trace-file"] = "TRACE_FILE"
+
+	pf.String("trace-output", "text", "(TRACE_OUTPUT) logs output format [text,json]")
+	err = viper.BindPFlag("trace-output", flags.Lookup("trace-output"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	argToEnv["trace-output"] = "TRACE_OUTPUT"
 }
 
 // NewLogger returns a logger based on the trace-output/trace-file configuration

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -78,12 +78,6 @@ func init() {
 	err = viper.BindEnv("s3-certificate-secret", "S3_CERTIFICATE_SECRET")
 	checkErr(err)
 
-	flags.String("trace-output", "text", "(TRACE_OUTPUT) logs output format [text,json]")
-	err = viper.BindPFlag("trace-output", flags.Lookup("trace-output"))
-	checkErr(err)
-	err = viper.BindEnv("trace-output", "TRACE_OUTPUT")
-	checkErr(err)
-
 	flags.String("ingress-class-name", "", "(INGRESS_CLASS_NAME) Name of the ingress class to use for apps. Leave empty to add no ingressClassName to the ingress.")
 	err = viper.BindPFlag("ingress-class-name", flags.Lookup("ingress-class-name"))
 	checkErr(err)


### PR DESCRIPTION
Fix #2292 

Added flag `--trace-file` to redirect tracing from stderr to arbitrary file for more persistent capture.
Flag name chosen to be consistent with the existing `--trace-level` and `--trace-output` flags.

Also moved `--trace-output` from `server` command to global definition and usability.