### PR TITLE
Moved middlewares to `middleware` package

### DIFF
--- a/internal/api/v1/middleware/auth.go
+++ b/internal/api/v1/middleware/auth.go
@@ -9,13 +9,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package middleware
 
 import (
 	"fmt"
 	"net/http"
 	"strings"
 
+	v1 "github.com/epinio/epinio/internal/api/v1"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	apierrors "github.com/epinio/epinio/pkg/api/core/v1/errors"
@@ -23,12 +24,12 @@ import (
 	"github.com/go-logr/logr"
 )
 
-func NamespaceAuthorizationMiddleware(c *gin.Context) {
+func NamespaceAuthorization(c *gin.Context) {
 	user := requestctx.User(c.Request.Context())
 	authorization(c, "namespace", user.Namespaces)
 }
 
-func GitconfigAuthorizationMiddleware(c *gin.Context) {
+func GitconfigAuthorization(c *gin.Context) {
 	user := requestctx.User(c.Request.Context())
 	authorization(c, "gitconfig", user.Gitconfigs)
 }
@@ -104,7 +105,7 @@ func restrictedPath(logger logr.Logger, path string) bool {
 	logger = logger.V(1).WithName("unrestrictedPath")
 
 	// check if the requested path is restricted
-	if _, found := AdminRoutes[path]; found {
+	if _, found := v1.AdminRoutes[path]; found {
 		logger.Info(fmt.Sprintf("path [%s] is an admin route, user unauthorized", path))
 		return true
 	}

--- a/internal/api/v1/middleware/auth_test.go
+++ b/internal/api/v1/middleware/auth_test.go
@@ -9,7 +9,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1_test
+package middleware_test
 
 import (
 	"context"
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 
 	v1 "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/internal/api/v1/middleware"
 	"github.com/epinio/epinio/internal/auth"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/gin-gonic/gin"
@@ -56,7 +57,7 @@ var _ = Describe("Authorization Middleware", func() {
 
 		When("url is not restricted", func() {
 			It("returns status code 200", func() {
-				v1.NamespaceAuthorizationMiddleware(c)
+				middleware.NamespaceAuthorization(c)
 				Expect(w.Code).To(Equal(http.StatusOK))
 			})
 		})
@@ -70,7 +71,7 @@ var _ = Describe("Authorization Middleware", func() {
 			})
 
 			It("returns status code 403", func() {
-				v1.NamespaceAuthorizationMiddleware(c)
+				middleware.NamespaceAuthorization(c)
 				Expect(w.Code).To(Equal(http.StatusForbidden))
 			})
 		})
@@ -79,14 +80,14 @@ var _ = Describe("Authorization Middleware", func() {
 			It("returns status code 403 for another namespace", func() {
 				c.Params = []gin.Param{{Key: "namespace", Value: "another-workspace"}}
 
-				v1.NamespaceAuthorizationMiddleware(c)
+				middleware.NamespaceAuthorization(c)
 				Expect(w.Code).To(Equal(http.StatusForbidden))
 			})
 
 			It("returns status code 200 for its namespace", func() {
 				c.Params = []gin.Param{{Key: "namespace", Value: "workspace"}}
 
-				v1.NamespaceAuthorizationMiddleware(c)
+				middleware.NamespaceAuthorization(c)
 				Expect(w.Code).To(Equal(http.StatusOK))
 			})
 		})

--- a/internal/api/v1/middleware/authentication.go
+++ b/internal/api/v1/middleware/authentication.go
@@ -1,0 +1,242 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/auth"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
+	"github.com/epinio/epinio/internal/dex"
+	"github.com/epinio/epinio/internal/helmchart"
+	apierrors "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/gin-gonic/gin"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// Authentication middleware authenticates the user either using the basic auth or the bearer token (OIDC)
+func Authentication(ctx *gin.Context) {
+	// we need this check to return a 401 instead of an error
+	authorizationHeader := ctx.Request.Header.Get("Authorization")
+	if authorizationHeader == "" {
+		response.Error(ctx, apierrors.NewAPIError("missing credentials", http.StatusUnauthorized))
+		ctx.Abort()
+		return
+	}
+
+	var user auth.User
+	var authError apierrors.APIErrors
+
+	if strings.HasPrefix(authorizationHeader, "Basic ") {
+		user, authError = basicAuthentication(ctx)
+	} else if strings.HasPrefix(authorizationHeader, "Bearer ") {
+		user, authError = oidcAuthentication(ctx)
+	} else {
+		authError = apierrors.NewAPIError("not supported Authorization Header", http.StatusUnauthorized)
+	}
+
+	if authError != nil {
+		response.Error(ctx, authError)
+		ctx.Abort()
+		return
+	}
+
+	// Write the user info in the context. It's needed by the next middleware
+	// to write it into the session.
+	newCtx := ctx.Request.Context()
+	newCtx = requestctx.WithUser(newCtx, user)
+	ctx.Request = ctx.Request.Clone(newCtx)
+}
+
+// basicAuthentication performs the Basic Authentication
+func basicAuthentication(ctx *gin.Context) (auth.User, apierrors.APIErrors) {
+	reqCtx := ctx.Request.Context()
+	logger := requestctx.Logger(reqCtx).WithName("basicAuthentication")
+	logger.V(1).Info("starting Basic Authentication")
+
+	userMap, err := loadUsersMap(ctx)
+	if err != nil {
+		return auth.User{}, apierrors.InternalError(err)
+	}
+
+	if len(userMap) == 0 {
+		return auth.User{}, apierrors.NewAPIError("no user found", http.StatusUnauthorized)
+	}
+
+	username, password, ok := ctx.Request.BasicAuth()
+	if !ok {
+		return auth.User{}, apierrors.NewInternalError("Couldn't extract user from the auth header")
+	}
+
+	err = bcrypt.CompareHashAndPassword([]byte(userMap[username].Password), []byte(password))
+	if err != nil {
+		return auth.User{}, apierrors.NewAPIError("wrong password", http.StatusUnauthorized)
+	}
+
+	return userMap[username], nil
+}
+
+// oidcAuthentication perform the OIDC authentication with dex
+func oidcAuthentication(ctx *gin.Context) (auth.User, apierrors.APIErrors) {
+	reqCtx := ctx.Request.Context()
+	logger := requestctx.Logger(reqCtx).WithName("oidcAuthentication")
+	logger.V(1).Info("starting OIDC Authentication")
+
+	oidcProvider, err := getOIDCProvider(ctx)
+	if err != nil {
+		return auth.User{}, apierrors.InternalError(err, "error getting OIDC provider")
+	}
+
+	authHeader := ctx.Request.Header.Get("Authorization")
+	token := strings.TrimPrefix(authHeader, "Bearer ")
+
+	idToken, err := oidcProvider.Verify(ctx, token)
+	if err != nil {
+		return auth.User{}, apierrors.NewAPIError(errors.Wrap(err, "token verification failed").Error(), http.StatusUnauthorized)
+	}
+
+	var claims struct {
+		Email           string   `json:"email"`
+		Groups          []string `json:"groups"`
+		FederatedClaims struct {
+			ConnectorID string `json:"connector_id"`
+		} `json:"federated_claims"`
+	}
+	if err := idToken.Claims(&claims); err != nil {
+		return auth.User{}, apierrors.NewAPIError(errors.Wrap(err, "error parsing claims").Error(), http.StatusUnauthorized)
+	}
+
+	role := getRoleFromProviderGroups(logger, oidcProvider, claims.FederatedClaims.ConnectorID, claims.Groups)
+
+	user, err := getOrCreateUserByEmail(ctx, claims.Email, role)
+	if err != nil {
+		return auth.User{}, apierrors.InternalError(err, "getting/creating user with email")
+	}
+
+	logger.V(1).Info("token verified", "user", fmt.Sprintf("%#v", user))
+
+	return user, nil
+}
+
+var oidcProvider *dex.OIDCProvider
+
+// getOIDCProvider returns a lazy constructed OIDC provider
+func getOIDCProvider(ctx context.Context) (*dex.OIDCProvider, error) {
+	if oidcProvider != nil {
+		return oidcProvider, nil
+	}
+
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get access to a kube client")
+	}
+
+	secret, err := cluster.GetSecret(ctx, helmchart.Namespace(), "dex-config")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get dex-config secret")
+	}
+
+	config, err := dex.NewConfigFromSecretData("epinio-api", secret.Data)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing the issuer URL")
+	}
+
+	oidcProvider, err := dex.NewOIDCProviderWithConfig(ctx, config)
+	if err != nil {
+		return nil, errors.Wrap(err, "constructing dexProviderConfig")
+	}
+
+	return oidcProvider, nil
+}
+
+// getRoleFromProviderGroups returns the user role, looking for it in the groups defined for the provider.
+// If there are no groups that matches then the default role 'user' is returned.
+// If a user has more than one group matching, the first from the Dex Configuration will be returned.
+func getRoleFromProviderGroups(logger logr.Logger, oidcProvider *dex.OIDCProvider, providerID string, groups []string) string {
+	defaultRole := "user"
+
+	pg, err := oidcProvider.GetProviderGroups(providerID)
+	if err != nil {
+		logger.Info(
+			"error getting provider groups",
+			"provider", providerID,
+		)
+
+		return defaultRole
+	}
+
+	roles := pg.GetRolesFromGroups(groups...)
+	if len(roles) == 0 {
+		logger.Info(
+			"no matching groups found in provider groups",
+			"provider", providerID,
+			"providerGroups", pg,
+			"groups", strings.Join(groups, ","),
+		)
+
+		return defaultRole
+	}
+
+	return roles[0]
+}
+
+func loadUsersMap(ctx context.Context) (map[string]auth.User, error) {
+	authService, err := auth.NewAuthServiceFromContext(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't create auth service from context")
+	}
+
+	users, err := authService.GetUsers(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't get users")
+	}
+
+	userMap := make(map[string]auth.User)
+	for _, user := range users {
+		userMap[user.Username] = user
+	}
+
+	return userMap, nil
+}
+
+func getOrCreateUserByEmail(ctx context.Context, email, role string) (auth.User, error) {
+	user := auth.User{}
+	var err error
+
+	authService, err := auth.NewAuthServiceFromContext(ctx)
+	if err != nil {
+		return user, errors.Wrap(err, "couldn't create auth service from context")
+	}
+
+	user, err = authService.GetUserByUsername(ctx, email)
+	if err != nil {
+		if err != auth.ErrUserNotFound {
+			return user, errors.Wrap(err, "couldn't get user")
+		}
+
+		user.Username = email
+		user.Role = role
+		user, err = authService.SaveUser(ctx, user)
+		if err != auth.ErrUserNotFound {
+			return user, errors.Wrap(err, "couldn't create user")
+		}
+	}
+
+	return user, nil
+}

--- a/internal/api/v1/middleware/middleware.go
+++ b/internal/api/v1/middleware/middleware.go
@@ -13,10 +13,27 @@ package middleware
 
 import (
 	v1 "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/version"
 	"github.com/gin-gonic/gin"
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 )
 
 func EpinioVersion(ctx *gin.Context) {
 	ctx.Header(v1.VersionHeader, version.Version)
+}
+
+// InitContext initialize the Request Context injecting the logger and the requestID
+func InitContext(logger logr.Logger) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		reqCtx := ctx.Request.Context()
+
+		requestID := uuid.NewString()
+		baseLogger := logger.WithValues("requestId", requestID)
+
+		reqCtx = requestctx.WithID(reqCtx, requestID)
+		reqCtx = requestctx.WithLogger(reqCtx, baseLogger)
+		ctx.Request = ctx.Request.WithContext(reqCtx)
+	}
 }

--- a/internal/api/v1/middleware/middleware.go
+++ b/internal/api/v1/middleware/middleware.go
@@ -1,0 +1,22 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	v1 "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/internal/version"
+	"github.com/gin-gonic/gin"
+)
+
+func EpinioVersion(ctx *gin.Context) {
+	ctx.Header(v1.VersionHeader, version.Version)
+}

