### PR TITLE
Tests: Fix port usage and reference issues

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -29,7 +29,7 @@ jobs:
           account-type: org
           org-name: epinio
           keep-at-least: 1
-          filter-tags: "v*-[0-9]*-g*", "test-*"
+          filter-tags: "v*-[0-9]*-g*, test-*"
           filter-include-untagged: true
           token: ${{ secrets.IMG_CLEANUP_TOKEN }}
       - name: Delete untagged containers older than a week

--- a/acceptance/api/v1/service_portforward_test.go
+++ b/acceptance/api/v1/service_portforward_test.go
@@ -54,7 +54,9 @@ var _ = Describe("ServicePortForward Endpoint", LService, func() {
 			catalogService = catalog.NginxCatalogService(catalogServiceName)
 			catalog.CreateCatalogService(catalogService)
 
-			catalogServiceURL = "http://" + catalogServiceHostname
+			// temporarily include :8080 to test port resolution
+			// catalogServiceURL = "http://" + catalogServiceHostname
+			catalogServiceURL = fmt.Sprintf("%s://%s:%s", parsed.Scheme, catalogServiceHostname, parsed.Port())
 
 			DeferCleanup(func() {
 				catalog.DeleteCatalogService(catalogService.Meta.Name)

--- a/acceptance/api/v1/service_portforward_test.go
+++ b/acceptance/api/v1/service_portforward_test.go
@@ -44,8 +44,12 @@ var _ = Describe("ServicePortForward Endpoint", LService, func() {
 			settings, err := env.GetSettingsFrom(testenv.EpinioYAML())
 			Expect(err).ToNot(HaveOccurred())
 
+			// parse the API URL to properly pull the hostname without duplicating a port entry.
+			parsed, err := url.Parse(settings.API)
+			Expect(err).ToNot(HaveOccurred())
+
 			catalogServiceName := catalog.NewCatalogServiceName()
-			catalogServiceHostname = strings.Replace(settings.API, `https://epinio`, catalogServiceName, 1)
+			catalogServiceHostname = strings.Replace(parsed.Hostname(), `epinio`, catalogServiceName, 1)
 
 			catalogService = catalog.NginxCatalogService(catalogServiceName)
 			catalog.CreateCatalogService(catalogService)

--- a/acceptance/login_test.go
+++ b/acceptance/login_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Login", LMisc, func() {
 		oldPort := parsed.Port()
 		randomPort := r.Intn(65535-1024) + 1024 // avoid well-known ports
 		if oldPort != fmt.Sprintf("%d", randomPort) {
-			randomPort += 1
+			randomPort -= 1 // subtract one to prevent exceeding port maximums
 		}
 		parsed.Host = fmt.Sprintf("%s:%d", host, randomPort)
 		serverURLWithPort := parsed.String()
@@ -191,9 +191,9 @@ var _ = Describe("Login", LMisc, func() {
 		}
 
 		Expect(outLines[0]).To(ContainSubstring("Login to your Epinio cluster"))
-		Expect(outLines[0]).To(ContainSubstring(randomPort))
+		Expect(outLines[0]).To(ContainSubstring(fmt.Sprintf("%d", randomPort)))
 
 		Expect(outLines[1]).To(ContainSubstring("error while checking CA"))
-		Expect(outLines[1]).To(ContainSubstring("%s: connect: connection refused", randomPort))
+		Expect(outLines[1]).To(ContainSubstring(fmt.Sprintf("%d: connect: connection refused", randomPort)))
 	})
 })

--- a/acceptance/login_test.go
+++ b/acceptance/login_test.go
@@ -176,7 +176,7 @@ var _ = Describe("Login", LMisc, func() {
 			p += 1
 		}
 		randomPort := fmt.Sprintf(`:%d`, p)
-		parsed.Host = fmt.Sprintf("%s:%s", host, randomPort)
+		parsed.Host = fmt.Sprintf("%s:%d", host, p)
 		serverURLWithPort := parsed.String()
 
 		out, err := env.Epinio("", "login", "-u", "epinio", "-p", env.EpinioPassword,

--- a/acceptance/login_test.go
+++ b/acceptance/login_test.go
@@ -171,12 +171,11 @@ var _ = Describe("Login", LMisc, func() {
 		// Get the current port (if any) and strip it
 		host := parsed.Hostname()
 		oldPort := parsed.Port()
-		p := r.Intn(65535-1024) + 1024 // avoid well-known ports
-		if oldPort != fmt.Sprintf("%d", p) {
-			p += 1
+		randomPort := r.Intn(65535-1024) + 1024 // avoid well-known ports
+		if oldPort != fmt.Sprintf("%d", randomPort) {
+			randomPort += 1
 		}
-		randomPort := fmt.Sprintf(`:%d`, p)
-		parsed.Host = fmt.Sprintf("%s:%d", host, p)
+		parsed.Host = fmt.Sprintf("%s:%d", host, randomPort)
 		serverURLWithPort := parsed.String()
 
 		out, err := env.Epinio("", "login", "-u", "epinio", "-p", env.EpinioPassword,

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -214,8 +214,12 @@ var _ = Describe("Services", LService, func() {
 				settings, err := env.GetSettingsFrom(testenv.EpinioYAML())
 				Expect(err).ToNot(HaveOccurred())
 
+				// parse the API URL to properly pull the hostname without duplicating a port entry.
+				parsed, err := url.Parse(settings.API)
+				Expect(err).ToNot(HaveOccurred())
+
 				serviceName := catalog.NewServiceName()
-				serviceHostname := strings.Replace(settings.API, `https://epinio`, serviceName, 1)
+				serviceHostname := strings.Replace(parsed.Hostname(), `epinio`, serviceName, 1)
 
 				out, err := env.Epinio("", "service", "create",
 					catalogService.Meta.Name, serviceName,
@@ -998,9 +1002,11 @@ var _ = Describe("Services", LService, func() {
 			settings, err := env.GetSettingsFrom(testenv.EpinioYAML())
 			Expect(err).ToNot(HaveOccurred())
 
-			serviceName = catalog.NewServiceName()
+			// parse the API URL to properly pull the hostname without duplicating a port entry.
 			parsed, err := url.Parse(settings.API)
 			Expect(err).ToNot(HaveOccurred())
+
+			serviceName = catalog.NewServiceName()
 			serviceHostname := strings.Replace(parsed.Hostname(), `epinio`, serviceName, 1)
 
 			out, err := env.Epinio("", "service", "create",
@@ -1165,10 +1171,14 @@ var _ = Describe("Services", LService, func() {
 			settings, err := env.GetSettingsFrom(testenv.EpinioYAML())
 			Expect(err).ToNot(HaveOccurred())
 
+			// parse the API URL to properly pull the hostname without duplicating a port entry.
+			parsed, err := url.Parse(settings.API)
+			Expect(err).ToNot(HaveOccurred())
+
 			appName = catalog.NewAppName()
 			service = catalog.NewServiceName()
 			containerImageURL := "epinio/sample-app"
-			serviceHostname := strings.Replace(settings.API, `https://epinio`, service, 1)
+			serviceHostname := strings.Replace(parsed.Hostname(), `epinio`, service, 1)
 
 			env.MakeContainerImageApp(appName, 1, containerImageURL)
 

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -998,7 +999,9 @@ var _ = Describe("Services", LService, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			serviceName = catalog.NewServiceName()
-			serviceHostname := strings.Replace(settings.API, `https://epinio`, serviceName, 1)
+			parsed, err := url.Parse(settings.API)
+			Expect(err).ToNot(HaveOccurred())
+			serviceHostname := strings.Replace(parsed.Hostname(), `epinio`, serviceName, 1)
 
 			out, err := env.Epinio("", "service", "create",
 				catalogService.Meta.Name, serviceName,

--- a/scripts/acceptance-cluster-setup-several-k8s-versions.sh
+++ b/scripts/acceptance-cluster-setup-several-k8s-versions.sh
@@ -18,7 +18,7 @@ MIRROR_NAME=epinio-acceptance-registry-mirror
 CLUSTER_NAME=epinio-acceptance
 export KUBECONFIG=$SCRIPT_DIR/../tmp/acceptance-kubeconfig
 # Get all available k3s releases, sort them, get rid of RCs and use tag format
-K3S_RELEASES=$(curl -sH "Accept: application/vnd.github.v3+json" 'https://api.github.com/repos/k3s-io/k3s/releases' | jq -r '.[] | select (.assets[].name == "k3s") | .name' | grep -v '\-rc' | sort -r | tr + -)
+K3S_RELEASES=$(curl -sH "Accept: application/vnd.github.v3+json" 'https://api.github.com/repos/k3s-io/k3s/releases' | jq -r '.[] | select(.assets and (.assets[]? | select(.name == "k3s"))) | .name' | grep -v '\-rc' | sort -r | tr + -)
 
 # k3s version selection (latest is default)
 if [[ "$K3S_KIND" == "latest" || "$K3S_KIND" == "" ]]; then

--- a/scripts/collect-coverage.sh
+++ b/scripts/collect-coverage.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+
 # Copyright © 2021 - 2023 SUSE LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/collect-coverage.sh
+++ b/scripts/collect-coverage.sh
@@ -21,7 +21,7 @@ source "${SCRIPT_DIR}/helpers.sh"
 prepare_system_domain
 
 # graceful exit for server
-curl -vk https://epinio."$EPINIO_SYSTEM_DOMAIN"/exit
+curl -vk https://epinio."$EPINIO_DOMAIN_AND_PORT"/exit
 
 # wait for restart and get name
 kubectl rollout status deployment -n epinio epinio-server


### PR DESCRIPTION
* fixes the port check by ensuring that a random port in a safe range is chosen, strips out an existing port (if specified), and doesn't use the existing port.
* use url.Parse instead of string replacement to correct tests when a port is specified.