### PR TITLE
Fixed `app export` on multinode clusters with RWO storage

### DIFF
--- a/internal/api/v1/application/export.go
+++ b/internal/api/v1/application/export.go
@@ -548,6 +548,24 @@ func createCopyJob(logger logr.Logger, localPath, destinationPath, authSecret, c
 					Annotations: map[string]string{},
 				},
 				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						PodAffinity: &corev1.PodAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app.kubernetes.io/name",
+												Operator: "In",
+												Values:   []string{"epinio-server"},
+											},
+										},
+									},
+									TopologyKey: "kubernetes.io/hostname",
+								},
+							},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:         "oci-push",

--- a/internal/api/v1/application/part.go
+++ b/internal/api/v1/application/part.go
@@ -286,6 +286,24 @@ func runDownloadImageJob(ctx context.Context, cluster *kubernetes.Cluster, jobNa
 					Annotations: map[string]string{},
 				},
 				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						PodAffinity: &corev1.PodAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app.kubernetes.io/name",
+												Operator: "In",
+												Values:   []string{"epinio-server"},
+											},
+										},
+									},
+									TopologyKey: "kubernetes.io/hostname",
+								},
+							},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:    "skopeo",


### PR DESCRIPTION
Fixes. #2605 

Export over webUI tested on multi worker k3s cluster and it seems to work, the export has been always scheduled on the same node as `epinio-server` pod is using.