### PR TITLE
Update traefik values for CI

### DIFF
--- a/acceptance/install/suite_test.go
+++ b/acceptance/install/suite_test.go
@@ -76,7 +76,7 @@ func InstallTraefik() {
 	out, err = proc.RunW("helm", "upgrade", "--install", "traefik", "traefik/traefik",
 		"-n", "traefik",
 		"--create-namespace",
-		"--set", "ports.web.redirectTo=websecure",
+		"--set", "ports.web.redirectTo.port=websecure",
 		"--set", "ingressClass.enabled=true",
 		"--set", "ingressClass.isDefaultClass=true",
 	)


### PR DESCRIPTION
Jobs using traefik started to fail, seems they changed their values `ports.web.redirectTo` to `ports.web.redirectTo.port`, anyway the CI is still failing but on something else.

Initial failure visible [here](https://github.com/epinio/epinio/actions/runs/6610814765/job/17953611984#step:12:281).

GKE-up https://github.com/epinio/epinio/actions/runs/6613463682
REK-up https://github.com/epinio/epinio/actions/runs/6613467617