### PR TITLE
Moved `version` and `exportregistries` commands

### DIFF
--- a/internal/cli/cmd/exportregistry.go
+++ b/internal/cli/cmd/exportregistry.go
@@ -1,0 +1,37 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/epinio/epinio/internal/cli/usercmd"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// NewExportRegistriesCmd returns a new 'epinio info' command
+func NewExportRegistriesCmd(client *usercmd.EpinioClient) *cobra.Command {
+	return &cobra.Command{
+		Use:   "export-registries",
+		Short: "List export registries",
+		Long:  "List export registries",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+
+			err := client.ExportregistryList(cmd.Context())
+			if err != nil {
+				return errors.Wrap(err, "error listing export registries")
+			}
+			return nil
+		},
+	}
+}

--- a/internal/cli/cmd/version.go
+++ b/internal/cli/cmd/version.go
@@ -9,27 +9,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli
+package cmd
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+	"runtime"
+
+	"github.com/epinio/epinio/internal/version"
 	"github.com/spf13/cobra"
 )
 
-// CmdExportRegistries implements the command: epinio export-registries
-var CmdExportRegistries = &cobra.Command{
-	Use:   "export-registries",
-	Short: "List export registries",
-	Long:  "List export registries",
-	Args:  cobra.ExactArgs(0),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-
-		err := client.ExportregistryList(cmd.Context())
-		if err != nil {
-			return errors.Wrap(err, "error listing export registries")
-		}
-
-		return nil
-	},
+// NewVersionCmd returns a new 'epinio version' command
+func NewVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the version number",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("Epinio Version: %s\n", version.Version)
+			fmt.Printf("Go Version: %s\n", runtime.Version())
+		},
+	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"runtime"
 	"strings"
 
 	"github.com/epinio/epinio/helpers/kubernetes/config"
@@ -148,11 +147,11 @@ func NewRootCmd() (*cobra.Command, error) {
 		cmd.NewTargetCmd(client),
 		cmd.NewConfigurationCmd(client, cfg),
 		CmdServer,
-		cmdVersion,
+		cmd.NewVersionCmd(),
 		cmd.NewServicesCmd(client, cfg),
 		cmd.NewLoginCmd(client),
 		cmd.NewLogoutCmd(client),
-		CmdExportRegistries, // See exportregistry.go for implementation
+		cmd.NewExportRegistriesCmd(client),
 	)
 
 	// Hidden command providing developer tools
@@ -174,15 +173,6 @@ func Execute() {
 		termui.NewUI().Problem().Msg(err.Error())
 		os.Exit(-1)
 	}
-}
-
-var cmdVersion = &cobra.Command{
-	Use:   "version",
-	Short: "Print the version number",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Epinio Version: %s\n", version.Version)
-		fmt.Printf("Go Version: %s\n", runtime.Version())
-	},
 }
 
 func checkErr(err error) {


### PR DESCRIPTION
Moved  `version` and `exportregistries` commands in `cmd` package.