### PR TITLE
Support configurable auth token expiry via env

### DIFF
--- a/helpers/authtoken/token.go
+++ b/helpers/authtoken/token.go
@@ -34,10 +34,10 @@ const (
 
 	// DefaultExpiry for the auth token when not configured
 	DefaultExpiry = 30 * time.Second
-)
 
-// AuthTokenDefaultExpiryEnv is the environment variable for configuring default token expiry
-const AuthTokenDefaultExpiryEnv = "AUTH_TOKEN_DEFAULT_EXPIRY"
+	// AuthTokenDefaultExpiryEnv is the environment variable for configuring default token expiry
+	AuthTokenDefaultExpiryEnv = "AUTH_TOKEN_DEFAULT_EXPIRY" // nolint:gosec
+)
 
 // GetDefaultExpiry returns the configured default token expiry from AUTH_TOKEN_DEFAULT_EXPIRY
 // (e.g. "30s", "60s", "2m"), or DefaultExpiry if not set or invalid.

--- a/helpers/authtoken/token.go
+++ b/helpers/authtoken/token.go
@@ -15,6 +15,7 @@ package authtoken
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"os"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -28,11 +29,30 @@ var (
 )
 
 const (
-	MaxExpiry = 30 * time.Second
+	// MaxExpiry is the maximum allowed expiry time for security (cap for configurable expiry)
+	MaxExpiry = 5 * time.Minute
 
-	// DefaultExpiry for the auth token
-	DefaultExpiry = MaxExpiry
+	// DefaultExpiry for the auth token when not configured
+	DefaultExpiry = 30 * time.Second
 )
+
+// AuthTokenDefaultExpiryEnv is the environment variable for configuring default token expiry
+const AuthTokenDefaultExpiryEnv = "AUTH_TOKEN_DEFAULT_EXPIRY"
+
+// GetDefaultExpiry returns the configured default token expiry from AUTH_TOKEN_DEFAULT_EXPIRY
+// (e.g. "30s", "60s", "2m"), or DefaultExpiry if not set or invalid.
+// Values are capped at MaxExpiry for security.
+func GetDefaultExpiry() time.Duration {
+	if val := os.Getenv(AuthTokenDefaultExpiryEnv); val != "" {
+		if d, err := time.ParseDuration(val); err == nil && d > 0 {
+			if d > MaxExpiry {
+				return MaxExpiry
+			}
+			return d
+		}
+	}
+	return DefaultExpiry
+}
 
 // EpinioClaims are the values we store in the JWT
 type EpinioClaims struct {

--- a/helpers/authtoken/token_test.go
+++ b/helpers/authtoken/token_test.go
@@ -22,7 +22,7 @@ import (
 
 var _ = Describe("Token", func() {
 	It("returns a valid JWT token and accepts it", func() {
-		token := authtoken.Create("armin", authtoken.DefaultExpiry)
+		token := authtoken.Create("armin", authtoken.GetDefaultExpiry())
 		Expect(token).ToNot(BeEmpty())
 
 		claims, err := authtoken.Validate(token)

--- a/internal/api/v1/authtoken.go
+++ b/internal/api/v1/authtoken.go
@@ -29,7 +29,7 @@ func AuthToken(c *gin.Context) APIErrors {
 	user := requestctx.User(requestContext).Username
 
 	response.OKReturn(c, models.AuthTokenResponse{
-		Token: authtoken.Create(user, authtoken.DefaultExpiry),
+		Token: authtoken.Create(user, authtoken.GetDefaultExpiry()),
 	})
 	return nil
 }


### PR DESCRIPTION
### PR Checklist
- [X] Linting Test is passing
- [X] New Unit and Acceptance tests written for the context of the PR
- [X] Unit Tests are passing
- [ ] Acceptance Tests are passing
- [X] Code is well documented
- [X] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened
 
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
Implements configurable default token expiry to address clock drift where short-lived auth tokens can expire before use (e.g. in staging workloads).

### Occurred changes and/or fixed issues
helpers/authtoken/token.go: Added GetDefaultExpiry() to read AUTH_TOKEN_DEFAULT_EXPIRY, MaxExpiry as security cap (5 min), separate DefaultExpiry (30s)
internal/api/v1/authtoken.go: Switched from DefaultExpiry to GetDefaultExpiry()
helpers/authtoken/token_test.go: Updated test to use GetDefaultExpiry()

### Technical notes summary
Token expiry is read from env var AUTH_TOKEN_DEFAULT_EXPIRY (e.g. 30s, 60s, 2m)
Values are capped at MaxExpiry (5 minutes)
Invalid or missing env var falls back to DefaultExpiry (30s)
Behaviour is unchanged when the env var is not set

### Areas or cases that should be tested

Default behaviour (no env var)
Deploy without server.defaultTokenExpiry
Confirm tokens expire after ~30 seconds
Custom expiry
Deploy with --set server.defaultTokenExpiry="60s" or kubectl set env deployment/epinio-server -n epinio 

### Areas which could experience regressions
WebSocket auth: Token validation is unchanged; only expiry duration is configurable
Auth token endpoint: Same response shape; only token lifetime changes
Helm upgrades: defaultTokenExpiry defaults to "30s" so existing installs stay compatible
Security: Longer expiry increases exposure if a token is stolen; cap at 5 minutes limits this
