### PR TITLE
Update nginx-ingress helm flag for `setAsDefaultIngress=true` in CI

### DIFF
--- a/acceptance/install/suite_test.go
+++ b/acceptance/install/suite_test.go
@@ -63,7 +63,7 @@ func InstallNginx() {
 	out, err = proc.RunW("helm", "upgrade", "--install", "nginx-ingress", "nginx-stable/nginx-ingress",
 		"-n", "ingress-nginx",
 		"--create-namespace",
-		"--set", "controller.setAsDefaultIngress=true",
+		"--set", "controller.ingressClass.setAsDefaultIngress=true",
 	)
 	Expect(err).NotTo(HaveOccurred(), out)
 }


### PR DESCRIPTION
Fix for EC2 and EKS CI jobs failures.
* Testrun on EKS: https://github.com/epinio/epinio/actions/runs/6352973837
* Testrun on EC2: https://github.com/epinio/epinio/actions/runs/6352978124

This PR uses new helm variable` controller.ingressClass.setAsDefaultIngress=true`, earlier it was just `controller.setAsDefaultIngress=true`

Another (not-so) related issue found when testing this manually https://github.com/epinio/epinio/issues/2619