### PR TITLE
Adding test for critical endpoints over different k8s versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -480,11 +480,7 @@ jobs:
           EPINIO_TIMEOUT_MULTIPLIER: 3
         run: |
           rm -f /tmp/cov*
-          K3S_IMAGE_LATEST=$(curl -sH "Accept: application/vnd.github.v3+json" \
-          'https://api.github.com/repos/k3s-io/k3s/releases' \
-          | jq -r '.[] | select (.assets[].name == "k3s") | .name' \
-          | grep -v '\-rc' | sort -r | head -n1 | tr + -)
-          export KUBERNETES_VERSION=$K3S_IMAGE_LATEST 
+          export K3S_KIND=latest
           make acceptance-cluster-setup-several-k8s-versions
           export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
           make install-cert-manager
@@ -511,11 +507,7 @@ jobs:
           EPINIO_TIMEOUT_MULTIPLIER: 3
         run: |
           rm -f /tmp/cov*
-          K3S_IMAGE_OLDEST=$(curl -sH "Accept: application/vnd.github.v3+json" \
-          'https://api.github.com/repos/k3s-io/k3s/releases' \
-          | jq -r '.[] | select (.assets[].name == "k3s") | .name' \
-          | grep -v '\-rc' | sort -r | tail -n1 | tr + -)
-          export KUBERNETES_VERSION=$K3S_IMAGE_OLDEST
+          export K3S_KIND=oldest
           make acceptance-cluster-setup-several-k8s-versions
           export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
           make install-cert-manager
@@ -535,7 +527,6 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         uses: colpal/actions-clean@v1
 
-  ###########################################
   acceptance-api-services:
     needs:
       - linter

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -429,6 +429,113 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         uses: colpal/actions-clean@v1
 
+  acceptance-api-cep-different-k8s:
+    needs:
+      - linter
+    runs-on: [self-hosted, epinio]
+
+    env:
+      GOCOVERDIR: /tmp
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        timeout-minutes: 5
+        with:
+          cache: false
+          go-version: ${{ env.SETUP_GO_VERSION }}
+
+      - name: Setup Ginkgo Test Framework
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.11.0
+
+      - name: Cache Tools
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/tools
+          key: ${{ runner.os }}-tools
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Install Tools
+        run: make tools-install
+
+      - name: Add Tools to PATH
+        run: |
+          echo "`pwd`/output/bin" >> $GITHUB_PATH
+      
+      - name: API Acceptance Tests on LATEST K3S version
+        env:
+          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          EPINIO_TIMEOUT_MULTIPLIER: 3
+        run: |
+          rm -f /tmp/cov*
+          K3S_IMAGE_LATEST=$(curl -sH "Accept: application/vnd.github.v3+json" \
+          'https://api.github.com/repos/k3s-io/k3s/releases' \
+          | jq -r '.[] | select (.assets[].name == "k3s") | .name' \
+          | grep -v '\-rc' | sort -r | head -n1 | tr + -)
+          export KUBERNETES_VERSION=$K3S_IMAGE_LATEST 
+          make acceptance-cluster-setup-several-k8s-versions
+          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+          make install-cert-manager
+          make prepare_environment_k3d
+          make test-acceptance-api-apps-critical-endpoints
+          scripts/collect-coverage.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: acceptance-api-apps
+          path: ./coverprofile.out
+
+      - name: Cleanup k3d cluster
+        if: always()
+        run: make acceptance-cluster-delete
+
+      - name: Clean all
+        if: ${{ github.event_name == 'schedule' }}
+        uses: colpal/actions-clean@v1
+
+      - name: API Acceptance Tests on OLDEST K3S version
+        env:
+          REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          EPINIO_TIMEOUT_MULTIPLIER: 3
+        run: |
+          rm -f /tmp/cov*
+          K3S_IMAGE_OLDEST=$(curl -sH "Accept: application/vnd.github.v3+json" \
+          'https://api.github.com/repos/k3s-io/k3s/releases' \
+          | jq -r '.[] | select (.assets[].name == "k3s") | .name' \
+          | grep -v '\-rc' | sort -r | tail -n1 | tr + -)
+          export KUBERNETES_VERSION=$K3S_IMAGE_OLDEST
+          make acceptance-cluster-setup-several-k8s-versions
+          export KUBECONFIG=$PWD/tmp/acceptance-kubeconfig
+          make install-cert-manager
+          make prepare_environment_k3d
+          make test-acceptance-api-apps-critical-endpoints
+          scripts/collect-coverage.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: acceptance-api-apps
+          path: ./coverprofile.out
+
+      - name: Cleanup k3d cluster
+        if: always()
+        run: make acceptance-cluster-delete
+
+      - name: Clean all
+        if: ${{ github.event_name == 'schedule' }}
+        uses: colpal/actions-clean@v1
+
+  ###########################################
   acceptance-api-services:
     needs:
       - linter

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ acceptance-cluster-setup:
 acceptance-cluster-setup-kind:
 	@./scripts/acceptance-cluster-setup-kind.sh
 
