### PR TITLE
Enable `namespace_read` actions by default

### DIFF
--- a/internal/auth/actions.yaml
+++ b/internal/auth/actions.yaml
@@ -5,30 +5,16 @@
   routes:
     - AuthToken
     - GitProxy
-
-# Namespace related actions
-- id: namespace
-  name: Namespace
-  dependsOn:
-    - namespace_read
-    - namespace_write
-
-# Namespace Read
-- id: namespace_read
-  name: Namespace Read
-  routes:
-    # neamespace read endpoints
+    # namespace read endpoints
     - Namespaces
     - NamespaceShow
-    # autocomplete
+    # namespace autocomplete
     - NamespacesMatch
     - NamespacesMatch0
 
 # Namespace Write
 - id: namespace_write
   name: Namespace Write
-  dependsOn:
-    - namespace_read
   routes:
     - NamespaceCreate
     - NamespaceDelete


### PR DESCRIPTION
Fix #2707 

This PR drops the `namespace_read` action, moving the Namespace read related endpoints enabled by default.