### PR TITLE
New rbac implementation

### DIFF
--- a/docs/decisions/20231013-authorization-roles.md
+++ b/docs/decisions/20231013-authorization-roles.md
@@ -139,7 +139,7 @@ data:
 
 #### Actions
 
-The actions are **hardcoded** as an embedded yaml file. This simplifies their management, and also enhances flexibility. An action can have some "dependencies", i.e.: the `app` action is a union of the `app_read`, `app_write`, `app_logs`, `app_exec`, and `app_portforward`.
+The actions are **hardcoded** as an embedded yaml file. This simplifies their management, and also enhances flexibility. An action can have some "dependencies", i.e.: the `app` action is a union of granular app actions plus `app_logs`, `app_exec`, and `app_portforward`.
 
 Every action lists the set of endpoints it allows. Note that some Epinio operations are formed from multiple endpoints, i.e. the `app push` consists of a Create, Update and others.
 
@@ -161,10 +161,19 @@ These actions enable operations on App commands and resources. They also enable 
 |-----------------|-------------
 | `app_read`        | Read permissions (app list and show, env list and show)
 | `app_logs`        | Read application logs
-| `app_write`       | Write permissions (app create, delete, push, export, stage, env set and unset)<br/>Depends on: `app_read`, `app_logs`
+| `app_restart`     | Restart permission (without write permissions) <br/>Depends on: `app_read`
+| `app_create`      | Create and upload/import applications<br/>Depends on: `app_read`, `app_logs`
+| `app_update`      | Update application settings/spec
+| `app_update_env`  | Update application environment variables (set and unset)
+| `app_update_configs` | Manage application configuration bindings (create and delete)
+| `app_stage`       | Stage an application<br/>Depends on: `app_read`, `app_logs`
+| `app_deploy`      | Deploy an application<br/>Depends on: `app_read`, `app_logs`
+| `app_export`      | Export an application image and metadata
+| `app_delete`      | Delete applications
+| `app_write`       | Backward-compatible umbrella for app create/update/delete/export/stage/deploy and app configuration/env updates
 | `app_exec`        | Perform an exec into a running application
 | `app_portforward` | Open a tunnel with the `port-forward` command
-| `app`             | All the above<br/>Depends on: `app_read`, `app_logs`, `app_write`, `app_exec`, `app_portforward`
+| `app`             | All app permissions (including granular app actions, logs, exec and port-forward)
 
 ##### Configuration
 
@@ -205,6 +214,17 @@ This action enables operations on Export Registries commands and resources. Only
 | Action ID                 | Description 
 |---------------------------|-------------
 | `export_registries_read`  | Read permissions
+
+#### Built-in Role Examples
+
+The following role IDs are shipped as ConfigMaps and can be assigned to users:
+
+| Role ID | Intended scope |
+|---------|----------------|
+| `view_only` | Read-only access to application, configuration, service, gitconfig and export-registry resources |
+| `application_developer` | Create/update applications without application delete and without non-application write permissions |
+| `application_manager` | Full application CRUD and runtime operations, without non-application write permissions |
+| `system_manager` | No-delete role: application create/update/runtime operations plus read-only access on other resource types |
 
 
 #### Pros

--- a/docs/decisions/20231013-authorization-roles.md
+++ b/docs/decisions/20231013-authorization-roles.md
@@ -157,23 +157,27 @@ These actions enable operations on Namespace commands and resources.
 
 These actions enable operations on App commands and resources. They also enable commands related to  AppCharts (`epinio app chart`) and application environment variables.
 
