### PR TITLE
Fix problem with Docusaurus generated page.

### DIFF
--- a/internal/cli/docs/generate-cli-docs.go
+++ b/internal/cli/docs/generate-cli-docs.go
@@ -179,6 +179,7 @@ func writeFileHeader(w io.Writer, sidebarLabel string) error {
 
 	_, err := fmt.Fprintf(w, `---
 sidebar_label: %s
+title: ""
 description: %s
 keywords: [epinio, kubernetes, %s]
 doc-type: [reference]


### PR DESCRIPTION
Fix problem with Docusaurus generated page where Docusaurus generates an
unwanted page title &lt;h1&gt; in the absence of a empty string title: "" in the front matter.


I should have picked up on it but was guilty of seeing what I wanted to see.