### PR TITLE
Add help to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,12 @@ VERSION ?= $(shell git describe --tags)$(VSUFFIX)
 CGO_ENABLED ?= 0
 export LDFLAGS += -X github.com/epinio/epinio/internal/version.Version=$(VERSION)
 
+.DEFAULT_GOAL := build
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN { section = ""; print "\nUsage:\n  make \033[36m<target>\033[0m" } /^#{5,}/ { next } /^# [A-Za-z]/ { section = substr($$0, 3); next } /^[a-zA-Z0-9_.-]+:.*$$/ { if ($$1 == ".PHONY") next; if (section != "") { print "\n\033[1m" section "\033[0m"; section = "" } split($$1, parts, ":"); printf "  \033[36m%-20s\033[0m\n", parts[1] }' $(MAKEFILE_LIST)
+
 build: build-amd64
 
 # amd64 variant


### PR DESCRIPTION
add help goal to the makefile but keep default goal as build 

if you run  `make help`, then you should see 

![image](https://github.com/user-attachments/assets/80b421a4-f7b2-4ae2-9a4f-739f4d9b3dbc)
and
![image](https://github.com/user-attachments/assets/cf2a3888-1bd5-4c70-a4ba-ca9a05d1d894)


closes #2847 