### PR TITLE
Added logger to AuthService

### DIFF
--- a/internal/api/v1/middleware/token.go
+++ b/internal/api/v1/middleware/token.go
@@ -53,7 +53,7 @@ func TokenAuth(ctx *gin.Context) {
 		return
 	}
 
-	authService, err := auth.NewAuthServiceFromContext(ctx)
+	authService, err := auth.NewAuthServiceFromContext(ctx, logger)
 	if err != nil {
 		response.Error(ctx, apierrors.InternalError(err))
 		ctx.Abort()

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -18,7 +18,9 @@ import (
 	"time"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/internal/names"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // User is a struct containing all the information of an Epinio User
@@ -135,4 +137,28 @@ func newUserFromSecret(secret corev1.Secret) User {
 	}
 
 	return user
+}
+
+// newSecretFromUser create a Secret from an Epinio User
+func newSecretFromUser(user User) corev1.Secret {
+	userSecretName := "r" + names.GenerateResourceName("user", user.Username)
+
+	return corev1.Secret{
+		Type: "Opaque",
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      userSecretName,
+			Namespace: "epinio",
+			Labels: map[string]string{
+				kubernetes.EpinioAPISecretLabelKey:     "true",
+				kubernetes.EpinioAPISecretRoleLabelKey: user.Role,
+			},
+		},
+		StringData: map[string]string{
+			"username": user.Username,
+		},
+	}
 }


### PR DESCRIPTION
This PR adds a logger and some logs to the AuthService.

```go
func NewAuthServiceFromContext(ctx context.Context, logger logr.Logger) (*AuthService, error) {
	cluster, err := kubernetes.GetCluster(ctx)
	if err != nil {
		return nil, errors.Wrap(err, "error getting kubernetes cluster")
	}

	return NewAuthService(logger, cluster), nil
}

func NewAuthService(logger logr.Logger, cluster *kubernetes.Cluster) *AuthService {
	return &AuthService{
		logger:          logger.WithName("AuthService"),
		SecretInterface: cluster.Kubectl.CoreV1().Secrets(helmchart.Namespace()),
	}
}
```

It was not possible fetching the logger from the Context because of a cycle dependency. Anyway since the creation of the AuthService was failing only because of the GetCluster the `NewAuthService` simplified some parts where the `Cluster` was already available. 