### PR TITLE
Switch to ingress-nginx from kubernetes.io in CI

### DIFF
--- a/acceptance/helpers/delete_clusters/delete_clusters.go
+++ b/acceptance/helpers/delete_clusters/delete_clusters.go
@@ -427,8 +427,8 @@ func CleanupNamespaces() error {
 func CleanupAWS_RKE2() error {
 	kubeconfig := os.Getenv("KUBECONFIG")
 
-	fmt.Println("Cleaning up nginx-ingress and namespaces ...")
-	out, err := proc.RunW("helm", "--kubeconfig", kubeconfig, "delete", "nginx-ingress", "-n", "ingress-nginx", "--wait")
+	fmt.Println("Cleaning up ingress-nginx and namespaces ...")
+	out, err := proc.RunW("helm", "--kubeconfig", kubeconfig, "delete", "ingress-nginx", "-n", "ingress-nginx", "--wait")
 	if err != nil {
 		return errors.Wrap(err, "helm cli command failed: "+out)
 	}

--- a/acceptance/install/scenario4_test.go
+++ b/acceptance/install/scenario4_test.go
@@ -89,12 +89,12 @@ var _ = Describe("<Scenario4> EKS, epinio-ca, on S3 storage", func() {
 		By("Checking LoadBalancer IP", func() {
 			// Ensure that Nginx LB is not in Pending state anymore, could take time
 			Eventually(func() string {
-				out, err := proc.RunW("kubectl", "get", "svc", "-n", "ingress-nginx", "nginx-ingress-controller", "--no-headers")
+				out, err := proc.RunW("kubectl", "get", "svc", "-n", "ingress-nginx", "ingress-nginx-controller", "--no-headers")
 				Expect(err).NotTo(HaveOccurred(), out)
 				return out
 			}, "4m", "2s").ShouldNot(ContainSubstring("<pending>"))
 
-			out, err := proc.RunW("kubectl", "get", "service", "-n", "ingress-nginx", "nginx-ingress-controller", "-o", "json")
+			out, err := proc.RunW("kubectl", "get", "service", "-n", "ingress-nginx", "ingress-nginx-controller", "-o", "json")
 			Expect(err).NotTo(HaveOccurred(), out)
 
 			// Check that an IP address for LB is configured

--- a/acceptance/install/suite_test.go
+++ b/acceptance/install/suite_test.go
@@ -56,14 +56,14 @@ func InstallCertManager() {
 }
 
 func InstallNginx() {
-	out, err := proc.RunW("helm", "repo", "add", "nginx-stable", "https://helm.nginx.com/stable")
+	out, err := proc.RunW("helm", "repo", "add", "ingress-nginx", "https://kubernetes.github.io/ingress-nginx")
 	Expect(err).NotTo(HaveOccurred(), out)
 	out, err = proc.RunW("helm", "repo", "update")
 	Expect(err).NotTo(HaveOccurred(), out)
-	out, err = proc.RunW("helm", "upgrade", "--install", "nginx-ingress", "nginx-stable/nginx-ingress",
-		"-n", "ingress-nginx",
+	out, err = proc.RunW("helm", "upgrade", "--install", "ingress-nginx", "ingress-nginx/ingress-nginx",
+		"--namespace", "ingress-nginx",
 		"--create-namespace",
-		"--set", "controller.ingressClass.setAsDefaultIngress=true",
+		"--set", "controller.ingressClassResource.default=true",
 	)
 	Expect(err).NotTo(HaveOccurred(), out)
 }


### PR DESCRIPTION
Ref. https://github.com/epinio/epinio/issues/2619

This PR replaces `nginx-ingress` from Nginx F5 Corp by `ingress-nginx` form kubernetes.io in our integration CI.

* This ingress controller is able to handle websockets on AWS ELB.
* Also now all resource names are unified to `ingress-nginx`.

Testruns:
* EKS https://github.com/epinio/epinio/actions/runs/6380950720
* RKE2 EC2 https://github.com/epinio/epinio/actions/runs/6380953420
