### PR TITLE
Fix panic when determining Ingress paths

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -85,8 +85,10 @@ func FromIngress(ingress networkingv1.Ingress) ([]Route, error) {
 	result := []Route{}
 	for _, r := range ingress.Spec.Rules {
 		domain := r.Host
-		for _, p := range r.HTTP.Paths {
-			result = append(result, Route{Domain: domain, Path: p.Path})
+		if r.HTTP != nil {
+			for _, p := range r.HTTP.Paths {
+				result = append(result, Route{Domain: domain, Path: p.Path})
+			}
 		}
 	}
 

--- a/internal/routes/routes_test.go
+++ b/internal/routes/routes_test.go
@@ -116,6 +116,21 @@ var _ = Describe("Route", func() {
 				}))
 			})
 		})
+		When("the Ingress has no HTTP paths", func() {
+			BeforeEach(func() {
+				routeIngress.Spec.Rules = []networkingv1.IngressRule{
+					{
+						Host: "example.com",
+					},
+				}
+			})
+			It("creates no rules", func() {
+				result, err := FromIngress(routeIngress)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeEmpty())
+			})
+		})
+
 	})
 
 	Describe("ToIngress", func() {


### PR DESCRIPTION
This fixes a panic in the Ingress route path determination.

Ingresses with no HTTP paths would result in a panic accessing the paths.