### PR TITLE
update buildpack versions

### DIFF
--- a/acceptance/api/v1/application_deploy_test.go
+++ b/acceptance/api/v1/application_deploy_test.go
@@ -34,7 +34,7 @@ var _ = Describe("AppDeploy Endpoint", LApplication, func() {
 	)
 
 	// defaultBuilder := "paketobuildpacks/builder:full"
-	defaultBuilder := "paketobuildpacks/builder-jammy-full:0.3.290"
+	defaultBuilder := "paketobuildpacks/builder-jammy-full:0.3.494"
 
 	BeforeEach(func() {
 		namespace = catalog.NewNamespaceName()

--- a/acceptance/api/v1/application_stage_test.go
+++ b/acceptance/api/v1/application_stage_test.go
@@ -39,7 +39,7 @@ var _ = Describe("AppStage Endpoint", LApplication, func() {
 	)
 
 	// defaultBuilder := "paketobuildpacks/builder:full"
-	defaultBuilder := "paketobuildpacks/builder-jammy-full:0.3.290"
+	defaultBuilder := "paketobuildpacks/builder-jammy-full:0.3.494"
 
 	BeforeEach(func() {
 		namespace = catalog.NewNamespaceName()

--- a/acceptance/api/v1/info_test.go
+++ b/acceptance/api/v1/info_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Info endpoint", LMisc, func() {
 		err = json.Unmarshal(bodyBytes, &info)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(info.DefaultBuilderImage).To(Equal("paketobuildpacks/builder-jammy-full:0.3.290"))
+		Expect(info.DefaultBuilderImage).To(Equal("paketobuildpacks/builder-jammy-full:0.3.494"))
 	})
 
 	It("includes the epinio server version in a header", func() {

--- a/acceptance/apps/suite_test.go
+++ b/acceptance/apps/suite_test.go
@@ -62,8 +62,8 @@ var _ = BeforeSuite(func() {
 		"-o", "jsonpath={.spec.rules[0].host}")
 	Expect(err).ToNot(HaveOccurred(), out)
 
-	serverURL = "https://" + out
-	websocketURL = "wss://" + out
+	serverURL = "https://" + out + ":8443"
+	websocketURL = "wss://" + out + ":8443"
 })
 
 var _ = AfterSuite(func() {

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -56,9 +56,9 @@ var _ = Describe("Apps", LApplication, func() {
 	wpBuilder := "paketobuildpacks/builder:0.2.443-full"
 
 	// defaultBuilder := "paketobuildpacks/builder:full"
-	defaultBuilder := "paketobuildpacks/builder-jammy-full:0.3.290"
+	defaultBuilder := "paketobuildpacks/builder-jammy-full:0.3.494"
 	// tinyBuilder := "paketobuildpacks/builder:tiny"
-	tinyBuilder := "paketobuildpacks/builder-jammy-tiny:0.0.197"
+	tinyBuilder := "paketobuildpacks/builder-jammy-tiny:0.0.364"
 
 	BeforeEach(func() {
 		namespace = catalog.NewNamespaceName()

--- a/acceptance/testenv/epinio.go
+++ b/acceptance/testenv/epinio.go
@@ -142,6 +142,6 @@ func EnsureDefaultWorkspace(epinioBinary string) {
 }
 
 func AppRouteFromOutput(out string) string {
-	routeRegexp := regexp.MustCompile(`Routes: .*\n.*(https:\/\/.*\.omg\.howdoi\.website)`)
+	routeRegexp := regexp.MustCompile(`Routes: .*\n.*(https:\/\/.*\.sslip\.io)`)
 	return routeRegexp.FindStringSubmatch(out)[1]
 }


### PR DESCRIPTION
Update base buildback versions

Breaking: The base build pack is updated from paketobuildpacks/builder-jammy-full:0.3.290 to paketobuildpacks/builder-jammy-full:0.3.494. Some applications may require config.toml or other configuration updates related to buildpack changes or changes to supported versions within the buildpack. Please refer to the paketobuildpacks/builder-jammy-full changelog for futher details.

depends on: https://github.com/epinio/helm-charts/pull/572