### PR TITLE
Added `/me` endpoint to check credentials

### DIFF
--- a/acceptance/api/v1/helpers_api_test.go
+++ b/acceptance/api/v1/helpers_api_test.go
@@ -104,6 +104,13 @@ func gitproxy(body io.Reader) ([]byte, int) {
 	return curl(http.MethodPost, endpoint, body)
 }
 
+func me() ([]byte, int) {
+	GinkgoHelper()
+
+	endpoint := makeEndpoint("me")
+	return curl(http.MethodGet, endpoint, nil)
+}
+
 func curl(method, endpoint string, body io.Reader) ([]byte, int) {
 	GinkgoHelper()
 

--- a/acceptance/api/v1/me_test.go
+++ b/acceptance/api/v1/me_test.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = FDescribe("Me endpoint", LMisc, func() {
+var _ = Describe("Me endpoint", LMisc, func() {
 
 	When("user is authenticated", func() {
 		It("returns info about the current user", func() {

--- a/acceptance/api/v1/me_test.go
+++ b/acceptance/api/v1/me_test.go
@@ -1,0 +1,48 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = FDescribe("Me endpoint", LMisc, func() {
+
+	When("user is authenticated", func() {
+		It("returns info about the current user", func() {
+			bodyBytes, statusCode := me()
+			Expect(statusCode).To(Equal(http.StatusOK))
+
+			responseMe := fromJSON[models.MeResponse](bodyBytes)
+			Expect(responseMe.User).To(Equal(env.EpinioUser))
+
+			fmt.Println(string(bodyBytes))
+		})
+	})
+
+	When("user is not authenticated", func() {
+		It("fails getting the current user", func() {
+			endpoint := makeEndpoint("me")
+			request, err := http.NewRequest("GET", endpoint, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			resp, err := env.Client().Do(request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+		})
+	})
+})

--- a/internal/api/v1/me.go
+++ b/internal/api/v1/me.go
@@ -1,0 +1,36 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
+
+	"github.com/gin-gonic/gin"
+
+	. "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+)
+
+// Me handles the API endpoint /me.
+// It returns some information about the current user
+func Me(c *gin.Context) APIErrors {
+	user := requestctx.User(c.Request.Context())
+
+	response.OKReturn(c, models.MeResponse{
+		User:       user.Username,
+		Role:       user.Role,
+		Namespaces: user.Namespaces,
+		Gitconfigs: user.Gitconfigs,
+	})
+	return nil
+}

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -101,6 +101,13 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 		apiv1.ErrorHandler(apiv1.Info),
 	)
 
+	// authenticated /me endpoint returns the current user (no other checks/middlewares needed)
+	router.GET("/api/v1/me",
+		middleware.Authentication,
+		middleware.EpinioVersion,
+		apiv1.ErrorHandler(apiv1.Me),
+	)
+
 	// Dex or no dex ?
 	if _, err := os.Stat(apiv1.DexPEMPath); err == nil {
 		// dex secret is present, load contained cert

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -46,6 +46,7 @@ type EpinioClient struct {
 //counterfeiter:generate -header ../../../LICENSE_HEADER . APIClient
 type APIClient interface {
 	AuthToken() (models.AuthTokenResponse, error)
+	Me() (models.MeResponse, error)
 
 	// app
 	AppCreate(req models.ApplicationCreateRequest, namespace string) (models.Response, error)

--- a/internal/cli/usercmd/login.go
+++ b/internal/cli/usercmd/login.go
@@ -337,6 +337,6 @@ func verifyCredentials(ctx context.Context, epinioSettings *settings.Settings, c
 		}
 	}
 
-	_, err := apiClient.Namespaces()
+	_, err := apiClient.Me()
 	return errors.Wrap(err, "error while connecting to the Epinio server")
 }

--- a/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
+++ b/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
@@ -683,6 +683,18 @@ type FakeAPIClient struct {
 		result1 models.InfoResponse
 		result2 error
 	}
+	MeStub        func() (models.MeResponse, error)
+	meMutex       sync.RWMutex
+	meArgsForCall []struct {
+	}
+	meReturns struct {
+		result1 models.MeResponse
+		result2 error
+	}
+	meReturnsOnCall map[int]struct {
+		result1 models.MeResponse
+		result2 error
+	}
 	NamespaceCreateStub        func(models.NamespaceCreateRequest) (models.Response, error)
 	namespaceCreateMutex       sync.RWMutex
 	namespaceCreateArgsForCall []struct {
@@ -4021,6 +4033,62 @@ func (fake *FakeAPIClient) InfoReturnsOnCall(i int, result1 models.InfoResponse,
 	}{result1, result2}
 }
 
+func (fake *FakeAPIClient) Me() (models.MeResponse, error) {
+	fake.meMutex.Lock()
+	ret, specificReturn := fake.meReturnsOnCall[len(fake.meArgsForCall)]
+	fake.meArgsForCall = append(fake.meArgsForCall, struct {
+	}{})
+	stub := fake.MeStub
+	fakeReturns := fake.meReturns
+	fake.recordInvocation("Me", []interface{}{})
+	fake.meMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeAPIClient) MeCallCount() int {
+	fake.meMutex.RLock()
+	defer fake.meMutex.RUnlock()
+	return len(fake.meArgsForCall)
+}
+
+func (fake *FakeAPIClient) MeCalls(stub func() (models.MeResponse, error)) {
+	fake.meMutex.Lock()
+	defer fake.meMutex.Unlock()
+	fake.MeStub = stub
+}
+
+func (fake *FakeAPIClient) MeReturns(result1 models.MeResponse, result2 error) {
+	fake.meMutex.Lock()
+	defer fake.meMutex.Unlock()
+	fake.MeStub = nil
+	fake.meReturns = struct {
+		result1 models.MeResponse
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeAPIClient) MeReturnsOnCall(i int, result1 models.MeResponse, result2 error) {
+	fake.meMutex.Lock()
+	defer fake.meMutex.Unlock()
+	fake.MeStub = nil
+	if fake.meReturnsOnCall == nil {
+		fake.meReturnsOnCall = make(map[int]struct {
+			result1 models.MeResponse
+			result2 error
+		})
+	}
+	fake.meReturnsOnCall[i] = struct {
+		result1 models.MeResponse
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeAPIClient) NamespaceCreate(arg1 models.NamespaceCreateRequest) (models.Response, error) {
 	fake.namespaceCreateMutex.Lock()
 	ret, specificReturn := fake.namespaceCreateReturnsOnCall[len(fake.namespaceCreateArgsForCall)]
@@ -5365,6 +5433,8 @@ func (fake *FakeAPIClient) Invocations() map[string][][]interface{} {
 	defer fake.headersMutex.RUnlock()
 	fake.infoMutex.RLock()
 	defer fake.infoMutex.RUnlock()
+	fake.meMutex.RLock()
+	defer fake.meMutex.RUnlock()
 	fake.namespaceCreateMutex.RLock()
 	defer fake.namespaceCreateMutex.RUnlock()
 	fake.namespaceDeleteMutex.RLock()

--- a/pkg/api/core/v1/client/http.go
+++ b/pkg/api/core/v1/client/http.go
@@ -318,7 +318,7 @@ func requestLogger(log logr.Logger, request *http.Request) logr.Logger {
 	if log.V(5).Enabled() {
 		log = log.WithValues(
 			"method", request.Method,
-			"uri", request.RequestURI,
+			"url", request.URL,
 			"body", bodyString,
 			"header", request.Header,
 		)

--- a/pkg/api/core/v1/client/info.go
+++ b/pkg/api/core/v1/client/info.go
@@ -22,3 +22,11 @@ func (c *Client) Info() (models.InfoResponse, error) {
 
 	return Get(c, endpoint, response)
 }
+
+// Me returns the current user
+func (c *Client) Me() (models.MeResponse, error) {
+	response := models.MeResponse{}
+	endpoint := "me"
+
+	return Get(c, endpoint, response)
+}

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -309,6 +309,14 @@ type InfoResponse struct {
 	OIDCEnabled         bool   `json:"oidc_enabled,omitempty"`
 }
 
+// MeResponse contains information about the current authenticated user
+type MeResponse struct {
+	User       string   `json:"user,omitempty"`
+	Role       string   `json:"role,omitempty"`
+	Namespaces []string `json:"namespaces,omitempty"`
+	Gitconfigs []string `json:"gitconfigs,omitempty"`
+}
+
 // AuthTokenResponse contains an auth token
 type AuthTokenResponse struct {
 	Token string `json:"token,omitempty"`


### PR DESCRIPTION
While doing the https://github.com/epinio/epinio/issues/2631 I needed to have an authenticated endpoint with no other middleware involved. This just to check the validity of the credentials.

At the moment the `/namespaces` endpoint was being used but with the new authorization roles there is the possibility that an authenticated user could not have the permission to list namespaces.

This PR adds a `/me` endpoint, that will return the current user:

```json
{
    "user": "epinio",
    "role": "user",
    "namespaces": [
        "workspace"
    ]
}
```