### PR TITLE
Update Chart & Images Download Logic

### DIFF
--- a/internal/api/v1/application/part.go
+++ b/internal/api/v1/application/part.go
@@ -327,10 +327,14 @@ func fetchAppArchive(
 	}
 
 	// app-image.tar
+	imageSize := imageInfo.Size()
+	if imageSize < 0 {
+		return apierror.InternalError(fmt.Errorf("invalid image file size: %d", imageSize))
+	}
 	w, err = zw.CreateHeader(&zip.FileHeader{
 		Name:               "app-image.tar",
 		Method:             zip.Store,
-		UncompressedSize64: uint64(imageInfo.Size()),
+		UncompressedSize64: uint64(imageSize),
 	})
 	if err != nil {
 		return apierror.InternalError(err)

--- a/internal/api/v1/application/part_test.go
+++ b/internal/api/v1/application/part_test.go
@@ -1,0 +1,127 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package application
+
+import "testing"
+
+// expectedPartNames is the canonical set of part names for GET .../part/:part.
+// Keep in sync with validPartNames in part.go.
+var expectedPartNames = []string{"manifest", "values", "chart", "image", "archive"}
+
+func TestValidPartNamesContract(t *testing.T) {
+	t.Run("has expected length", func(t *testing.T) {
+		if got := len(validPartNames); got != len(expectedPartNames) {
+			t.Errorf("validPartNames length = %d, want %d", got, len(expectedPartNames))
+		}
+	})
+
+	t.Run("includes archive", func(t *testing.T) {
+		var found bool
+		for _, p := range validPartNames {
+			if p == "archive" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("validPartNames must include 'archive'")
+		}
+	})
+
+	t.Run("equals expected set", func(t *testing.T) {
+		if len(validPartNames) != len(expectedPartNames) {
+			t.Skip("length mismatch already reported")
+		}
+		seen := make(map[string]bool)
+		for _, p := range validPartNames {
+			if seen[p] {
+				t.Errorf("duplicate part name: %q", p)
+			}
+			seen[p] = true
+		}
+		for _, want := range expectedPartNames {
+			if !seen[want] {
+				t.Errorf("validPartNames missing %q", want)
+			}
+		}
+	})
+}
+
+func TestIsValidPartName(t *testing.T) {
+	t.Run("archive is valid", func(t *testing.T) {
+		if !isValidPartName("archive") {
+			t.Error("expected 'archive' to be a valid part name")
+		}
+	})
+
+	t.Run("all valid part names accepted", func(t *testing.T) {
+		for _, part := range validPartNames {
+			if !isValidPartName(part) {
+				t.Errorf("expected %q to be valid", part)
+			}
+		}
+	})
+
+	t.Run("invalid part name rejected", func(t *testing.T) {
+		invalid := []string{
+			"", "invalid", "ARCHIVE", "chart ", " image", "values\n",
+			"arch", "archiv", "archives", "manifesto", "chart\t",
+			"Manifest", "VALUES", "Chart", "Image",
+		}
+		for _, part := range invalid {
+			if isValidPartName(part) {
+				t.Errorf("expected %q to be invalid", part)
+			}
+		}
+	})
+
+	t.Run("only exact match accepted", func(t *testing.T) {
+		// Substrings or supersets of valid names must be rejected
+		for _, valid := range validPartNames {
+			if len(valid) > 1 && isValidPartName(valid[:1]) {
+				t.Errorf("prefix %q of %q should be invalid", valid[:1], valid)
+			}
+			withSuffix := valid + "x"
+			if isValidPartName(withSuffix) {
+				t.Errorf("expected %q to be invalid", withSuffix)
+			}
+		}
+	})
+}
+
+func TestValidPartNamesNoDuplicates(t *testing.T) {
+	seen := make(map[string]bool)
+	for _, p := range validPartNames {
+		if seen[p] {
+			t.Errorf("duplicate in validPartNames: %q", p)
+		}
+		seen[p] = true
+	}
+}
+
+func TestExpectedPartNamesUsed(t *testing.T) {
+	// Ensure test's expectedPartNames is not stale (same count and includes archive)
+	if len(expectedPartNames) != len(validPartNames) {
+		t.Errorf("expectedPartNames in test file out of sync with validPartNames (len %d vs %d)",
+			len(expectedPartNames), len(validPartNames))
+	}
+	var hasArchive bool
+	for _, p := range expectedPartNames {
+		if p == "archive" {
+			hasArchive = true
+			break
+		}
+	}
+	if !hasArchive {
+		t.Error("expectedPartNames must include 'archive'")
+	}
+}


### PR DESCRIPTION
### PR Checklist
- [X] Linting Test is passing
- [X] New Unit and Acceptance tests written for the context of the PR
- [X] Unit Tests are passing
- [ ] Acceptance Tests are passing
- [X] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened
 
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
Export of "Chart and Images" in the Rancher extension was slow (e.g. stuck in "Compressing Files" for several minutes). This adds a server-side archive option and keeps a simple fallback so the UI can avoid client-side zipping when the backend supports it.

### Occurred changes and/or fixed issues
- **Backend (epinio):** New `archive` part for app export: `GET .../part/archive` streams a single zip containing `values.yaml`, `app-chart.tar.gz`, and `app-image.tar`. Implemented in `internal/api/v1/application/part.go` (handler `fetchAppArchive`).
- **UI (epinio/ui):** Export "Chart and Images" now tries the archive endpoint first; if it fails (e.g. old backend or 400), it falls back to the existing flow (fetch values, chart, image, then zip in the browser). Progress during the zip step ("Compressing Files (X%)") was added for the fallback path. i18n added for archive download steps.

### Technical notes summary
- **Backend:** `GetPart` accepts `part=archive` in addition to `manifest`, `values`, `chart`, `image`. No new route; same path with different part. The handler builds the zip on the server (values from helm, chart from cache, image via existing job + PVC) and streams it with `Content-Disposition: attachment`.
- **UI:** Single strategy: call `fetchPart('archive')`; on success, download the blob. On failure (e.g. 400 "unknown part"), use the three-part flow and JSZip as before. Archive download shows progress via `onDownloadProgress` and step labels.

### Areas or cases that should be tested
- **With backend that has archive (this PR):** Export "Chart and Images" for a running app. One network request to `archive`; zip downloads. Test in both standalone Epinio UI and Rancher extension.
- **With backend without archive (old server):** Same export; should see requests for `values`, `chart`, `image`, then "Compressing Files" with percentage; zip downloads. No regression.
- **Manifest export:** Unchanged; still exports manifest only.
- **Browser:** Test in Chrome; reviewer to test in another browser (e.g. Firefox or Edge).
- **Steps to reproduce export:**
1. Deploy an app and wait until it is Running.
2. Open Applications → select the app → ⋮ → "Export App".
3. Select the "Chart and Images" tab → click Export.
4. Confirm the zip downloads (either via single `archive` request or three parts + Compressing Files).

### Areas which could experience regressions
- **App export to registry** (different code path): No change; ensure `POST .../export` (export to registry) still works.
- **Other part endpoints:** Ensure `part/values`, `part/chart`, `part/image`, `part/manifest` behave as before (used by fallback and CLI).
- **Old Epinio server + new UI:** Must fall back cleanly to three-part flow (no archive); verify no console errors and export completes.
- **Cancellation:** Cancel during archive download or during three-part download; ensure pending requests are cancelled and UI resets.
