### PR TITLE
Moved some CLI commands to `cmd` package

### DIFF
--- a/internal/cli/cmd/clientsync.go
+++ b/internal/cli/cmd/clientsync.go
@@ -9,15 +9,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli
+package cmd
 
 import (
+	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 // NewClientSyncCmd implements the command: epinio client-sync
-func NewClientSyncCmd() *cobra.Command {
+func NewClientSyncCmd(client *usercmd.EpinioClient) *cobra.Command {
 	return &cobra.Command{
 		Use:   "client-sync",
 		Short: "Downloads a client binary matching the currently logged server",

--- a/internal/cli/cmd/clientsync_test.go
+++ b/internal/cli/cmd/clientsync_test.go
@@ -9,11 +9,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli_test
+package cmd_test
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -21,7 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/epinio/epinio/internal/cli"
+	"github.com/epinio/epinio/internal/cli/cmd"
 	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/epinio/epinio/internal/cli/usercmd/usercmdfakes"
 	"github.com/epinio/epinio/internal/selfupdater/selfupdaterfakes"
@@ -49,7 +48,7 @@ var _ = Describe("Command 'epinio client-sync'", func() {
 	)
 
 	BeforeEach(func() {
-		epinioClient, err := usercmd.New(context.Background())
+		epinioClient, err := usercmd.New()
 		Expect(err).To(BeNil())
 
 		mock = &usercmdfakes.FakeAPIClient{}
@@ -61,8 +60,8 @@ var _ = Describe("Command 'epinio client-sync'", func() {
 		mockUpdater = &selfupdaterfakes.FakeUpdater{}
 		epinioClient.Updater = mockUpdater
 
-		clientSyncCmd = cli.NewClientSyncCmd()
-		cli.SetClient(epinioClient)
+		clientSyncCmd = cmd.NewClientSyncCmd(epinioClient)
+
 		clientSyncCmd.SetErr(output)
 		clientSyncCmd.SetArgs([]string{"client-sync"})
 	})

--- a/internal/cli/cmd/info.go
+++ b/internal/cli/cmd/info.go
@@ -1,0 +1,37 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/epinio/epinio/internal/cli/usercmd"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// NewInfoCmd returns a new 'epinio info' command
+func NewInfoCmd(client *usercmd.EpinioClient) *cobra.Command {
+	return &cobra.Command{
+		Use:   "info",
+		Short: "Shows information about the Epinio environment",
+		Long:  "Shows status and versions for epinio's server-side components.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+
+			err := client.Info()
+			if err != nil {
+				return errors.Wrap(err, "error retrieving Epinio environment information")
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/cli/cmd/info_test.go
+++ b/internal/cli/cmd/info_test.go
@@ -9,16 +9,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli_test
+package cmd_test
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"io/ioutil"
 	"strings"
 
-	"github.com/epinio/epinio/internal/cli"
+	"github.com/epinio/epinio/internal/cli/cmd"
 	"github.com/epinio/epinio/internal/cli/usercmd"
 	"github.com/epinio/epinio/internal/cli/usercmd/usercmdfakes"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
@@ -37,7 +36,7 @@ var _ = Describe("Command 'epinio info'", func() {
 	)
 
 	BeforeEach(func() {
-		epinioClient, err := usercmd.New(context.Background())
+		epinioClient, err := usercmd.New()
 		Expect(err).To(BeNil())
 
 		mock = &usercmdfakes.FakeAPIClient{}
@@ -46,8 +45,8 @@ var _ = Describe("Command 'epinio info'", func() {
 		output = &bytes.Buffer{}
 		epinioClient.UI().SetOutput(output)
 
-		infoCmd = cli.NewInfoCmd()
-		cli.SetClient(epinioClient)
+		infoCmd = cmd.NewInfoCmd(epinioClient)
+
 		infoCmd.SetErr(output)
 		infoCmd.SetArgs([]string{"info"})
 	})

--- a/internal/cli/cmd/suite_test.go
+++ b/internal/cli/cmd/suite_test.go
@@ -9,28 +9,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli
+package cmd_test
 
 import (
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-// NewInfoCmd returns a new 'epinio info' command
-func NewInfoCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "info",
-		Short: "Shows information about the Epinio environment",
-		Long:  "Shows status and versions for epinio's server-side components.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-
-			err := client.Info()
-			if err != nil {
-				return errors.Wrap(err, "error retrieving Epinio environment information")
-			}
-
-			return nil
-		},
-	}
+func TestEpinio(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Epinio Suite CMD")
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -131,6 +131,7 @@ func NewRootCmd() (*cobra.Command, error) {
 
 	rootCmd.AddCommand(
 		CmdCompletion,
+		CmdSettings,
 		cmd.NewInfoCmd(client),
 		cmd.NewClientSyncCmd(client),
 		CmdGitconfig,

--- a/internal/cli/usercmd/app_test.go
+++ b/internal/cli/usercmd/app_test.go
@@ -49,8 +49,11 @@ var _ = Describe("Client Apps unit tests", Label("wip"), func() {
 			})
 
 			It("returns no error", func() {
-				epinioClient, err := usercmd.NewEpinioClient(&settings.Settings{Namespace: "workspace"}, fake)
+				epinioClient, err := usercmd.New()
 				Expect(err).ToNot(HaveOccurred())
+
+				epinioClient.Settings = &settings.Settings{Namespace: "workspace"}
+				epinioClient.API = fake
 
 				err = epinioClient.AppRestage("appname", false)
 				Expect(err).ToNot(HaveOccurred())
@@ -74,8 +77,11 @@ var _ = Describe("Client Apps unit tests", Label("wip"), func() {
 			})
 
 			It("returns no error and it won't stage", func() {
-				epinioClient, err := usercmd.NewEpinioClient(&settings.Settings{Namespace: "workspace"}, fake)
+				epinioClient, err := usercmd.New()
 				Expect(err).ToNot(HaveOccurred())
+
+				epinioClient.Settings = &settings.Settings{Namespace: "workspace"}
+				epinioClient.API = fake
 
 				err = epinioClient.AppRestage("appname", false)
 				Expect(err).ToNot(HaveOccurred())

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -130,23 +130,8 @@ type APIClient interface {
 	Headers() map[string]string
 }
 
-func New(ctx context.Context) (*EpinioClient, error) {
-	cfg, err := settings.Load()
-	if err != nil {
-		return nil, errors.Wrap(err, "error loading settings")
-	}
-
-	apiClient := epinioapi.New(ctx, cfg)
-
-	return NewEpinioClient(cfg, apiClient)
-}
-
-func NewEpinioClient(cfg *settings.Settings, apiClient APIClient) (*EpinioClient, error) {
+func New() (*EpinioClient, error) {
 	logger := tracelog.NewLogger().WithName("EpinioClient").V(3)
-
-	log := logger.WithName("NewEpinioClient")
-	log.Info("Ingress API", "url", cfg.API)
-	log.Info("Settings API", "url", cfg.API)
 
 	updater, err := getUpdater(runtime.GOOS)
 	if err != nil {
@@ -154,12 +139,25 @@ func NewEpinioClient(cfg *settings.Settings, apiClient APIClient) (*EpinioClient
 	}
 
 	return &EpinioClient{
-		API:      apiClient,
-		ui:       termui.NewUI(),
-		Settings: cfg,
-		Log:      logger,
-		Updater:  updater,
+		ui:      termui.NewUI(),
+		Log:     logger,
+		Updater: updater,
 	}, nil
+}
+
+func (c *EpinioClient) Init(ctx context.Context) error {
+	cfg, err := settings.Load()
+	if err != nil {
+		return errors.Wrap(err, "error loading settings")
+	}
+	c.Settings = cfg
+
+	log := c.Log.WithName("Init")
+	log.Info("Ingress API", "url", cfg.API)
+	log.Info("Settings API", "url", cfg.API)
+
+	c.API = epinioapi.New(ctx, cfg)
+	return nil
 }
 
 func (cli *EpinioClient) UI() *termui.UI {

--- a/internal/cli/usercmd/login.go
+++ b/internal/cli/usercmd/login.go
@@ -88,7 +88,12 @@ func (c *EpinioClient) Login(ctx context.Context, username, password, address st
 		// Note: Create a new client for this. `c` cannot be assumed to be properly initialized,
 		// as it was created before the login was performed and saved.
 
-		client, err := New(ctx)
+		client, err := New()
+		if err != nil {
+			return err
+		}
+
+		err = client.Init(ctx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Since the `settings update-ca` dropped the "admin" operations we can drop the `admincmd` and `usercmd` definitions.

To do so imo it will be nice to have a `cli/cmd` package with all the commands, and leaving the `EpinioClient` in the parent `cli` package.

```
cli/
 |- cmd/ (all the commands here)
 |- termui/ (the "display" library)
 | client.go (all the misc/common stuff in the parent)
```

Having a look at this I've understood the problem of creating the EpinioClient in the root command, and I've fixed it. Since the loading of the flags is done after the command creation we need to create the EpinioClient before, but then finalize its creation (here with an `Init` func) later in the PersistentPreRunE. In this way we are going to load the right settings specified by the user.