--- a/internal/api/v1/middleware/namespace.go
+++ b/internal/api/v1/middleware/namespace.go
@@ -9,7 +9,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package middleware
 
 import (
 	"fmt"
@@ -22,9 +22,9 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// NamespaceMiddleware is a gin middleware used to check if a namespaced route is valid.
+// NamespaceExists is a gin middleware used to check if a namespaced route is valid.
 // It checks the validity of the requested namespace, returning a 404 if it doesn't exists
-func NamespaceMiddleware(c *gin.Context) {
+func NamespaceExists(c *gin.Context) {
 	logger := requestctx.Logger(c.Request.Context()).WithName("NamespaceMiddleware")
 	ctx := c.Request.Context()
 

--- a/internal/api/v1/middleware/suite_test.go
+++ b/internal/api/v1/middleware/suite_test.go
@@ -1,0 +1,24 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEpinio(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Epinio V1 Middleware Suite")
+}

--- a/internal/api/v1/middleware/token.go
+++ b/internal/api/v1/middleware/token.go
@@ -1,0 +1,80 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/epinio/epinio/helpers/authtoken"
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/auth"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
+	apierrors "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// TokenAuth middleware is used to authenticate a user from a 'authtoken'
+// It's used when trying to establish a websocket connections for authenticated users.
+func TokenAuth(ctx *gin.Context) {
+	logger := requestctx.Logger(ctx.Request.Context()).WithName("TokenAuth")
+	logger.V(1).Info("Authtoken authentication")
+
+	token := ctx.Query("authtoken")
+	claims, err := authtoken.Validate(token)
+	if err != nil {
+		apiErr := apierrors.NewAPIError("unknown token validation error", http.StatusUnauthorized)
+		if ve, ok := err.(*jwt.ValidationError); ok {
+			if ve.Errors&jwt.ValidationErrorMalformed != 0 {
+				apiErr.Title = "malformed token format"
+
+			} else if ve.Errors&(jwt.ValidationErrorExpired|jwt.ValidationErrorNotValidYet) != 0 {
+				apiErr.Title = "token expired"
+
+			} else {
+				apiErr.Title = "cannot handle token"
+			}
+		}
+
+		// detailed log message
+		logger.V(2).Info(apiErr.Title, "error", err.Error())
+		// not too specific log message for unauthorized client
+		response.Error(ctx, apiErr)
+		ctx.Abort()
+		return
+	}
+
+	authService, err := auth.NewAuthServiceFromContext(ctx)
+	if err != nil {
+		response.Error(ctx, apierrors.InternalError(err))
+		ctx.Abort()
+		return
+	}
+
+	// find the user and add it in the context
+	users, err := authService.GetUsers(ctx)
+	if err != nil {
+		response.Error(ctx, apierrors.InternalError(err))
+		ctx.Abort()
+		return
+	}
+
+	for _, user := range users {
+		if user.Username == claims.Username {
+			newCtx := ctx.Request.Context()
+			newCtx = requestctx.WithUser(newCtx, user)
+			ctx.Request = ctx.Request.Clone(newCtx)
+
+			break
+		}
+	}
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -61,7 +61,7 @@ func (s *AuthService) GetUsers(ctx context.Context) ([]User, error) {
 
 	users := []User{}
 	for _, secret := range secrets {
-		users = append(users, NewUserFromSecret(secret))
+		users = append(users, newUserFromSecret(secret))
 	}
 
 	return users, nil
@@ -110,7 +110,7 @@ func (s *AuthService) SaveUser(ctx context.Context, user User) (User, error) {
 		return User{}, err
 	}
 
-	return NewUserFromSecret(*createdUserSecret), nil
+	return newUserFromSecret(*createdUserSecret), nil
 }
 
 // AddNamespaceToUser will add the specified namespace to the User

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -13,7 +13,6 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -21,25 +20,17 @@ import (
 	"strings"
 	"time"
 
-	"github.com/epinio/epinio/helpers/authtoken"
-	"github.com/epinio/epinio/helpers/kubernetes"
 	apiv1 "github.com/epinio/epinio/internal/api/v1"
 	"github.com/epinio/epinio/internal/api/v1/middleware"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/auth"
-	"github.com/epinio/epinio/internal/cli/server/requestctx"
-	"github.com/epinio/epinio/internal/dex"
 	"github.com/epinio/epinio/internal/domain"
-	"github.com/epinio/epinio/internal/helmchart"
 	apierrors "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/bcrypt"
 
 	"github.com/alron/ginlogr"
 	"github.com/gin-gonic/gin"
 	"github.com/go-logr/logr"
-	"github.com/golang-jwt/jwt/v4"
-	"github.com/google/uuid"
 	"github.com/mattn/go-colorable"
 	"github.com/spf13/viper"
 )
@@ -101,7 +92,7 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 	router.Use(
 		ginLogger,
 		ginRecoveryLogger,
-		initContextMiddleware(logger),
+		middleware.InitContext(logger),
 	)
 
 	// No authentication, no session. This is epinio's version and auth information.
@@ -128,7 +119,7 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 	// Register api routes
 	{
 		apiRoutesGroup := router.Group(apiv1.Root,
-			authMiddleware,
+			middleware.Authentication,
 			middleware.EpinioVersion,
 			middleware.NamespaceExists,
 			middleware.NamespaceAuthorization,
@@ -140,7 +131,7 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 	// Register web socket routes
 	{
 		wapiRoutesGroup := router.Group(apiv1.WsRoot,
-			tokenAuthMiddleware,
+			middleware.TokenAuth,
 			middleware.EpinioVersion,
 			middleware.NamespaceExists,
 			middleware.NamespaceAuthorization,
@@ -184,284 +175,4 @@ func swaggerHandler(c *gin.Context) {
 	swaggerMap["host"] = "epinio." + mainDomain
 
 	c.JSON(http.StatusOK, swaggerMap)
-}
-
-// initContextMiddleware initialize the Request Context injecting the logger and the requestID
-func initContextMiddleware(logger logr.Logger) gin.HandlerFunc {
-	return func(ctx *gin.Context) {
-		reqCtx := ctx.Request.Context()
-
-		requestID := uuid.NewString()
-		baseLogger := logger.WithValues("requestId", requestID)
-
-		reqCtx = requestctx.WithID(reqCtx, requestID)
-		reqCtx = requestctx.WithLogger(reqCtx, baseLogger)
-		ctx.Request = ctx.Request.WithContext(reqCtx)
-	}
-}
-
-var oidcProvider *dex.OIDCProvider
-
-// getOIDCProvider returns a lazy constructed OIDC provider
-func getOIDCProvider(ctx context.Context) (*dex.OIDCProvider, error) {
-	if oidcProvider != nil {
-		return oidcProvider, nil
-	}
-
-	cluster, err := kubernetes.GetCluster(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get access to a kube client")
-	}
-
-	secret, err := cluster.GetSecret(ctx, helmchart.Namespace(), "dex-config")
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get dex-config secret")
-	}
-
-	config, err := dex.NewConfigFromSecretData("epinio-api", secret.Data)
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing the issuer URL")
-	}
-
-	oidcProvider, err := dex.NewOIDCProviderWithConfig(ctx, config)
-	if err != nil {
-		return nil, errors.Wrap(err, "constructing dexProviderConfig")
-	}
-
-	return oidcProvider, nil
-}
-
-// authMiddleware authenticates the user either using the basic auth or the bearer token (OIDC)
-func authMiddleware(ctx *gin.Context) {
-	// we need this check to return a 401 instead of an error
-	authorizationHeader := ctx.Request.Header.Get("Authorization")
-	if authorizationHeader == "" {
-		response.Error(ctx, apierrors.NewAPIError("missing credentials", http.StatusUnauthorized))
-		ctx.Abort()
-		return
-	}
-
-	var user auth.User
-	var authError apierrors.APIErrors
-
-	if strings.HasPrefix(authorizationHeader, "Basic ") {
-		user, authError = basicAuthentication(ctx)
-	} else if strings.HasPrefix(authorizationHeader, "Bearer ") {
-		user, authError = oidcAuthentication(ctx)
-	} else {
-		authError = apierrors.NewAPIError("not supported Authorization Header", http.StatusUnauthorized)
-	}
-
-	if authError != nil {
-		response.Error(ctx, authError)
-		ctx.Abort()
-		return
-	}
-
-	// Write the user info in the context. It's needed by the next middleware
-	// to write it into the session.
-	newCtx := ctx.Request.Context()
-	newCtx = requestctx.WithUser(newCtx, user)
-	ctx.Request = ctx.Request.Clone(newCtx)
-}
-
-// basicAuthentication performs the Basic Authentication
-func basicAuthentication(ctx *gin.Context) (auth.User, apierrors.APIErrors) {
-	reqCtx := ctx.Request.Context()
-	logger := requestctx.Logger(reqCtx).WithName("basicAuthentication")
-	logger.V(1).Info("starting Basic Authentication")
-
-	userMap, err := loadUsersMap(ctx)
-	if err != nil {
-		return auth.User{}, apierrors.InternalError(err)
-	}
-
-	if len(userMap) == 0 {
-		return auth.User{}, apierrors.NewAPIError("no user found", http.StatusUnauthorized)
-	}
-
-	username, password, ok := ctx.Request.BasicAuth()
-	if !ok {
-		return auth.User{}, apierrors.NewInternalError("Couldn't extract user from the auth header")
-	}
-
-	err = bcrypt.CompareHashAndPassword([]byte(userMap[username].Password), []byte(password))
-	if err != nil {
-		return auth.User{}, apierrors.NewAPIError("wrong password", http.StatusUnauthorized)
-	}
-
-	return userMap[username], nil
-}
-
-// oidcAuthentication perform the OIDC authentication with dex
-func oidcAuthentication(ctx *gin.Context) (auth.User, apierrors.APIErrors) {
-	reqCtx := ctx.Request.Context()
-	logger := requestctx.Logger(reqCtx).WithName("oidcAuthentication")
-	logger.V(1).Info("starting OIDC Authentication")
-
-	oidcProvider, err := getOIDCProvider(ctx)
-	if err != nil {
-		return auth.User{}, apierrors.InternalError(err, "error getting OIDC provider")
-	}
-
-	authHeader := ctx.Request.Header.Get("Authorization")
-	token := strings.TrimPrefix(authHeader, "Bearer ")
-
-	idToken, err := oidcProvider.Verify(ctx, token)
-	if err != nil {
-		return auth.User{}, apierrors.NewAPIError(errors.Wrap(err, "token verification failed").Error(), http.StatusUnauthorized)
-	}
-
-	var claims struct {
-		Email           string   `json:"email"`
-		Groups          []string `json:"groups"`
-		FederatedClaims struct {
-			ConnectorID string `json:"connector_id"`
-		} `json:"federated_claims"`
-	}
-	if err := idToken.Claims(&claims); err != nil {
-		return auth.User{}, apierrors.NewAPIError(errors.Wrap(err, "error parsing claims").Error(), http.StatusUnauthorized)
-	}
-
-	role := getRoleFromProviderGroups(logger, oidcProvider, claims.FederatedClaims.ConnectorID, claims.Groups)
-
-	user, err := getOrCreateUserByEmail(ctx, claims.Email, role)
-	if err != nil {
-		return auth.User{}, apierrors.InternalError(err, "getting/creating user with email")
-	}
-
-	logger.V(1).Info("token verified", "user", fmt.Sprintf("%#v", user))
-
-	return user, nil
-}
-
-// getRoleFromProviderGroups returns the user role, looking for it in the groups defined for the provider.
-// If there are no groups that matches then the default role 'user' is returned.
-// If a user has more than one group matching, the first from the Dex Configuration will be returned.
-func getRoleFromProviderGroups(logger logr.Logger, oidcProvider *dex.OIDCProvider, providerID string, groups []string) string {
-	defaultRole := "user"
-
-	pg, err := oidcProvider.GetProviderGroups(providerID)
-	if err != nil {
-		logger.Info(
-			"error getting provider groups",
-			"provider", providerID,
-		)
-
-		return defaultRole
-	}
-
-	roles := pg.GetRolesFromGroups(groups...)
-	if len(roles) == 0 {
-		logger.Info(
-			"no matching groups found in provider groups",
-			"provider", providerID,
-			"providerGroups", pg,
-			"groups", strings.Join(groups, ","),
-		)
-
-		return defaultRole
-	}
-
-	return roles[0]
-}
-
-func loadUsersMap(ctx context.Context) (map[string]auth.User, error) {
-	authService, err := auth.NewAuthServiceFromContext(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "couldn't create auth service from context")
-	}
-
-	users, err := authService.GetUsers(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "couldn't get users")
-	}
-
-	userMap := make(map[string]auth.User)
-	for _, user := range users {
-		userMap[user.Username] = user
-	}
-
-	return userMap, nil
-}
-
-func getOrCreateUserByEmail(ctx context.Context, email, role string) (auth.User, error) {
-	user := auth.User{}
-	var err error
-
-	authService, err := auth.NewAuthServiceFromContext(ctx)
-	if err != nil {
-		return user, errors.Wrap(err, "couldn't create auth service from context")
-	}
-
-	user, err = authService.GetUserByUsername(ctx, email)
-	if err != nil {
-		if err != auth.ErrUserNotFound {
-			return user, errors.Wrap(err, "couldn't get user")
-		}
-
-		user.Username = email
-		user.Role = role
-		user, err = authService.SaveUser(ctx, user)
-		if err != auth.ErrUserNotFound {
-			return user, errors.Wrap(err, "couldn't create user")
-		}
-	}
-
-	return user, nil
-}
-
-// tokenAuthMiddleware is only used to establish websocket connections for authenticated users
-func tokenAuthMiddleware(ctx *gin.Context) {
-	logger := requestctx.Logger(ctx.Request.Context()).WithName("TokenAuthMiddleware")
-	logger.V(1).Info("Authtoken authentication")
-
-	token := ctx.Query("authtoken")
-	claims, err := authtoken.Validate(token)
-	if err != nil {
-		apiErr := apierrors.NewAPIError("unknown token validation error", http.StatusUnauthorized)
-		if ve, ok := err.(*jwt.ValidationError); ok {
-			if ve.Errors&jwt.ValidationErrorMalformed != 0 {
-				apiErr.Title = "malformed token format"
-
-			} else if ve.Errors&(jwt.ValidationErrorExpired|jwt.ValidationErrorNotValidYet) != 0 {
-				apiErr.Title = "token expired"
-
-			} else {
-				apiErr.Title = "cannot handle token"
-			}
-		}
-
-		// detailed log message
-		logger.V(2).Info(apiErr.Title, "error", err.Error())
-		// not too specific log message for unauthorized client
-		response.Error(ctx, apiErr)
-		ctx.Abort()
-		return
-	}
-
-	authService, err := auth.NewAuthServiceFromContext(ctx)
-	if err != nil {
-		response.Error(ctx, apierrors.InternalError(err))
-		ctx.Abort()
-		return
-	}
-
-	// find the user and add it in the context
-	users, err := authService.GetUsers(ctx)
-	if err != nil {
-		response.Error(ctx, apierrors.InternalError(err))
-		ctx.Abort()
-		return
-	}
-
-	for _, user := range users {
-		if user.Username == claims.Username {
-			newCtx := ctx.Request.Context()
-			newCtx = requestctx.WithUser(newCtx, user)
-			ctx.Request = ctx.Request.Clone(newCtx)
-
-			break
-		}
-	}
 }

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/epinio/epinio/helpers/authtoken"
 	"github.com/epinio/epinio/helpers/kubernetes"
 	apiv1 "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/internal/api/v1/middleware"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/auth"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
@@ -130,9 +131,9 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 		apiRoutesGroup := router.Group(apiv1.Root,
 			authMiddleware,
 			versionMiddleware,
-			apiv1.NamespaceMiddleware,
-			apiv1.NamespaceAuthorizationMiddleware,
-			apiv1.GitconfigAuthorizationMiddleware,
+			middleware.NamespaceExists,
+			middleware.NamespaceAuthorization,
+			middleware.GitconfigAuthorization,
 		)
 		apiv1.Lemon(apiRoutesGroup)
 	}
@@ -142,8 +143,8 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 		wapiRoutesGroup := router.Group(apiv1.WsRoot,
 			tokenAuthMiddleware,
 			versionMiddleware,
-			apiv1.NamespaceMiddleware,
-			apiv1.NamespaceAuthorizationMiddleware,
+			middleware.NamespaceExists,
+			middleware.NamespaceAuthorization,
 			// gitconfig has no websocket routes
 		)
 		apiv1.Spice(wapiRoutesGroup)

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -31,7 +31,6 @@ import (
 	"github.com/epinio/epinio/internal/dex"
 	"github.com/epinio/epinio/internal/domain"
 	"github.com/epinio/epinio/internal/helmchart"
-	"github.com/epinio/epinio/internal/version"
 	apierrors "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
@@ -107,7 +106,7 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 
 	// No authentication, no session. This is epinio's version and auth information.
 	router.GET("/api/v1/info",
-		versionMiddleware,
+		middleware.EpinioVersion,
 		apiv1.ErrorHandler(apiv1.Info),
 	)
 
@@ -130,7 +129,7 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 	{
 		apiRoutesGroup := router.Group(apiv1.Root,
 			authMiddleware,
-			versionMiddleware,
+			middleware.EpinioVersion,
 			middleware.NamespaceExists,
 			middleware.NamespaceAuthorization,
 			middleware.GitconfigAuthorization,
@@ -142,7 +141,7 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 	{
 		wapiRoutesGroup := router.Group(apiv1.WsRoot,
 			tokenAuthMiddleware,
-			versionMiddleware,
+			middleware.EpinioVersion,
 			middleware.NamespaceExists,
 			middleware.NamespaceAuthorization,
 			// gitconfig has no websocket routes
@@ -230,10 +229,6 @@ func getOIDCProvider(ctx context.Context) (*dex.OIDCProvider, error) {
 	}
 
 	return oidcProvider, nil
-}
-
-func versionMiddleware(ctx *gin.Context) {
-	ctx.Header(apiv1.VersionHeader, version.Version)
 }
 
 // authMiddleware authenticates the user either using the basic auth or the bearer token (OIDC)


### PR DESCRIPTION
To remove some code from the `internal/api/v1` this PR moves some middlewares into the new `internal/api/v1/middleware` package.

It also renames the functon `NewUserFromSecret`to `newUserFromSecret` to make it private.
This function should be used only internally, and the callers should use the AuthService to fetch the users.
This is needed to avoid issues when creating users manually, instead of fetching them completely (filling them with Roles and whatever needed).