### PR TITLE
Change service name definition, switch to metadata.name for consistency

### DIFF
--- a/internal/services/catalog.go
+++ b/internal/services/catalog.go
@@ -122,7 +122,7 @@ func (s *ServiceClient) convertUnstructuredIntoCatalogService(unstructured unstr
 
 	return &models.CatalogService{
 		Meta: models.MetaLite{
-			Name:      catalogService.Spec.Name,
+			Name:      unstructured.GetName(),
 			CreatedAt: unstructured.GetCreationTimestamp(),
 		},
 		SecretTypes:      secretTypes,


### PR DESCRIPTION
fix #2699 

Competes against #2709 .
Advantages:
 - Direct access to resource by name. No List-query, no searching.
 - Uniqueness of name enforced by K. No need to handle conflicting definitions.

Regarding the ticket's note of
> The exposed name should be used, because it's the one exposed in the catalog.

note that the standard catalog has matching metadata.name and spec.name. Technically the metadata.name is exposed.

