### PR TITLE
fix: Remove the multipart file after the upload process is complete:

### DIFF
--- a/internal/api/v1/application/upload.go
+++ b/internal/api/v1/application/upload.go
@@ -13,8 +13,8 @@ package application
 
 import (
 	"io"
-	"os"
 	"mime/multipart"
+	"os"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
@@ -54,8 +54,8 @@ func Upload(c *gin.Context) apierror.APIErrors {
 	log.V(2).Info("parsing multipart form")
 
 	file, fileheader, err := c.Request.FormFile("file")
-	
-  if err != nil {
+
+	if err != nil {
 		return apierror.NewBadRequestError(err.Error()).WithDetails("can't read multipart file input")
 	}
 	defer file.Close()
@@ -94,17 +94,17 @@ func Upload(c *gin.Context) apierror.APIErrors {
 
 	log.Info("uploaded app", "namespace", namespace, "app", name, "blobUID", blobUID)
 
-  /*Delete the temporary file created by the multipart form if upload is 
-  successful. If it fails the net/http package doesn't store the multipart file
-  in tmp directory and dumps it from memory/any partial file is not stored.*/
-  if tempFile, err := fileheader.Open(); err == nil {
-    if osFile, ok := tempFile.(*os.File); ok {
-      tempPath := osFile.Name()
-      log.Info("Deleting multipart temp file", "path", tempPath)
-      os.Remove(tempPath)
-    } 
-    tempFile.Close()
-  }
+	/*Delete the temporary file created by the multipart form if upload is
+	  successful. If it fails the net/http package doesn't store the multipart file
+	  in tmp directory and dumps it from memory/any partial file is not stored.*/
+	if tempFile, err := fileheader.Open(); err == nil {
+		if osFile, ok := tempFile.(*os.File); ok {
+			tempPath := osFile.Name()
+			log.Info("Deleting multipart temp file", "path", tempPath)
+			os.Remove(tempPath)
+		}
+		tempFile.Close()
+	}
 
 	response.OKReturn(c, models.UploadResponse{
 		BlobUID: blobUID,


### PR DESCRIPTION
To test this add larger files to your directory (I used 50, 100, and 250mb). You may need to adjust your ingress to allow larger files through, specifically the `proxy-body-size`. Also note that the `proxy-read-timeout` may need to be adjusted to support the longer wait times for uploading files. 

Navigate to the the tmp directory on the epinio server using this path `/var/lib/kubelet/pods/<uuid>/volumes/kubernetes.io~empty-dir/tmp-volume `. When the file is uploaded but before its uploaded to s3, you will see the multipart file. After that is complete the file will be removed. 