-| Action ID       | Description 
-|-----------------|-------------
-| `app_read`        | Read permissions (app list and show, env list and show)
-| `app_logs`        | Read application logs
-| `app_restart`     | Restart permission (without write permissions) <br/>Depends on: `app_read`
-| `app_create`      | Create and upload/import applications<br/>Depends on: `app_read`, `app_logs`
-| `app_update`      | Update application settings/spec
-| `app_update_env`  | Update application environment variables (set and unset)
-| `app_update_configs` | Manage application configuration bindings (create and delete)
-| `app_stage`       | Stage an application<br/>Depends on: `app_read`, `app_logs`
-| `app_deploy`      | Deploy an application<br/>Depends on: `app_read`, `app_logs`
-| `app_export`      | Export an application image and metadata
-| `app_delete`      | Delete applications
-| `app_write`       | Backward-compatible umbrella for app create/update/delete/export/stage/deploy and app configuration/env updates
-| `app_exec`        | Perform an exec into a running application
-| `app_portforward` | Open a tunnel with the `port-forward` command
-| `app`             | All app permissions (including granular app actions, logs, exec and port-forward)
+| Action ID             | Description 
+|-----------------------|-------------
+| `app_read`            | Read permissions (app list and show, env list and show)
+| `app_logs`            | Read application logs
+| `app_restart`         | Restart permission (without write permissions) <br/>Depends on: `app_read`
+| `app_create`          | Create and upload/import applications<br/>Depends on: `app_read`, `app_logs`
+| `app_update`          | Generic application update (patch) covering routes, chart values, instances and settings
+| `app_scale`           | Scale applications by changing the desired number of instances (implemented via the `AppUpdate` endpoint)
+| `app_update_env`      | Update application environment variables (set and unset)
+| `app_update_configs`  | Manage application configuration bindings (create and delete)
+| `app_update_routes`   | Update application routes/domains (implemented via the `AppUpdate` endpoint)
+| `app_update_settings` | Update application settings (chart values) stored on the App resource (implemented via the `AppUpdate` endpoint)
+| `app_update_chart`    | Update application chart selection and values (implemented via the `AppUpdate` endpoint)
+| `app_stage`           | Stage an application<br/>Depends on: `app_read`, `app_logs`
+| `app_deploy`          | Deploy an application<br/>Depends on: `app_read`, `app_logs`
+| `app_export`          | Export an application image and metadata
+| `app_delete`          | Delete applications
+| `app_write`           | Backward-compatible umbrella for app create/update/delete/export/stage/deploy and all application update operations (including scale, routes, settings, chart and env/config updates)
+| `app_exec`            | Perform an exec into a running application
+| `app_portforward`     | Open a tunnel with the `port-forward` command
+| `app`                 | All app permissions (including granular app actions, logs, exec and port-forward)
 
 ##### Configuration
 

--- a/docs/howtos/README.md
+++ b/docs/howtos/README.md
@@ -4,3 +4,4 @@ Practical Guides to solving practical problems.
 
   - [How to build and run Epinio from source](development.md)
   - [How to work with the acceptance tests](acceptance_tests.md)
+  - [RBAC User Management](rbac_user_management.md) — Create users and assign roles (application_manager, application_developer, etc.)

