### PR TITLE
epinio-binary grown to 100Mi

### DIFF
--- a/scripts/patch-epinio-deployment.sh
+++ b/scripts/patch-epinio-deployment.sh
@@ -61,7 +61,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: 150Mi
 EOF
 
 echo "Creating the dummy copier Pod"


### PR DESCRIPTION
RKE2-EC2-CI job started to fail because temporary PV for devel epinio-service binary (used by `make patch-epinio-deployment`) doesn't fit the binary anymore:

```
  pod/epinio-copier condition met
  Copying the binary on the PVC
  mv: write error: No space left on device
  command terminated with exit code 1
```

Its PVC was requesting 100Mi originally, now changed to 150Mi. 

A bit strange is that it doesn't fail on other public clouds, most probably the used `Longhorn` storage provider is more strict or using a different block-size.

Testrun:
https://github.com/epinio/epinio/actions/runs/6971231046