### PR TITLE
fix disk request handling with a default of last resort.

### DIFF
--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -84,6 +84,11 @@ func ensurePVC(ctx context.Context, cluster *kubernetes.Cluster, ar models.AppRe
 		return nil
 	}
 
+	// Insert a default of last resort. See also note below.
+	if diskRequest == "" {
+		diskRequest = "1Gi"
+	}
+
 	// From here on, only if the PVC is missing
 	_, err = cluster.Kubectl.CoreV1().PersistentVolumeClaims(helmchart.Namespace()).
 		Create(ctx, &corev1.PersistentVolumeClaim{


### PR DESCRIPTION
Ref #2508

While an empty disk request should not happen (default from chart) the user could force it empty, or a mismatched chart not set it.