### PR TITLE
fix/add configuration for logs command 2812

### DIFF
--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -16,7 +16,9 @@ package application
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -602,7 +604,7 @@ func Logs(ctx context.Context, logChan chan tailer.ContainerLogLine, wg *sync.Wa
 		Since:                 duration.LogHistory(),
 		AllNamespaces:         true,
 		LabelSelector:         selector,
-		TailLines:             nil,
+		TailLines:             getTailLines(),
 		Namespace:             "",
 		PodQuery:              regexp.MustCompile(".*"),
 	}
@@ -950,5 +952,15 @@ func fetch(ctx context.Context, cluster *kubernetes.Cluster, app *models.App) er
 	}
 
 	app.Status = models.ApplicationRunning
+	return nil
+}
+
+// getTailLines returns the number of log lines to tail based on LOG_TAIL_LINES env var
+func getTailLines() *int64 {
+	if val := os.Getenv("LOG_TAIL_LINES"); val != "" {
+		if lines, err := strconv.ParseInt(val, 10, 64); err == nil {
+			return &lines
+		}
+	}
 	return nil
 }

--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -15,6 +15,8 @@ package duration
 
 import (
 	"log"
+	"os"
+	"strconv"
 	"time"
 
 	flag "github.com/spf13/pflag"
@@ -91,6 +93,12 @@ func UserAbort() time.Duration {
 }
 
 // LogHistory returns the duration to reach into the past for tailing logs.
+// LogHistory returns the duration to reach into the past for tailing logs.
 func LogHistory() time.Duration {
+	if hours := os.Getenv("LOG_HISTORY_HOURS"); hours != "" {
+		if h, err := strconv.ParseInt(hours, 10, 64); err == nil {
+			return time.Duration(h) * time.Hour
+		}
+	}
 	return logHistory
 }


### PR DESCRIPTION
```
Closes #2812 
```

This adds environment variables to configure parameters of the getLogs function on the kubectl client.