### PR TITLE
Keep images built for CI separate from release images by way of tagging

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -29,7 +29,7 @@ jobs:
           account-type: org
           org-name: epinio
           keep-at-least: 1
-          filter-tags: v*-[0-9]*-g*
+          filter-tags: "v*-[0-9]*-g*", "test-*"
           filter-include-untagged: true
           token: ${{ secrets.IMG_CLEANUP_TOKEN }}
       - name: Delete untagged containers older than a week

--- a/.github/workflows/gke-upgrade.yml
+++ b/.github/workflows/gke-upgrade.yml
@@ -171,7 +171,7 @@ jobs:
         run: |
           # EPINIO_UPGRADED triggers starting with a released epinio in suite setup, and the upgrade sequence
           echo "System Domain: $GKE_DOMAIN"
-          export EPINIO_CURRENT_TAG="$(git describe --tags)"
+          export EPINIO_CURRENT_TAG="test-$(git describe --tags)"
           # Run GKE integrated install + upgrade test
           mkdir dist
           scripts/get-latest-epinio.sh

--- a/.github/workflows/rke-upgrade.yml
+++ b/.github/workflows/rke-upgrade.yml
@@ -162,7 +162,7 @@ jobs:
           # Get a free IP address on server's network
           export RANGE_IP="$(scripts/get-free-ip.sh)"
           export EPINIO_SYSTEM_DOMAIN="$(sed -e 's/-.*$//' <<< ${RANGE_IP}).omg.howdoi.website"
-          export EPINIO_CURRENT_TAG="$(git describe --tags)"
+          export EPINIO_CURRENT_TAG="test-$(git describe --tags)"
           pwd
           # Run RKE integrated install + upgrade test using latest epinio release
           mkdir dist

--- a/.github/workflows/upgrade-bound.yml
+++ b/.github/workflows/upgrade-bound.yml
@@ -89,7 +89,7 @@ jobs:
         env:
           REGEX: Upgrade2
         run: |
-          export EPINIO_CURRENT_TAG="$(git describe --tags)"
+          export EPINIO_CURRENT_TAG="test-$(git describe --tags)"
           # We have to export the EPINIO_SYSTEM_DOMAIN
           # before executing the ginkgo test
           source scripts/helpers.sh

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -89,7 +89,7 @@ jobs:
         env:
           REGEX: Upgrade1 
         run: |
-          export EPINIO_CURRENT_TAG="$(git describe --tags)"
+          export EPINIO_CURRENT_TAG="test-$(git describe --tags)"
           # We have to export the EPINIO_SYSTEM_DOMAIN
           # before executing the ginkgo test
           source scripts/helpers.sh

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -12,7 +12,7 @@
 
 set -e
 
-version="$(git describe --tags)"
+version="test-$(git describe --tags)"
 imageEpServer="ghcr.io/epinio/epinio-server"
 imageUnpacker="ghcr.io/epinio/epinio-unpacker"
 

--- a/scripts/prepare-environment-k3d.sh
+++ b/scripts/prepare-environment-k3d.sh
@@ -23,7 +23,7 @@ UNAME="$(uname | tr "[:upper:]" "[:lower:]")"
 EPINIO_BINARY="./dist/epinio-$UNAME-amd64"
 
 # IMAGE_TAG is the one built from the 'make build-images'
-IMAGE_TAG="$(git describe --tags)"
+IMAGE_TAG="test-$(git describe --tags)"
 
 function check_dependency {
 	for dep in "$@"


### PR DESCRIPTION
fix #2599
fix #2594

separate images build for testing from release images by a tag-prefix
add cleanup of images tagged this way