### PR TITLE
Fix/colpal rate limits

### DIFF
--- a/.github/workflows/clientsync.yml
+++ b/.github/workflows/clientsync.yml
@@ -98,7 +98,8 @@ jobs:
       - name: Cleanup k3d cluster
         if: always()
         run: make acceptance-cluster-delete
-
-      - name: Clean all
-        if: ${{ github.event_name == 'schedule' }}
-        uses: colpal/actions-clean@v1
+        
+      # # Comment out this cleanup step, since runners only exist for one job. Otherwise this is causing docker pull rate limit issues.
+      # - name: Clean all
+      #   if: ${{ github.event_name == 'schedule' }}
+      #   uses: colpal/actions-clean@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,9 +136,10 @@ jobs:
         if: always()
         run: make acceptance-cluster-delete
 
-      - name: Clean all
-        if: ${{ github.event_name == 'schedule' }}
-        uses: colpal/actions-clean@v1
+      # # Comment out this cleanup step, since runners only exist for one job. Otherwise this is causing docker pull rate limit issues.
+      # - name: Clean all
+      #   if: ${{ github.event_name == 'schedule' }}
+      #   uses: colpal/actions-clean@v1
 
   acceptance-cli-apps:
     needs:
@@ -208,9 +209,10 @@ jobs:
         if: always()
         run: make acceptance-cluster-delete
 
-      - name: Clean all
-        if: ${{ github.event_name == 'schedule' }}
-        uses: colpal/actions-clean@v1
+      # # Comment out this cleanup step, since runners only exist for one job. Otherwise this is causing docker pull rate limit issues.
+      # - name: Clean all
+      #   if: ${{ github.event_name == 'schedule' }}
+      #   uses: colpal/actions-clean@v1
 
   acceptance-cli-services:
     needs:
@@ -279,9 +281,10 @@ jobs:
         if: always()
         run: make acceptance-cluster-delete
 
-      - name: Clean all
-        if: ${{ github.event_name == 'schedule' }}
-        uses: colpal/actions-clean@v1
+      # # Comment out this cleanup step, since runners only exist for one job. Otherwise this is causing docker pull rate limit issues.
+      # - name: Clean all
+      #   if: ${{ github.event_name == 'schedule' }}
+      #   uses: colpal/actions-clean@v1
 
   acceptance-api:
     needs:
@@ -351,9 +354,10 @@ jobs:
         if: always()
         run: make acceptance-cluster-delete
 
-      - name: Clean all
-        if: ${{ github.event_name == 'schedule' }}
-        uses: colpal/actions-clean@v1
+      # # Comment out this cleanup step, since runners only exist for one job. Otherwise this is causing docker pull rate limit issues.
+      # - name: Clean all
+      #   if: ${{ github.event_name == 'schedule' }}
+      #   uses: colpal/actions-clean@v1
 
   acceptance-api-apps:
     needs:
@@ -423,9 +427,10 @@ jobs:
         if: always()
         run: make acceptance-cluster-delete
 
-      - name: Clean all
-        if: ${{ github.event_name == 'schedule' }}
-        uses: colpal/actions-clean@v1
+      # # Comment out this cleanup step, since runners only exist for one job. Otherwise this is causing docker pull rate limit issues.
+      # - name: Clean all
+      #   if: ${{ github.event_name == 'schedule' }}
+      #   uses: colpal/actions-clean@v1
 
   acceptance-api-cep-different-k8s:
     needs:
@@ -517,9 +522,10 @@ jobs:
         if: always()
         run: make acceptance-cluster-delete
 
-      - name: Clean all
-        if: ${{ github.event_name == 'schedule' }}
-        uses: colpal/actions-clean@v1
+      # # Comment out this cleanup step, since runners only exist for one job. Otherwise this is causing docker pull rate limit issues.
+      # - name: Clean all
+      #   if: ${{ github.event_name == 'schedule' }}
+      #   uses: colpal/actions-clean@v1
 
   acceptance-api-services:
     needs:
@@ -588,9 +594,10 @@ jobs:
         if: always()
         run: make acceptance-cluster-delete
 
