### PR TITLE
Fix "toolchain not available"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@
 
 module github.com/epinio/epinio
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/adrg/xdg v0.4.0


### PR DESCRIPTION
The go version was missing a trailing .0 after an update.
https://github.com/golang/go/issues/65568#issuecomment-1954876836

This fixes issues related to `cmd/go: download go1.22 for darwin/arm64: toolchain not available`