### PR TITLE
Add `--output`  flag with JSON support for Epinio namespace list and show commands

### DIFF
--- a/acceptance/namespaces_test.go
+++ b/acceptance/namespaces_test.go
@@ -12,7 +12,10 @@
 package acceptance_test
 
 import (
+	"encoding/json"
+
 	"github.com/epinio/epinio/acceptance/helpers/catalog"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
 
 	. "github.com/epinio/epinio/acceptance/helpers/matchers"
 	. "github.com/onsi/ginkgo/v2"
@@ -100,6 +103,16 @@ var _ = Describe("Namespaces", LNamespace, func() {
 				),
 			)
 		})
+
+		It("lists namespaces in JSON format", func() {
+			out, err := env.Epinio("", "namespace", "list", namespaceName, "--output", "json")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			namespaces := models.NamespaceList{}
+			err = json.Unmarshal([]byte(out), &namespaces)
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(namespaces).ToNot(BeEmpty())
+		})
 	})
 
 	Describe("namespace show", func() {
@@ -174,6 +187,16 @@ var _ = Describe("Namespaces", LNamespace, func() {
 						WithRow("Configurations", configurationName),
 					),
 				)
+			})
+
+			It("shows a namespace in JSON format", func() {
+				out, err := env.Epinio("", "namespace", "show", namespaceName, "--output", "json")
+				Expect(err).ToNot(HaveOccurred(), out)
+
+				namespace := models.Namespace{}
+				err = json.Unmarshal([]byte(out), &namespace)
+				Expect(err).ToNot(HaveOccurred(), out)
+				Expect(namespace.Meta.Name).To(Equal(namespaceName))
 			})
 		})
 	})