+acceptance-cluster-setup-several-k8s-versions:
+	@./scripts/acceptance-cluster-setup-several-k8s-versions.sh
+
 test-acceptance: showfocus
 	ginkgo ${STANDARD_TEST_OPTIONS} acceptance/. acceptance/api/v1/. acceptance/apps/.
 
@@ -147,6 +150,12 @@ test-acceptance-upgrade: showfocus
 test-acceptance-install: showfocus
 	# TODO support for labels is coming in ginkgo v2
 	ginkgo -v --nodes ${GINKGO_NODES} --focus "${REGEX}" --randomize-all --flake-attempts=${FLAKE_ATTEMPTS} acceptance/install/.
+
+test-acceptance-api-apps-critical-endpoints: showfocus
+	ginkgo ${STANDARD_TEST_OPTIONS} --focus-file "application_exec_test.go" --label-filter "application" acceptance/api/v1/.
+	ginkgo ${STANDARD_TEST_OPTIONS} --focus-file "application_portforward_test.go" --label-filter "application" acceptance/api/v1/.
+	ginkgo ${STANDARD_TEST_OPTIONS} --focus-file "application_logs_test.go" --label-filter "application" acceptance/api/v1/.
+	ginkgo ${STANDARD_TEST_OPTIONS} --focus-file "service_portforward_test.go" --label-filter "service" acceptance/api/v1/.
 
 showfocus:
 	@if test `cat acceptance/*.go acceptance/apps/*.go acceptance/api/v1/*.go | grep -c 'FIt\|FWhen\|FDescribe\|FContext'` -gt 0 ; then echo ; echo 'Focus:' ; grep 'FIt\|FWhen\|FDescribe\|FContext' acceptance/*.go acceptance/apps/*.go acceptance/api/v1/*.go ; echo ; fi

--- a/scripts/acceptance-cluster-setup-several-k8s-versions.sh
+++ b/scripts/acceptance-cluster-setup-several-k8s-versions.sh
@@ -17,23 +17,21 @@ NETWORK_NAME=epinio-acceptance
 MIRROR_NAME=epinio-acceptance-registry-mirror
 CLUSTER_NAME=epinio-acceptance
 export KUBECONFIG=$SCRIPT_DIR/../tmp/acceptance-kubeconfig
-K3S_IMAGE_LATEST=$(curl -sH "Accept: application/vnd.github.v3+json" 'https://api.github.com/repos/k3s-io/k3s/releases' | jq -r '.[] | select (.assets[].name == "k3s") | .name' | grep -v '\-rc' | sort -r | head -n1 | tr + -)
-K3S_IMAGE_OLDEST=$(curl -sH "Accept: application/vnd.github.v3+json" 'https://api.github.com/repos/k3s-io/k3s/releases' | jq -r '.[] | select (.assets[].name == "k3s") | .name' | grep -v '\-rc' | sort -r | tail -n1 | tr + -)
 
-# To run the script export $KUBERNETES_VERSION 
-# to either K3S_IMAGE_LATEST or K3S_IMAGE_OLDEST
-# If nothing is set, it will run latest K3s
+# k3s version selection (latest is default)
+if [[ "$K3S_KIND" == "latest" || "$K3S_KIND" == ""  ]]; then 
+    K3S_IMAGE_LATEST=$(curl -sH "Accept: application/vnd.github.v3+json" 'https://api.github.com/repos/k3s-io/k3s/releases' | jq -r '.[] | select (.assets[].name == "k3s") | .name' | grep -v '\-rc' | sort -r | tr + - | head -n1)
+    echo "-------------------------------------------------------------------------------------------------"
+    echo "Flag K3S_RELEASES set to latest k3s version or empty, using LATEST k3s version: $K3S_IMAGE_LATEST"
+    echo "-------------------------------------------------------------------------------------------------"
+    K3S_IMAGE=${K3S_IMAGE:-rancher/k3s:$K3S_IMAGE_LATEST}
 
-if [[ "$KUBERNETES_VERSION" == "" ]]; then
-echo "--------------------------------------------------------------------------------"
-echo "Flag KUBERNETES_VERSION set empty, using LATEST k3s version: '$K3S_IMAGE_LATEST'"
-echo "--------------------------------------------------------------------------------"
-K3S_IMAGE=${K3S_IMAGE:-rancher/k3s:$K3S_IMAGE_LATEST}
-else
-echo "---------------------------------------------------------------------------------"
-echo "Flag KUBERNETES_VERSION detected, using k3s version: '$KUBERNETES_VERSION'"
-echo "---------------------------------------------------------------------------------"
-K3S_IMAGE=${K3S_IMAGE:-rancher/k3s:$KUBERNETES_VERSION}
+elif [[ "$K3S_KIND" == "oldest" ]]; then 
+    K3S_IMAGE_OLDEST=$(curl -sH "Accept: application/vnd.github.v3+json" 'https://api.github.com/repos/k3s-io/k3s/releases' | jq -r '.[] | select (.assets[].name == "k3s") | .name' | grep -v '\-rc' | sort -r | tr + - | tail -n1)
+    echo "------------------------------------------------------------------------"
+    echo "Flag K3S_RELEASES set empty, using OLDEST k3s version: $K3S_IMAGE_OLDEST"
+    echo "------------------------------------------------------------------------"
+    K3S_IMAGE=${K3S_IMAGE:-rancher/k3s:$K3S_IMAGE_OLDEST}
 fi
 
 check_deps() {

--- a/scripts/acceptance-cluster-setup-several-k8s-versions.sh
+++ b/scripts/acceptance-cluster-setup-several-k8s-versions.sh
@@ -17,10 +17,9 @@ NETWORK_NAME=epinio-acceptance
 MIRROR_NAME=epinio-acceptance-registry-mirror
 CLUSTER_NAME=epinio-acceptance
 export KUBECONFIG=$SCRIPT_DIR/../tmp/acceptance-kubeconfig
+# Get all available k3s releases, sort them, get rid of RCs and use tag format
 K3S_RELEASES=$(curl -sH "Accept: application/vnd.github.v3+json" 'https://api.github.com/repos/k3s-io/k3s/releases' | jq -r '.[] | select (.assets[].name == "k3s") | .name' | grep -v '\-rc' | sort -r | tr + -)
 
-
-# Get all available k3s releases, sort them, get rid of RCs and use tag format
 # k3s version selection (latest is default)
 if [[ "$K3S_KIND" == "latest" || "$K3S_KIND" == "" ]]; then
     K3S_IMAGE_TAG=$(echo $K3S_RELEASES | awk '{print $1}')

--- a/scripts/acceptance-cluster-setup-several-k8s-versions.sh
+++ b/scripts/acceptance-cluster-setup-several-k8s-versions.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Copyright © 2021 - 2023 SUSE LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+NETWORK_NAME=epinio-acceptance
+MIRROR_NAME=epinio-acceptance-registry-mirror
+CLUSTER_NAME=epinio-acceptance
+export KUBECONFIG=$SCRIPT_DIR/../tmp/acceptance-kubeconfig
+K3S_IMAGE_LATEST=$(curl -sH "Accept: application/vnd.github.v3+json" 'https://api.github.com/repos/k3s-io/k3s/releases' | jq -r '.[] | select (.assets[].name == "k3s") | .name' | grep -v '\-rc' | sort -r | head -n1 | tr + -)
+K3S_IMAGE_OLDEST=$(curl -sH "Accept: application/vnd.github.v3+json" 'https://api.github.com/repos/k3s-io/k3s/releases' | jq -r '.[] | select (.assets[].name == "k3s") | .name' | grep -v '\-rc' | sort -r | tail -n1 | tr + -)
+
+# To run the script export $KUBERNETES_VERSION 
+# to either K3S_IMAGE_LATEST or K3S_IMAGE_OLDEST
+# If nothing is set, it will run latest K3s
+
+if [[ "$KUBERNETES_VERSION" == "" ]]; then
+echo "--------------------------------------------------------------------------------"
+echo "Flag KUBERNETES_VERSION set empty, using LATEST k3s version: '$K3S_IMAGE_LATEST'"
+echo "--------------------------------------------------------------------------------"
+K3S_IMAGE=${K3S_IMAGE:-rancher/k3s:$K3S_IMAGE_LATEST}
+else
+echo "---------------------------------------------------------------------------------"
+echo "Flag KUBERNETES_VERSION detected, using k3s version: '$KUBERNETES_VERSION'"
+echo "---------------------------------------------------------------------------------"
+K3S_IMAGE=${K3S_IMAGE:-rancher/k3s:$KUBERNETES_VERSION}
+fi
+
+check_deps() {
+  if ! command -v k3d &> /dev/null
+  then
+      echo "k3d could not be found"
+      exit
+  fi
+}
+
+existingCluster() {
+  k3d cluster list | grep ${CLUSTER_NAME}
+}
+
+if [[ "$(existingCluster)" != "" ]]; then
+  echo "Cluster already exists, skipping creation."
+  exit 0
+fi
+
+echo "Ensuring a network"
+docker network create $NETWORK_NAME || echo "Network already exists"
+
+if [[ "$SHARED_REGISTRY_MIRROR" == "" ]]; then
+  echo "Ensuring registry mirror (even if it's stopped)"
+  existingMirror=$(docker ps -a --filter name=$MIRROR_NAME -q)
+  if [[ $existingMirror  == "" ]]; then
+    echo "No mirror found, creating one"
+    docker run -d --network $NETWORK_NAME --name $MIRROR_NAME \
+      -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io \
+      -e REGISTRY_PROXY_USERNAME="${REGISTRY_USERNAME}" \
+      -e REGISTRY_PROXY_PASSWORD="${REGISTRY_PASSWORD}" \
+      registry:2
+  else
+    docker start $MIRROR_NAME # In case it was stopped (we used "-a" when listing)
+  fi
+else
+  echo "Using local registry mirror"
+  MIRROR_NAME="$SHARED_REGISTRY_MIRROR"
+fi
+
+echo "Writing epinio settings yaml"
+TMP_CONFIG="$(mktemp)"
+trap "rm -f $TMP_CONFIG" EXIT
+
+cat << EOF > $TMP_CONFIG
+mirrors:
+  "docker.io":
+    endpoint:
+      - http://$MIRROR_NAME:5000
+EOF
+
+echo "Creating a new one named $CLUSTER_NAME"
+if [ -z ${EXPOSE_ACCEPTANCE_CLUSTER_PORTS+x} ]; then
+  # Without exposing ports on the host:
+  k3d cluster create $CLUSTER_NAME --network $NETWORK_NAME --registry-config $TMP_CONFIG --image "$K3S_IMAGE" $EPINIO_K3D_INSTALL_ARGS
+else
+  # Exposing ports on the host:
+  k3d cluster create $CLUSTER_NAME --network $NETWORK_NAME --registry-config $TMP_CONFIG -p '80:80@server:0' -p '443:443@server:0' --image "$K3S_IMAGE" $EPINIO_K3D_INSTALL_ARGS
+fi
+k3d kubeconfig get $CLUSTER_NAME > $KUBECONFIG
+
+echo "Waiting for node to be ready"
+nodeName=$(kubectl get nodes -o name)
+kubectl wait --for=condition=Ready "$nodeName"
+
+date
+echo "Waiting for the deployments of the foundational configurations to be ready"
+# 1200s = 20 min, to handle even a horrendously slow setup. Regular is 10 to 30 seconds.
+kubectl wait --for=condition=Available --namespace kube-system deployment/metrics-server		--timeout=1200s
+kubectl wait --for=condition=Available --namespace kube-system deployment/coredns			--timeout=1200s
+kubectl wait --for=condition=Available --namespace kube-system deployment/local-path-provisioner	--timeout=1200s
+date
+
+echo "Done! The cluster is ready."


### PR DESCRIPTION
Implements: https://github.com/epinio/epinio/issues/2038

# Done
- New jobs on CI workflow to run over check the latest k3s version and oldest ones
- New script `acceptance-cluster-setup-several-k8s-versions.sh` that sets up k3s versions based on previous flags
- Triggers 4 tests at the moment on the newer and oldest k3s versions:
`application_exec_test.go`, `application_portforward_test.go`, `application_logs_test.go`, `service_portforward_test.go` 