--- a/docs/howtos/rbac_user_management.md
+++ b/docs/howtos/rbac_user_management.md
@@ -100,7 +100,7 @@ The response `roles` array should include the assigned roles (e.g. `application_
 
 ### "User unauthorized" (403) when creating an application
 
-1. **Check the Secret annotation**: `kubectl get secret <secret-name> -n epinio -o jsonpath='{.metadata.annotations.epinio\.io/roles}'` — must include `application_manager` (or `application_developer`) so the role allows app create.
+1. **Check the Secret annotation**: `kubectl get secret <secret-name> -n epinio -o jsonpath='{.metadata.annotations.epinio.io/roles}'` — must include `application_manager` (or `application_developer`) so the role allows app create.
 2. **Global vs namespaced role**: If the annotation is **global** (e.g. `application_manager` with no `:namespace`), the user can access any namespace and no `namespaces` field is needed. If the role is **namespaced** (e.g. `application_manager:workspace`), the Secret's `namespaces` field must include the namespace(s) the user may use.
    ```bash
    kubectl get secret <secret-name> -n epinio -o jsonpath='{.data.namespaces}' | base64 -d

--- a/docs/howtos/rbac_user_management.md
+++ b/docs/howtos/rbac_user_management.md
@@ -31,7 +31,7 @@ Users are defined as Kubernetes Secrets in the Epinio namespace. Each user needs
 2. **Annotation**: `epinio.io/roles: "<role1>,<role2>:<namespace>,..."` — the roles to assign
 3. **Data**: `username` (plain text), `password` (bcrypt hash), optionally `namespaces` (newline-separated list)
 
-### Example: Application Manager
+### Example: Application Manager (global role — access any namespace)
 
 ```yaml
 apiVersion: v1
@@ -43,24 +43,37 @@ metadata:
   labels:
     epinio.io/api-user-credentials: "true"
   annotations:
-    epinio.io/roles: "application_manager,application_manager:my-namespace"
+    epinio.io/roles: "application_manager"
 stringData:
   username: "app-manager"
   password: "<bcrypt-hash-of-password>"
+```
+
+With a **global** role (no `:namespace` suffix), the user can access **any** namespace; the `namespaces` field is not required.
+
+### Example: Application Manager (namespace-scoped)
+
+To restrict an app-manager to specific namespaces only, use a namespaced role and list namespaces:
+
+```yaml
+  annotations:
+    epinio.io/roles: "application_manager:my-namespace"
+stringData:
+  ...
   namespaces: |
     my-namespace
-    other-namespace
 ```
 
 ### Role Annotation Format
 
-- `application_manager` — global role (applies when no namespace-scoped role matches)
-- `application_manager:my-namespace` — role scoped to `my-namespace`
+- `application_manager` — global role: user can access **all namespaces** (no `namespaces` field needed).
+- `application_manager:my-namespace` — role scoped to `my-namespace`; user can only access namespaces listed in the Secret's `namespaces` field.
 - Multiple roles: comma-separated, e.g. `application_manager,view_only:audit-ns`
 
 ### Namespaces
 
-For namespace-scoped actions (create app, list apps in namespace), the user's Secret must list allowed namespaces in the `namespaces` field (newline-separated). Users can only perform actions in namespaces listed there.
+- **Global role** (e.g. `application_manager`, `view_only`): the user may access any namespace; the `namespaces` field is optional.
+- **Namespaced roles only** (e.g. `application_manager:workspace`): the user may only perform actions in namespaces listed in the Secret's `namespaces` field (newline-separated).
 
 ## Generating Passwords
 
@@ -85,10 +98,13 @@ The response `roles` array should include the assigned roles (e.g. `application_
 
 ## Troubleshooting
 
-If a user gets "User unauthorized" when creating or deleting apps:
+### "User unauthorized" (403) when creating an application
 
-1. **Check the Secret annotation**: `kubectl get secret <secret-name> -n epinio -o jsonpath='{.metadata.annotations.epinio\.io/roles}'` — must include `application_manager` (or appropriate role), not `user`.
-2. **Check namespaces**: The `namespaces` field must include the namespace where the user is trying to create apps.
+1. **Check the Secret annotation**: `kubectl get secret <secret-name> -n epinio -o jsonpath='{.metadata.annotations.epinio\.io/roles}'` — must include `application_manager` (or `application_developer`) so the role allows app create.
+2. **Global vs namespaced role**: If the annotation is **global** (e.g. `application_manager` with no `:namespace`), the user can access any namespace and no `namespaces` field is needed. If the role is **namespaced** (e.g. `application_manager:workspace`), the Secret's `namespaces` field must include the namespace(s) the user may use.
+   ```bash
+   kubectl get secret <secret-name> -n epinio -o jsonpath='{.data.namespaces}' | base64 -d
+   ```
 3. **Check role ConfigMaps exist**: `kubectl get configmap -n epinio -l epinio.io/role=true` — should list `epinio-role-application-manager`, etc.
 4. **Restart Epinio server** if ConfigMaps were added after install: `kubectl rollout restart deployment/epinio-server -n epinio`
 

--- a/docs/howtos/rbac_user_management.md
+++ b/docs/howtos/rbac_user_management.md
@@ -1,0 +1,95 @@
+# RBAC User Management
+
+This guide explains how operators can create and manage Epinio users with role-based access control (RBAC).
+
+## Overview
+
+Epinio supports predefined roles that control what users can do:
+
+| Role ID | Description |
+|---------|-------------|
+| `view_only` | Read-only access to apps, configurations, services, gitconfigs, export registries |
+| `application_developer` | Create and update applications; no delete; no configuration/service write |
+| `application_manager` | Full application CRUD (create, update, delete) and runtime operations |
+| `system_manager` | Application CRUD + read-only on configurations and services; no delete on configs/services |
+
+## Enable RBAC Roles (Install Time)
+
+By default, Epinio installs these role ConfigMaps. To disable them:
+
+```bash
+helm install epinio ... --set api.rbac.enabled=false
+```
+
+With `api.rbac.enabled=true` (default), end users can be assigned `application_manager`, `application_developer`, etc. With it disabled, only the default `user` and `blank` roles are available.
+
+## Creating Users
+
+Users are defined as Kubernetes Secrets in the Epinio namespace. Each user needs:
+
+1. **Label**: `epinio.io/api-user-credentials: "true"`
+2. **Annotation**: `epinio.io/roles: "<role1>,<role2>:<namespace>,..."` — the roles to assign
+3. **Data**: `username` (plain text), `password` (bcrypt hash), optionally `namespaces` (newline-separated list)
+
+### Example: Application Manager
+
+```yaml
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: my-app-manager
+  namespace: epinio
+  labels:
+    epinio.io/api-user-credentials: "true"
+  annotations:
+    epinio.io/roles: "application_manager,application_manager:my-namespace"
+stringData:
+  username: "app-manager"
+  password: "<bcrypt-hash-of-password>"
+  namespaces: |
+    my-namespace
+    other-namespace
+```
+
+### Role Annotation Format
+
+- `application_manager` — global role (applies when no namespace-scoped role matches)
+- `application_manager:my-namespace` — role scoped to `my-namespace`
+- Multiple roles: comma-separated, e.g. `application_manager,view_only:audit-ns`
+
+### Namespaces
+
+For namespace-scoped actions (create app, list apps in namespace), the user's Secret must list allowed namespaces in the `namespaces` field (newline-separated). Users can only perform actions in namespaces listed there.
+
+## Generating Passwords
+
+Use bcrypt to hash passwords. Example with Python:
+
+```python
+import bcrypt
+password = b"my-secure-password"
+hashed = bcrypt.hashpw(password, bcrypt.gensalt()).decode("utf-8")
+print(hashed)
+```
+
+## Verifying Roles
+
+After creating a user, they can check their roles:
+
+```bash
+curl -k -u username:password "https://<epinio-url>/api/v1/me"
+```
+
+The response `roles` array should include the assigned roles (e.g. `application_manager`), not just the default `user` role.
+
+## Troubleshooting
+
+If a user gets "User unauthorized" when creating or deleting apps:
+
+1. **Check the Secret annotation**: `kubectl get secret <secret-name> -n epinio -o jsonpath='{.metadata.annotations.epinio\.io/roles}'` — must include `application_manager` (or appropriate role), not `user`.
+2. **Check namespaces**: The `namespaces` field must include the namespace where the user is trying to create apps.
+3. **Check role ConfigMaps exist**: `kubectl get configmap -n epinio -l epinio.io/role=true` — should list `epinio-role-application-manager`, etc.
+4. **Restart Epinio server** if ConfigMaps were added after install: `kubectl rollout restart deployment/epinio-server -n epinio`
+
+For detailed troubleshooting steps, see the Epinio documentation or the RBAC troubleshooting guide in your Epinio source repository.

--- a/internal/api/v1/middleware/auth.go
+++ b/internal/api/v1/middleware/auth.go
@@ -45,13 +45,24 @@ func RoleAuthorization(c *gin.Context) {
 	}
 }
 
+// NamespaceAuthorization ensures the user is allowed to access the requested namespace.
+// Users with a global role (e.g. application_manager, view_only without ":namespace") may access any namespace.
+// Other users may only access namespaces listed in their Secret's "namespaces" field.
 func NamespaceAuthorization(c *gin.Context) {
 	user := requestctx.User(c.Request.Context())
+	if user.HasGlobalRole() {
+		return
+	}
 	authorization(c, "namespace", user.Namespaces)
 }
 
+// GitconfigAuthorization ensures the user is allowed to access the requested gitconfig.
+// Users with a global role may access any gitconfig; others are restricted to user.Gitconfigs.
 func GitconfigAuthorization(c *gin.Context) {
 	user := requestctx.User(c.Request.Context())
+	if user.HasGlobalRole() {
+		return
+	}
 	authorization(c, "gitconfig", user.Gitconfigs)
 }
 

--- a/internal/auth/action_test.go
+++ b/internal/auth/action_test.go
@@ -27,6 +27,43 @@ var _ = Describe("Auth actions", func() {
 			Expect(actions).ToNot(BeEmpty())
 		})
 
+		It("defines granular application actions with the expected routes", func() {
+			_, err := auth.InitActions()
+			Expect(err).ToNot(HaveOccurred())
+
+			appCreate, found := auth.ActionsMap["app_create"]
+			Expect(found).To(BeTrue())
+			Expect(appCreate.Routes).To(ContainElement("AppCreate"))
+			Expect(appCreate.Routes).To(ContainElement("AppImportGit"))
+			Expect(appCreate.Routes).To(ContainElement("AppUpload"))
+
+			appUpdateEnv, found := auth.ActionsMap["app_update_env"]
+			Expect(found).To(BeTrue())
+			Expect(appUpdateEnv.Routes).To(ContainElement("EnvSet"))
+			Expect(appUpdateEnv.Routes).To(ContainElement("EnvUnset"))
+
+			appUpdateConfigs, found := auth.ActionsMap["app_update_configs"]
+			Expect(found).To(BeTrue())
+			Expect(appUpdateConfigs.Routes).To(ContainElement("ConfigurationBindingCreate"))
+			Expect(appUpdateConfigs.Routes).To(ContainElement("ConfigurationBindingDelete"))
+
+			appScale, found := auth.ActionsMap["app_scale"]
+			Expect(found).To(BeTrue())
+			Expect(appScale.Routes).To(ContainElement("AppUpdate"))
+
+			appUpdateRoutes, found := auth.ActionsMap["app_update_routes"]
+			Expect(found).To(BeTrue())
+			Expect(appUpdateRoutes.Routes).To(ContainElement("AppUpdate"))
+
+			appUpdateSettings, found := auth.ActionsMap["app_update_settings"]
+			Expect(found).To(BeTrue())
+			Expect(appUpdateSettings.Routes).To(ContainElement("AppUpdate"))
+
+			appUpdateChart, found := auth.ActionsMap["app_update_chart"]
+			Expect(found).To(BeTrue())
+			Expect(appUpdateChart.Routes).To(ContainElement("AppUpdate"))
+		})
+
 		It("keeps app_write as compatibility action", func() {
 			_, err := auth.InitActions()
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/auth/action_test.go
+++ b/internal/auth/action_test.go
@@ -26,5 +26,25 @@ var _ = Describe("Auth actions", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actions).ToNot(BeEmpty())
 		})
+
+		It("keeps app_write as compatibility action", func() {
+			_, err := auth.InitActions()
+			Expect(err).ToNot(HaveOccurred())
+
+			appWrite, found := auth.ActionsMap["app_write"]
+			Expect(found).To(BeTrue())
+
+			// app_write is now a composite action and should still cover existing write paths.
+			Expect(appWrite.Routes).To(ContainElement("AppCreate"))
+			Expect(appWrite.Routes).To(ContainElement("AppDelete"))
+			Expect(appWrite.Routes).To(ContainElement("AppDeploy"))
+			Expect(appWrite.Routes).To(ContainElement("AppStage"))
+			Expect(appWrite.Routes).To(ContainElement("AppUpdate"))
+			Expect(appWrite.Routes).To(ContainElement("EnvSet"))
+			Expect(appWrite.Routes).To(ContainElement("ConfigurationBindingCreate"))
+			// Keep legacy dependency behavior too.
+			Expect(appWrite.Routes).To(ContainElement("AppShow"))
+			Expect(appWrite.WsRoutes).To(ContainElement("AppLogs"))
+		})
 	})
 })

--- a/internal/auth/actions.yaml
+++ b/internal/auth/actions.yaml
@@ -28,8 +28,12 @@
     - app_create
     - app_delete
     - app_update
+    - app_scale
     - app_update_env
+    - app_update_routes
     - app_update_configs
+    - app_update_settings
+    - app_update_chart
     - app_stage
     - app_deploy
     - app_export
@@ -81,8 +85,12 @@
     - app_create
     - app_delete
     - app_update
+    - app_scale
     - app_update_env
+    - app_update_routes
     - app_update_configs
+    - app_update_settings
+    - app_update_chart
     - app_stage
     - app_deploy
     - app_export
@@ -116,6 +124,14 @@
   routes:
     - AppUpdate
 
+# App Scale
+- id: app_scale
+  name: App Scale
+  dependsOn:
+    - app_read
+  routes:
+    - AppUpdate
+
 # App Update Environment
 - id: app_update_env
   name: App Update Environment
@@ -133,6 +149,30 @@
   routes:
     - ConfigurationBindingCreate
     - ConfigurationBindingDelete
+
+# App Update Routes
+- id: app_update_routes
+  name: App Update Routes
+  dependsOn:
+    - app_read
+  routes:
+    - AppUpdate
+
+# App Update Settings
+- id: app_update_settings
+  name: App Update Settings
+  dependsOn:
+    - app_read
+  routes:
+    - AppUpdate
+
+# App Update Chart
+- id: app_update_chart
+  name: App Update Chart
+  dependsOn:
+    - app_read
+  routes:
+    - AppUpdate
 
 # App Stage
 - id: app_stage

--- a/internal/auth/actions.yaml
+++ b/internal/auth/actions.yaml
@@ -25,6 +25,14 @@
   name: App
   dependsOn:
     - app_read
+    - app_create
+    - app_delete
+    - app_update
+    - app_update_env
+    - app_update_configs
+    - app_stage
+    - app_deploy
+    - app_export
     - app_write
     - app_logs
     - app_exec
@@ -70,24 +78,88 @@
   dependsOn:
     - app_read
     - app_logs
+    - app_create
+    - app_delete
+    - app_update
+    - app_update_env
+    - app_update_configs
+    - app_stage
+    - app_deploy
+    - app_export
+    - app_restart
+
+# App Create
+- id: app_create
+  name: App Create
+  dependsOn:
+    - app_read
+    - app_logs
   routes:
     - AppCreate
+    - AppImportGit
+    - AppUpload
+
+# App Delete
+- id: app_delete
+  name: App Delete
+  dependsOn:
+    - app_read
+  routes:
     - AppDelete
     - AppBatchDelete
-    - AppDeploy
-    - AppImportGit
-    - AppRestart
-    - AppStage
+
+# App Update
+- id: app_update
+  name: App Update
+  dependsOn:
+    - app_read
+  routes:
     - AppUpdate
-    - AppUpload
-    - AppPart # export part
-    - AppExport # export to registry
-    # app env
+
+# App Update Environment
+- id: app_update_env
+  name: App Update Environment
+  dependsOn:
+    - app_read
+  routes:
     - EnvSet
     - EnvUnset
-    # configuration bindings
+
+# App Update Configurations
+- id: app_update_configs
+  name: App Update Configurations
+  dependsOn:
+    - app_read
+  routes:
     - ConfigurationBindingCreate
     - ConfigurationBindingDelete
+
+# App Stage
+- id: app_stage
+  name: App Stage
+  dependsOn:
+    - app_read
+    - app_logs
+  routes:
+    - AppStage
+
+# App Deploy
+- id: app_deploy
+  name: App Deploy
+  dependsOn:
+    - app_read
+    - app_logs
+  routes:
+    - AppDeploy
+
+# App Export
+- id: app_export
+  name: App Export
+  dependsOn:
+    - app_read
+  routes:
+    - AppPart # export part
+    - AppExport # export to registry
 
 # App Logs
 - id: app_logs

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -320,7 +320,9 @@ type NamespacedResource interface {
 
 // FilterResources returns only the NamespacedResources where the user has permissions
 func FilterResources[T NamespacedResource](user User, resources []T) []T {
-	if user.IsAdmin() {
+	// Admins and users with at least one global role (e.g. view_only, application_manager)
+	// can see resources in all namespaces.
+	if user.IsAdmin() || user.HasGlobalRole() {
 		return resources
 	}
 
@@ -345,7 +347,9 @@ type GitconfigResource interface {
 
 // FilterResources returns only the GitconfigResources where the user has permissions
 func FilterGitconfigResources[T GitconfigResource](user User, resources []T) []T {
-	if user.IsAdmin() {
+	// Admins and users with at least one global role (e.g. view_only, application_manager)
+	// can see gitconfigs in all namespaces.
+	if user.IsAdmin() || user.HasGlobalRole() {
 		return resources
 	}
 

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -131,6 +131,17 @@ func (u *User) IsAllowed(method, fullPath string, params map[string]string) bool
 	return globalRoles.IsAllowed(method, fullPath)
 }
 
+// HasGlobalRole returns true if the user has at least one role that is not scoped to a namespace.
+// Such users are allowed to access any namespace (see NamespaceAuthorization middleware).
+func (u *User) HasGlobalRole() bool {
+	for _, r := range u.Roles {
+		if r.Namespace == "" {
+			return true
+		}
+	}
+	return false
+}
+
 // IsAdmin returns true if a user has a global admin role
 func (u *User) IsAdmin() bool {
 	_, found := u.Roles.FindByID("admin")


### PR DESCRIPTION
### PR Checklist
- [X] Linting Test is passing
- [X] New Unit and Acceptance tests written for the context of the PR
- [X] Unit Tests are passing
- [ ] Acceptance Tests are passing
- [X] Code is well documented
- [X] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened
 
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Implements the new RBAC role system in the Epinio Helm chart. The chart now installs role ConfigMaps (`application_manager`, `application_developer`, `view_only`, `system_manager`) by default, allowing operators to create users and assign these roles via Kubernetes Secrets. Adds operator documentation for RBAC user management.

### Occurred changes and/or fixed issues
- Role resolution from Secrets (`epinio.io/roles` annotation) and role ConfigMaps
- Action-based authorization checks across application, namespace, configuration, and service endpoints
- `/api/v1/me` endpoint returning user, roles, namespaces, and gitconfigs for UI/CLI

### Technical notes summary
- Roles are read from ConfigMaps with label `epinio.io/role: "true"`; each ConfigMap defines `id`, `name`, and `actions`
- User roles are specified via Secret annotation `epinio.io/roles` (e.g. `application_manager,application_manager:namespace`)
- Authorization checks use `internal/auth` action IDs (e.g. `app_create`, `app_delete`, `configuration_read`)

### Areas or cases that should be tested
- Login as admin user; verify full access to create/delete apps, configurations, services
- Login as RBAC user (e.g. `application_manager`); verify Create/Delete app work, API returns correct permissions
- Login as view-only user; verify API rejects create/delete requests
- Call `epinio whoami` or `/api/v1/me`; verify roles and namespaces are returned correctly

### Areas which could experience regressions
- **Auth middleware:** Ensure unauthenticated requests still fail correctly
- **Role resolution:** Users with invalid or missing role annotations should not gain unintended permissions
- **Existing admin/default users:** Verify continued access when using default `user`/`admin` roles