--- a/internal/cli/commons.go
+++ b/internal/cli/commons.go
@@ -203,3 +203,19 @@ func filteredMatchingFinder(args []string, prefix string, finder func(prefix str
 
 	return filteredMatches
 }
+
+type flagCompletionFunc func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+
+func newStaticFlagsCompletionFunc(allowedValues []string) flagCompletionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		matches := []string{}
+
+		for _, allowed := range allowedValues {
+			if strings.HasPrefix(allowed, toComplete) {
+				matches = append(matches, allowed)
+			}
+		}
+
+		return matches, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/internal/cli/enum_flag.go
+++ b/internal/cli/enum_flag.go
@@ -1,0 +1,59 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+// enumValue implements the Value interface
+// It can be used to define a flag with a set of allowed values
+// Ref:
+// - https://github.com/spf13/pflag/blob/2e9d26c8c37aae03e3f9d4e90b7116f5accb7cab/flag.go#L185-L191
+// - https://github.com/spf13/pflag/issues/236#issuecomment-931600452
+type enumValue struct {
+	Allowed []string
+	Value   string
+}
+
+// newEnumValue give a list of allowed flag parameters, where the second argument is the default
+func newEnumValue(allowed []string, d string) *enumValue {
+	return &enumValue{
+		Allowed: allowed,
+		Value:   d,
+	}
+}
+
+func (a enumValue) String() string {
+	return a.Value
+}
+
+func (a *enumValue) Set(p string) error {
+	isIncluded := func(opts []string, val string) bool {
+		for _, opt := range opts {
+			if val == opt {
+				return true
+			}
+		}
+		return false
+	}
+	if !isIncluded(a.Allowed, p) {
+		return fmt.Errorf("%s is not included in %s", p, strings.Join(a.Allowed, ","))
+	}
+	a.Value = p
+	return nil
+}
+
+func (a *enumValue) Type() string {
+	return "string"
+}

--- a/internal/cli/namespaces.go
+++ b/internal/cli/namespaces.go
@@ -48,11 +48,15 @@ func init() {
 	flags.BoolVarP(&gNamespaceForceFlag, "force", "f", false, "force namespace deletion")
 	flags.BoolVar(&gNamespaceAllFlag, "all", false, "delete all namespaces")
 
-	CmdNamespaceList.Flags().StringVarP(&flagOutput, "output", "o", "text", "Sets output format [text,json]")
-	checkErr(viper.BindPFlag("output", CmdNamespaceList.Flags().Lookup("output")))
+	flagOutput = newEnumValue([]string{"text", "json"}, "text")
 
-	CmdNamespaceShow.Flags().StringVarP(&flagOutput, "output", "o", "text", "Sets output format [text,json]")
+	CmdNamespaceList.Flags().VarP(flagOutput, "output", "o", "sets output format [text|json]")
+	checkErr(viper.BindPFlag("output", CmdNamespaceList.Flags().Lookup("output")))
+	checkErr(CmdNamespaceList.RegisterFlagCompletionFunc("output", newStaticFlagsCompletionFunc(flagOutput.Allowed)))
+
+	CmdNamespaceShow.Flags().VarP(flagOutput, "output", "o", "sets output format [text|json]")
 	checkErr(viper.BindPFlag("output", CmdNamespaceShow.Flags().Lookup("output")))
+	checkErr(CmdNamespaceShow.RegisterFlagCompletionFunc("output", newStaticFlagsCompletionFunc(flagOutput.Allowed)))
 
 	CmdNamespace.AddCommand(CmdNamespaceCreate)
 	CmdNamespace.AddCommand(CmdNamespaceList)

--- a/internal/cli/namespaces.go
+++ b/internal/cli/namespaces.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -46,6 +47,12 @@ func init() {
 	flags := CmdNamespaceDelete.Flags()
 	flags.BoolVarP(&gNamespaceForceFlag, "force", "f", false, "force namespace deletion")
 	flags.BoolVar(&gNamespaceAllFlag, "all", false, "delete all namespaces")
+
+	CmdNamespaceList.Flags().StringVarP(&flagOutput, "output", "o", "text", "Sets output format [text,json]")
+	checkErr(viper.BindPFlag("output", CmdNamespaceList.Flags().Lookup("output")))
+
+	CmdNamespaceShow.Flags().StringVarP(&flagOutput, "output", "o", "text", "Sets output format [text,json]")
+	checkErr(viper.BindPFlag("output", CmdNamespaceShow.Flags().Lookup("output")))
 
 	CmdNamespace.AddCommand(CmdNamespaceCreate)
 	CmdNamespace.AddCommand(CmdNamespaceList)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,7 +39,7 @@ var (
 
 	flagSettingsFile string
 	flagHeaders      []string
-	flagOutput       string
+	flagOutput       *enumValue
 )
 
 // NewRootCmd returns the rootCmd, that is the main `epinio` cli.
@@ -65,7 +65,7 @@ func NewRootCmd() (*cobra.Command, error) {
 				return errors.Wrap(err, "initializing client")
 			}
 
-			if flagOutput == "json" {
+			if flagOutput.String() == "json" {
 				client.UI().EnableJSON()
 				client.API.DisableVersionWarning()
 			}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -67,6 +67,7 @@ func NewRootCmd() (*cobra.Command, error) {
 
 			if flagOutput == "json" {
 				client.UI().EnableJSON()
+				client.API.DisableVersionWarning()
 			}
 
 			for _, header := range flagHeaders {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,6 +39,7 @@ var (
 
 	flagSettingsFile string
 	flagHeaders      []string
+	flagOutput       string
 )
 
 // NewRootCmd returns the rootCmd, that is the main `epinio` cli.
@@ -62,6 +63,10 @@ func NewRootCmd() (*cobra.Command, error) {
 			err := client.Init(cmd.Context())
 			if err != nil {
 				return errors.Wrap(err, "initializing client")
+			}
+
+			if flagOutput == "json" {
+				client.UI().EnableJSON()
 			}
 
 			for _, header := range flagHeaders {

--- a/internal/cli/termui/ui.go
+++ b/internal/cli/termui/ui.go
@@ -13,6 +13,7 @@ package termui
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -53,8 +54,9 @@ const (
 // UI contains functionality for dealing with the user
 // on the CLI
 type UI struct {
-	output    io.Writer
-	verbosity int // Verbosity level for user messages.
+	output      io.Writer
+	verbosity   int // Verbosity level for user messages.
+	jsonEnabled bool
 }
 
 // Message represents a piece of information we want displayed to the user
@@ -93,6 +95,22 @@ func NewUI() *UI {
 	return &UI{
 		output:    color.Output,
 		verbosity: verbosity(),
+	}
+}
+
+func (u *UI) EnableJSON() {
+	u.verbosity = -1
+	u.jsonEnabled = true
+}
+
+func (u *UI) DisableJSON() {
+	u.verbosity = verbosity()
+	u.jsonEnabled = false
+}
+
+func (u *UI) JSON(value any) {
+	if u.jsonEnabled {
+		_ = json.NewEncoder(u.output).Encode(value)
 	}
 }
 

--- a/internal/cli/usercmd/namespace.go
+++ b/internal/cli/usercmd/namespace.go
@@ -97,6 +97,8 @@ func (c *EpinioClient) Namespaces() error {
 
 	msg.Msg("Epinio Namespaces:")
 
+	c.ui.JSON(namespaces)
+
 	return nil
 }
 
@@ -251,6 +253,8 @@ func (c *EpinioClient) ShowNamespace(namespace string) error {
 		WithTableRow("Configurations", strings.Join(space.Configurations, "\n"))
 
 	msg.Msg("Details:")
+
+	c.ui.JSON(space)
 
 	return nil
 }


### PR DESCRIPTION
This PR adds the support for the JSON output in the `namespace list` and `namespace show` commands.

When selected it will silence the warning version, and it will still output a user-readable error in case of failure. The exit code will be a non-zero though. Not sure if we should provide a JSON error as well instead of a plain text.

```
-> % epinio namespace show workspace --output json | jq
{
  "meta": {
    "name": "workspace",
    "createdAt": "2023-09-04T13:04:52Z"
  },
  "apps": [
    "sample"
  ]
}
```

It also adds an `enumValue` flag that can be used to provide a flag with a fixed set of values, and its completion func.