### PR TITLE
Pre release chekcs added

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,27 @@ jobs:
           echo LATEST_TAG: $LATEST_TAG
           echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_OUTPUT
 
+      - name: Validate version parity
+        id: validate_version
+        run: |
+          chmod +x scripts/validate-version-parity.sh
+          export EPINIO_VERSION=${{ steps.get_latest_tag.outputs.LATEST_TAG }}
+          
+          # Run validation in strict mode to block releases on version mismatch
+          # This prevents the issue reported in #2774 where binaries don't match chart version
+          echo "Validating that release tag ${{ steps.get_latest_tag.outputs.LATEST_TAG }} matches helm chart version..."
+          ./scripts/validate-version-parity.sh strict
+          
+          if [ $? -eq 0 ]; then
+            echo "✅ Version parity validated successfully"
+          else
+            echo "❌ Version mismatch detected - blocking release"
+            echo "::error::Cannot release: Epinio version ${{ steps.get_latest_tag.outputs.LATEST_TAG }} does not match helm chart version"
+            echo "::error::Please ensure the helm-charts submodule is updated to match this release tag"
+            exit 1
+          fi
+        continue-on-error: false
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/validate-version-parity.yml
+++ b/.github/workflows/validate-version-parity.yml
@@ -1,0 +1,184 @@
+# Copyright © 2021 - 2023 SUSE LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Validate Version Parity
+
+on:
+  # Run on pull requests that modify version-related files
+  pull_request:
+    paths:
+      - 'internal/version/version.go'
+      - 'helm-charts/**'
+      - '.github/workflows/validate-version-parity.yml'
+      - 'scripts/validate-version-parity.sh'
+  
+  # Run on main branch when version files are updated
+  push:
+    branches:
+      - main
+    paths:
+      - 'internal/version/version.go'
+      - 'helm-charts/**'
+  
+  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Validation mode (check, warn, strict)'
+        required: false
+        default: 'check'
+        type: choice
+        options:
+          - check
+          - warn
+          - strict
+      epinio_version:
+        description: 'Epinio version to check (leave empty for auto-detect)'
+        required: false
+        type: string
+
+  # Run weekly to catch any drift
+  schedule:
+    - cron: '0 0 * * 1'  # Every Monday at midnight
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      
+      - name: Set validation mode
+        id: set_mode
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            MODE="${{ inputs.mode }}"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Use strict mode for PRs to catch issues early
+            MODE="strict"
+          else
+            MODE="check"
+          fi
+          echo "mode=$MODE" >> $GITHUB_OUTPUT
+          echo "Validation mode: $MODE"
+      
+      - name: Set Epinio version
+        id: set_version
+        run: |
+          if [ -n "${{ inputs.epinio_version }}" ]; then
+            echo "EPINIO_VERSION=${{ inputs.epinio_version }}" >> $GITHUB_ENV
+            echo "Using manual version: ${{ inputs.epinio_version }}"
+          else
+            # For PRs, don't set EPINIO_VERSION - let the script read from version.go
+            # For other events, use git tag
+            if [ "${{ github.event_name }}" != "pull_request" ]; then
+              VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "unknown")
+              echo "EPINIO_VERSION=$VERSION" >> $GITHUB_ENV
+              echo "Auto-detected version: $VERSION"
+            else
+              echo "PR mode: Will read version from internal/version/version.go"
+            fi
+          fi
+      
+      - name: Make validation script executable
+        run: chmod +x scripts/validate-version-parity.sh
+      
+      - name: Run version parity validation
+        id: validate
+        run: |
+          set +e  # Don't exit on error, we want to capture output
+          OUTPUT=$(./scripts/validate-version-parity.sh "${{ steps.set_mode.outputs.mode }}" 2>&1)
+          EXIT_CODE=$?
+          
+          # Save output for later use
+          echo "$OUTPUT"
+          echo "$OUTPUT" > /tmp/validation-output.txt
+          
+          # Set output variables
+          echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
+          
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "validation_failed=true" >> $GITHUB_OUTPUT
+          else
+            echo "validation_failed=false" >> $GITHUB_OUTPUT
+          fi
+          
+          exit $EXIT_CODE
+        continue-on-error: true
+      
+      - name: Check validation result
+        if: steps.validate.outputs.validation_failed == 'true'
+        run: |
+          echo "::error::Version parity validation failed"
+          exit 1
+      
+      - name: Comment on PR with validation results
+        if: github.event_name == 'pull_request' && steps.validate.outputs.validation_failed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let output = '';
+            try {
+              output = fs.readFileSync('/tmp/validation-output.txt', 'utf8');
+            } catch (e) {
+              output = 'Could not read validation output';
+            }
+            
+            const body = `## ⚠️ Version Parity Check Failed
+            
+            The Epinio version (from \`internal/version/version.go\`) does not match the Helm chart version.
+            
+            ### Validation Output
+            \`\`\`
+            ${output}
+            \`\`\`
+            
+            ### Required Actions
+            
+            Please ensure that:
+            1. \`internal/version/version.go\` has the correct \`ChartVersion\` value
+            2. The helm-charts submodule is updated to match this version
+            3. Both versions are synchronized before merging
+            
+            ### How to Fix
+            
+            \`\`\`bash
+            # Check current versions
+            make validate-version-parity
+            
+            # Update helm-charts submodule if needed
+            cd helm-charts
+            git checkout main
+            git pull
+            cd ..
+            git add helm-charts
+            
+            # Verify the fix
+            make validate-version-parity-strict
+            \`\`\`
+            
+            See the [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.`;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,36 @@ This does not cover other tools included in Epinio.
 Kubernetes has its own [release versioning](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#kubernetes-release-versioning)
 scheme that looks like SemVer but is semantically different.
 
+## Version Parity Validation
+
+Epinio includes automated validation to ensure that the binary release version matches the Helm chart version. This prevents issues where users might install a Helm chart that references CLI binaries that don't exist.
+
+### Before Creating a Release
+
+Always validate version parity before creating a release tag:
+
+```bash
+make validate-version-parity-strict
+```
+
+### When Updating Versions
+
+If you're modifying version-related files (`internal/version/version.go` or the helm-charts submodule), the CI will automatically run validation checks. Address any warnings or failures before merging.
+
+### Local Validation
+
+You can run validation checks locally at any time:
+
+```bash
+# Check version parity (informational)
+make validate-version-parity
+
+# Strict validation (fails on mismatch)
+make validate-version-parity-strict
+```
+
+For more details, see [Version Parity Validation](docs/howtos/version_parity_validation.md).
+
 ## Coding Style
 
 Epinio expects its Go code to be formatted with `go fmt`.

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,18 @@ test:
 tag:
 	@git describe --tags --abbrev=0
 
+validate-version-parity:
+	@chmod +x scripts/validate-version-parity.sh
+	@./scripts/validate-version-parity.sh check
+
+validate-version-parity-strict:
+	@chmod +x scripts/validate-version-parity.sh
+	@./scripts/validate-version-parity.sh strict
+
+test-version-validation:
+	@chmod +x scripts/test-validate-version-parity.sh
+	@./scripts/test-validate-version-parity.sh
+
 ########################################################################
 # Acceptance tests
 

--- a/docs/howtos/version_parity_validation.md
+++ b/docs/howtos/version_parity_validation.md
@@ -1,0 +1,204 @@
+# Version Parity Validation
+
+## Overview
+
+Version parity validation ensures that the Epinio binary release version matches the Helm chart version. This prevents issues where users might try to install a Helm chart that references CLI binaries that don't exist.
+
+## Background
+
+Issue [#2774](https://github.com/epinio/epinio/issues/2774) identified a problem where the Helm chart version (v1.11.1) did not correspond with the available Epinio release binaries. Users attempting to download the CLI for that version would encounter 404 errors because the binaries were never released.
+
+## How It Works
+
+The validation system includes:
+
+1. **Validation Script** (`scripts/validate-version-parity.sh`): A bash script that compares the Epinio version with the Helm chart version
+2. **GitHub Actions Workflow** (`.github/workflows/validate-version-parity.yml`): Automated validation on PRs and scheduled checks
+3. **Release Gate**: Validation step in the release workflow to catch mismatches before release
+4. **Makefile Targets**: Easy local validation commands
+
+## Usage
+
+### Local Validation
+
+Check version parity locally:
+
+```bash
+make validate-version-parity
+```
+
+Strict validation (fails on mismatch):
+
+```bash
+make validate-version-parity-strict
+```
+
+Direct script usage:
+
+```bash
+# Check mode (default)
+./scripts/validate-version-parity.sh check
+
+# Warning mode (warns but doesn't fail)
+./scripts/validate-version-parity.sh warn
+
+# Strict mode (fails on mismatch)
+./scripts/validate-version-parity.sh strict
+
+# With custom Chart.yaml path
+./scripts/validate-version-parity.sh check helm-charts/chart/epinio/Chart.yaml
+
+# Override version
+EPINIO_VERSION=v1.13.0 ./scripts/validate-version-parity.sh check
+```
+
+### CI/CD Integration
+
+The validation runs automatically:
+
+- **On Pull Requests**: When version-related files are modified
+- **On Main Branch**: When version files are updated
+- **Weekly**: Every Monday to catch any version drift
+- **On Release**: Before creating a new release (strict mode)
+- **Manual Trigger**: Can be triggered manually via GitHub Actions UI
+
+### Validation Modes
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| `check` | Reports version mismatch but doesn't fail | Default mode for information |
+| `warn` | Shows warnings and proceeds | Local testing, manual checks |
+| `strict` | Fails on version mismatch | PR validation, release workflow, pre-release gates |
+
+## Release Process
+
+### Current Behavior
+
+During a release, the validation runs in **strict mode**:
+- ✅ Reports if versions match and allows release to proceed
+- ❌ **Blocks release** if versions mismatch (prevents issue #2774)
+- 📝 Creates detailed error messages for quick resolution
+
+On pull requests, the validation also runs in **strict mode**:
+- ✅ Validates changes to `internal/version/version.go` against helm chart
+- ❌ Fails the PR check if versions don't match
+- 💬 Posts a detailed comment on the PR with fix instructions
+
+## Troubleshooting
+
+### Version Mismatch Detected
+
+If validation reports a version mismatch:
+
+1. **Check the Epinio version**:
+   ```bash
+   git describe --tags --abbrev=0
+   ```
+
+2. **Check the Helm chart version**:
+   ```bash
+   cat helm-charts/chart/epinio/Chart.yaml | grep 'appVersion'
+   ```
+
+3. **Update the helm-charts submodule**:
+   ```bash
+   git submodule update --init --recursive helm-charts
+   cd helm-charts
+   git checkout main
+   git pull origin main
+   cd ..
+   git add helm-charts
+   git commit -m "Update helm-charts submodule"
+   ```
+
+4. **Coordinate with helm-charts repository**: Ensure the helm-charts repository has the correct version before releasing
+
+### Helm-charts Submodule Not Initialized
+
+The validation script can work without the submodule:
+- It will automatically attempt to initialize the submodule
+- If that fails, it fetches the Chart.yaml from the remote repository
+- This ensures validation works in CI environments
+
+### Unknown Versions
+
+If versions cannot be determined:
+- In `check` or `warn` mode: Validation is skipped with a warning
+- In `strict` mode: Validation fails to prevent releasing with unknown versions
+
+## Best Practices
+
+1. **Before Creating a Release Tag**:
+   ```bash
+   make validate-version-parity-strict
+   ```
+
+2. **After Updating helm-charts Submodule**:
+   ```bash
+   make validate-version-parity
+   ```
+
+3. **In CI/CD Pipelines**: Use `warn` mode to alert but not block
+4. **For Release Gates**: Use `strict` mode to prevent version mismatches
+
+## Architecture
+
+### Version Sources
+
+- **Epinio Version** (priority order):
+  1. `EPINIO_VERSION` environment variable (explicit override)
+  2. `internal/version/version.go` → `ChartVersion` variable (for PR validation)
+  3. `GITHUB_REF_NAME` in GitHub Actions (for release tags)
+  4. `git describe --tags` (fallback)
+
+- **Helm Chart Version**:
+  - From `helm-charts/chart/epinio/Chart.yaml` (local)
+  - From GitHub raw content (remote fallback)
+  - Uses `appVersion` field (matches Epinio release version)
+
+### PR Validation Flow
+
+When a PR modifies `internal/version/version.go`:
+
+1. Script reads `ChartVersion` from the modified `version.go`
+2. Compares with `appVersion` in helm-charts
+3. If mismatch: PR check **fails** and detailed comment is posted
+4. If match: PR check passes
+
+This ensures developers update both files together.
+
+### Integration Points
+
+```
+┌─────────────────────┐
+│  Release Workflow   │
+│                     │
+│  1. Create Tag      │
+│  2. Validate        │◄──── Version Parity Check
+│  3. Build Binaries  │
+│  4. Release         │
+│  5. Notify Helm     │
+└─────────────────────┘
+```
+
+## Contributing
+
+When adding new version-related features:
+
+1. Update the validation script if version sources change
+2. Test all validation modes
+3. Update this documentation
+4. Consider impact on CI/CD pipelines
+
+## Related Issues
+
+- [#2774](https://github.com/epinio/epinio/issues/2774) - Original issue that motivated this validation
+
+## Questions or Issues
+
+If you encounter problems with version validation:
+
+1. Check the [Troubleshooting](#troubleshooting) section
+2. Review GitHub Actions logs
+3. Run local validation with verbose output
+4. Open an issue with details about the mismatch

--- a/scripts/test-validate-version-parity.sh
+++ b/scripts/test-validate-version-parity.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+# Copyright © 2021 - 2023 SUSE LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test script for validate-version-parity.sh
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+VALIDATION_SCRIPT="$SCRIPT_DIR/validate-version-parity.sh"
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+print_test() {
+    echo -e "${YELLOW}TEST: $1${NC}"
+}
+
+print_pass() {
+    echo -e "${GREEN}✓ PASS: $1${NC}"
+}
+
+print_fail() {
+    echo -e "${RED}✗ FAIL: $1${NC}"
+}
+
+# Make validation script executable
+chmod +x "$VALIDATION_SCRIPT"
+
+# Test counter
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Create temporary Chart.yaml for testing
+TEMP_DIR=$(mktemp -d)
+TEMP_CHART="$TEMP_DIR/Chart.yaml"
+
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+
+trap cleanup EXIT
+
+# Test 1: Matching versions
+print_test "Test 1: Matching versions (v1.0.0 == v1.0.0)"
+TESTS_RUN=$((TESTS_RUN + 1))
+cat > "$TEMP_CHART" << EOF
+apiVersion: v2
+name: epinio
+version: 1.0.0
+appVersion: v1.0.0
+EOF
+
+if EPINIO_VERSION=v1.0.0 "$VALIDATION_SCRIPT" check "$TEMP_CHART" &>/dev/null; then
+    print_pass "Matching versions detected correctly"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    print_fail "Failed to detect matching versions"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+echo ""
+
+# Test 2: Matching versions without 'v' prefix
+print_test "Test 2: Matching versions without v prefix (1.0.0 == v1.0.0)"
+TESTS_RUN=$((TESTS_RUN + 1))
+cat > "$TEMP_CHART" << EOF
+apiVersion: v2
+name: epinio
+version: 1.0.0
+appVersion: 1.0.0
+EOF
+
+if EPINIO_VERSION=v1.0.0 "$VALIDATION_SCRIPT" check "$TEMP_CHART" &>/dev/null; then
+    print_pass "Version normalization works correctly"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    print_fail "Version normalization failed"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+echo ""
+
+# Test 3: Mismatching versions in check mode (should pass)
+print_test "Test 3: Mismatching versions in check mode (should warn but pass)"
+TESTS_RUN=$((TESTS_RUN + 1))
+cat > "$TEMP_CHART" << EOF
+apiVersion: v2
+name: epinio
+version: 1.0.0
+appVersion: v1.0.0
+EOF
+
+if EPINIO_VERSION=v1.1.0 "$VALIDATION_SCRIPT" check "$TEMP_CHART" &>/dev/null; then
+    print_pass "Check mode allows mismatch"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    print_fail "Check mode should not fail on mismatch"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+echo ""
+
+# Test 4: Mismatching versions in strict mode (should fail)
+print_test "Test 4: Mismatching versions in strict mode (should fail)"
+TESTS_RUN=$((TESTS_RUN + 1))
+cat > "$TEMP_CHART" << EOF
+apiVersion: v2
+name: epinio
+version: 1.0.0
+appVersion: v1.0.0
+EOF
+
+if EPINIO_VERSION=v1.1.0 "$VALIDATION_SCRIPT" strict "$TEMP_CHART" &>/dev/null; then
+    print_fail "Strict mode should fail on mismatch"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+else
+    print_pass "Strict mode correctly fails on mismatch"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+fi
+echo ""
+
+# Test 5: Mismatching versions in warn mode (should pass)
+print_test "Test 5: Mismatching versions in warn mode (should warn but pass)"
+TESTS_RUN=$((TESTS_RUN + 1))
+cat > "$TEMP_CHART" << EOF
+apiVersion: v2
+name: epinio
+version: 1.0.0
+appVersion: v1.0.0
+EOF
+
+if EPINIO_VERSION=v1.1.0 "$VALIDATION_SCRIPT" warn "$TEMP_CHART" &>/dev/null; then
+    print_pass "Warn mode allows mismatch"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    print_fail "Warn mode should not fail on mismatch"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+echo ""
+
+# Test 6: Help flag
+print_test "Test 6: Help flag"
+TESTS_RUN=$((TESTS_RUN + 1))
+if "$VALIDATION_SCRIPT" --help &>/dev/null; then
+    print_pass "Help flag works"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    print_fail "Help flag failed"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+echo ""
+
+# Test 7: RC versions
+print_test "Test 7: Release candidate versions"
+TESTS_RUN=$((TESTS_RUN + 1))
+cat > "$TEMP_CHART" << EOF
+apiVersion: v2
+name: epinio
+version: 1.13.8-rc1
+appVersion: v1.13.8-rc1
+EOF
+
+if EPINIO_VERSION=v1.13.8-rc1 "$VALIDATION_SCRIPT" check "$TEMP_CHART" &>/dev/null; then
+    print_pass "RC versions work correctly"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    print_fail "RC version validation failed"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+echo ""
+
+# Test 8: Reading from version.go (mock)
+print_test "Test 8: Reading version from version.go"
+TESTS_RUN=$((TESTS_RUN + 1))
+
+# Create a mock version.go file
+TEMP_VERSION_DIR="$TEMP_DIR/internal/version"
+mkdir -p "$TEMP_VERSION_DIR"
+cat > "$TEMP_VERSION_DIR/version.go" << 'EOF'
+package version
+
+var Version = "v0.0.0-dev"
+var ChartVersion = "v1.2.0"
+EOF
+
+# Create matching chart
+cat > "$TEMP_CHART" << EOF
+apiVersion: v2
+name: epinio
+version: 1.2.0
+appVersion: v1.2.0
+EOF
+
+# Run validation from temp directory to pick up mock version.go
+if (cd "$TEMP_DIR" && "$SCRIPT_DIR/validate-version-parity.sh" check "$(basename $TEMP_CHART)" &>/dev/null); then
+    print_pass "Successfully reads version from version.go"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    print_fail "Failed to read version from version.go"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+echo ""
+
+# Test 9: Version.go mismatch detection
+print_test "Test 9: Detect mismatch when reading from version.go"
+TESTS_RUN=$((TESTS_RUN + 1))
+
+# version.go already has v1.2.0 from test 8
+# Create mismatched chart
+cat > "$TEMP_CHART" << EOF
+apiVersion: v2
+name: epinio
+version: 1.3.0
+appVersion: v1.3.0
+EOF
+
+# Run validation from temp directory - should fail in strict mode
+if (cd "$TEMP_DIR" && "$SCRIPT_DIR/validate-version-parity.sh" strict "$(basename $TEMP_CHART)" &>/dev/null); then
+    print_fail "Should detect mismatch from version.go"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+else
+    print_pass "Correctly detects mismatch from version.go"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+fi
+echo ""
+
+# Print summary
+echo "================================================"
+echo "Test Summary"
+echo "================================================"
+echo "Tests run:    $TESTS_RUN"
+echo -e "${GREEN}Tests passed: $TESTS_PASSED${NC}"
+if [ $TESTS_FAILED -gt 0 ]; then
+    echo -e "${RED}Tests failed: $TESTS_FAILED${NC}"
+else
+    echo -e "${GREEN}Tests failed: $TESTS_FAILED${NC}"
+fi
+echo "================================================"
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    exit 1
+else
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi

--- a/scripts/validate-version-parity.sh
+++ b/scripts/validate-version-parity.sh
@@ -1,0 +1,272 @@
+#!/bin/bash
+# Copyright © 2021 - 2023 SUSE LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_error() {
+    echo -e "${RED}ERROR: $1${NC}" >&2
+}
+
+print_success() {
+    echo -e "${GREEN}SUCCESS: $1${NC}" >&2
+}
+
+print_warning() {
+    echo -e "${YELLOW}WARNING: $1${NC}" >&2
+}
+
+print_info() {
+    echo "INFO: $1" >&2
+}
+
+# Get the Epinio version from version.go file
+get_epinio_version_from_code() {
+    local version_file="internal/version/version.go"
+    
+    if [ ! -f "$version_file" ]; then
+        echo "not-found"
+        return 1
+    fi
+    
+    # Extract ChartVersion from version.go
+    # Look for: var ChartVersion = "v1.2.3"
+    local version=$(grep 'var ChartVersion =' "$version_file" | sed 's/.*= *"\(.*\)".*/\1/' | tr -d ' ')
+    
+    if [ -z "$version" ] || [ "$version" = "v0.0.0-dev" ]; then
+        # If ChartVersion is not set or is dev, fall back to git tag
+        return 1
+    fi
+    
+    echo "$version"
+}
+
+# Get the Epinio version from git tags or environment
+get_epinio_version() {
+    # Priority order:
+    # 1. Explicit EPINIO_VERSION env var (for testing and overrides)
+    # 2. Version from version.go (for PR validation)
+    # 3. GITHUB_REF_NAME (for release tags in GitHub Actions)
+    # 4. Latest git tag (fallback)
+    
+    if [ -n "$EPINIO_VERSION" ]; then
+        echo "$EPINIO_VERSION"
+    else
+        # Try to get from version.go first (for PR validation)
+        local code_version=$(get_epinio_version_from_code 2>/dev/null)
+        if [ $? -eq 0 ] && [ -n "$code_version" ]; then
+            echo "$code_version"
+        elif [ -n "$GITHUB_REF_NAME" ]; then
+            echo "$GITHUB_REF_NAME"
+        else
+            git describe --tags --abbrev=0 2>/dev/null || echo "unknown"
+        fi
+    fi
+}
+
+# Get the Chart version from helm-charts submodule
+get_chart_version() {
+    local chart_file="$1"
+    
+    if [ ! -f "$chart_file" ]; then
+        echo "not-found"
+        return 1
+    fi
+    
+    # Extract version from Chart.yaml (handle both 'version:' and 'appVersion:')
+    local chart_version=$(grep '^version:' "$chart_file" | awk '{print $2}' | tr -d '"' | tr -d "'")
+    local app_version=$(grep '^appVersion:' "$chart_file" | awk '{print $2}' | tr -d '"' | tr -d "'")
+    
+    # We care about the appVersion as it should match the Epinio release version
+    if [ -n "$app_version" ]; then
+        echo "$app_version"
+    else
+        echo "$chart_version"
+    fi
+}
+
+# Fetch the Chart version from remote helm-charts repository
+get_chart_version_from_remote() {
+    local version="$1"
+    local helm_charts_repo="https://raw.githubusercontent.com/epinio/helm-charts/main/chart/epinio/Chart.yaml"
+    
+    print_info "Fetching Chart.yaml from remote repository..."
+    
+    if command -v curl &> /dev/null; then
+        local chart_content=$(curl -sL "$helm_charts_repo" 2>/dev/null)
+    elif command -v wget &> /dev/null; then
+        local chart_content=$(wget -qO- "$helm_charts_repo" 2>/dev/null)
+    else
+        print_error "Neither curl nor wget is available"
+        return 1
+    fi
+    
+    if [ -z "$chart_content" ]; then
+        print_error "Failed to fetch Chart.yaml from remote"
+        return 1
+    fi
+    
+    local app_version=$(echo "$chart_content" | grep '^appVersion:' | awk '{print $2}' | tr -d '"' | tr -d "'")
+    
+    if [ -n "$app_version" ]; then
+        echo "$app_version"
+    else
+        echo "unknown"
+    fi
+}
+
+# Normalize version (remove 'v' prefix if present for comparison)
+normalize_version() {
+    echo "$1" | sed 's/^v//'
+}
+
+# Main validation logic
+main() {
+    local mode="${1:-check}"  # check, warn, or strict
+    local chart_file="${2:-helm-charts/chart/epinio/Chart.yaml}"
+    
+    print_info "Validating version parity between Epinio release and Helm chart..."
+    print_info "Mode: $mode"
+    echo ""
+    
+    # Get Epinio version
+    local epinio_version=$(get_epinio_version)
+    
+    # Determine the source of the version
+    if [ -n "$EPINIO_VERSION" ]; then
+        print_info "Epinio version: $epinio_version (from EPINIO_VERSION env var)"
+    else
+        local code_version=$(get_epinio_version_from_code 2>/dev/null)
+        if [ $? -eq 0 ] && [ -n "$code_version" ] && [ "$code_version" != "v0.0.0-dev" ]; then
+            print_info "Epinio version: $epinio_version (from internal/version/version.go)"
+        elif [ -n "$GITHUB_REF_NAME" ]; then
+            print_info "Epinio version: $epinio_version (from GITHUB_REF_NAME)"
+        else
+            print_info "Epinio version: $epinio_version (from git tag)"
+        fi
+    fi
+    
+    # Initialize helm-charts submodule if not already initialized
+    if [ -d "helm-charts" ] && [ ! -f "$chart_file" ]; then
+        print_info "Helm-charts submodule not initialized. Attempting to initialize..."
+        git submodule update --init --recursive helm-charts 2>/dev/null || {
+            print_warning "Failed to initialize helm-charts submodule"
+            print_info "Attempting to fetch Chart version from remote repository..."
+            chart_version=$(get_chart_version_from_remote "$epinio_version")
+        }
+    fi
+    
+    # Get Chart version
+    local chart_version
+    if [ -f "$chart_file" ]; then
+        chart_version=$(get_chart_version "$chart_file")
+        print_info "Chart version (from local): $chart_version"
+    else
+        chart_version=$(get_chart_version_from_remote "$epinio_version")
+        print_info "Chart version (from remote): $chart_version"
+    fi
+    
+    echo ""
+    
+    # Normalize versions for comparison
+    local epinio_version_normalized=$(normalize_version "$epinio_version")
+    local chart_version_normalized=$(normalize_version "$chart_version")
+    
+    # Skip validation if versions are unknown or not found
+    if [ "$epinio_version" = "unknown" ] || [ "$chart_version" = "not-found" ] || [ "$chart_version" = "unknown" ]; then
+        print_warning "Unable to determine versions for comparison"
+        if [ "$mode" = "strict" ]; then
+            print_error "Strict mode enabled: version validation failed"
+            exit 1
+        fi
+        print_info "Skipping validation"
+        exit 0
+    fi
+    
+    # Compare versions
+    if [ "$epinio_version_normalized" = "$chart_version_normalized" ]; then
+        print_success "Version parity validated successfully!"
+        print_info "  Epinio version: $epinio_version"
+        print_info "  Chart version:  $chart_version"
+        exit 0
+    else
+        local message="Version mismatch detected!\n"
+        message+="  Epinio version: $epinio_version\n"
+        message+="  Chart version:  $chart_version\n"
+        message+="\nThis may indicate that:\n"
+        message+="  1. The helm chart needs to be updated to match this release\n"
+        message+="  2. The wrong version tag is being released\n"
+        message+="  3. The helm-charts submodule is out of date\n"
+        message+="\nPlease ensure version parity before proceeding with the release."
+        
+        case "$mode" in
+            strict)
+                print_error "$message"
+                echo ""
+                print_error "Strict mode enabled: Release blocked due to version mismatch"
+                exit 1
+                ;;
+            warn)
+                print_warning "$message"
+                echo ""
+                print_warning "Warning mode: Proceeding despite version mismatch"
+                exit 0
+                ;;
+            *)
+                print_warning "$message"
+                exit 0
+                ;;
+        esac
+    fi
+}
+
+# Show usage
+usage() {
+    cat << EOF
+Usage: $0 [MODE] [CHART_FILE]
+
+Validate version parity between Epinio release and Helm chart.
+
+Modes:
+  check   - Check and report version parity (default)
+  warn    - Show warnings but don't fail
+  strict  - Fail if versions don't match (use for release gates)
+
+Arguments:
+  CHART_FILE  - Path to Chart.yaml (default: helm-charts/chart/epinio/Chart.yaml)
+
+Environment Variables:
+  EPINIO_VERSION  - Override Epinio version (defaults to git describe)
+  GITHUB_REF_NAME - Used in GitHub Actions to get the tag name
+
+Examples:
+  $0 check
+  $0 strict
+  $0 warn helm-charts/chart/epinio/Chart.yaml
+  EPINIO_VERSION=v1.11.1 $0 strict
+
+EOF
+}
+
+# Parse arguments
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    usage
+    exit 0
+fi
+
+main "$@"


### PR DESCRIPTION
use
make validate-version-parity
make validate-version-parity-strict
to validate before releasing

### PR Checklist
- [ X] Linting Test is passing
- [ X] New Unit and Acceptance tests written for the context of the PR
- [ X] Unit Tests are passing
- [ ] Acceptance Tests are passing
- [ X] Code is well documented
- [x] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened
 
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
Validates Epinio version against Helm chart version

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as a requirement or for convenience. -->

### Technical notes summary
Technical details:
- Script compares ChartVersion from internal/version/version.go with
  appVersion from helm-charts/chart/epinio/Chart.yaml
- PR workflow runs in strict mode, fails check on mismatch
- Release workflow runs in strict mode, blocks release on mismatch
- All logging to stderr to prevent output pollution
- Fallback to remote Chart.yaml if submodule not initialized

### Areas or cases that should be tested
<!-- Areas that should be tested. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if they have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed, which may be affected by the changes, which would require prior research to avoid regressions. -->
