### PR TITLE
Added `--output json` to info command

### DIFF
--- a/acceptance/info_test.go
+++ b/acceptance/info_test.go
@@ -12,6 +12,9 @@
 package acceptance_test
 
 import (
+	"encoding/json"
+
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -26,5 +29,16 @@ var _ = Describe("Info", LMisc, func() {
 		Expect(out).To(ContainSubstring(`Epinio Server Version: `))
 		Expect(out).To(ContainSubstring(`Epinio Client Version: `))
 		Expect(out).To(ContainSubstring(`OIDC enabled: `))
+	})
+
+	It("succeeds with JSON", func() {
+		out, err := env.Epinio("", "info", "--output", "json")
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		info := &models.InfoResponse{}
+		err = json.Unmarshal([]byte(out), info)
+		Expect(err).ToNot(HaveOccurred(), out)
+		Expect(info.Platform).ToNot(BeEmpty())
+		Expect(info.Version).ToNot(BeEmpty())
 	})
 })

--- a/internal/cli/cmd/info.go
+++ b/internal/cli/cmd/info.go
@@ -18,8 +18,8 @@ import (
 )
 
 // NewInfoCmd returns a new 'epinio info' command
-func NewInfoCmd(client *usercmd.EpinioClient) *cobra.Command {
-	return &cobra.Command{
+func NewInfoCmd(client *usercmd.EpinioClient, rootCfg *RootConfig) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "info",
 		Short: "Shows information about the Epinio environment",
 		Long:  "Shows status and versions for epinio's server-side components.",
@@ -34,4 +34,10 @@ func NewInfoCmd(client *usercmd.EpinioClient) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().VarP(rootCfg.Output, "output", "o", "sets output format [text|json]")
+	bindFlag(cmd, "output")
+	bindFlagCompletionFunc(cmd, "output", NewStaticFlagsCompletionFunc(rootCfg.Output.Allowed))
+
+	return cmd
 }

--- a/internal/cli/cmd/info_test.go
+++ b/internal/cli/cmd/info_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Command 'epinio info'", func() {
 		output = &bytes.Buffer{}
 		epinioClient.UI().SetOutput(output)
 
-		infoCmd = cmd.NewInfoCmd(epinioClient)
+		infoCmd = cmd.NewInfoCmd(epinioClient, cmd.NewRootConfig())
 	})
 
 	When("the api returns a complete response", func() {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -138,7 +138,7 @@ func NewRootCmd() (*cobra.Command, error) {
 	rootCmd.AddCommand(
 		CmdCompletion,
 		cmd.NewSettingsCmd(client),
-		cmd.NewInfoCmd(client),
+		cmd.NewInfoCmd(client, cfg),
 		cmd.NewClientSyncCmd(client),
 		cmd.NewGitconfigCmd(client),
 		cmd.NewNamespaceCmd(client, cfg),

--- a/internal/cli/usercmd/info.go
+++ b/internal/cli/usercmd/info.go
@@ -21,17 +21,21 @@ func (c *EpinioClient) Info() error {
 	log.Info("start")
 	defer log.Info("return")
 
-	v, err := c.API.Info()
+	info, err := c.API.Info()
 	if err != nil {
 		return err
 	}
 
+	if c.ui.JSONEnabled() {
+		return c.ui.JSON(info)
+	}
+
 	c.ui.Success().
-		WithStringValue("Platform", v.Platform).
-		WithStringValue("Kubernetes Version", v.KubeVersion).
-		WithStringValue("Epinio Server Version", v.Version).
+		WithStringValue("Platform", info.Platform).
+		WithStringValue("Kubernetes Version", info.KubeVersion).
+		WithStringValue("Epinio Server Version", info.Version).
 		WithStringValue("Epinio Client Version", version.Version).
-		WithBoolValue("OIDC enabled", v.OIDCEnabled).
+		WithBoolValue("OIDC enabled", info.OIDCEnabled).
 		Msg("Epinio Environment")
 
 	return nil


### PR DESCRIPTION
This PR adds the `--output` flag to enable JSON output for the `epinio info` command.

This was needed to get the info for the [epinio/extension-docker-desktop](https://github.com/epinio/extension-docker-desktop).

https://github.com/epinio/extension-docker-desktop/blob/40c9d56a2e038849ade0a189d2b3b143610d4398/ui/src/epinio/API.js#L10-L13