### PR TITLE
Added `gitproxy` endpoint

### DIFF
--- a/acceptance/api/v1/gitproxy_test.go
+++ b/acceptance/api/v1/gitproxy_test.go
@@ -1,0 +1,64 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Gitproxy endpoint", LMisc, func() {
+	It("proxies the request to github", func() {
+		gitproxyRequest := models.GitProxyRequest{
+			URL: "https://api.github.com/repos/epinio/epinio",
+		}
+
+		resp, statusCode := gitproxy(toJSON(gitproxyRequest))
+		Expect(statusCode).To(Equal(http.StatusOK))
+
+		var m map[string]interface{}
+		err := json.Unmarshal(resp, &m)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(m["id"]).To(BeEquivalentTo(311485110))
+		Expect(m["full_name"]).To(Equal("epinio/epinio"))
+	})
+
+	It("fails for unknown endpoint", func() {
+		gitproxyRequest := models.GitProxyRequest{
+			URL: "https://example.com",
+		}
+
+		resp, statusCode := gitproxy(toJSON(gitproxyRequest))
+		ExpectBadRequestError(resp, statusCode, "invalid proxied URL: unknown URL 'https://example.com'")
+	})
+
+	It("fails for invalid JSON", func() {
+		resp, statusCode := gitproxy(strings.NewReader(`sjkskl`))
+		ExpectBadRequestError(resp, statusCode, "invalid character 's' looking for beginning of value")
+	})
+
+	It("fails for non whitelisted APIs", func() {
+		gitproxyRequest := models.GitProxyRequest{
+			URL: "https://api.github.com/users",
+		}
+
+		resp, statusCode := gitproxy(toJSON(gitproxyRequest))
+		ExpectBadRequestError(resp, statusCode, "invalid proxied URL: invalid Github URL: '/users'")
+	})
+})

--- a/acceptance/api/v1/helpers_api_test.go
+++ b/acceptance/api/v1/helpers_api_test.go
@@ -97,6 +97,13 @@ func appImportGit(namespace, app, gitURL, revision string) ([]byte, int) {
 	return bodyBytes, response.StatusCode
 }
 
