### PR TITLE
Removing clean all job between older / latest k8s versions on cep test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -496,10 +496,6 @@ jobs:
         if: always()
         run: make acceptance-cluster-delete
 
-      - name: Clean all
-        if: ${{ github.event_name == 'schedule' }}
-        uses: colpal/actions-clean@v1
-
       - name: API Acceptance Tests on OLDEST K3S version
         env:
           REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Removing clean all step on `acceptance-api-cep-different-k8s` test to avoid removing the repo previously checked-out: https://github.com/epinio/epinio/actions/runs/6540958700/job/17768926316#step:14:21

