### PR TITLE
Update release-sandbox.yml docker-login action version

### DIFF
--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -48,7 +48,7 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.CFCIBOT_DOCKERHUB_USERNAME }}
           password: ${{ secrets.CFCIBOT_DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
Docker login action appears to be failing, likely because it is an old version and may not be compatible with updates runners