### PR TITLE
detect users defined multiple times and reject them

### DIFF
--- a/internal/api/v1/middleware/authentication.go
+++ b/internal/api/v1/middleware/authentication.go
@@ -95,26 +95,9 @@ func basicAuthentication(ctx *gin.Context, logger logr.Logger, authService *auth
 		return auth.User{}, apierrors.NewInternalError("Couldn't extract user or password from the auth header")
 	}
 
-	userMap, err := loadUsersMap(ctx, authService)
+	user, err := authService.GetUserByUsername(ctx, username)
 	if err != nil {
-		return auth.User{}, apierrors.InternalError(err)
-	}
-
-	if len(userMap) == 0 {
-		return auth.User{}, apierrors.NewAPIError("no users found", http.StatusUnauthorized)
-	}
-
-	user, found := userMap[username]
-	if !found {
-		count, ok := authService.Counts[username]
-		if ok && (count > 1) {
-			return auth.User{}, apierrors.NewAPIError("user defined multiple times, talk to operator",
-				http.StatusUnauthorized).
-				WithDetailsf("username '%s' defined %d times", username, count)
-		}
-
-		return auth.User{}, apierrors.NewAPIError("user not found", http.StatusUnauthorized).
-			WithDetailsf("username '%s' not found in user map", username)
+		return auth.User{}, apierrors.NewAPIError(err.Error(), http.StatusUnauthorized)
 	}
 
 	err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password))
@@ -251,20 +234,6 @@ func getRolesFromProviderGroups(logger logr.Logger, oidcProvider *dex.OIDCProvid
 	}
 
 	return roles
-}
-
-func loadUsersMap(ctx context.Context, authService *auth.AuthService) (map[string]auth.User, error) {
-	users, err := authService.GetUsers(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "couldn't get users")
-	}
-
-	userMap := make(map[string]auth.User)
-	for _, user := range users {
-		userMap[user.Username] = user
-	}
-
-	return userMap, nil
 }
 
 // getOrCreateUserByEmail returns the user with the matching email, or if it not exists, it will create a new user.

--- a/internal/api/v1/middleware/authentication.go
+++ b/internal/api/v1/middleware/authentication.go
@@ -106,6 +106,13 @@ func basicAuthentication(ctx *gin.Context, logger logr.Logger, authService *auth
 
 	user, found := userMap[username]
 	if !found {
+		count, ok := authService.Counts[username]
+		if ok && (count > 1) {
+			return auth.User{}, apierrors.NewAPIError("user defined multiple times, talk to operator",
+				http.StatusUnauthorized).
+				WithDetailsf("username '%s' defined %d times", username, count)
+		}
+
 		return auth.User{}, apierrors.NewAPIError("user not found", http.StatusUnauthorized).
 			WithDetailsf("username '%s' not found in user map", username)
 	}

--- a/internal/api/v1/middleware/token.go
+++ b/internal/api/v1/middleware/token.go
@@ -60,21 +60,16 @@ func TokenAuth(ctx *gin.Context) {
 		return
 	}
 
-	// find the user and add it in the context
-	users, err := authService.GetUsers(ctx)
+	// find the user and add it to the context
+
+	user, err := authService.GetUserByUsername(ctx, claims.Username)
 	if err != nil {
 		response.Error(ctx, apierrors.InternalError(err))
 		ctx.Abort()
 		return
 	}
 
-	for _, user := range users {
-		if user.Username == claims.Username {
-			newCtx := ctx.Request.Context()
-			newCtx = requestctx.WithUser(newCtx, user)
-			ctx.Request = ctx.Request.Clone(newCtx)
-
-			break
-		}
-	}
+	newCtx := ctx.Request.Context()
+	newCtx = requestctx.WithUser(newCtx, user)
+	ctx.Request = ctx.Request.Clone(newCtx)
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -34,7 +34,7 @@ import (
 
 var (
 	ErrUserNotFound = errors.New("user not found")
-	ErrUserMultiple = errors.New("user defined multiple times, please talk to the operator")
+	ErrUsernameConflict = errors.New("this user is defined multiple times, please talk to the operator")
 )
 
 //counterfeiter:generate -header ../../LICENSE_HEADER k8s.io/client-go/kubernetes/typed/core/v1.SecretInterface
@@ -157,7 +157,7 @@ func (s *AuthService) GetUserByUsername(ctx context.Context, username string) (U
 	if ok && (count > 1) {
 		s.Logger.V(1).Info("user defined multiple times", "user", username, "count", count)
 
-		return User{}, ErrUserMultiple
+		return User{}, ErrUsernameConflict
 	}
 
 	s.Logger.V(1).Info("user not found")

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -65,10 +65,10 @@ func NewAuthService(logger logr.Logger, cluster *kubernetes.Cluster) *AuthServic
 	}
 }
 
-// getUsers returns all the Epinio users with no conflicting definitions. it further returns a map
+// GetUsers returns all the Epinio users with no conflicting definitions. it further returns a map
 // of definition counts enabling the caller to distinguish between `truly does not exist` versus
 // `has conflicting definitions`.
-func (s *AuthService) getUsers(ctx context.Context) ([]User, DefinitionCount, error) {
+func (s *AuthService) GetUsers(ctx context.Context) ([]User, DefinitionCount, error) {
 	s.Logger.V(1).Info("GetUsers")
 
 	secrets, err := s.getUsersSecrets(ctx)
@@ -145,7 +145,7 @@ func (s *AuthService) GetRoles(ctx context.Context) (Roles, error) {
 func (s *AuthService) GetUserByUsername(ctx context.Context, username string) (User, error) {
 	s.Logger.V(1).Info("GetUserByUsername", "username", username)
 
-	users, counts, err := s.getUsers(ctx)
+	users, counts, err := s.GetUsers(ctx)
 	if err != nil {
 		return User{}, errors.Wrap(err, "error getting users")
 	}
@@ -156,7 +156,7 @@ func (s *AuthService) GetUserByUsername(ctx context.Context, username string) (U
 		}
 	}
 
-	// user not found. check if this was because it was filtered out by getUsers() due to
+	// user not found. check if this was because it was filtered out by GetUsers() due to
 	// conflicting definitions for it.
 
 	count, ok := counts[username]
@@ -212,7 +212,7 @@ func (s *AuthService) UpdateUser(ctx context.Context, user User) (User, error) {
 func (s *AuthService) RemoveNamespaceFromUsers(ctx context.Context, namespace string) error {
 	s.Logger.V(1).Info("RemoveNamespaceFromUsers", "namespace", namespace)
 
-	users, _, err := s.getUsers(ctx)
+	users, _, err := s.GetUsers(ctx)
 	if err != nil {
 		return errors.Wrap(err, "error getting users")
 	}
@@ -242,7 +242,7 @@ func (s *AuthService) RemoveNamespaceFromUsers(ctx context.Context, namespace st
 func (s *AuthService) RemoveGitconfigFromUsers(ctx context.Context, gitconfig string) error {
 	s.Logger.V(1).Info("RemoveGitconfigFromUsers", "gitconfig", gitconfig)
 
-	users, _, err := s.getUsers(ctx)
+	users, _, err := s.GetUsers(ctx)
 	if err != nil {
 		return errors.Wrap(err, "error getting users")
 	}


### PR DESCRIPTION
fix #2692 

users defined multiple times are filtered, i.e. seen as not existing, primarily.
enough data is kept to report them as `defined multiple times`, instead of as `not `found`.