### PR TITLE
Update cosign-installer version

### DIFF
--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: anchore/sbom-action/download-syft@v0.14.3
 
-      - uses: sigstore/cosign-installer@v3.1.1
+      - uses: sigstore/cosign-installer@v3.7.0
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
Update cosign to resolve build issues.
`error updating to TUF remote mirror: invalid key`
ref: https://github.com/sigstore/cosign/issues/3614