### PR TITLE
Disable upgrade responder for now

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -65,12 +65,12 @@ jobs:
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 
-      - name: Update Upgrade Responder Response JSON config
-        run: ./scripts/upgrade-responder-release-update.sh
-        env:
-          COGNITO_USERNAME: ${{ secrets.UPGRADE_RESPONDER_COGNITO_USERNAME }}
-          COGNITO_PASSWORD: ${{ secrets.UPGRADE_RESPONDER_COGNITO_PASSWORD }}
-          COGNITO_CLIENT_ID: ${{ secrets.UPGRADE_RESPONDER_COGNITO_CLIENT_ID }}
-          EKS_ENDPOINT: ${{ secrets.UPGRADE_RESPONDER_EKS_ENDPOINT }}
-          K8S_NAMESPACE: epinio
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+      # - name: Update Upgrade Responder Response JSON config
+      #   run: ./scripts/upgrade-responder-release-update.sh
+      #   env:
+      #     COGNITO_USERNAME: ${{ secrets.UPGRADE_RESPONDER_COGNITO_USERNAME }}
+      #     COGNITO_PASSWORD: ${{ secrets.UPGRADE_RESPONDER_COGNITO_PASSWORD }}
+      #     COGNITO_CLIENT_ID: ${{ secrets.UPGRADE_RESPONDER_COGNITO_CLIENT_ID }}
+      #     EKS_ENDPOINT: ${{ secrets.UPGRADE_RESPONDER_EKS_ENDPOINT }}
+      #     K8S_NAMESPACE: epinio
+      #     COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}

--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -73,13 +73,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 
-      - name: Update Upgrade Responder Response JSON config (dry run)
-        run: ./scripts/upgrade-responder-release-update.sh
-        env:
-          COGNITO_USERNAME: ${{ secrets.UPGRADE_RESPONDER_COGNITO_USERNAME }}
-          COGNITO_PASSWORD: ${{ secrets.UPGRADE_RESPONDER_COGNITO_PASSWORD }}
-          COGNITO_CLIENT_ID: ${{ secrets.UPGRADE_RESPONDER_COGNITO_CLIENT_ID }}
-          EKS_ENDPOINT: ${{ secrets.UPGRADE_RESPONDER_EKS_ENDPOINT }}
-          K8S_NAMESPACE: epinio
-          K8S_DRY_RUN: client
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+      # - name: Update Upgrade Responder Response JSON config (dry run)
+      #   run: ./scripts/upgrade-responder-release-update.sh
+      #   env:
+      #     COGNITO_USERNAME: ${{ secrets.UPGRADE_RESPONDER_COGNITO_USERNAME }}
+      #     COGNITO_PASSWORD: ${{ secrets.UPGRADE_RESPONDER_COGNITO_PASSWORD }}
+      #     COGNITO_CLIENT_ID: ${{ secrets.UPGRADE_RESPONDER_COGNITO_CLIENT_ID }}
+      #     EKS_ENDPOINT: ${{ secrets.UPGRADE_RESPONDER_EKS_ENDPOINT }}
+      #     K8S_NAMESPACE: epinio
+      #     K8S_DRY_RUN: client
+      #     COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
 Upgrade Responser was used to gather deployment metrics and was previously integrated with a private EKS cluster. This needs to be disabled until it can be set up again.