### PR TITLE
Account for role validation in initialization prior to readiness

### DIFF
--- a/docs/decisions/20231013-authorization-roles.md
+++ b/docs/decisions/20231013-authorization-roles.md
@@ -139,7 +139,7 @@ data:
 
 #### Actions
 
-The actions are **hardcoded** as an embedded yaml file. This simplifies their management, and also enhances flexibility. An action can have some "dependencies", i.e.: the `namespace` action is a union of the `namespace_read` and `namespace_write`.
+The actions are **hardcoded** as an embedded yaml file. This simplifies their management, and also enhances flexibility. An action can have some "dependencies", i.e.: the `app` action is a union of the `app_read`, `app_write`, `app_logs`, `app_exec`, and `app_portforward`.
 
 Every action lists the set of endpoints it allows. Note that some Epinio operations are formed from multiple endpoints, i.e. the `app push` consists of a Create, Update and others.
 
@@ -151,9 +151,7 @@ These actions enable operations on Namespace commands and resources.
 
 | Action ID         | Description 
 |-------------------|-------------
-| `namespace_read`    | Read permissions (list, show)
-| `namespace_write`   | Write permissions (create, delete)<br/>Depends on: `namespace_read`
-| `namespace`         | All the above<br/>Depends on: `namespace_read`, `namespace_write`
+| `namespace_write`   | Write permissions (create, delete)
 
 ##### App
 

--- a/internal/auth/role.go
+++ b/internal/auth/role.go
@@ -100,10 +100,12 @@ func NewRole(id, name, defaultVal string, actionIDs []string) (Role, error) {
 	for _, actionID := range actionIDs {
 		action, found := ActionsMap[actionID]
 		if !found {
-			return role, fmt.Errorf("action '%s' in role '%s' does not exists", actionID, id)
+			actionErr := fmt.Errorf("action '%s' in role '%s' does not exists", actionID, id)
+		    fmt.Println("ERROR:", actionErr)
+		} else {
+			actions = append(actions, action)
 		}
 
-		actions = append(actions, action)
 	}
 
 	var defaultBool bool

--- a/internal/auth/role.go
+++ b/internal/auth/role.go
@@ -101,7 +101,7 @@ func NewRole(id, name, defaultVal string, actionIDs []string) (Role, error) {
 		action, found := ActionsMap[actionID]
 		if !found {
 			actionErr := fmt.Errorf("action '%s' in role '%s' does not exists", actionID, id)
-		    fmt.Println("ERROR:", actionErr)
+			fmt.Println("ERROR:", actionErr)
 		} else {
 			actions = append(actions, action)
 		}


### PR DESCRIPTION
`namespace_read` is an outdated action and has been removed from Epinio's collection of actions internally some time ago.  So the [docs for adding a user](https://docs.epinio.io/references/authorization#namespace) are outdated considering that table still mentions the removed action, this PR removes references to `namespace_read` in the docs.

When using this invalid action, a redeployment of `epinio-server` leads to a container in CrashLoopBackOff.  The container crashes due to the following:

```
2025/06/27 17:46:51 Settings-0xc00013e1e0: "level"=4 "msg"="Loading" "from"="/tmp/settings.yaml"
2025/06/27 17:46:51 Settings-0xc00013e1e0: "level"=4 "msg"="Loaded" "value"="namespace=(workspace), user=(), pass=(), access_token=({   0001-01-01 00:00:00 +0000 UTC}), api=(), wss=(), color=(true), appchart=(), @()"
2025/06/27 17:46:51 EpinioClient/Init: "level"=4 "msg"="Ingress API" "url"=""
2025/06/27 17:46:51 EpinioClient/Init: "level"=4 "msg"="Settings API" "url"=""
2025/06/27 17:46:51 EpinioServer/AuthService: "level"=2 "msg"="GetRoles"

❌  error creating handler: initializing authentication: loading Epinio roles: action 'namespace_read' in role 'readonlyRole' does not exists
```
Before the container crashes, it is marked as ready.  This means that the old working pod is now terminated and subsequently, Epinio is no longer accessible.  This PR attempts to consider for role validation, checking its completion before returning an `OK` status to the readiness probe, thus leaving the previously working `epinio-server` running and usable.

This PR addresses the error handling for the invalid roles/actions.  It now simply logs the error and does not add the action to the collection.  As opposed to crashing the container.