+func gitproxy(body io.Reader) ([]byte, int) {
+	GinkgoHelper()
+
+	endpoint := makeEndpoint(v1.Routes.Path("GitProxy"))
+	return curl(http.MethodPost, endpoint, body)
+}
+
 func curl(method, endpoint string, body io.Reader) ([]byte, int) {
 	GinkgoHelper()
 

--- a/helpers/cahash/cahash.go
+++ b/helpers/cahash/cahash.go
@@ -60,3 +60,26 @@ func DecodeOneCert(raw []byte) (*x509.Certificate, error) {
 
 	return nil, errors.New("failed find PEM data")
 }
+
+// DecodeCerts iterates over pem blocks and load all the valid certificates
+func DecodeCerts(raw []byte) ([]*x509.Certificate, error) {
+	certs := []*x509.Certificate{}
+
+	byteData := raw
+	for len(byteData) > 0 {
+		block, rest := pem.Decode(byteData)
+		if block == nil {
+			return nil, errors.New("failed decoding PEM data")
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			byteData = rest
+			continue // pem block is not a cert? (e.g. maybe it was a dh_params block)
+		}
+
+		certs = append(certs, cert)
+	}
+
+	return certs, nil
+}

--- a/internal/api/v1/auth_test.go
+++ b/internal/api/v1/auth_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/epinio/epinio/internal/auth"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/gin-gonic/gin"
-	"github.com/go-logr/stdr"
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -35,7 +35,7 @@ var _ = Describe("Authorization Middleware", func() {
 		gin.SetMode(gin.TestMode)
 		w = httptest.NewRecorder()
 		c, _ = gin.CreateTestContext(w)
-		ctx = requestctx.WithLogger(context.Background(), stdr.New(nil))
+		ctx = requestctx.WithLogger(context.Background(), logr.Discard())
 		url = "http://url.com/endpoint"
 	})
 

--- a/internal/api/v1/gitproxy/gitproxy.go
+++ b/internal/api/v1/gitproxy/gitproxy.go
@@ -61,7 +61,7 @@ func Proxy(c *gin.Context, gitManager *gitbridge.Manager) apierror.APIErrors {
 	}
 
 	if err := ValidateURL(proxyRequest.URL); err != nil {
-		return apierror.NewBadRequestError("invalid proxied URL")
+		return apierror.NewBadRequestErrorf("invalid proxied URL: %s", err.Error())
 	}
 
 	// create request to proxy
@@ -146,9 +146,6 @@ func ValidateURL(proxiedURL string) error {
 // - /search/repositories
 func validateGithubURL(path string) error {
 	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
-	if len(parts) < 2 {
-		return fmt.Errorf("invalid Github URL. Too few parts: [%s]", strings.Join(parts, ","))
-	}
 
 	// with 2 parts we support this endpoint:
 	// - /search/repositories
@@ -156,7 +153,6 @@ func validateGithubURL(path string) error {
 		if parts[0] == "search" && parts[1] == "repositories" {
 			return nil
 		}
-		return fmt.Errorf("invalid Github URL with 2 parts: [%s]", strings.Join(parts, ","))
 	}
 
 	// with 3 parts we support these endpoints:
@@ -167,7 +163,6 @@ func validateGithubURL(path string) error {
 			(parts[0] == "users" && parts[2] == "repos") {
 			return nil
 		}
-		return fmt.Errorf("invalid Github URL with 3 parts: [%s]", strings.Join(parts, ","))
 	}
 
 	// with 4 parts we support these endpoints:
@@ -177,7 +172,6 @@ func validateGithubURL(path string) error {
 		if parts[0] == "repos" && (parts[3] == "commits" || parts[3] == "branches") {
 			return nil
 		}
-		return fmt.Errorf("invalid Github URL with 4 parts: [%s]", strings.Join(parts, ","))
 	}
 
 	// with 5 parts we support this endpoint:
@@ -186,10 +180,9 @@ func validateGithubURL(path string) error {
 		if parts[0] == "repos" && parts[3] == "branches" {
 			return nil
 		}
-		return fmt.Errorf("invalid Github URL with 5 parts: [%s]", strings.Join(parts, ","))
 	}
 
-	return fmt.Errorf("invalid Github URL. Too many parts: [%s]", strings.Join(parts, ","))
+	return fmt.Errorf("invalid Github URL: '%s'", path)
 }
 
 // validateGitlabURL will validate if the requested API is a whitelisted one.
@@ -212,7 +205,6 @@ func validateGitlabURL(path string) error {
 		if parts[0] == "avatar" {
 			return nil
 		}
-		return fmt.Errorf("invalid Github URL with 1 part1: [%s]", parts[0])
 	}
 
 	// with 2 parts we support these endpoints:
@@ -224,7 +216,6 @@ func validateGitlabURL(path string) error {
 			parts[0] == "projects" || parts[1] == "projects" {
 			return nil
 		}
-		return fmt.Errorf("invalid Github URL with 2 parts: [%s]", strings.Join(parts, ","))
 	}
 
 	// with 4 parts we support these endpoints:
@@ -235,7 +226,6 @@ func validateGitlabURL(path string) error {
 			(parts[3] == "branches" || parts[3] == "commits") {
 			return nil
 		}
-		return fmt.Errorf("invalid Github URL with 3 parts: [%s]", strings.Join(parts, ","))
 	}
 
 	// with 5 parts we support this endpoint:
@@ -244,10 +234,9 @@ func validateGitlabURL(path string) error {
 		if parts[0] == "projects" && parts[2] == "repository" && parts[3] == "branches" {
 			return nil
 		}
-		return fmt.Errorf("invalid Github URL with 5 parts: [%s]", strings.Join(parts, ","))
 	}
 
-	return fmt.Errorf("invalid Github URL '%s'. Parts: [%s]", path, strings.Join(parts, ","))
+	return fmt.Errorf("invalid Gitlab URL '%s'", path)
 }
 
 // getProxyClient will create a *http.Client based on the provided *gitbridge.Configuration.

--- a/internal/api/v1/gitproxy/gitproxy.go
+++ b/internal/api/v1/gitproxy/gitproxy.go
@@ -1,0 +1,158 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitproxy
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+
+	"github.com/epinio/epinio/helpers/kubernetes"
+	gitbridge "github.com/epinio/epinio/internal/bridge/git"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
+	"github.com/epinio/epinio/internal/helmchart"
+	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+)
+
+func ProxyHandler(c *gin.Context) apierror.APIErrors {
+	ctx := c.Request.Context()
+	logger := requestctx.Logger(ctx)
+
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	gitManager, err := gitbridge.NewManager(logger, cluster.Kubectl.CoreV1().Secrets(helmchart.Namespace()))
+	if err != nil {
+		return apierror.InternalError(err, "creating git configuration manager")
+	}
+
+	return Proxy(c, gitManager)
+}
+
+func Proxy(c *gin.Context, gitManager *gitbridge.Manager) apierror.APIErrors {
+	ctx := c.Request.Context()
+	logger := requestctx.Logger(ctx)
+
+	proxyRequest := &models.GitProxyRequest{}
+	if err := c.BindJSON(proxyRequest); err != nil {
+		return apierror.NewBadRequestError(err.Error())
+	}
+
+	if _, err := url.Parse(proxyRequest.URL); err != nil {
+		return apierror.NewBadRequestError("invalid proxied URL")
+	}
+
+	// create request to proxy
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyRequest.URL, nil)
+	if err != nil {
+		return apierror.InternalError(err, "creating proxy request")
+	}
+
+	// if specified look for the git configuration
+	var gitConfig *gitbridge.Configuration
+	if proxyRequest.Gitconfig != "" {
+		for i := range gitManager.Configurations {
+			if proxyRequest.Gitconfig == gitManager.Configurations[i].ID {
+				gitConfig = &gitManager.Configurations[i]
+				break
+			}
+		}
+		if gitConfig == nil {
+			logger.Info("gitconfig not found", "id", proxyRequest.Gitconfig)
+		}
+	}
+
+	if gitConfig != nil {
+		// check BasicAuth
+		if gitConfig.Username != "" && gitConfig.Password != "" {
+			req.SetBasicAuth(gitConfig.Username, gitConfig.Password)
+		}
+	}
+
+	client, err := getProxyClient(gitConfig)
+	if err != nil {
+		return apierror.InternalError(err, "creating proxy client")
+	}
+
+	err = doRequest(client, req, c.Writer)
+	if err != nil {
+		return apierror.InternalError(err, "proxying request")
+	}
+
+	return nil
+}
+
+func getProxyClient(gitConfig *gitbridge.Configuration) (*http.Client, error) {
+	client := &http.Client{}
+
+	if gitConfig == nil {
+		return client, nil
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	if gitConfig != nil {
+		tlsConfig.InsecureSkipVerify = gitConfig.SkipSSL
+
+		// add custom certs
+		// https://github.com/go-git/go-git/blob/0377d0627fa4e32a576634f441e72153807e395a/plumbing/transport/http/common.go#L187-L201
+
+		if len(gitConfig.Certificate) > 0 {
+			rootCAs, err := x509.SystemCertPool()
+			if err != nil {
+				return nil, errors.Wrap(err, "loading SystemCertPool")
+			}
+			if rootCAs == nil {
+				rootCAs = x509.NewCertPool()
+			}
+			rootCAs.AppendCertsFromPEM(gitConfig.Certificate)
+
+			tlsConfig.RootCAs = rootCAs
+		}
+	}
+
+	transport.TLSClientConfig = tlsConfig
+	client.Transport = transport
+
+	return client, nil
+}
+
+func doRequest(client *http.Client, req *http.Request, writer http.ResponseWriter) error {
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "executing proxied request")
+	}
+
+	writer.WriteHeader(resp.StatusCode)
+
+	for k, values := range resp.Header {
+		for _, v := range values {
+			writer.Header().Add(k, v)
+		}
+	}
+
+	_, err = io.Copy(writer, resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "copying proxied response")
+	}
+
+	return nil
+}

