### PR TITLE
Added new Authorization Roles

### DIFF
--- a/acceptance/api/v1/namespace_auth_test.go
+++ b/acceptance/api/v1/namespace_auth_test.go
@@ -190,9 +190,9 @@ var _ = Describe("Users Namespace", LNamespace, func() {
 					response.Body.Close()
 				})
 
-				It("doesn't show the other user's namespace", func() {
+				It("shows the other user's namespace", func() {
 					response := showNamespace(user1, passwordUser1, commonNamespace)
-					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
 					response.Body.Close()
 				})
 			})

--- a/acceptance/api/v1/namespace_auth_test.go
+++ b/acceptance/api/v1/namespace_auth_test.go
@@ -190,9 +190,9 @@ var _ = Describe("Users Namespace", LNamespace, func() {
 					response.Body.Close()
 				})
 
-				It("shows the other user's namespace", func() {
+				It("doesn't show the other user's namespace", func() {
 					response := showNamespace(user1, passwordUser1, commonNamespace)
-					Expect(response.StatusCode).To(Equal(http.StatusOK))
+					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
 					response.Body.Close()
 				})
 			})

--- a/acceptance/helpers/machine/users.go
+++ b/acceptance/helpers/machine/users.go
@@ -57,7 +57,7 @@ func (m *Machine) CreateEpinioUser(role string, namespaces []string) (string, st
 	// build roles (default for global role, and admin for its namespaces)
 	roles := []string{role}
 	for _, namespace := range namespaces {
-		roles = append(roles, "admin::"+namespace)
+		roles = append(roles, "admin:"+namespace)
 	}
 
 	secret.ObjectMeta.Annotations = map[string]string{

--- a/acceptance/helpers/machine/users.go
+++ b/acceptance/helpers/machine/users.go
@@ -54,6 +54,16 @@ func (m *Machine) CreateEpinioUser(role string, namespaces []string) (string, st
 		},
 	}
 
+	// build roles (default for global role, and admin for its namespaces)
+	roles := []string{role}
+	for _, namespace := range namespaces {
+		roles = append(roles, "admin::"+namespace)
+	}
+
+	secret.ObjectMeta.Annotations = map[string]string{
+		"epinio.io/roles": strings.Join(roles, ","),
+	}
+
 	secretTmpFile := catalog.NewTmpName("tmpUserFile") + `.json`
 	file, err := os.Create(secretTmpFile)
 	Expect(err).ToNot(HaveOccurred())

--- a/acceptance/users_test.go
+++ b/acceptance/users_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Users", LMisc, func() {
 	var uri string
 
 	BeforeEach(func() {
-		uri = fmt.Sprintf("%s%s/namespaces", serverURL, v1.Root)
+		uri = fmt.Sprintf("%s%s/me", serverURL, v1.Root)
 		request, err = http.NewRequest("GET", uri, strings.NewReader(""))
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/helpers/kubernetes/cluster.go
+++ b/helpers/kubernetes/cluster.go
@@ -53,6 +53,7 @@ var (
 	EpinioAPISecretLabelKey         = fmt.Sprintf("%s/%s", APISGroupName, "api-user-credentials")
 	EpinioAPISecretLabelValue       = "true"
 	EpinioAPIGitCredentialsLabelKey = fmt.Sprintf("%s/%s", APISGroupName, "api-git-credentials")
+	EpinioAPISecretRoleLabelKey     = fmt.Sprintf("%s/%s", APISGroupName, "role")
 	EpinioAPIExportRegistryLabelKey = fmt.Sprintf("%s/%s", APISGroupName, "api-export-registry")
 
 	EpinioAPIConfigMapRolesLabelKey   = fmt.Sprintf("%s/%s", APISGroupName, "role")

--- a/helpers/kubernetes/cluster.go
+++ b/helpers/kubernetes/cluster.go
@@ -53,8 +53,10 @@ var (
 	EpinioAPISecretLabelKey         = fmt.Sprintf("%s/%s", APISGroupName, "api-user-credentials")
 	EpinioAPISecretLabelValue       = "true"
 	EpinioAPIGitCredentialsLabelKey = fmt.Sprintf("%s/%s", APISGroupName, "api-git-credentials")
-	EpinioAPISecretRoleLabelKey     = fmt.Sprintf("%s/%s", APISGroupName, "role")
 	EpinioAPIExportRegistryLabelKey = fmt.Sprintf("%s/%s", APISGroupName, "api-export-registry")
+
+	EpinioAPIConfigMapRolesLabelKey   = fmt.Sprintf("%s/%s", APISGroupName, "role")
+	EpinioAPISecretRolesAnnotationKey = fmt.Sprintf("%s/%s", APISGroupName, "roles")
 )
 
 // Memoization of GetCluster

--- a/internal/api/v1/me.go
+++ b/internal/api/v1/me.go
@@ -26,9 +26,19 @@ import (
 func Me(c *gin.Context) APIErrors {
 	user := requestctx.User(c.Request.Context())
 
+	roles := []models.Role{}
+	for _, r := range user.Roles {
+		roles = append(roles, models.Role{
+			ID:        r.ID,
+			Name:      r.Name,
+			Namespace: r.Namespace,
+			Default:   r.Default,
+		})
+	}
+
 	response.OKReturn(c, models.MeResponse{
 		User:       user.Username,
-		Role:       user.Role,
+		Roles:      roles,
 		Namespaces: user.Namespaces,
 		Gitconfigs: user.Gitconfigs,
 	})

--- a/internal/api/v1/middleware/auth.go
+++ b/internal/api/v1/middleware/auth.go
@@ -46,16 +46,7 @@ func RoleAuthorization(c *gin.Context) {
 
 func NamespaceAuthorization(c *gin.Context) {
 	user := requestctx.User(c.Request.Context())
-	allowedNamespaces := user.Namespaces
-
-	// if the user has a Role attached to a namespace then it means he's allowed for it
-	for _, role := range user.Roles {
-		if role.Namespace != "" {
-			allowedNamespaces = append(allowedNamespaces, role.Namespace)
-		}
-	}
-
-	authorization(c, "namespace", allowedNamespaces)
+	authorization(c, "namespace", user.Namespaces)
 }
 
 func GitconfigAuthorization(c *gin.Context) {

--- a/internal/api/v1/middleware/auth.go
+++ b/internal/api/v1/middleware/auth.go
@@ -61,7 +61,11 @@ func authorization(c *gin.Context, label string, allowed []string) {
 	method := c.Request.Method
 	path := c.Request.URL.Path
 
-	logger.Info(fmt.Sprintf("authorization request from user [%s] with roles [%s] for [%s - %s]", user.Username, user.Roles.IDs(), method, path))
+	roleIDs := strings.Join(user.Roles.IDs(), ",")
+	logger.Info(fmt.Sprintf(
+		"authorization request from user [%s] with roles [%s] for [%s - %s]",
+		user.Username, roleIDs, method, path,
+	))
 
 	if user.IsAdmin() {
 		logger.V(1).WithName("authorizeAdmin").Info("user [admin] is authorized")
@@ -87,9 +91,10 @@ func authorization(c *gin.Context, label string, allowed []string) {
 	for _, rsrc := range resourceNames {
 		authorized := authorizeUser(logger, label, rsrc, allowed)
 
+		roleIDs := strings.Join(user.Roles.IDs(), ",")
 		logger.Info(fmt.Sprintf(
 			"user [%s] with roles [%s] authorized [%t] for %s [%s]",
-			user.Username, user.Roles.IDs(), authorized, label, rsrc,
+			user.Username, roleIDs, authorized, label, rsrc,
 		))
 
 		if !authorized {

--- a/internal/api/v1/middleware/auth_test.go
+++ b/internal/api/v1/middleware/auth_test.go
@@ -59,16 +59,8 @@ var _ = Describe("Authorization Middleware", func() {
 				},
 			}
 
-			userNamespace2Role := auth.Role{
-				ID:        "reader",
-				Namespace: "workspace2",
-				Actions: []auth.Action{
-					auth.ActionsMap["namespace"],
-				},
-			}
-
 			ctx = requestctx.WithUser(ctx, auth.User{
-				Roles:      []auth.Role{userRole, userNamespace2Role},
+				Roles:      []auth.Role{userRole},
 				Namespaces: []string{"workspace"},
 			})
 		})
@@ -104,13 +96,6 @@ var _ = Describe("Authorization Middleware", func() {
 
 			It("returns status code 200 for its namespace", func() {
 				c.Params = []gin.Param{{Key: "namespace", Value: "workspace"}}
-
-				middleware.NamespaceAuthorization(c)
-				Expect(w.Code).To(Equal(http.StatusOK))
-			})
-
-			It("returns status code 200 for a namespace where he has a role", func() {
-				c.Params = []gin.Param{{Key: "namespace", Value: "workspace2"}}
 
 				middleware.NamespaceAuthorization(c)
 				Expect(w.Code).To(Equal(http.StatusOK))

--- a/internal/api/v1/middleware/auth_test.go
+++ b/internal/api/v1/middleware/auth_test.go
@@ -38,6 +38,9 @@ var _ = Describe("Authorization Middleware", func() {
 		c, _ = gin.CreateTestContext(w)
 		ctx = requestctx.WithLogger(context.Background(), logr.Discard())
 		url = "http://url.com/endpoint"
+
+		err := v1.InitAuth()
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	JustBeforeEach(func() {
@@ -49,8 +52,15 @@ var _ = Describe("Authorization Middleware", func() {
 	Context("user has Role 'user'", func() {
 
 		BeforeEach(func() {
+			userRole := auth.Role{
+				ID: "user",
+				Actions: []auth.Action{
+					auth.ActionsMap["namespace"],
+				},
+			}
+
 			ctx = requestctx.WithUser(ctx, auth.User{
-				Role:       "user",
+				Roles:      []auth.Role{userRole},
 				Namespaces: []string{"workspace"},
 			})
 		})

--- a/internal/api/v1/middleware/auth_test.go
+++ b/internal/api/v1/middleware/auth_test.go
@@ -59,8 +59,16 @@ var _ = Describe("Authorization Middleware", func() {
 				},
 			}
 
+			userNamespace2Role := auth.Role{
+				ID:        "reader",
+				Namespace: "workspace2",
+				Actions: []auth.Action{
+					auth.ActionsMap["namespace"],
+				},
+			}
+
 			ctx = requestctx.WithUser(ctx, auth.User{
-				Roles:      []auth.Role{userRole},
+				Roles:      []auth.Role{userRole, userNamespace2Role},
 				Namespaces: []string{"workspace"},
 			})
 		})
@@ -96,6 +104,13 @@ var _ = Describe("Authorization Middleware", func() {
 
 			It("returns status code 200 for its namespace", func() {
 				c.Params = []gin.Param{{Key: "namespace", Value: "workspace"}}
+
+				middleware.NamespaceAuthorization(c)
+				Expect(w.Code).To(Equal(http.StatusOK))
+			})
+
+			It("returns status code 200 for a namespace where he has a role", func() {
+				c.Params = []gin.Param{{Key: "namespace", Value: "workspace2"}}
 
 				middleware.NamespaceAuthorization(c)
 				Expect(w.Code).To(Equal(http.StatusOK))

--- a/internal/api/v1/middleware/authentication.go
+++ b/internal/api/v1/middleware/authentication.go
@@ -200,7 +200,7 @@ func getRolesFromProviderGroups(logger logr.Logger, oidcProvider *dex.OIDCProvid
 
 		userRole, found := auth.EpinioRoles.FindByID(roleID)
 		if !found {
-			logger.Info(fmt.Sprintf("no role found in Epinio with roleID '%s'", roleID))
+			logger.Info(fmt.Sprintf("role not found in Epinio with roleID '%s'", roleID))
 			continue
 		}
 

--- a/internal/api/v1/namespace/create.go
+++ b/internal/api/v1/namespace/create.go
@@ -71,6 +71,12 @@ func Create(c *gin.Context) apierror.APIErrors {
 
 	// add the namespace to the User's namespaces
 	user.AddNamespace(namespaceName)
+
+	adminRole := auth.AdminRole
+	adminRole.Namespace = namespaceName
+
+	user.Roles = append(user.Roles, adminRole)
+
 	user, err = authService.UpdateUser(ctx, user)
 	if err != nil {
 		errDetail := fmt.Sprintf("error adding namespace [%s] to user [%s]", namespaceName, user.Username)

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -244,6 +244,7 @@ func Spice(router *gin.RouterGroup) {
 	}
 }
 
+// InitAuthAndRoles will init the Auth (loading the Actions and Endpoints) and the Roles
 func InitAuthAndRoles(rolesGetter auth.RolesGetter) error {
 	if err := InitAuth(); err != nil {
 		return err
@@ -252,6 +253,8 @@ func InitAuthAndRoles(rolesGetter auth.RolesGetter) error {
 	return auth.InitRoles(rolesGetter)
 }
 
+// InitAuth will init the Actions, and it will add to the actions the relevant endpoints.
+// This was needed because the Routes cannot be referred in the auth package for a cycle dependency.
 func InitAuth() error {
 	actions, err := auth.InitActions()
 	if err != nil {
@@ -294,7 +297,7 @@ func InitAuth() error {
 }
 
 // validateActionRoutes will check if the routes were mapped to actions.
-// This will prevent to have some unavailable routes that cannot be reached.
+// This prevents the existence of unavailable routes that cannot be reached.
 func validateActionRoutes(availableRoutes routes.NamedRoutes, assignedRoutes map[string]struct{}) error {
 	for routeID := range availableRoutes {
 		if _, found := assignedRoutes[routeID]; !found {

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -260,7 +260,7 @@ func InitAuth() error {
 
 	// maps to check the routes and wsRoutes assigned to the actions.
 	// They are used to validate that we have put every API to at least an action
-	// and that we have not forget to map any of them.
+	// and that we have not forgotten to map any of them.
 	assignedRoutes := make(map[string]struct{})
 	assignedWsRoutes := make(map[string]struct{})
 

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -253,7 +253,7 @@ func InitAuthAndRoles(rolesGetter auth.RolesGetter) error {
 }
 
 func InitAuth() error {
-	actions, err := auth.LoadActions()
+	actions, err := auth.InitActions()
 	if err != nil {
 		return err
 	}

--- a/internal/auth/action.go
+++ b/internal/auth/action.go
@@ -1,0 +1,128 @@
+package auth
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/epinio/epinio/helpers/routes"
+	"github.com/pkg/errors"
+	"golang.org/x/exp/maps"
+	"gopkg.in/yaml.v2"
+
+	// embedding
+	_ "embed"
+)
+
+//go:embed actions.yaml
+var actionsYAML []byte
+
+// ActionsMap holds the available actions that can be assigned to a Role
+// Call LoadActions to load the actions from the actions.yaml file.
+var ActionsMap = make(Actions)
+
+type Actions map[string]Action
+
+// Action defines a possible action that can be performed and the allowed Endpoints.
+type Action struct {
+	ID        string     `yaml:"id"`
+	Name      string     `yaml:"name"`
+	DependsOn []string   `yaml:"dependsOn"`
+	Endpoints []Endpoint `yaml:"-"`
+
+	Routes   []string `yaml:"routes"`
+	WsRoutes []string `yaml:"wsRoutes"`
+}
+
+// Endpoint is an API endpoint with verb, base path (i.e.: /api/v1 ) and path (i.e.: /apps)
+type Endpoint struct {
+	Method   string
+	BasePath string
+	Path     string
+}
+
+func NewEndpoint(route routes.Route) Endpoint {
+	return newEndpoint("/api/v1", route)
+}
+
+func NewWsEndpoint(route routes.Route) Endpoint {
+	return newEndpoint("/wapi/v1", route)
+}
+
+func newEndpoint(basePath string, route routes.Route) Endpoint {
+	return Endpoint{
+		Method:   route.Method,
+		BasePath: basePath,
+		Path:     route.Path,
+	}
+}
+
+func (e *Endpoint) FullPath() string {
+	return e.BasePath + e.Path
+}
+
+func LoadActions() ([]Action, error) {
+	actions := []Action{}
+
+	err := yaml.Unmarshal(actionsYAML, &actions)
+	if err != nil {
+		return actions, errors.Wrap(err, "loading actions from yaml")
+	}
+
+	// load map for quick lookup
+	for _, action := range actions {
+		ActionsMap[action.ID] = action
+	}
+
+	// load dependencies routes and wsRoutes
+	for i, action := range actions {
+		for _, dependencyID := range action.DependsOn {
+			// TODO check existence
+			dependency, found := ActionsMap[dependencyID]
+			if !found {
+				return actions, fmt.Errorf("action dependency '%s' not found in ActionsMap [actions.yaml]", dependencyID)
+			}
+			action = action.Merge(dependency)
+		}
+
+		ActionsMap[action.ID] = action
+		actions[i] = action
+	}
+
+	return actions, nil
+}
+
+// IsAllowed check if the action allows the called APIs checking the available endpoints
+func (a *Action) IsAllowed(method, fullpath string) bool {
+	for _, e := range a.Endpoints {
+		// find if the action allows the requested API
+		if e.Method == method && e.FullPath() == fullpath {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Merge will add the routes and wsRoutes from the dependency into the action
+func (a *Action) Merge(dependency Action) Action {
+	a.Routes = mergeAndSort(a.Routes, dependency.Routes)
+	a.WsRoutes = mergeAndSort(a.WsRoutes, dependency.WsRoutes)
+	return *a
+}
+
+// mergeAndSort will merge the values from the second array into the first.
+// It will remove the duplicates and sort the resulting array.
+func mergeAndSort(arr1, arr2 []string) []string {
+	arr1 = append(arr1, arr2...)
+
+	// unique map
+	m := make(map[string]struct{})
+	for _, v := range arr1 {
+		m[v] = struct{}{}
+	}
+
+	uniqueValues := maps.Keys(m)
+	sort.Strings(uniqueValues)
+
+	return uniqueValues
+}

--- a/internal/auth/action.go
+++ b/internal/auth/action.go
@@ -60,7 +60,7 @@ func (e *Endpoint) FullPath() string {
 	return e.BasePath + e.Path
 }
 
-func LoadActions() ([]Action, error) {
+func InitActions() ([]Action, error) {
 	actions := []Action{}
 
 	err := yaml.Unmarshal(actionsYAML, &actions)

--- a/internal/auth/action.go
+++ b/internal/auth/action.go
@@ -60,6 +60,7 @@ func (e *Endpoint) FullPath() string {
 	return e.BasePath + e.Path
 }
 
+// InitActions will load the yaml containing the Actions/Routes mapping, and their dependencies
 func InitActions() ([]Action, error) {
 	actions := []Action{}
 

--- a/internal/auth/action_test.go
+++ b/internal/auth/action_test.go
@@ -1,20 +1,30 @@
-package auth
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package auth collects structures and functions around the
+// generation and processing of credentials.
+package auth_test
 
 import (
-	"fmt"
-	"testing"
+	"github.com/epinio/epinio/internal/auth"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestNewFromYAML(t *testing.T) {
-	tests := []struct {
-		name string
-	}{
-		{name: "foo"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			actions, err := LoadActions()
-			fmt.Println(actions, err)
+var _ = Describe("Auth actions", func() {
+	Describe("InitActions", func() {
+		It("works", func() {
+			actions, err := auth.InitActions()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actions).ToNot(BeEmpty())
 		})
-	}
-}
+	})
+})

--- a/internal/auth/action_test.go
+++ b/internal/auth/action_test.go
@@ -1,0 +1,20 @@
+package auth
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNewFromYAML(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "foo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actions, err := LoadActions()
+			fmt.Println(actions, err)
+		})
+	}
+}

--- a/internal/auth/actions.yaml
+++ b/internal/auth/actions.yaml
@@ -157,6 +157,7 @@
   dependsOn:
     - service_read
     - service_write
+    - service_portforward
 
 # Service Read
 - id: service_read
@@ -226,7 +227,7 @@
     - GitconfigBatchDelete
 
 # Export Registries
-- id: export_registries
+- id: export_registries_read
   name: Export Registries
   routes:
     - Exportregistries

--- a/internal/auth/actions.yaml
+++ b/internal/auth/actions.yaml
@@ -1,0 +1,234 @@
+# Default action
+# This action will contain all the endpoints that are allowed by default
+- id: default
+  name: Default
+  routes:
+    - GitProxy
+
+# Namespace related actions
+- id: namespace
+  name: Namespace
+  dependsOn:
+    - namespace_read
+    - namespace_write
+
+# Namespace Read
+- id: namespace_read
+  name: Namespace Read
+  routes:
+    # neamespace read endpoints
+    - Namespaces
+    - NamespaceShow
+    # autocomplete
+    - NamespacesMatch
+    - NamespacesMatch0
+
+# Namespace Write
+- id: namespace_write
+  name: Namespace Write
+  dependsOn:
+    - namespace_read
+  routes:
+    - NamespaceCreate
+    - NamespaceDelete
+    - NamespaceBatchDelete
+
+# Applications related actions
+- id: app
+  name: App
+  dependsOn:
+    - app_read
+    - app_write
+    - app_logs
+    - app_exec
+    - app_portforward
+
+# App Read
+- id: app_read
+  name: App Read
+  routes:
+    # app read endpoints
+    - AllApps
+    - Apps
+    - AppShow
+    - StagingComplete
+    - AppRunning
+    - AppValidateCV
+    # app autocomplete
+    - AppMatch
+    - AppMatch0
+    # app env endpoints
+    - EnvList
+    - EnvShow
+    # app env autocomplete
+    - EnvMatch
+    - EnvMatch0
+    # app chart endpoints
+    - ChartList
+    - ChartShow
+    - ChartMatch
+    - ChartMatch0
+
+# App Write
+- id: app_write
+  name: App Write
+  dependsOn:
+    - app_read
+    - app_logs
+  routes:
+    - AppCreate
+    - AppDelete
+    - AppBatchDelete
+    - AppDeploy
+    - AppImportGit
+    - AppRestart
+    - AppStage
+    - AppUpdate
+    - AppUpload
+    - AppPart # export part
+    - AppExport # export to registry
+    # app env
+    - EnvSet
+    - EnvUnset
+    # configuration bindings
+    - ConfigurationBindingCreate
+    - ConfigurationBindingDelete
+
+# App Logs
+- id: app_logs
+  name: App Logs
+  routes:
+    - AuthToken
+  wsRoutes:
+    - AppLogs
+    - StagingLogs
+
+# App Exec
+- id: app_exec
+  name: App Exec
+  routes:
+    - AuthToken
+  wsRoutes:
+    - AppExec
+
+# App PortForward
+- id: app_portforward
+  name: App PortForward
+  routes:
+    - AuthToken
+  wsRoutes:
+    - AppPortForward
+
+# Configuration related actions
+- id: configuration
+  name: Configuration
+  dependsOn:
+    - configuration_read
+    - configuration_write
+
+# Configuration Read
+- id: configuration_read
+  name: Configuration Read
+  routes:
+    # configuration read endpoints
+    - ConfigurationApps
+    - AllConfigurations
+    - Configurations
+    - ConfigurationShow
+    # configuration autocomplete
+    - ConfigurationMatch
+    - ConfigurationMatch0
+
+# Configuration Write
+- id: configuration_write
+  name: Configuration Write
+  dependsOn:
+    - configuration_read
+  routes:
+    - ConfigurationCreate
+    - ConfigurationBatchDelete
+    - ConfigurationDelete
+    - ConfigurationUpdate
+    - ConfigurationReplace
+
+# Service related actions
+- id: service
+  name: Service
+  dependsOn:
+    - service_read
+    - service_write
+
+# Service Read
+- id: service_read
+  name: Service Read
+  routes:
+    # service catalog endpoints
+    - ServiceCatalog
+    - ServiceCatalogShow
+    - ServiceCatalogMatch
+    - ServiceCatalogMatch0
+    # service read endpoints
+    - ServiceApps
+    - AllServices
+    - ServiceList
+    - ServiceShow
+    # service autocomplete endpoints
+    - ServiceMatch
+    - ServiceMatch0
+
+# Service Write
+- id: service_write
+  name: Service Write
+  dependsOn:
+    - service_read
+  routes:
+    # service write endpoints
+    - ServiceCreate
+    - ServiceDelete
+    - ServiceBatchDelete
+    - ServiceUpdate
+    - ServiceReplace
+    - ServiceBind
+    - ServiceUnbind
+
+# Service Write
+- id: service_portforward
+  name: Service Port Forward
+  routes:
+    - AuthToken
+  wsRoutes:
+    - ServicePortForward
+
+# Gitconfig related actions
+- id: gitconfig
+  name: Gitconfig
+  dependsOn:
+    - gitconfig_read
+    - gitconfig_write
+
+# Gitconfig Read
+- id: gitconfig_read
+  name: Gitconfig Read
+  routes:
+    - Gitconfigs
+    - GitconfigShow
+    - GitconfigsMatch
+    - GitconfigsMatch0
+
+# Gitconfig Write
+- id: gitconfig_write
+  name: Gitconfig Write
+  dependsOn:
+    - gitconfig_read
+  routes:
+    - GitconfigCreate
+    - GitconfigDelete
+    - GitconfigBatchDelete
+
+# Export Registries
+- id: export_registries
+  name: Export Registries
+  routes:
+    - Exportregistries
+    - ExportregistriesMatch
+    - ExportregistriesMatch0

--- a/internal/auth/actions.yaml
+++ b/internal/auth/actions.yaml
@@ -3,6 +3,7 @@
 - id: default
   name: Default
   routes:
+    - AuthToken
     - GitProxy
 
 # Namespace related actions
@@ -97,8 +98,6 @@
 # App Logs
 - id: app_logs
   name: App Logs
-  routes:
-    - AuthToken
   wsRoutes:
     - AppLogs
     - StagingLogs
@@ -106,16 +105,12 @@
 # App Exec
 - id: app_exec
   name: App Exec
-  routes:
-    - AuthToken
   wsRoutes:
     - AppExec
 
 # App PortForward
 - id: app_portforward
   name: App PortForward
-  routes:
-    - AuthToken
   wsRoutes:
     - AppPortForward
 
@@ -195,8 +190,6 @@
 # Service Write
 - id: service_portforward
   name: Service Port Forward
-  routes:
-    - AuthToken
   wsRoutes:
     - ServicePortForward
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -104,7 +104,8 @@ func (s *AuthService) GetRoles(ctx context.Context) (Roles, error) {
 		epinioRoles = append(epinioRoles, role)
 	}
 
-	s.Logger.V(1).Info(fmt.Sprintf("found %d roles", len(epinioRoles)), "roles", epinioRoles.IDs())
+	roleIDs := strings.Join(epinioRoles.IDs(), ",")
+	s.Logger.V(1).Info(fmt.Sprintf("found %d roles", len(epinioRoles)), "roles", roleIDs)
 
 	return epinioRoles, nil
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -291,6 +291,13 @@ func FilterResources[T NamespacedResource](user User, resources []T) []T {
 		namespacesMap[ns] = struct{}{}
 	}
 
+	// if the user has a Role attached to a namespace then it means he's allowed for it
+	for _, role := range user.Roles {
+		if role.Namespace != "" {
+			namespacesMap[role.Namespace] = struct{}{}
+		}
+	}
+
 	filteredResources := []T{}
 	for _, resource := range resources {
 		if _, allowed := namespacesMap[resource.Namespace()]; allowed {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -282,8 +282,7 @@ type NamespacedResource interface {
 
 // FilterResources returns only the NamespacedResources where the user has permissions
 func FilterResources[T NamespacedResource](user User, resources []T) []T {
-	adminRole, found := user.Roles.FindByID("admin")
-	if found && adminRole.Namespace == "" {
+	if user.IsAdmin() {
 		return resources
 	}
 
@@ -308,8 +307,7 @@ type GitconfigResource interface {
 
 // FilterResources returns only the GitconfigResources where the user has permissions
 func FilterGitconfigResources[T GitconfigResource](user User, resources []T) []T {
-	adminRole, found := user.Roles.FindByID("admin")
-	if found && adminRole.Namespace == "" {
+	if user.IsAdmin() {
 		return resources
 	}
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -292,13 +292,6 @@ func FilterResources[T NamespacedResource](user User, resources []T) []T {
 		namespacesMap[ns] = struct{}{}
 	}
 
-	// if the user has a Role attached to a namespace then it means he's allowed for it
-	for _, role := range user.Roles {
-		if role.Namespace != "" {
-			namespacesMap[role.Namespace] = struct{}{}
-		}
-	}
-
 	filteredResources := []T{}
 	for _, resource := range resources {
 		if _, allowed := namespacesMap[resource.Namespace()]; allowed {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Auth users", func() {
 				})
 
 				Expect(err).ToNot(HaveOccurred())
-				role, found := result.Roles.FindByID("another")
+				role, found := result.Roles.FindByIDAndNamespace("another", "workspace")
 				Expect(role.ID).To(Equal("another"))
 				Expect(role.Namespace).To(Equal("workspace"))
 				Expect(found).To(BeTrue())

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Auth users", func() {
 		When("updating user with different role and namespaces", func() {
 			It("will be updated", func() {
 				oldUser := newUserSecret("user2", "password", "user", "workspace\nworkspace2")
-				updatedUserSecret := newUserSecret("user2", "password", "another::workspace", "")
+				updatedUserSecret := newUserSecret("user2", "password", "another:workspace", "")
 
 				// setup mock
 				fakeSecret.GetReturns(&oldUser, nil)

--- a/internal/auth/role.go
+++ b/internal/auth/role.go
@@ -167,10 +167,16 @@ func InitRoles(rolesGetter RolesGetter) error {
 	return nil
 }
 
-func ExtractRoleIDNamespace(idNamespace string) (string, string) {
-	userRoleNamespace := strings.Split(idNamespace, "::")
-	if len(userRoleNamespace) > 1 {
-		return userRoleNamespace[0], userRoleNamespace[1]
+//	will parse the roleID, returning the roleID without the namespace, and the namespace
+//
+// i.e.:
+//
+//	"admin" will return "admin" and ""
+//	"admin::workspace" will return "admin" and "workspace"
+func ParseRoleID(roleID string) (string, string) {
+	roleIDAndNamespace := strings.Split(roleID, "::")
+	if len(roleIDAndNamespace) > 1 {
+		return roleIDAndNamespace[0], roleIDAndNamespace[1]
 	}
-	return userRoleNamespace[0], ""
+	return roleIDAndNamespace[0], ""
 }

--- a/internal/auth/role.go
+++ b/internal/auth/role.go
@@ -10,16 +10,20 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// AdminRole is a special role. It permits all actions.
-var AdminRole = Role{
-	ID:   "admin",
-	Name: "Admin Role",
-}
+const RoleNamespaceDelimiter = ":"
 
-// EpinioRoles are all the available Epinio roles.
-// It is initialized with the AdminRole, and then it will load the other available Roles
-// with the auth.InitRoles function.
-var EpinioRoles Roles = Roles{AdminRole}
+var (
+	// AdminRole is a special role. It permits all actions.
+	AdminRole = Role{
+		ID:   "admin",
+		Name: "Admin Role",
+	}
+
+	// EpinioRoles are all the available Epinio roles.
+	// It is initialized with the AdminRole, and then it will load the other available Roles
+	// with the auth.InitRoles function.
+	EpinioRoles Roles = Roles{AdminRole}
+)
 
 type Roles []Role
 
@@ -52,7 +56,7 @@ func (roles Roles) IDs() string {
 	for _, role := range roles {
 		id := role.ID
 		if role.Namespace != "" {
-			id = id + "::" + role.Namespace
+			id = role.ID + RoleNamespaceDelimiter + role.Namespace
 		}
 		ids = append(ids, id)
 	}
@@ -172,9 +176,9 @@ func InitRoles(rolesGetter RolesGetter) error {
 // i.e.:
 //
 //	"admin" will return "admin" and ""
-//	"admin::workspace" will return "admin" and "workspace"
+//	"admin:workspace" will return "admin" and "workspace"
 func ParseRoleID(roleID string) (string, string) {
-	roleIDAndNamespace := strings.Split(roleID, "::")
+	roleIDAndNamespace := strings.Split(roleID, RoleNamespaceDelimiter)
 	if len(roleIDAndNamespace) > 1 {
 		return roleIDAndNamespace[0], roleIDAndNamespace[1]
 	}

--- a/internal/auth/role.go
+++ b/internal/auth/role.go
@@ -161,7 +161,7 @@ func InitRoles(rolesGetter RolesGetter) error {
 	return nil
 }
 
-//	will parse the roleID, returning the roleID without the namespace, and the namespace
+// ParseRoleID parses the "full" roleID, returning the roleID without the namespace, and the namespace
 //
 // i.e.:
 //

--- a/internal/auth/role.go
+++ b/internal/auth/role.go
@@ -1,0 +1,176 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// AdminRole is a special role, that has permission of every action
+var AdminRole = Role{
+	ID:   "admin",
+	Name: "Admin Role",
+}
+
+// EpinioRoles are all the available Epinio roles.
+// It is initialized with the AdminRole, and then it will load the other available Roles
+// with the auth.InitRoles function.
+var EpinioRoles Roles = Roles{AdminRole}
+
+type Roles []Role
+
+// Role define an Epinio role, loaded from ConfigMaps
+type Role struct {
+	ID string
+	// Name is a friendly name for the Role
+	Name string
+	// Namespace is the namespace where this role is applied to
+	Namespace string
+	Actions   []Action
+	// Default is set to true if the Role id the default one
+	Default bool
+}
+
+// Default return the default role, if found
+func (roles Roles) Default() (Role, bool) {
+	for _, role := range roles {
+		if role.Default {
+			return role, true
+		}
+	}
+	return Role{}, false
+}
+
+// IDs return the concatenated IDs of the roles (namescoped)
+func (roles Roles) IDs() string {
+	ids := make([]string, 0)
+
+	for _, role := range roles {
+		id := role.ID
+		if role.Namespace != "" {
+			id = id + "::" + role.Namespace
+		}
+		ids = append(ids, id)
+	}
+
+	return strings.Join(ids, ",")
+}
+
+// FindByID return the role matching the id (not namescoped)
+func (roles Roles) FindByID(id string) (Role, bool) {
+	for _, role := range roles {
+		if role.ID == id {
+			return role, true
+		}
+	}
+	return Role{}, false
+}
+
+func (roles Roles) IsAllowed(method, fullpath string) bool {
+	for _, r := range roles {
+		if r.IsAllowed(method, fullpath) {
+			return true
+		}
+	}
+	return false
+}
+
+func NewRole(id, name, defaultVal string, actionIDs []string) (Role, error) {
+	var role Role
+	var err error
+
+	// init the actions with the default action
+	actions := []Action{ActionsMap["default"]}
+
+	for _, actionID := range actionIDs {
+		action, found := ActionsMap[actionID]
+		if !found {
+			return role, fmt.Errorf("action '%s' defined in role '%s' does not exists", actionID, id)
+		}
+
+		actions = append(actions, action)
+	}
+
+	var defaultBool bool
+	if defaultVal != "" {
+		defaultBool, err = strconv.ParseBool(defaultVal)
+		if err != nil {
+			return role, err
+		}
+	}
+
+	return Role{
+		ID:      id,
+		Name:    name,
+		Default: defaultBool,
+		Actions: actions,
+	}, nil
+}
+
+func (r *Role) IsAllowed(method, fullpath string) bool {
+	if r.ID == "admin" {
+		return true
+	}
+
+	for _, a := range r.Actions {
+		if a.IsAllowed(method, fullpath) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func newRoleFromConfigMap(config corev1.ConfigMap) (Role, error) {
+	actionsData := strings.TrimSpace(config.Data["actions"])
+	actionIDs := strings.Split(actionsData, "\n")
+
+	// init the actions with the default action
+	actions := []Action{ActionsMap["default"]}
+
+	for _, actionID := range actionIDs {
+		action, found := ActionsMap[actionID]
+		if !found {
+			return Role{}, fmt.Errorf("action '%s' in role '%s' does not exists", actionID, config.Name)
+		}
+
+		actions = append(actions, action)
+	}
+
+	return NewRole(
+		config.Data["id"],
+		config.Data["name"],
+		config.Data["default"],
+		actionIDs,
+	)
+}
+
+type RolesGetter interface {
+	GetRoles(context.Context) (Roles, error)
+}
+
+func InitRoles(rolesGetter RolesGetter) error {
+	roles, err := rolesGetter.GetRoles(context.Background())
+	if err != nil {
+		return err
+	}
+	EpinioRoles = append(EpinioRoles, roles...)
+
+	if _, found := EpinioRoles.Default(); !found {
+		return errors.New("cannot InitRoles: missing default role")
+	}
+
+	return nil
+}
+
+func ExtractRoleIDNamespace(idNamespace string) (string, string) {
+	userRoleNamespace := strings.Split(idNamespace, "::")
+	if len(userRoleNamespace) > 1 {
+		return userRoleNamespace[0], userRoleNamespace[1]
+	}
+	return userRoleNamespace[0], ""
+}

--- a/internal/auth/role.go
+++ b/internal/auth/role.go
@@ -68,8 +68,13 @@ func (roles Roles) IDs() []string {
 
 // FindByID return the role matching the id (not namescoped)
 func (roles Roles) FindByID(id string) (Role, bool) {
+	return roles.FindByIDAndNamespace(id, "")
+}
+
+// FindByIDAndNamespace return the role matching the id and namescoped
+func (roles Roles) FindByIDAndNamespace(id, namespace string) (Role, bool) {
 	for _, role := range roles {
-		if role.ID == id {
+		if role.ID == id && role.Namespace == namespace {
 			return role, true
 		}
 	}

--- a/internal/auth/role.go
+++ b/internal/auth/role.go
@@ -10,7 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// AdminRole is a special role, that has permission of every action
+// AdminRole is a special role. It permits all actions.
 var AdminRole = Role{
 	ID:   "admin",
 	Name: "Admin Role",

--- a/internal/auth/role.go
+++ b/internal/auth/role.go
@@ -9,7 +9,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const RoleNamespaceDelimiter = ":"
+const (
+	RolesDelimiter         = ","
+	RoleNamespaceDelimiter = ":"
+)
 
 var (
 	// AdminRole is a special role. It permits all actions.
@@ -48,8 +51,8 @@ func (roles Roles) Default() (Role, bool) {
 	return Role{}, false
 }
 
-// IDs return the concatenated IDs of the roles (namescoped)
-func (roles Roles) IDs() string {
+// IDs return the IDs of the roles (namescoped)
+func (roles Roles) IDs() []string {
 	ids := make([]string, 0)
 
 	for _, role := range roles {
@@ -60,7 +63,7 @@ func (roles Roles) IDs() string {
 		ids = append(ids, id)
 	}
 
-	return strings.Join(ids, ",")
+	return ids
 }
 
 // FindByID return the role matching the id (not namescoped)

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -250,7 +250,7 @@ func updateUserSecretData(user User, userSecret *corev1.Secret) *corev1.Secret {
 	return userSecret
 }
 
-// IsUpdateUserNeeded returns whetever a user needs to be updates, and the user with the updated informations
+// IsUpdateUserNeeded returns whenever a user needs to be updated, and the user with the updated information
 func IsUpdateUserNeeded(logger logr.Logger, user User) (User, bool) {
 	var updateNeeded bool
 
@@ -279,7 +279,7 @@ func IsUpdateUserNeeded(logger logr.Logger, user User) (User, bool) {
 	return user, updateNeeded
 }
 
-// isUpdateUserRoleNeeded returns whetever the roles of a user needs to be updated, and the updated roles
+// isUpdateUserRoleNeeded returns whenever the roles of a user need to be updated, and the updated roles
 func isUpdateUserRoleNeeded(previousRoles, actualRoles []string) ([]string, bool) {
 
 	// if they differs they are not the same
@@ -301,7 +301,7 @@ func isUpdateUserRoleNeeded(previousRoles, actualRoles []string) ([]string, bool
 	return previousRoles, false
 }
 
-// isUpdateUserNamespacesNeeded returns whetever the namespaces of a user needs to be updated, and the updated namespaces
+// isUpdateUserNamespacesNeeded returns whenever the namespaces of a user need to be updated, and the updated namespaces
 func isUpdateUserNamespacesNeeded(namespaces []string, roles Roles) ([]string, bool) {
 	namespaceMap := map[string]struct{}{}
 

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -54,21 +54,33 @@ func (u *User) AddNamespace(namespace string) {
 	u.Namespaces = append(u.Namespaces, namespace)
 }
 
-// RemoveNamespace removes a namespace from the User's namespaces.
+// RemoveNamespace removes a namespace from the User's namespaces and any namescoped roles.
 // It returns false if the namespace was not there
-func (u *User) RemoveNamespace(namespace string) bool {
-	updatedNamespaces := []string{}
+func (u *User) RemoveNamespace(namespaceToRemove string) bool {
 	removed := false
 
+	updatedNamespaces := []string{}
+	updatedRoles := Roles{}
+
 	for _, ns := range u.Namespaces {
-		if ns != namespace {
-			updatedNamespaces = append(updatedNamespaces, ns)
-		} else {
+		if ns == namespaceToRemove {
 			removed = true
+		} else {
+			updatedNamespaces = append(updatedNamespaces, ns)
+		}
+	}
+
+	for _, role := range u.Roles {
+		if role.Namespace == namespaceToRemove {
+			removed = true
+		} else {
+			updatedRoles = append(updatedRoles, role)
 		}
 	}
 
 	u.Namespaces = updatedNamespaces
+	u.Roles = updatedRoles
+
 	return removed
 }
 

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -116,6 +116,12 @@ func (u *User) IsAllowed(method, fullPath string, params map[string]string) bool
 	return globalRoles.IsAllowed(method, fullPath)
 }
 
+// IsAdmin returns true if a user has a global admin role
+func (u *User) IsAdmin() bool {
+	adminRole, found := u.Roles.FindByID("admin")
+	return found && adminRole.Namespace == ""
+}
+
 func filterRolesByNamespace(roles Roles, namespace string) Roles {
 	filteredRoles := Roles{}
 	for _, role := range roles {
@@ -148,7 +154,7 @@ func newUserFromSecret(logger logr.Logger, secret corev1.Secret) User {
 	}
 
 	for _, userRole := range user.roleIDs {
-		userRoleID, userRoleNamespace := ExtractRoleIDNamespace(userRole)
+		userRoleID, userRoleNamespace := ParseRoleID(userRole)
 
 		// find the role for the user
 		userRole, found := EpinioRoles.FindByID(userRoleID)

--- a/internal/auth/user_test.go
+++ b/internal/auth/user_test.go
@@ -1,0 +1,189 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package auth collects structures and functions around the
+// generation and processing of credentials.
+package auth_test
+
+import (
+	"github.com/epinio/epinio/internal/auth"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Auth users", func() {
+
+	Describe("IsAllowed", func() {
+
+		var (
+			appGetRole             auth.Role
+			appGetNamespaceRole    auth.Role
+			appDeleteRole          auth.Role
+			appDeleteNamespaceRole auth.Role
+		)
+
+		BeforeEach(func() {
+			appGetAction := auth.Action{
+				Name: "app_get",
+				Endpoints: []auth.Endpoint{
+					{Method: "GET", BasePath: "/api/v1", Path: "/app"},
+				},
+			}
+
+			appDeleteAction := auth.Action{
+				Name: "app_delete",
+				Endpoints: []auth.Endpoint{
+					{Method: "DELETE", BasePath: "/api/v1", Path: "/app"},
+				},
+			}
+
+			appGetRole = auth.Role{
+				ID:      "app-get-role",
+				Actions: []auth.Action{appGetAction},
+			}
+			appGetNamespaceRole = auth.Role{
+				ID:        "app-get-role-workspace",
+				Namespace: "workspace",
+				Actions:   []auth.Action{appGetAction},
+			}
+			appDeleteRole = auth.Role{
+				ID:      "app-delete-role",
+				Actions: []auth.Action{appGetAction, appDeleteAction},
+			}
+			appDeleteNamespaceRole = auth.Role{
+				ID:        "app-delete-role-workspace",
+				Namespace: "workspace",
+				Actions:   []auth.Action{appGetAction, appDeleteAction},
+			}
+		})
+
+		When("the user has no roles", func() {
+
+			It("is not allowed", func() {
+				user := auth.User{}
+
+				allowed := user.IsAllowed("GET", "/api/v1/app", nil)
+				Expect(allowed).Should(BeFalse())
+
+				params := map[string]string{"namespace": "workspace"}
+				allowed = user.IsAllowed("DELETE", "/api/v1/app", params)
+				Expect(allowed).Should(BeFalse())
+			})
+		})
+
+		When("the user has a global admin role", func() {
+
+			It("is allowed for every API requests", func() {
+				user := auth.User{
+					Roles: auth.Roles{{ID: "admin"}},
+				}
+
+				allowed := user.IsAllowed("GET", "/api/v1/app", nil)
+				Expect(allowed).Should(BeTrue())
+
+				params := map[string]string{"namespace": "workspace"}
+				allowed = user.IsAllowed("DELETE", "/api/v1/app", params)
+				Expect(allowed).Should(BeTrue())
+			})
+		})
+
+		When("the user has admin role for a namespace", func() {
+
+			It("is allowed only for namespaced requests", func() {
+				user := auth.User{
+					Roles: auth.Roles{{ID: "admin", Namespace: "workspace"}},
+				}
+
+				allowed := user.IsAllowed("GET", "/api/v1/app", nil)
+				Expect(allowed).Should(BeFalse())
+
+				params := map[string]string{"namespace": "workspace"}
+				allowed = user.IsAllowed("DELETE", "/api/v1/app", params)
+				Expect(allowed).Should(BeTrue())
+			})
+		})
+
+		When("the user has all the roles", func() {
+
+			var user auth.User
+
+			BeforeEach(func() {
+				user = auth.User{
+					Roles: auth.Roles{
+						appGetRole, appGetNamespaceRole,
+						appDeleteRole, appDeleteNamespaceRole,
+					},
+				}
+			})
+
+			It("is allowed for every API requests", func() {
+				allowed := user.IsAllowed("GET", "/api/v1/app", nil)
+				Expect(allowed).Should(BeTrue())
+
+				allowed = user.IsAllowed("DELETE", "/api/v1/app", nil)
+				Expect(allowed).Should(BeTrue())
+			})
+
+			It("is allowed for every namespaced API requests", func() {
+				params := map[string]string{"namespace": "workspace"}
+
+				allowed := user.IsAllowed("GET", "/api/v1/app", params)
+				Expect(allowed).Should(BeTrue())
+
+				allowed = user.IsAllowed("DELETE", "/api/v1/app", params)
+				Expect(allowed).Should(BeTrue())
+			})
+
+			It("is not allowed for unkwown API requests or methods", func() {
+				allowed := user.IsAllowed("POST", "/api/v1/app", nil)
+				Expect(allowed).Should(BeFalse())
+
+				allowed = user.IsAllowed("POST", "/api/v1/unknown", nil)
+				Expect(allowed).Should(BeFalse())
+			})
+		})
+
+		When("the user has a global GET role but a namespaced DELETE role", func() {
+
+			var user auth.User
+
+			BeforeEach(func() {
+				user = auth.User{
+					Roles: auth.Roles{
+						appGetRole, appDeleteNamespaceRole,
+					},
+				}
+			})
+
+			It("succeed to GET on a non namespaced endpoint", func() {
+				allowed := user.IsAllowed("GET", "/api/v1/app", nil)
+				Expect(allowed).Should(BeTrue())
+			})
+
+			It("fails to GET on a namespaced endpoint", func() {
+				params := map[string]string{"namespace": "workspace"}
+				allowed := user.IsAllowed("DELETE", "/api/v1/unknown", params)
+				Expect(allowed).Should(BeFalse())
+			})
+
+			It("succeed to DELETE on a namespaced endpoint", func() {
+				params := map[string]string{"namespace": "workspace"}
+				allowed := user.IsAllowed("GET", "/api/v1/app", params)
+				Expect(allowed).Should(BeTrue())
+			})
+
+			It("fails to DELETE on a non namespaced endpoint", func() {
+				allowed := user.IsAllowed("DELETE", "/api/v1/unknown", nil)
+				Expect(allowed).Should(BeFalse())
+			})
+		})
+	})
+})

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -144,6 +144,7 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 			middleware.TokenAuth,
 			middleware.EpinioVersion,
 			middleware.NamespaceExists,
+			middleware.RoleAuthorization,
 			middleware.NamespaceAuthorization,
 			// gitconfig has no websocket routes
 		)

--- a/internal/dex/config.go
+++ b/internal/dex/config.go
@@ -34,8 +34,9 @@ type ProviderGroups struct {
 }
 
 type Group struct {
-	ID   string `yaml:"id"`
-	Role string `yaml:"role"`
+	ID    string   `yaml:"id"`
+	Role  string   `yaml:"role"`
+	Roles []string `yaml:"roles"`
 }
 
 func NewConfig(issuer, clientID string) (Config, error) {

--- a/internal/dex/dex.go
+++ b/internal/dex/dex.go
@@ -138,7 +138,7 @@ func (pg *ProviderGroups) GetRolesFromGroups(groupIDs ...string) []string {
 
 	for _, g := range pg.Groups {
 		if slices.Contains(groupIDs, g.ID) {
-			roles = append(roles, g.Role)
+			roles = append(roles, g.Roles...)
 		}
 	}
 

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -312,9 +312,16 @@ type InfoResponse struct {
 // MeResponse contains information about the current authenticated user
 type MeResponse struct {
 	User       string   `json:"user,omitempty"`
-	Role       string   `json:"role,omitempty"`
+	Roles      []Role   `json:"roles,omitempty"`
 	Namespaces []string `json:"namespaces,omitempty"`
 	Gitconfigs []string `json:"gitconfigs,omitempty"`
+}
+
+type Role struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Default   bool   `json:"default"`
 }
 
 // AuthTokenResponse contains an auth token


### PR DESCRIPTION
See: https://github.com/epinio/epinio/issues/2631
- ADR: https://github.com/epinio/epinio/pull/2677
- Docs: https://github.com/epinio/docs/pull/360
- Charts: https://github.com/epinio/helm-charts/pull/506

---

This PR adds the new authorization roles. Please take a look at the ADR and docs to have a background over the implementation.

An Epinio user may have multiple roles, global or namescoped. A namescoped role will take action only over namescoped endpoints, while for requests that are not-namescoped then a global role is required. For example the "namespace create" action is global, and a global role with the `namespace_write` action is required.

A role has multiple Actions (i.e. `namespace_write`, `app_read`, ...), and every action has multiple Endpoints. An Endpoint has a 1:1 relation within an Epinio endpoint/api. The matching within actions and endpoints is mapped into an `actions.yaml` file, and loaded at the startup. Also the roles are loaded at the beginning.

Some considerations:
- a "default" role has to be defined. This role is the one that will be applied if no roles are found during an oidc authentication, or if a user doesn't have any roles. The `user` role is created as default during the Epinio installation, but another one could be defined setting the `default` field into the Role ConfigMap.
- if a user has a namescoped role then it has also access to the resources of that namespace, if authorized. This allows a dynamic namespace association for user created during the OIDC authentication
- no roles cleanup is done during a namespace delete. This was done to allows restore of previous permissions while recreating previously deleted namespaces