### PR TITLE
Fixed missing custom headers for `app logs` and `service port-forward`

### DIFF
--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -16,6 +16,7 @@ package usercmd
 
 import (
 	"context"
+	"net/http"
 	"runtime"
 
 	"github.com/epinio/epinio/helpers/kubernetes/tailer"
@@ -135,7 +136,7 @@ type APIClient interface {
 	VersionWarningEnabled() bool
 
 	SetHeader(k, v string)
-	Headers() map[string]string
+	Headers() http.Header
 }
 
 func New() (*EpinioClient, error) {

--- a/internal/cli/usercmd/login.go
+++ b/internal/cli/usercmd/login.go
@@ -17,6 +17,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -99,8 +100,10 @@ func (c *EpinioClient) Login(ctx context.Context, username, password, address st
 		}
 		client.API.DisableVersionWarning()
 
-		for k, v := range customHeaders {
-			client.API.SetHeader(k, v)
+		for k, values := range customHeaders {
+			for _, v := range values {
+				client.API.SetHeader(k, v)
+			}
 		}
 
 		// we don't need anything, just checking if the namespace exist and we have permissions
@@ -320,7 +323,7 @@ func updateSettings(address, username, password, serverCertificate string) (*set
 	return epinioSettings, nil
 }
 
-func verifyCredentials(ctx context.Context, epinioSettings *settings.Settings, customHeaders map[string]string) error {
+func verifyCredentials(ctx context.Context, epinioSettings *settings.Settings, customHeaders http.Header) error {
 	// Ensure that the settings have a location to get passed the client's check for it.
 	// Here it is ok to not have an actual location and file, because we are logging in, and at
 	// the end of the operation the relevant file will be created. Only having an API matters,
@@ -328,8 +331,10 @@ func verifyCredentials(ctx context.Context, epinioSettings *settings.Settings, c
 	epinioSettings.Location = "fake"
 	apiClient := epinioapi.New(ctx, epinioSettings)
 
-	for k, v := range customHeaders {
-		apiClient.SetHeader(k, v)
+	for k, values := range customHeaders {
+		for _, v := range values {
+			apiClient.SetHeader(k, v)
+		}
 	}
 
 	_, err := apiClient.Namespaces()

--- a/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
+++ b/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
@@ -14,6 +14,7 @@ package usercmdfakes
 
 import (
 	"context"
+	"net/http"
 	"sync"
 
 	"github.com/epinio/epinio/helpers/kubernetes/tailer"
@@ -660,15 +661,15 @@ type FakeAPIClient struct {
 		result1 models.GitconfigsMatchResponse
 		result2 error
 	}
-	HeadersStub        func() map[string]string
+	HeadersStub        func() http.Header
 	headersMutex       sync.RWMutex
 	headersArgsForCall []struct {
 	}
 	headersReturns struct {
-		result1 map[string]string
+		result1 http.Header
 	}
 	headersReturnsOnCall map[int]struct {
-		result1 map[string]string
+		result1 http.Header
 	}
 	InfoStub        func() (models.InfoResponse, error)
 	infoMutex       sync.RWMutex
@@ -3911,7 +3912,7 @@ func (fake *FakeAPIClient) GitconfigsMatchReturnsOnCall(i int, result1 models.Gi
 	}{result1, result2}
 }
 
-func (fake *FakeAPIClient) Headers() map[string]string {
+func (fake *FakeAPIClient) Headers() http.Header {
 	fake.headersMutex.Lock()
 	ret, specificReturn := fake.headersReturnsOnCall[len(fake.headersArgsForCall)]
 	fake.headersArgsForCall = append(fake.headersArgsForCall, struct {
@@ -3935,32 +3936,32 @@ func (fake *FakeAPIClient) HeadersCallCount() int {
 	return len(fake.headersArgsForCall)
 }
 
-func (fake *FakeAPIClient) HeadersCalls(stub func() map[string]string) {
+func (fake *FakeAPIClient) HeadersCalls(stub func() http.Header) {
 	fake.headersMutex.Lock()
 	defer fake.headersMutex.Unlock()
 	fake.HeadersStub = stub
 }
 
-func (fake *FakeAPIClient) HeadersReturns(result1 map[string]string) {
+func (fake *FakeAPIClient) HeadersReturns(result1 http.Header) {
 	fake.headersMutex.Lock()
 	defer fake.headersMutex.Unlock()
 	fake.HeadersStub = nil
 	fake.headersReturns = struct {
-		result1 map[string]string
+		result1 http.Header
 	}{result1}
 }
 
-func (fake *FakeAPIClient) HeadersReturnsOnCall(i int, result1 map[string]string) {
+func (fake *FakeAPIClient) HeadersReturnsOnCall(i int, result1 http.Header) {
 	fake.headersMutex.Lock()
 	defer fake.headersMutex.Unlock()
 	fake.HeadersStub = nil
 	if fake.headersReturnsOnCall == nil {
 		fake.headersReturnsOnCall = make(map[int]struct {
-			result1 map[string]string
+			result1 http.Header
 		})
 	}
 	fake.headersReturnsOnCall[i] = struct {
-		result1 map[string]string
+		result1 http.Header
 	}{result1}
 }
 

--- a/pkg/api/core/v1/client/apps.go
+++ b/pkg/api/core/v1/client/apps.go
@@ -235,7 +235,7 @@ func (c *Client) AppLogs(namespace, appName, stageID string, follow bool, printC
 	}
 
 	websocketURL := fmt.Sprintf("%s%s/%s?%s", c.Settings.WSS, api.WsRoot, endpoint, queryParams.Encode())
-	webSocketConn, resp, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{})
+	webSocketConn, resp, err := websocket.DefaultDialer.Dial(websocketURL, c.Headers())
 	if err != nil {
 		// Report detailed error found in the server response
 		if resp != nil && resp.StatusCode != http.StatusOK {

--- a/pkg/api/core/v1/client/client.go
+++ b/pkg/api/core/v1/client/client.go
@@ -31,7 +31,7 @@ type Client struct {
 	log              logr.Logger
 	Settings         *epiniosettings.Settings
 	HttpClient       *http.Client
-	customHeaders    map[string]string
+	customHeaders    http.Header
 	noVersionWarning bool
 }
 
@@ -74,16 +74,16 @@ func New(ctx context.Context, settings *epiniosettings.Settings) *Client {
 		log:           log,
 		Settings:      settings,
 		HttpClient:    oauth2.NewClient(ctx, tokenSource),
-		customHeaders: make(map[string]string),
+		customHeaders: http.Header{},
 	}
 }
 
 func (c *Client) SetHeader(key, value string) {
 	if c.customHeaders != nil {
-		c.customHeaders[key] = value
+		c.customHeaders.Set(key, value)
 	}
 }
 
-func (c *Client) Headers() map[string]string {
+func (c *Client) Headers() http.Header {
 	return c.customHeaders
 }

--- a/pkg/api/core/v1/client/http.go
+++ b/pkg/api/core/v1/client/http.go
@@ -128,8 +128,10 @@ func DoWithHandlers[T any](
 		return response, err
 	}
 
-	for key, value := range c.customHeaders {
-		request.Header.Set(key, value)
+	for key, values := range c.customHeaders {
+		for _, value := range values {
+			request.Header.Set(key, value)
+		}
 	}
 
 	reqLog := requestLogger(c.log, request)

--- a/pkg/api/core/v1/client/portforwarder.go
+++ b/pkg/api/core/v1/client/portforwarder.go
@@ -170,7 +170,7 @@ func (pf *ServicePortForwarder) handleConnection(localConn net.Conn) error {
 
 	portForwardURL.Scheme = "wss"
 
-	c, _, err := websocket.DefaultDialer.Dial(portForwardURL.String(), nil)
+	c, _, err := websocket.DefaultDialer.Dial(portForwardURL.String(), pf.Client.Headers())
 	if err != nil {
 		pf.Client.log.V(1).Error(err, "error dialing")
 		return err


### PR DESCRIPTION
Fix #2560 

This PR fixes the missing custom headers for the `app logs` command and the `service port-forward` command.  
`app exec` and `app port-forward` are still broken because they are using the spdy protocol instead of plain/standard websockets. See https://github.com/epinio/epinio/issues/2244 for the tracking issue.