### PR TITLE
Update user roles on each new login session

### DIFF
--- a/internal/api/v1/gitconfig/create.go
+++ b/internal/api/v1/gitconfig/create.go
@@ -92,7 +92,8 @@ func Create(c *gin.Context) apierror.APIErrors {
 	}
 
 	// add the gitconfig to the User's gitconfigs
-	err = authService.AddGitconfigToUser(ctx, user.Username, request.ID)
+	user.AddGitconfig(request.ID)
+	user, err = authService.UpdateUser(ctx, user)
 	if err != nil {
 		errDetail := fmt.Sprintf("error adding gitconfig [%s] to user [%s]", request.ID, user.Username)
 		return apierror.InternalError(err, errDetail)

--- a/internal/api/v1/middleware/authentication.go
+++ b/internal/api/v1/middleware/authentication.go
@@ -226,17 +226,26 @@ func getOrCreateUserByEmail(ctx context.Context, logger logr.Logger, email, role
 
 	user, err = authService.GetUserByUsername(ctx, email)
 	if err != nil {
+		// something bad happened
 		if err != auth.ErrUserNotFound {
 			return user, errors.Wrap(err, "couldn't get user")
 		}
 
+		// no user was found, create a new one
+
 		user.Username = email
 		user.Role = role
 		user, err = authService.SaveUser(ctx, user)
-		if err != auth.ErrUserNotFound {
+		if err != nil {
 			return user, errors.Wrap(err, "couldn't create user")
 		}
 	}
 
+	// update the existing user
+	user.Role = role
+	user, err = authService.UpdateUser(ctx, user)
+	if err != nil {
+		return user, errors.Wrap(err, "couldn't create user")
+	}
 	return user, nil
 }

--- a/internal/api/v1/namespace/create.go
+++ b/internal/api/v1/namespace/create.go
@@ -70,7 +70,8 @@ func Create(c *gin.Context) apierror.APIErrors {
 	}
 
 	// add the namespace to the User's namespaces
-	err = authService.AddNamespaceToUser(ctx, user.Username, namespaceName)
+	user.AddNamespace(namespaceName)
+	user, err = authService.UpdateUser(ctx, user)
 	if err != nil {
 		errDetail := fmt.Sprintf("error adding namespace [%s] to user [%s]", namespaceName, user.Username)
 		return apierror.InternalError(err, errDetail)


### PR DESCRIPTION
Fix #2561 
Ref doc: https://github.com/epinio/docs/pull/340

This PR adds the `UpdateUser` method to the AuthService in order to update the User also during the next oidc logins.

It removes also the `AddNamespaceToUser` and `AddGitconfigToUser` methods. These were useless when we already have the `User` available. We can update it directly, without loading again the users and look for the user.