### PR TITLE
Added support for additional tls certs to custom services

### DIFF
--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -157,7 +157,7 @@ func DeployService(ctx context.Context, parameters ServiceParameters) error {
 
 	if serviceRepoURL != "" {
 		if repoAuth.Certs != "" {
-			certFile := fmt.Sprintf("/tmp/svc-cert-%d.pem", time.Now().UnixNano())
+			certFile = fmt.Sprintf("/tmp/svc-cert-%d.pem", time.Now().UnixNano())
 			err = os.WriteFile(certFile, []byte(repoAuth.Certs), 0600)
 			if err != nil {
 				return err

--- a/internal/services/catalog.go
+++ b/internal/services/catalog.go
@@ -122,7 +122,7 @@ func (s *ServiceClient) convertUnstructuredIntoCatalogService(unstructured unstr
 				// Create file if missing.
 				err = os.WriteFile(fileName, []byte(pemData), 0600)
 				if err != nil {
-					return err
+					return nil, err
 				}
 			}
 			// File exists (either created now, or in the past)

--- a/pkg/api/core/v1/models/service.go
+++ b/pkg/api/core/v1/models/service.go
@@ -128,13 +128,18 @@ type CatalogService struct {
 // HelmRepo matches github.com/epinio/application/api/v1 HelmRepo
 // Reason for existence: Do not expose the internal CRD struct in the API.
 type HelmRepo struct {
-	Name string   `json:"name,omitempty"`
-	URL  string   `json:"url,omitempty"`
+	Name string `json:"name,omitempty"`
+	URL  string `json:"url,omitempty"`
+	// "Secret string" - Name of kube secret containing auth information, i.e
+	// username, password, certs. Optional. See `convertUnstructuredIntoCatalogService`
+	// for the code initializing this field from the kube secret.
 	Auth HelmAuth `json:"-"`
 }
 
-// HelmAuth contains the credentials to login into an OCI registry or a private Helm repository
+// HelmAuth contains the credentials to login into an OCI registry or a private Helm
+// repository. It may contain the path to a pod-local CERT file for securing the channel.
 type HelmAuth struct {
 	Username string `json:"-"`
 	Password string `json:"-"`
+	Certs    string `json:"-"`
 }

--- a/pkg/api/core/v1/models/service.go
+++ b/pkg/api/core/v1/models/service.go
@@ -137,7 +137,8 @@ type HelmRepo struct {
 }
 
 // HelmAuth contains the credentials to login into an OCI registry or a private Helm
-// repository. It may contain the path to a pod-local CERT file for securing the channel.
+// repository. It may contain the PEM-encoded data of additional certs used to secure
+// the channel.
 type HelmAuth struct {
 	Username string `json:"-"`
 	Password string `json:"-"`


### PR DESCRIPTION
fix #2555 

Similar to the support for certs by export to OCI registries.
Difference:
  - cert data is in the main secret holding repo credentials
  - export has the data in a separate secret referenced by name from the cred secret

might be better to adjust code here to use a separate secret as well, allow for sharing with export, and between services
