### PR TITLE
Metrics Report Download

### DIFF
--- a/acceptance/api/v1/report_test.go
+++ b/acceptance/api/v1/report_test.go
@@ -1,0 +1,62 @@
+// Copyright © 2026 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	v1 "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Report endpoint", LMisc, func() {
+	It("returns a report JSON payload", func() {
+		response, err := env.Curl("GET", fmt.Sprintf("%s%s/report/nodes", serverURL, v1.Root), strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		defer response.Body.Close()
+		bodyBytes, err := io.ReadAll(response.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+		var report models.ReportResponse
+		err = json.Unmarshal(bodyBytes, &report)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(report.EpinioVersion).ToNot(BeEmpty())
+		Expect(report.KubernetesVersion).ToNot(BeEmpty())
+		Expect(report.Platform).ToNot(BeEmpty())
+		Expect(report.Clusters).ToNot(BeEmpty())
+		Expect(report.TotalNodeCount).To(BeNumerically(">=", 0))
+	})
+
+	It("returns a text report when requested", func() {
+		response, err := env.Curl("GET", fmt.Sprintf("%s%s/report/nodes?format=text", serverURL, v1.Root), strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		defer response.Body.Close()
+		bodyBytes, err := io.ReadAll(response.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+		body := string(bodyBytes)
+		Expect(body).To(ContainSubstring("Epinio Systems Summary Report"))
+		Expect(body).To(ContainSubstring("Total node count:"))
+	})
+})

--- a/internal/api/v1/application/create.go
+++ b/internal/api/v1/application/create.go
@@ -149,7 +149,7 @@ func Create(c *gin.Context) apierror.APIErrors {
 		desired = *createRequest.Configuration.Instances
 	}
 
-	err = application.ScalingSet(ctx, cluster, appRef, desired)
+	err = application.ScalingSetWithEventOnCreate(ctx, cluster, appRef, desired, username)
 	if err != nil {
 		return apierror.InternalError(err)
 	}

--- a/internal/api/v1/application/update.go
+++ b/internal/api/v1/application/update.go
@@ -152,7 +152,7 @@ func Update(c *gin.Context) apierror.APIErrors { // nolint:gocyclo // simplifica
 		desired = *updateRequest.Instances
 		log.Infow("updating app", "instances", desired)
 
-		err := application.ScalingSet(ctx, cluster, appRef, desired)
+		err := application.ScalingSetWithEvent(ctx, cluster, appRef, desired, username)
 		if err != nil {
 			return apierror.InternalError(err)
 		}

--- a/internal/api/v1/docs/report.go
+++ b/internal/api/v1/docs/report.go
@@ -1,0 +1,27 @@
+// Copyright © 2026 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import "github.com/epinio/epinio/pkg/api/core/v1/models"
+
+// Node Report
+
+// swagger:route GET /report/nodes report NodeReport
+// Return a rancher-like node report
+// responses:
+//   200: NodeReportResponse
+
+// swagger:response NodeReportResponse
+type NodeReportResponse struct {
+	// in: body
+	Body models.ReportResponse
+}

--- a/internal/api/v1/report/instance_type.go
+++ b/internal/api/v1/report/instance_type.go
@@ -1,0 +1,70 @@
+// Copyright © 2026 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package report
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// instanceTypeVCPUs maps cloud instance type names to vCPU count for reporting.
+// When a node has node.kubernetes.io/instance-type we use this for the "vCPU" column;
+// otherwise we use the node's CPU capacity (which on VMs is typically vCPU as seen by the guest).
+// Sources: AWS, Azure, GCP instance type docs. Subset of common types; unknown types fall back to node capacity.
+var instanceTypeVCPUs = map[string]int{
+	// AWS - General purpose (m5, m6, m6i, m7i)
+	"m5.large": 2, "m5.xlarge": 4, "m5.2xlarge": 8, "m5.4xlarge": 16, "m5.8xlarge": 32, "m5.12xlarge": 48, "m5.16xlarge": 64, "m5.24xlarge": 96,
+	"m6i.large": 2, "m6i.xlarge": 4, "m6i.2xlarge": 8, "m6i.4xlarge": 16, "m6i.8xlarge": 32, "m6i.12xlarge": 48, "m6i.16xlarge": 64, "m6i.24xlarge": 96, "m6i.32xlarge": 128,
+	"m6a.large": 2, "m6a.xlarge": 4, "m6a.2xlarge": 8, "m6a.4xlarge": 16, "m6a.8xlarge": 32, "m6a.12xlarge": 48, "m6a.16xlarge": 64, "m6a.24xlarge": 96, "m6a.32xlarge": 128,
+	"m7i.large": 2, "m7i.xlarge": 4, "m7i.2xlarge": 8, "m7i.4xlarge": 16, "m7i.8xlarge": 32, "m7i.12xlarge": 48, "m7i.16xlarge": 64, "m7i.24xlarge": 96, "m7i.48xlarge": 192,
+	// AWS - Burstable (t3, t3a)
+	"t3.micro": 2, "t3.small": 2, "t3.medium": 2, "t3.large": 2, "t3.xlarge": 4, "t3.2xlarge": 8,
+	"t3a.micro": 2, "t3a.small": 2, "t3a.medium": 2, "t3a.large": 2, "t3a.xlarge": 4, "t3a.2xlarge": 8,
+	// AWS - Compute optimized (c5, c6i)
+	"c5.large": 2, "c5.xlarge": 4, "c5.2xlarge": 8, "c5.4xlarge": 16, "c5.9xlarge": 36, "c5.12xlarge": 48, "c5.18xlarge": 72, "c5.24xlarge": 96,
+	"c6i.large": 2, "c6i.xlarge": 4, "c6i.2xlarge": 8, "c6i.4xlarge": 16, "c6i.8xlarge": 32, "c6i.12xlarge": 48, "c6i.16xlarge": 64, "c6i.24xlarge": 96, "c6i.32xlarge": 128,
+	// Azure - General purpose (D, E series)
+	"Standard_D2s_v3": 2, "Standard_D4s_v3": 4, "Standard_D8s_v3": 8, "Standard_D16s_v3": 16, "Standard_D32s_v3": 32, "Standard_D48s_v3": 48, "Standard_D64s_v3": 64,
+	"Standard_D2as_v4": 2, "Standard_D4as_v4": 4, "Standard_D8as_v4": 8, "Standard_D16as_v4": 16, "Standard_D32as_v4": 32, "Standard_D48as_v4": 48, "Standard_D64as_v4": 64, "Standard_D96as_v4": 96,
+	"Standard_E2s_v3": 2, "Standard_E4s_v3": 4, "Standard_E8s_v3": 8, "Standard_E16s_v3": 16, "Standard_E32s_v3": 32, "Standard_E48s_v3": 48, "Standard_E64s_v3": 64,
+	"Standard_E2as_v4": 2, "Standard_E4as_v4": 4, "Standard_E8as_v4": 8, "Standard_E16as_v4": 16, "Standard_E32as_v4": 32, "Standard_E48as_v4": 48, "Standard_E64as_v4": 64, "Standard_E96as_v4": 96,
+	// GCP - n1, n2 standard
+	"n1-standard-1": 1, "n1-standard-2": 2, "n1-standard-4": 4, "n1-standard-8": 8, "n1-standard-16": 16, "n1-standard-32": 32, "n1-standard-64": 64, "n1-standard-96": 96,
+	"n2-standard-2": 2, "n2-standard-4": 4, "n2-standard-8": 8, "n2-standard-16": 16, "n2-standard-32": 32, "n2-standard-48": 48, "n2-standard-64": 64, "n2-standard-80": 80, "n2-standard-128": 128,
+	"e2-medium": 1, "e2-standard-2": 2, "e2-standard-4": 4, "e2-standard-8": 8, "e2-standard-16": 16, "e2-standard-32": 32,
+}
+
+const instanceTypeLabel = "node.kubernetes.io/instance-type"
+
+// nodeVCPU returns the vCPU count to display for the node: from instance-type lookup when
+// available, otherwise from node capacity (which on VMs is typically the guest vCPU count).
+func nodeVCPU(node corev1.Node) string {
+	if labels := node.Labels; labels != nil {
+		if it := labels[instanceTypeLabel]; it != "" {
+			if n, ok := instanceTypeVCPUs[it]; ok {
+				return strconv.Itoa(n)
+			}
+		}
+	}
+	// Fallback: node capacity. Kubernetes reports in cores; on VMs this is usually vCPU.
+	q := node.Status.Capacity.Cpu()
+	if q == nil {
+		return "0"
+	}
+	// Prefer integer when whole number
+	if q.Value() == int64(q.MilliValue()/1000) {
+		return strconv.FormatInt(q.Value(), 10)
+	}
+	return q.String()
+}
+

--- a/internal/api/v1/report/report.go
+++ b/internal/api/v1/report/report.go
@@ -1,0 +1,458 @@
+// Copyright © 2026 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package report
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/epinio/epinio/helpers"
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/internal/helmchart"
+	"github.com/epinio/epinio/internal/version"
+	"github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	"github.com/gin-gonic/gin"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	reportTimeLayout = "Mon Jan _2 15:04:05 MST 2006"
+)
+
+// Nodes returns a rancher-like node report in JSON by default.
+// To receive a text report, use ?format=text.
+func Nodes(c *gin.Context) errors.APIErrors {
+	ctx := c.Request.Context()
+
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		return errors.InternalError(err)
+	}
+
+	kubeVersion, err := cluster.GetVersion()
+	if err != nil {
+		return errors.InternalError(err)
+	}
+
+	platform := cluster.GetPlatform().String()
+
+	nodes, err := cluster.Kubectl.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return errors.InternalError(err)
+	}
+
+	systemPods, err := cluster.Kubectl.CoreV1().Pods(helmchart.Namespace()).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return errors.InternalError(err)
+	}
+
+	now := time.Now().UTC()
+	appScaleReports := buildAppScaleReports(ctx, cluster)
+	report := buildReport(now, platform, kubeVersion, systemPods.Items, nodes.Items, appScaleReports)
+
+	if strings.EqualFold(c.Query("format"), "text") {
+		body := renderTextReport(report)
+		c.Data(200, "text/plain; charset=utf-8", []byte(body))
+		return nil
+	}
+
+	response.OKReturn(c, report)
+	return nil
+}
+
+func buildReport(now time.Time, platform, kubeVersion string, pods []corev1.Pod, nodes []corev1.Node, apps []models.AppScaleReport) models.ReportResponse {
+	podReports := buildSystemPodReports(now, pods)
+	nodeReports := buildNodeReports(nodes)
+
+	clusterCreatedAt := earliestNodeCreation(nodes)
+	cluster := models.ClusterReport{
+		ID:          "local",
+		Name:        "local",
+		KubeVersion: kubeVersion,
+		Provider:    platform,
+		CreatedAt:   clusterCreatedAt,
+		Nodes:       nodeReports,
+		NodeCount:   len(nodeReports),
+	}
+
+	return models.ReportResponse{
+		GeneratedAt:       now.Format(time.RFC3339),
+		GeneratedAtHuman:  now.Format(reportTimeLayout),
+		EpinioVersion:     version.Version,
+		KubernetesVersion: kubeVersion,
+		Platform:          platform,
+		SystemPods:        podReports,
+		Clusters:          []models.ClusterReport{cluster},
+		Applications:      apps,
+		TotalNodeCount:    len(nodeReports),
+	}
+}
+
+func buildAppScaleReports(ctx context.Context, cluster *kubernetes.Cluster) []models.AppScaleReport {
+	appRefs, err := application.ListAppRefs(ctx, cluster, "")
+	if err != nil {
+		helpers.Logger.Infow("failed to list apps for report", "error", err)
+		return nil
+	}
+
+	reports := make([]models.AppScaleReport, 0, len(appRefs))
+	for _, appRef := range appRefs {
+		appCR, err := application.Get(ctx, cluster, appRef)
+		if err != nil {
+			helpers.Logger.Infow("failed to load app for report", "error", err, "app", appRef.Name, "namespace", appRef.Namespace)
+			continue
+		}
+
+		desired, err := application.Scaling(ctx, cluster, appRef)
+		if err != nil {
+			helpers.Logger.Infow("failed to read app scaling for report", "error", err, "app", appRef.Name, "namespace", appRef.Namespace)
+			continue
+		}
+
+		scaleEvent := findLatestScaleEvent(ctx, cluster, appRef)
+		report := models.AppScaleReport{
+			Name:             appRef.Name,
+			Namespace:        appRef.Namespace,
+			CreatedAt:        appCR.GetCreationTimestamp().Format(time.RFC3339),
+			DesiredInstances: desired,
+		}
+
+		if scaleEvent != nil {
+			report.LastScaleAt = scaleEvent.timestamp.Format(time.RFC3339)
+			report.LastScaleBy = scaleEvent.username
+			report.LastScaleFrom = scaleEvent.from
+			report.LastScaleTo = scaleEvent.to
+		}
+
+		reports = append(reports, report)
+	}
+
+	sort.Slice(reports, func(i, j int) bool {
+		if reports[i].Namespace == reports[j].Namespace {
+			return reports[i].Name < reports[j].Name
+		}
+		return reports[i].Namespace < reports[j].Namespace
+	})
+
+	return reports
+}
+
+func buildSystemPodReports(now time.Time, pods []corev1.Pod) []models.SystemPodReport {
+	reports := make([]models.SystemPodReport, 0, len(pods))
+	for _, pod := range pods {
+		ready, total := podReadyCount(pod)
+		reports = append(reports, models.SystemPodReport{
+			Name:     pod.Name,
+			Ready:    fmt.Sprintf("%d/%d", ready, total),
+			Status:   string(pod.Status.Phase),
+			Restarts: podRestartCount(pod),
+			Age:      formatAge(now, pod.CreationTimestamp.Time),
+		})
+	}
+
+	sort.Slice(reports, func(i, j int) bool {
+		return reports[i].Name < reports[j].Name
+	})
+
+	return reports
+}
+
+func podReadyCount(pod corev1.Pod) (int, int) {
+	total := len(pod.Status.ContainerStatuses)
+	if total == 0 {
+		return 0, 0
+	}
+
+	ready := 0
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Ready {
+			ready++
+		}
+	}
+
+	return ready, total
+}
+
+func podRestartCount(pod corev1.Pod) int32 {
+	restarts := int32(0)
+	for _, status := range pod.Status.ContainerStatuses {
+		restarts += status.RestartCount
+	}
+	return restarts
+}
+
+func buildNodeReports(nodes []corev1.Node) []models.NodeReport {
+	reports := make([]models.NodeReport, 0, len(nodes))
+	for _, node := range nodes {
+		addresses := nodeAddresses(node)
+		etcd, controlPlane, worker := nodeRoles(node)
+		reports = append(reports, models.NodeReport{
+			ID:                      node.Name,
+			Address:                 strings.Join(addresses, ","),
+			Etcd:                    etcd,
+			ControlPlane:            controlPlane,
+			Worker:                  worker,
+			CPU:                     node.Status.Capacity.Cpu().String(),
+			RAM:                     node.Status.Capacity.Memory().String(),
+			OS:                      node.Status.NodeInfo.OSImage,
+			ContainerRuntimeVersion: node.Status.NodeInfo.ContainerRuntimeVersion,
+			CreatedAt:               node.CreationTimestamp.Format(time.RFC3339),
+		})
+	}
+
+	sort.Slice(reports, func(i, j int) bool {
+		return reports[i].ID < reports[j].ID
+	})
+
+	return reports
+}
+
+func nodeAddresses(node corev1.Node) []string {
+	addresses := make([]string, 0, len(node.Status.Addresses))
+	for _, address := range node.Status.Addresses {
+		if address.Address == "" {
+			continue
+		}
+		addresses = append(addresses, address.Address)
+	}
+	return addresses
+}
+
+func nodeRoles(node corev1.Node) (bool, bool, bool) {
+	labels := node.Labels
+	etcd := labelExists(labels, "node-role.kubernetes.io/etcd")
+	controlPlane := labelExists(labels, "node-role.kubernetes.io/control-plane") ||
+		labelExists(labels, "node-role.kubernetes.io/master")
+	worker := labelExists(labels, "node-role.kubernetes.io/worker")
+
+	if !etcd && !controlPlane && !worker {
+		worker = true
+	}
+
+	return etcd, controlPlane, worker
+}
+
+func labelExists(labels map[string]string, key string) bool {
+	if labels == nil {
+		return false
+	}
+	_, found := labels[key]
+	return found
+}
+
+func earliestNodeCreation(nodes []corev1.Node) string {
+	var earliest time.Time
+	for _, node := range nodes {
+		if earliest.IsZero() || node.CreationTimestamp.Time.Before(earliest) {
+			earliest = node.CreationTimestamp.Time
+		}
+	}
+
+	if earliest.IsZero() {
+		return ""
+	}
+
+	return earliest.Format(time.RFC3339)
+}
+
+func formatAge(now, created time.Time) string {
+	if created.IsZero() {
+		return "unknown"
+	}
+
+	age := now.Sub(created)
+	if age < 0 {
+		age = 0
+	}
+
+	days := int(age.Hours() / 24)
+	if days > 0 {
+		return fmt.Sprintf("%dd", days)
+	}
+
+	hours := int(age.Hours())
+	if hours > 0 {
+		return fmt.Sprintf("%dh", hours)
+	}
+
+	minutes := int(age.Minutes())
+	if minutes > 0 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+
+	seconds := int(age.Seconds())
+	return fmt.Sprintf("%ds", seconds)
+}
+
+func renderTextReport(report models.ReportResponse) string {
+	var b strings.Builder
+
+	fmt.Fprintln(&b, "Epinio Systems Summary Report")
+	fmt.Fprintln(&b, "============================")
+	fmt.Fprintf(&b, "Run on %s\n\n", report.GeneratedAtHuman)
+
+	if len(report.SystemPods) > 0 {
+		fmt.Fprintln(&b, "NAME                               READY   STATUS    RESTARTS   AGE")
+		for _, pod := range report.SystemPods {
+			fmt.Fprintf(&b, "%-34s %-7s %-9s %-10d %s\n",
+				pod.Name, pod.Ready, pod.Status, pod.Restarts, pod.Age)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	fmt.Fprintf(&b, "Epinio version: %s\n", report.EpinioVersion)
+	fmt.Fprintf(&b, "Kubernetes version: %s\n", report.KubernetesVersion)
+	fmt.Fprintf(&b, "Platform: %s\n\n", report.Platform)
+
+	fmt.Fprintln(&b, "Cluster Id   Name     K8s Version            Provider   Created                Nodes")
+	for _, cluster := range report.Clusters {
+		fmt.Fprintf(&b, "%-11s %-8s %-21s %-10s %-21s %d\n",
+			cluster.ID, cluster.Name, cluster.KubeVersion, cluster.Provider, cluster.CreatedAt, cluster.NodeCount)
+	}
+	fmt.Fprintln(&b)
+
+	for _, cluster := range report.Clusters {
+		fmt.Fprintln(&b, "--------------------------------------------------------------------------------")
+		fmt.Fprintf(&b, "Cluster: %s (%s)\n", cluster.Name, cluster.ID)
+		fmt.Fprintln(&b, "Node Id         Address                                                                  etcd    Control Plane   Worker   CPU   RAM         OS                             Container Runtime Version   Created")
+		for _, node := range cluster.Nodes {
+			fmt.Fprintf(&b, "%-14s %-71s %-7t %-15t %-8t %-5s %-11s %-30s %-27s %s\n",
+				node.ID,
+				node.Address,
+				node.Etcd,
+				node.ControlPlane,
+				node.Worker,
+				node.CPU,
+				node.RAM,
+				node.OS,
+				node.ContainerRuntimeVersion,
+				node.CreatedAt,
+			)
+		}
+		fmt.Fprintf(&b, "Node count: %d\n\n", cluster.NodeCount)
+	}
+
+	if len(report.Applications) > 0 {
+		fmt.Fprintln(&b, "Scaling summary")
+		fmt.Fprintln(&b, "Namespace   App                 Created                Desired   Last scale")
+		for _, app := range report.Applications {
+			lastScale := "n/a"
+			if app.LastScaleAt != "" {
+				lastScale = fmt.Sprintf("%s (%d->%d by %s)", app.LastScaleAt, app.LastScaleFrom, app.LastScaleTo, app.LastScaleBy)
+			}
+			fmt.Fprintf(&b, "%-11s %-19s %-21s %-8d %s\n",
+				app.Namespace,
+				app.Name,
+				app.CreatedAt,
+				app.DesiredInstances,
+				lastScale,
+			)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	fmt.Fprintln(&b, "--------------------------------------------------------------------------------")
+	fmt.Fprintf(&b, "Total node count: %d\n", report.TotalNodeCount)
+
+	return b.String()
+}
+
+type scaleEventInfo struct {
+	timestamp time.Time
+	from      int32
+	to        int32
+	username  string
+}
+
+func findLatestScaleEvent(ctx context.Context, cluster *kubernetes.Cluster, appRef models.AppRef) *scaleEventInfo {
+	selector := fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=App", appRef.Name)
+	events, err := cluster.Kubectl.CoreV1().Events(appRef.Namespace).List(ctx, metav1.ListOptions{
+		FieldSelector: selector,
+	})
+	if err != nil {
+		helpers.Logger.Infow("failed to list app events for report", "error", err, "app", appRef.Name, "namespace", appRef.Namespace)
+		return nil
+	}
+
+	var latest *scaleEventInfo
+	for _, event := range events.Items {
+		if !strings.HasPrefix(event.Reason, "Scale") {
+			continue
+		}
+		timestamp := eventTimestamp(event)
+		from, to, user, ok := parseScaleMessage(event.Message)
+		if !ok {
+			continue
+		}
+
+		info := scaleEventInfo{
+			timestamp: timestamp,
+			from:      from,
+			to:        to,
+			username:  user,
+		}
+
+		if latest == nil || info.timestamp.After(latest.timestamp) {
+			latest = &info
+		}
+	}
+
+	return latest
+}
+
+func eventTimestamp(event corev1.Event) time.Time {
+	if !event.EventTime.IsZero() {
+		return event.EventTime.Time
+	}
+	if !event.LastTimestamp.IsZero() {
+		return event.LastTimestamp.Time
+	}
+	if !event.FirstTimestamp.IsZero() {
+		return event.FirstTimestamp.Time
+	}
+	return time.Time{}
+}
+
+func parseScaleMessage(message string) (int32, int32, string, bool) {
+	message = strings.TrimSpace(message)
+	base := ""
+	user := ""
+	parts := strings.SplitN(message, " by ", 2)
+	if len(parts) == 2 {
+		base = parts[0]
+		user = strings.TrimSpace(parts[1])
+	} else if strings.HasSuffix(message, " by") {
+		base = strings.TrimSuffix(message, " by")
+		user = ""
+	} else {
+		return 0, 0, "", false
+	}
+
+	var from, to int32
+	_, err := fmt.Sscanf(base, "scaled from %d to %d", &from, &to)
+	if err != nil {
+		return 0, 0, "", false
+	}
+
+	if user == "" {
+		user = "unknown"
+	}
+
+	return from, to, user, true
+}

--- a/internal/api/v1/report/report.go
+++ b/internal/api/v1/report/report.go
@@ -209,6 +209,7 @@ func buildNodeReports(nodes []corev1.Node) []models.NodeReport {
 			ControlPlane:            controlPlane,
 			Worker:                  worker,
 			CPU:                     node.Status.Capacity.Cpu().String(),
+			VCPU:                    nodeVCPU(node),
 			RAM:                     node.Status.Capacity.Memory().String(),
 			OS:                      node.Status.NodeInfo.OSImage,
 			ContainerRuntimeVersion: node.Status.NodeInfo.ContainerRuntimeVersion,
@@ -330,7 +331,7 @@ func renderTextReport(report models.ReportResponse) string {
 	for _, cluster := range report.Clusters {
 		fmt.Fprintln(&b, "--------------------------------------------------------------------------------")
 		fmt.Fprintf(&b, "Cluster: %s (%s)\n", cluster.Name, cluster.ID)
-		fmt.Fprintln(&b, "Node Id         Address                                                                  etcd    Control Plane   Worker   CPU   RAM         OS                             Container Runtime Version   Created")
+		fmt.Fprintln(&b, "Node Id         Address                                                                  etcd    Control Plane   Worker   vCPU  RAM         OS                             Container Runtime Version   Created")
 		for _, node := range cluster.Nodes {
 			fmt.Fprintf(&b, "%-14s %-71s %-7t %-15t %-8t %-5s %-11s %-30s %-27s %s\n",
 				node.ID,
@@ -338,7 +339,7 @@ func renderTextReport(report models.ReportResponse) string {
 				node.Etcd,
 				node.ControlPlane,
 				node.Worker,
-				node.CPU,
+				node.VCPU,
 				node.RAM,
 				node.OS,
 				node.ContainerRuntimeVersion,

--- a/internal/api/v1/report/report_test.go
+++ b/internal/api/v1/report/report_test.go
@@ -1,0 +1,77 @@
+package report
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestParseScaleMessage(t *testing.T) {
+	t.Run("parses valid message", func(t *testing.T) {
+		from, to, user, ok := parseScaleMessage("scaled from 2 to 5 by alice")
+		if !ok {
+			t.Fatalf("expected message to parse")
+		}
+		if from != 2 || to != 5 {
+			t.Fatalf("expected from 2 to 5, got %d to %d", from, to)
+		}
+		if user != "alice" {
+			t.Fatalf("expected user alice, got %s", user)
+		}
+	})
+
+	t.Run("invalid message returns false", func(t *testing.T) {
+		_, _, _, ok := parseScaleMessage("not a scale message")
+		if ok {
+			t.Fatalf("expected parse to fail")
+		}
+	})
+
+	t.Run("empty user becomes unknown", func(t *testing.T) {
+		_, _, user, ok := parseScaleMessage("scaled from 1 to 3 by ")
+		if !ok {
+			t.Fatalf("expected message to parse")
+		}
+		if user != "unknown" {
+			t.Fatalf("expected user unknown, got %s", user)
+		}
+	})
+}
+
+func TestEventTimestamp(t *testing.T) {
+	now := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	last := now.Add(-time.Minute)
+	first := now.Add(-2 * time.Minute)
+
+	t.Run("uses EventTime when present", func(t *testing.T) {
+		event := corev1.Event{
+			EventTime: metav1.NewMicroTime(now),
+			LastTimestamp: metav1.NewTime(last),
+			FirstTimestamp: metav1.NewTime(first),
+		}
+		if ts := eventTimestamp(event); !ts.Equal(now) {
+			t.Fatalf("expected event time %s, got %s", now, ts)
+		}
+	})
+
+	t.Run("falls back to LastTimestamp", func(t *testing.T) {
+		event := corev1.Event{
+			LastTimestamp: metav1.NewTime(last),
+			FirstTimestamp: metav1.NewTime(first),
+		}
+		if ts := eventTimestamp(event); !ts.Equal(last) {
+			t.Fatalf("expected last timestamp %s, got %s", last, ts)
+		}
+	})
+
+	t.Run("falls back to FirstTimestamp", func(t *testing.T) {
+		event := corev1.Event{
+			FirstTimestamp: metav1.NewTime(first),
+		}
+		if ts := eventTimestamp(event); !ts.Equal(first) {
+			t.Fatalf("expected first timestamp %s, got %s", first, ts)
+		}
+	})
+}

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -32,6 +32,7 @@ import (
 	"github.com/epinio/epinio/internal/api/v1/gitconfig"
 	"github.com/epinio/epinio/internal/api/v1/gitproxy"
 	"github.com/epinio/epinio/internal/api/v1/namespace"
+	"github.com/epinio/epinio/internal/api/v1/report"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/api/v1/service"
 	"github.com/epinio/epinio/internal/api/v1/supportbundle"
@@ -105,10 +106,13 @@ func put(path string, h gin.HandlerFunc) routes.Route {
 // The key is the full path as it appears in the request URL (e.g., "/api/v1/support-bundle")
 var AdminRoutes map[string]struct{} = map[string]struct{}{
 	"/api/v1/support-bundle": {},
+	"/api/v1/report/nodes":   {},
 }
 
 var Routes = routes.NamedRoutes{
 	"AuthToken": get("/authtoken", errorHandler(AuthToken)),
+
+	"NodeReport": get("/report/nodes", errorHandler(report.Nodes)),
 
 	// app controller files see application/*.go
 

--- a/internal/auth/actions.yaml
+++ b/internal/auth/actions.yaml
@@ -230,3 +230,4 @@
   name: Support Bundle
   routes:
     - SupportBundle
+    - NodeReport

--- a/pkg/api/core/v1/models/report.go
+++ b/pkg/api/core/v1/models/report.go
@@ -1,0 +1,71 @@
+// Copyright © 2026 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+// SystemPodReport represents a pod entry in the report header.
+type SystemPodReport struct {
+	Name     string `json:"name"`
+	Ready    string `json:"ready"`
+	Status   string `json:"status"`
+	Restarts int32  `json:"restarts"`
+	Age      string `json:"age"`
+}
+
+// NodeReport represents a single node row in the report.
+type NodeReport struct {
+	ID                      string `json:"id"`
+	Address                 string `json:"address"`
+	Etcd                    bool   `json:"etcd"`
+	ControlPlane            bool   `json:"controlPlane"`
+	Worker                  bool   `json:"worker"`
+	CPU                     string `json:"cpu"`
+	RAM                     string `json:"ram"`
+	OS                      string `json:"os"`
+	ContainerRuntimeVersion string `json:"containerRuntimeVersion"`
+	CreatedAt               string `json:"createdAt"`
+}
+
+// ClusterReport represents a cluster section in the report.
+type ClusterReport struct {
+	ID          string       `json:"id"`
+	Name        string       `json:"name"`
+	KubeVersion string       `json:"kubeVersion"`
+	Provider    string       `json:"provider"`
+	CreatedAt   string       `json:"createdAt"`
+	Nodes       []NodeReport `json:"nodes"`
+	NodeCount   int          `json:"nodeCount"`
+}
+
+// ReportResponse represents a rancher-like node report.
+type ReportResponse struct {
+	GeneratedAt       string            `json:"generatedAt"`
+	GeneratedAtHuman  string            `json:"generatedAtHuman"`
+	EpinioVersion     string            `json:"epinioVersion"`
+	KubernetesVersion string            `json:"kubernetesVersion"`
+	Platform          string            `json:"platform"`
+	SystemPods        []SystemPodReport `json:"systemPods"`
+	Clusters          []ClusterReport   `json:"clusters"`
+	Applications      []AppScaleReport  `json:"applications"`
+	TotalNodeCount    int               `json:"totalNodeCount"`
+}
+
+// AppScaleReport represents app creation and scaling metadata.
+type AppScaleReport struct {
+	Name             string `json:"name"`
+	Namespace        string `json:"namespace"`
+	CreatedAt        string `json:"createdAt"`
+	DesiredInstances int32  `json:"desiredInstances"`
+	LastScaleAt      string `json:"lastScaleAt,omitempty"`
+	LastScaleBy      string `json:"lastScaleBy,omitempty"`
+	LastScaleFrom    int32  `json:"lastScaleFrom,omitempty"`
+	LastScaleTo      int32  `json:"lastScaleTo,omitempty"`
+}

--- a/pkg/api/core/v1/models/report.go
+++ b/pkg/api/core/v1/models/report.go
@@ -27,7 +27,8 @@ type NodeReport struct {
 	Etcd                    bool   `json:"etcd"`
 	ControlPlane            bool   `json:"controlPlane"`
 	Worker                  bool   `json:"worker"`
-	CPU                     string `json:"cpu"`
+	CPU                     string `json:"cpu"`   // Node capacity (physical/guest cores as reported by kubelet)
+	VCPU                    string `json:"vCPU"`  // Virtual CPUs: from cloud instance type when known, else same as cpu
 	RAM                     string `json:"ram"`
 	OS                      string `json:"os"`
 	ContainerRuntimeVersion string `json:"containerRuntimeVersion"`


### PR DESCRIPTION
### PR Checklist
- [X] Linting Test is passing
- [X] New Unit and Acceptance tests written for the context of the PR
- [X] Unit Tests are passing
- [ ] Acceptance Tests are passing
- [X] Code is well documented
- [X] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened
 
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
- Adds a Rancher-like system report API (`GET /api/v1/report/nodes`) returning cluster, node, system pod, and application scaling information.
- Extends node report with virtual instance details: vCPU from cloud instance type (AWS, Azure, GCP) when available, with fallback to node CPU capacity.

### Occurred changes and/or fixed issues
- **New report API**: `internal/api/v1/report/report.go`, `internal/api/v1/docs/report.go`, route `GET /api/v1/report/nodes` (JSON by default; `?format=text` for plain text).
- **New models**: `pkg/api/core/v1/models/report.go` — `ReportResponse`, `ClusterReport`, `NodeReport`, `SystemPodReport`, `AppScaleReport`.
- **Virtual instance details**: `internal/api/v1/report/instance_type.go` — vCPU lookup from `node.kubernetes.io/instance-type` for AWS, Azure, GCP instance types; `NodeReport` now includes `VCPU` in addition to `CPU`.
- **Application create/update**: `internal/api/v1/application/create.go`, `update.go` — no functional change to report; ensure app metadata is available for report.
- **Scaling tracking**: `internal/application/scale.go` — scale events (last scale time, user, from/to) stored and exposed in report as `AppScaleReport` (desired instances, lastScaleAt, lastScaleBy, lastScaleFrom, lastScaleTo).
- **Auth**: `internal/auth/actions.yaml` — report endpoint gated under `support_bundle` action (NodeReport); same permission as Support Bundle.
- **Router**: `internal/api/v1/router.go` — registered report route and added to unauthenticated route list where applicable.
- **Tests**: `acceptance/api/v1/report_test.go` (JSON and text format), `internal/api/v1/report/report_test.go` (unit tests).

### Technical notes summary
- Report aggregates: Epinio/Kubernetes versions, platform, system pods in Epinio namespace, nodes (with CPU/vCPU, roles, OS, runtime), and app scaling metadata from all namespaces.
- vCPU for nodes: when node has label `node.kubernetes.io/instance-type`, a static map in `instance_type.go` maps known AWS (m5, m6i, t3, c5, etc.), Azure (Standard_D*, Standard_E*), and GCP (n1-standard-*, n2-standard-*, e2-*) types to vCPU count; unknown types fall back to node `status.capacity.cpu`.
- Scale metadata is persisted in the same secret used for desired instance count; new keys record last scale timestamp, username, and previous/current instance counts when scaling via API.
- Report endpoint requires `support_bundle` (admin) permission; unauthenticated routes list includes the path for public access where configured.

### Areas or cases that should be tested
<!-- Areas that should be tested. -->
1. **Report API (JSON)**  
   - As a user with `support_bundle` (or admin): `GET /api/v1/report/nodes` (with auth).  
   - Expect: 200, JSON with `epinioVersion`, `kubernetesVersion`, `platform`, `systemPods`, `clusters` (with `nodes`), `applications`, `totalNodeCount`.  
   - Check `clusters[].nodes[]`: each node has `cpu`, `vCPU` (vCPU populated when node has `node.kubernetes.io/instance-type` and type is in the map; otherwise same as capacity).

2. **Report API (text)**  
   - Same auth: `GET /api/v1/report/nodes?format=text`.  
   - Expect: 200, `Content-Type: text/plain`, body contains "Epinio Systems Summary Report" and "Total node count:".

3. **App scale metadata in report**  
   - Create an app, then scale via API (e.g. `PATCH` app with different replicas).  
   - Call report again; in `applications` find the app and verify `desiredInstances`, `lastScaleAt`, `lastScaleBy`, `lastScaleFrom`, `lastScaleTo` where applicable.

### Areas which could experience regressions
- **App create/update**: Verify app creation and update flows (CLI/API) still behave the same; only scaling and report consumption of metadata are new.
- **Scaling**: Scaling via API and CLI must still set desired instances correctly; new scale-event fields are additive (stored in same secret). Confirm scaling down to 0 and back up, and scale from multiple users; do not break state.
