### PR TITLE
Added better error handling for panics

### DIFF
--- a/internal/api/v1/middleware/recovery.go
+++ b/internal/api/v1/middleware/recovery.go
@@ -1,0 +1,39 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"fmt"
+
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
+	apierrors "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/gin-gonic/gin"
+)
+
+func Recovery() gin.HandlerFunc {
+	return gin.CustomRecovery(func(c *gin.Context, anyerr any) {
+		ctx := c.Request.Context()
+		logger := requestctx.Logger(ctx).WithName("RecoveryMiddleware")
+
+		err, ok := anyerr.(error)
+		if !ok {
+			err = fmt.Errorf("unknown error type occurred [%T]", anyerr)
+		}
+
+		logger.Error(err, "recovered from panic")
+
+		// we don't want to expose internal details to the client
+		response.Error(c, apierrors.NewInternalError("something bad happened"))
+		c.Abort()
+	})
+}

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -59,7 +59,6 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 	router.NoRoute(func(ctx *gin.Context) {
 		response.Error(ctx, apierrors.NewNotFoundError("route", ctx.Request.URL.Path))
 	})
-	router.Use(middleware.Recovery())
 
 	// Do not set header if nothing is specified.
 	accessControlAllowOrigin := strings.TrimSuffix(viper.GetString("access-control-allow-origin"), "/")
@@ -92,6 +91,7 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 	// Add common middlewares to all the routes declared after
 	router.Use(
 		ginLogger,
+		middleware.Recovery,
 		middleware.InitContext(logger),
 	)
 

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -59,7 +59,7 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 	router.NoRoute(func(ctx *gin.Context) {
 		response.Error(ctx, apierrors.NewNotFoundError("route", ctx.Request.URL.Path))
 	})
-	router.Use(gin.Recovery())
+	router.Use(middleware.Recovery())
 
 	// Do not set header if nothing is specified.
 	accessControlAllowOrigin := strings.TrimSuffix(viper.GetString("access-control-allow-origin"), "/")
@@ -80,7 +80,6 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 	}
 
 	ginLogger := ginlogr.Ginlogr(logger, time.RFC3339, true)
-	ginRecoveryLogger := ginlogr.RecoveryWithLogr(logger, time.RFC3339, true, true)
 
 	// Register routes - No authentication, no logging, no session.
 	// This is the healthcheck.
@@ -93,7 +92,6 @@ func NewHandler(logger logr.Logger) (*gin.Engine, error) {
 	// Add common middlewares to all the routes declared after
 	router.Use(
 		ginLogger,
-		ginRecoveryLogger,
 		middleware.InitContext(logger),
 	)
 

--- a/pkg/api/core/v1/client/http.go
+++ b/pkg/api/core/v1/client/http.go
@@ -287,16 +287,17 @@ func handleError(logger logr.Logger, response *http.Response) error {
 		return errors.Wrap(err, "reading response body")
 	}
 
-	var responseErr apierrors.ErrorResponse
-	err = json.Unmarshal(bodyBytes, &responseErr)
-	if err != nil {
-		logger.Error(err, "decoding json error")
-		return errors.Wrap(err, "parsing error response")
-	}
-
 	epinioError := &APIError{
 		StatusCode: response.StatusCode,
-		Err:        &responseErr,
+		Err:        &apierrors.ErrorResponse{},
+	}
+
+	if len(bodyBytes) > 0 {
+		err = json.Unmarshal(bodyBytes, epinioError.Err)
+		if err != nil {
+			logger.Error(err, "decoding json error")
+			return errors.Wrap(err, "parsing error response")
+		}
 	}
 
 	logger.V(1).Info("response is not StatusOK: " + epinioError.Error())

--- a/pkg/api/core/v1/client/http_test.go
+++ b/pkg/api/core/v1/client/http_test.go
@@ -32,6 +32,8 @@ var _ = Describe("Client HTTP", func() {
 	var requestInterceptor func(r *http.Request)
 
 	JustBeforeEach(func() {
+		requestInterceptor = func(r *http.Request) {}
+
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer GinkgoRecover()
 

--- a/pkg/api/core/v1/errors/errors.go
+++ b/pkg/api/core/v1/errors/errors.go
@@ -32,7 +32,7 @@ type APIErrors interface {
 type APIError struct {
 	Status  int    `json:"status"`
 	Title   string `json:"title"`
-	Details string `json:"details"`
+	Details string `json:"details,omitempty"`
 }
 
 var _ APIErrors = APIError{}


### PR DESCRIPTION
FIx #2704 

This PR adds a better error handling for panics.

The standard Gin recovery middleware is now used, returning now a JSON error instead of the empty response, without exposing internal details about the error occurred. Now the server logs are easier to read when it panics.

An additional check on the CLI was added anyway, trying to parse the JSON error only if the body is present.

## Server logs

![Screenshot from 2023-11-22 17-57-21](https://github.com/epinio/epinio/assets/1763949/349fa8da-41ad-40a3-97ee-1b7d3a4556c9)

## CLI

![Screenshot from 2023-11-22 18-25-37](https://github.com/epinio/epinio/assets/1763949/838172e8-a59a-4c3d-bdab-b3dc8266a02d)
