### PR TITLE
Updated staging scripts

### DIFF
--- a/assets/golang-sample-app/Procfile
+++ b/assets/golang-sample-app/Procfile
@@ -1,1 +1,0 @@
-web: golang-sample-app


### PR DESCRIPTION
This PR updates the staging scripts removing the hardcoded `-process-type=web` flag.

This means that we are not forced to use a Procfile specifying the `web` process to run, but we are relying on the default detected by the Buildpacks.

We can still provide a Procfile to customize it, if needed.