### PR TITLE
Procfile for golang-sample-app needed for upgrade tests

### DIFF
--- a/acceptance/install/suite_test.go
+++ b/acceptance/install/suite_test.go
@@ -127,11 +127,9 @@ func UpgradeSequence(epinioHelper epinio.Epinio, domain string) {
 			// TODO - remove once v1.11.0 is released - temporary workaround for upgrade tests
 			By("Write Procfile for golang-sample-app pre-upgrade (needed for v1.10.0)", func() {
 				currentDir, err := os.Getwd()
-				fmt.Println(currentDir)
 				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-				appDir := currentDir + "assets/golang-sample-app"
-				fmt.Println(appDir)
+				// currentDir is ~/actions-runner/_work/epinio/epinio/acceptance/install
+				appDir := currentDir + "/../../assets/golang-sample-app"
 				procfile_content := "web: golang-sample-app\n"
 				procfile_filePath := appDir + "/Procfile"
 
@@ -243,11 +241,9 @@ func UpgradeSequence(epinioHelper epinio.Epinio, domain string) {
 			// TODO - remove once v1.11.0 is released - temporary workaround for upgrade tests
 			By("Remove Procfile from golang-sample-app post-upgrade (needed for v1.10.0)", func() {
 				currentDir, err := os.Getwd()
-				fmt.Println(currentDir)
 				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-				appDir := currentDir + "assets/golang-sample-app"
-				fmt.Println(appDir)
+				// currentDir is ~/actions-runner/_work/epinio/epinio/acceptance/install
+				appDir := currentDir + "/../../assets/golang-sample-app"
 				procfile_filePath := appDir + "/Procfile"
 
 				err = os.Remove(procfile_filePath)

--- a/acceptance/install/suite_test.go
+++ b/acceptance/install/suite_test.go
@@ -124,6 +124,25 @@ func UpgradeSequence(epinioHelper epinio.Epinio, domain string) {
 			By("Versions before upgrade")
 			env.Versions()
 
+			// TODO - remove once v1.11.0 is released - temporary workaround for upgrade tests
+			By("Write Procfile for golang-sample-app pre-upgrade (needed for v1.10.0)", func() {
+				currentDir, err := os.Getwd()
+				fmt.Println(currentDir)
+				ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+				appDir := currentDir + "assets/golang-sample-app"
+				fmt.Println(appDir)
+				procfile_content := "web: golang-sample-app\n"
+				procfile_filePath := appDir + "/Procfile"
+
+				file, err := os.Create(procfile_filePath)
+				Expect(err).NotTo(HaveOccurred())
+				defer file.Close()
+
+				_, err = file.WriteString(procfile_content)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
 			// Deploy a simple application before upgrading Epinio, check that it is reachable
 			By("Deploy application pre-upgrade")
 			env.MakeGolangApp(beforeApp, 1, true)
@@ -220,6 +239,20 @@ func UpgradeSequence(epinioHelper epinio.Epinio, domain string) {
 			out, err = env.Epinio("", "service", "catalog")
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(ContainSubstring(afterCatalog))
+
+			// TODO - remove once v1.11.0 is released - temporary workaround for upgrade tests
+			By("Remove Procfile from golang-sample-app post-upgrade (needed for v1.10.0)", func() {
+				currentDir, err := os.Getwd()
+				fmt.Println(currentDir)
+				ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+				appDir := currentDir + "assets/golang-sample-app"
+				fmt.Println(appDir)
+				procfile_filePath := appDir + "/Procfile"
+
+				err = os.Remove(procfile_filePath)
+				Expect(err).NotTo(HaveOccurred())
+			})
 
 			// Check that we can create an application after the upgrade, incl. reachability
 			By("Create application post-upgrade")


### PR DESCRIPTION
fixes #2682 

Temporary fix before we release E v1.11.0 with updated staging script which doesn't need the Procfile for web applications anymore.

* Writes a Procfile to `assets/golang-sample-app` before deploying application on released E version (v1.10.0)
* Removes the Procfile before deploying the same app on upgraded E (dev build)

Code from this PR should be removed once we release v1.11.0 which will not need the `Procfile` anymore.

Testrun:
RKE-CI-UPGRADE https://github.com/epinio/epinio/actions/runs/6640722970/job/18041876124