### PR TITLE
added go mod tidy to the linting env to fix import errors

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -31,7 +31,15 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+
+      - name: Run go mod tidy
+        run: go mod tidy
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         timeout-minutes: 10


### PR DESCRIPTION
This PR will fix the Undefined issues when running CI linting tests. You can see the errors in this issue: #2785 

What does this PR do?

This PR will add another step to the lint phase which will run a 'go mod tidy'. This way all of the packages will be loaded into the gocache and the linter will be able to reference these objects.

Testing:

To test this simply you can follow the steps of the linter on a local machine:
1. clone the epinio repo
2. run the linter as specified via the test: `golangci-lint run --timeout=10m --skip-files docs.go`
3. note the failed import
4. run `go mod tidy` to update the local go cache
5. rerun the lint and notice the import errors are gone.