--- a/internal/api/v1/gitproxy/gitproxy.go
+++ b/internal/api/v1/gitproxy/gitproxy.go
@@ -191,8 +191,9 @@ func validateGithubURL(path string) error {
 // The supported APIs are:
 // - /avatar
 // - /search/repositories
-// - /USERNAME/projects
 // - /projects/USERNAME%2FREPO
+// - /users/USERNAME/projects
+// - /groups/USERNAME/projects
 // - /projects/USERNAME%2FREPO/repository/branches
 // - /projects/USERNAME%2FREPO/repository/commits
 // - /projects/REPO/repository/branches/BRANCH
@@ -209,11 +210,18 @@ func validateGitlabURL(path string) error {
 
 	// with 2 parts we support these endpoints:
 	// - /search/repositories
-	// - /USERNAME/projects
 	// - /projects/USERNAME%2FREPO
 	if len(parts) == 2 {
-		if (parts[0] == "search" && parts[1] == "repositories") ||
-			parts[0] == "projects" || parts[1] == "projects" {
+		if path == "/search/repositories" || parts[0] == "projects" {
+			return nil
+		}
+	}
+
+	// with 3 parts we support these endpoints:
+	// - /users/USERNAME/projects
+	// - /groups/USERNAME/projects
+	if len(parts) == 3 {
+		if (parts[0] == "users" || parts[0] == "groups") && parts[2] == "projects" {
 			return nil
 		}
 	}

--- a/internal/api/v1/gitproxy/gitproxy_test.go
+++ b/internal/api/v1/gitproxy/gitproxy_test.go
@@ -183,6 +183,7 @@ var _ = Describe("Gitproxy Endpoint", func() {
 			setupAndRun("/")
 			setupAndRun("/any")
 			setupAndRun("/search/something")
+			setupAndRun("/USERNAME/projects")
 			setupAndRun("/projects/USERNAME%2FREPO/repository/stars")
 			setupAndRun("/projects/USERNAME%2FREPO/repository/commits/BRANCH")
 			setupAndRun("/api/with/too/many/parts/api")
@@ -191,7 +192,8 @@ var _ = Describe("Gitproxy Endpoint", func() {
 		It("passes for Gitlab Server whitelisted URLs", func() {
 			// - /api/v4/avatar
 			// - /api/v4/search/repositories
-			// - /api/v4/USERNAME/projects
+			// - /api/v4/users/USERNAME/projects
+			// - /api/v4/groups/USERNAME/projects
 			// - /api/v4/projects/USERNAME%2FREPO
 			// - /api/v4/projects/USERNAME%2FREPO/repository/commits
 			// - /api/v4/projects/USERNAME%2FREPO/repository/branches
@@ -206,7 +208,8 @@ var _ = Describe("Gitproxy Endpoint", func() {
 
 			setupAndRun("/avatar")
 			setupAndRun("/search/repositories")
-			setupAndRun("/USERNAME/projects")
+			setupAndRun("/users/USERNAME/projects")
+			setupAndRun("/groups/USERNAME/projects")
 			setupAndRun("/projects/USERNAME%2FREPO")
 			setupAndRun("/projects/USERNAME%2FREPO/repository/commits")
 			setupAndRun("/projects/USERNAME%2FREPO/repository/branches")

--- a/internal/api/v1/gitproxy/gitproxy_test.go
+++ b/internal/api/v1/gitproxy/gitproxy_test.go
@@ -1,0 +1,200 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitproxy_test
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/epinio/epinio/internal/api/v1/gitproxy"
+	gitbridge "github.com/epinio/epinio/internal/bridge/git"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
+	"github.com/gin-gonic/gin"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Gitproxy Endpoint", func() {
+	var w *httptest.ResponseRecorder
+	var c *gin.Context
+	var ctx context.Context
+
+	BeforeEach(func() {
+		gin.SetMode(gin.TestMode)
+
+		w = httptest.NewRecorder()
+		c, _ = gin.CreateTestContext(w)
+		ctx = requestctx.WithLogger(context.Background(), logr.Discard())
+	})
+
+	When("JSON is malformed", func() {
+		It("returns status code 400", func() {
+			body := strings.NewReader(`{"url":"https://api.gi`)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "url", body)
+			Expect(err).ToNot(HaveOccurred())
+			c.Request = req
+
+			gitManager := &gitbridge.Manager{Configurations: []gitbridge.Configuration{}}
+			errs := gitproxy.Proxy(c, gitManager)
+			Expect(w.Code).To(Equal(http.StatusBadRequest))
+			Expect(errs).To(HaveOccurred())
+		})
+	})
+
+	When("URL is malformed", func() {
+		It("returns status code 400", func() {
+			body := strings.NewReader(`{"url":"postgres://user:abc{DEf1=ghi@example.com:5432/db?sslmode=require"}`)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "url", body)
+			Expect(err).ToNot(HaveOccurred())
+			c.Request = req
+
+			gitManager := &gitbridge.Manager{Configurations: []gitbridge.Configuration{}}
+			errs := gitproxy.Proxy(c, gitManager)
+			Expect(errs).To(HaveOccurred())
+		})
+	})
+
+	When("proxying the request", func() {
+		It("returns the same response", func() {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(201)
+				fmt.Fprintf(w, `{"foo":"bar"}`)
+			}))
+			defer srv.Close()
+
+			body := strings.NewReader(fmt.Sprintf(`{"url":"%s/repos/epinio/epinio","gitconfig":"missing"}`, srv.URL))
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "url", body)
+			Expect(err).ToNot(HaveOccurred())
+			c.Request = req
+
+			gitManager := &gitbridge.Manager{Configurations: []gitbridge.Configuration{}}
+			errs := gitproxy.Proxy(c, gitManager)
+			Expect(errs).ToNot(HaveOccurred())
+			Expect(w.Code).To(Equal(http.StatusCreated))
+
+			b, err := io.ReadAll(w.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(b)).To(Equal(`{"foo":"bar"}`))
+		})
+
+		When("gitconfig with username and password is provided", func() {
+			It("passes the BasicAuth header and returns the proxied response", func() {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					authHeader := r.Header.Get("Authorization")
+					Expect(authHeader).To(Equal("Basic ZXBpbmlvOnBhc3N3b3Jk"))
+
+					w.WriteHeader(201)
+					fmt.Fprintf(w, `{"foo":"bar"}`)
+				}))
+				defer srv.Close()
+
+				body := strings.NewReader(fmt.Sprintf(`{"url":"%s/repos/epinio/epinio","gitconfig":"my-git-conf"}`, srv.URL))
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, "url", body)
+				Expect(err).ToNot(HaveOccurred())
+				c.Request = req
+
+				gitManager := &gitbridge.Manager{Configurations: []gitbridge.Configuration{
+					{ID: "my-git-conf", Username: "epinio", Password: "password"},
+				}}
+				errs := gitproxy.Proxy(c, gitManager)
+				Expect(errs).ToNot(HaveOccurred())
+				Expect(w.Code).To(Equal(http.StatusCreated))
+
+				b, err := io.ReadAll(w.Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(b)).To(Equal(`{"foo":"bar"}`))
+			})
+		})
+	})
+
+	When("proxying the request to HTTPS server", func() {
+		When("no gitconfig is provided", func() {
+			It("fails for unknown authority", func() {
+				srv := httptest.NewTLSServer(nil)
+				defer srv.Close()
+
+				body := strings.NewReader(fmt.Sprintf(`{"url":"%s/repos/epinio/epinio"}`, srv.URL))
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, "url", body)
+				Expect(err).ToNot(HaveOccurred())
+				c.Request = req
+
+				gitManager := &gitbridge.Manager{Configurations: []gitbridge.Configuration{}}
+				errs := gitproxy.Proxy(c, gitManager)
+				Expect(errs).To(HaveOccurred())
+			})
+		})
+
+		When("gitconfig with skipSSL is provided", func() {
+			It("returns the proxied response", func() {
+				srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(201)
+					fmt.Fprintf(w, `{"foo":"bar"}`)
+				}))
+				defer srv.Close()
+
+				body := strings.NewReader(fmt.Sprintf(`{"url":"%s/repos/epinio/epinio","gitconfig":"my-git-conf"}`, srv.URL))
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, "url", body)
+				Expect(err).ToNot(HaveOccurred())
+				c.Request = req
+
+				gitManager := &gitbridge.Manager{Configurations: []gitbridge.Configuration{
+					{ID: "my-git-conf", SkipSSL: true},
+				}}
+				errs := gitproxy.Proxy(c, gitManager)
+				Expect(errs).ToNot(HaveOccurred())
+				Expect(w.Code).To(Equal(http.StatusCreated))
+
+				b, err := io.ReadAll(w.Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(b)).To(Equal(`{"foo":"bar"}`))
+			})
+		})
+
+		When("gitconfig with the right CA bundle is provided", func() {
+			It("returns the proxied response", func() {
+				srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(201)
+					fmt.Fprintf(w, `{"foo":"bar"}`)
+				}))
+				defer srv.Close()
+
+				body := strings.NewReader(fmt.Sprintf(`{"url":"%s/repos/epinio/epinio","gitconfig":"my-git-conf"}`, srv.URL))
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, "url", body)
+				Expect(err).ToNot(HaveOccurred())
+				c.Request = req
+
+				conn, err := tls.Dial("tcp", strings.TrimPrefix(srv.URL, "https://"), &tls.Config{InsecureSkipVerify: true})
+				Expect(err).ToNot(HaveOccurred())
+				defer conn.Close()
+				pemCert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: conn.ConnectionState().PeerCertificates[0].Raw})
+
+				gitManager := &gitbridge.Manager{Configurations: []gitbridge.Configuration{
+					{ID: "my-git-conf", Certificate: pemCert},
+				}}
+				errs := gitproxy.Proxy(c, gitManager)
+				Expect(errs).ToNot(HaveOccurred())
+				Expect(w.Code).To(Equal(http.StatusCreated))
+
+				b, err := io.ReadAll(w.Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(b)).To(Equal(`{"foo":"bar"}`))
+			})
+		})
+	})
+})