-      - name: Clean all
-        if: ${{ github.event_name == 'schedule' }}
-        uses: colpal/actions-clean@v1
+      # # Comment out this cleanup step, since runners only exist for one job. Otherwise this is causing docker pull rate limit issues.
+      # - name: Clean all
+      #   if: ${{ github.event_name == 'schedule' }}
+      #   uses: colpal/actions-clean@v1
 
   acceptance-apps:
     needs:
@@ -679,9 +686,10 @@ jobs:
         if: always()
         run: make acceptance-cluster-delete
 
-      - name: Clean all
-        if: ${{ github.event_name == 'schedule' }}
-        uses: colpal/actions-clean@v1
+      # # Comment out this cleanup step, since runners only exist for one job. Otherwise this is causing docker pull rate limit issues.
+      # - name: Clean all
+      #   if: ${{ github.event_name == 'schedule' }}
+      #   uses: colpal/actions-clean@v1
 
   upload-coverage:
     needs:

--- a/.github/workflows/rke-upgrade.yml
+++ b/.github/workflows/rke-upgrade.yml
@@ -173,6 +173,7 @@ jobs:
           sudo sh /usr/local/bin/rke2-uninstall.sh
 
       # Only on RKE, as it uses a self-hosted runner
-      - name: Clean all
-        if: ${{ github.event_name == 'schedule' }}
-        uses: colpal/actions-clean@v1
+      # # Comment out this cleanup step, since runners only exist for one job. Otherwise this is causing docker pull rate limit issues.
+      # - name: Clean all
+      #   if: ${{ github.event_name == 'schedule' }}
+      #   uses: colpal/actions-clean@v1

--- a/.github/workflows/rke.yml
+++ b/.github/workflows/rke.yml
@@ -153,6 +153,7 @@ jobs:
           sudo sh /usr/local/bin/rke2-uninstall.sh
 
       # Only on RKE, as it uses a self-hosted runner
-      - name: Clean all
-        if: ${{ github.event_name == 'schedule' }}
-        uses: colpal/actions-clean@v1
+      # # Comment out this cleanup step, since runners only exist for one job. Otherwise this is causing docker pull rate limit issues.
+      # - name: Clean all
+      #   if: ${{ github.event_name == 'schedule' }}
+      #   uses: colpal/actions-clean@v1

--- a/.github/workflows/rke2-lh-ec2.yml
+++ b/.github/workflows/rke2-lh-ec2.yml
@@ -269,6 +269,7 @@ jobs:
           go run acceptance/helpers/delete_clusters/delete_clusters.go
 
       # Only on RKE, as it uses a self-hosted runner
-      - name: Clean all
-        if: ${{ github.event_name == 'schedule' }}
-        uses: colpal/actions-clean@v1
+      # # Comment out this cleanup step, since runners only exist for one job. Otherwise this is causing docker pull rate limit issues.
+      # - name: Clean all
+      #   if: ${{ github.event_name == 'schedule' }}
+      #   uses: colpal/actions-clean@v1

--- a/.github/workflows/upgrade-bound.yml
+++ b/.github/workflows/upgrade-bound.yml
@@ -98,6 +98,7 @@ jobs:
         if: always()
         run: make acceptance-cluster-delete
 
-      - name: Clean all
-        if: ${{ github.event_name == 'schedule' }}
-        uses: colpal/actions-clean@v1
+      # # Comment out this cleanup step, since runners only exist for one job. Otherwise this is causing docker pull rate limit issues.
+      # - name: Clean all
+      #   if: ${{ github.event_name == 'schedule' }}
+      #   uses: colpal/actions-clean@v1

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -98,6 +98,7 @@ jobs:
         if: always()
         run: make acceptance-cluster-delete
 
-      - name: Clean all
-        if: ${{ github.event_name == 'schedule' }}
-        uses: colpal/actions-clean@v1
+      # # Comment out this cleanup step, since runners only exist for one job. Otherwise this is causing docker pull rate limit issues.
+      # - name: Clean all
+      #   if: ${{ github.event_name == 'schedule' }}
+      #   uses: colpal/actions-clean@v1


### PR DESCRIPTION
comment out colpal since it's requiring extra unauthenticated image pulls as part of dependency building. This should be unnecessary for our ephemeral runners.