### PR TITLE
commented out docker login for CI tests - temp until creds are resolved

### DIFF
--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -47,11 +47,11 @@ jobs:
           cache: false
           go-version: ${{ env.SETUP_GO_VERSION }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
+      #- name: Login to Docker Hub
+      #  uses: docker/login-action@v2
+      #  with:
+      #    username: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
+      #    password: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
temp comment out of docker credentials. This will help the CI test pass until we get creds worked out.