--- a/internal/api/v1/gitproxy/suite_test.go
+++ b/internal/api/v1/gitproxy/suite_test.go
@@ -1,0 +1,24 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitproxy_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEpinio(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Epinio Suite Gitproxy")
+}

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -27,6 +27,7 @@ import (
 	"github.com/epinio/epinio/internal/api/v1/env"
 	"github.com/epinio/epinio/internal/api/v1/exportregistry"
 	"github.com/epinio/epinio/internal/api/v1/gitconfig"
+	"github.com/epinio/epinio/internal/api/v1/gitproxy"
 	"github.com/epinio/epinio/internal/api/v1/namespace"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/api/v1/service"
@@ -208,6 +209,8 @@ var Routes = routes.NamedRoutes{
 	// Note, the second registration catches calls with an empty pattern!
 	"ExportregistriesMatch":  get("/exportregistrymatches/:pattern", errorHandler(exportregistry.Match)),
 	"ExportregistriesMatch0": get("/exportregistrymatches", errorHandler(exportregistry.Match)),
+
+	"GitProxy": post("/gitproxy", errorHandler(gitproxy.ProxyHandler)),
 }
 
 var WsRoutes = routes.NamedRoutes{

--- a/pkg/api/core/v1/models/gitproxy.go
+++ b/pkg/api/core/v1/models/gitproxy.go
@@ -1,0 +1,17 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+type GitProxyRequest struct {
+	URL       string `json:"url,omitempty"`
+	Gitconfig string `json:"gitconfig,omitempty"`
+}


### PR DESCRIPTION
This PR adds the `/gitproxy` endpoint.

This endpoint will proxy some of the Github and Gitlab APIs. If a gitconfig ID is provided then this will be used to enrich the request (with the token, or skipping the SSL verification, or custom certificates).
