### PR TITLE
Builder image validation

### DIFF
--- a/acceptance/helpers/delete_clusters/delete_clusters.go
+++ b/acceptance/helpers/delete_clusters/delete_clusters.go
@@ -424,7 +424,7 @@ func GetKubeconfigAWS_RKE2(runID string) error {
 	}
 
 	kubeconfig_rke2 := []byte(strings.Replace(server_config, "127.0.0.1", server_hostname, 1))
-	err = os.WriteFile(kubeconfig, kubeconfig_rke2, 0600)
+	err = os.WriteFile(kubeconfig, kubeconfig_rke2, 0600) // #nosec G703 -- kubeconfig path from cluster config
 	if err != nil {
 		return errors.Wrap(err, "Failed to create "+kubeconfig)
 	}

--- a/acceptance/helpers/machine/curl.go
+++ b/acceptance/helpers/machine/curl.go
@@ -24,7 +24,7 @@ func (m *Machine) Curl(method, uri string, requestBody io.Reader) (*http.Respons
 		return nil, err
 	}
 	request.SetBasicAuth(m.user, m.password)
-	return m.Client().Do(request)
+	return m.Client().Do(request) // #nosec G704 -- acceptance test helper, URL from test
 }
 
 func (m *Machine) Client() *http.Client {

--- a/acceptance/helpers/machine/gitconfig.go
+++ b/acceptance/helpers/machine/gitconfig.go
@@ -45,7 +45,7 @@ func (m *Machine) MakeGitconfigWithoutCleanup(gitConfigName string) {
 	Expect(err).ToNot(HaveOccurred())
 
 	tmpTokenFile := path.Join(tmpTokenDir, "token")
-	err = os.WriteFile(tmpTokenFile, []byte(os.Getenv("PRIVATE_REPO_IMPORT_PAT")), 0600)
+	err = os.WriteFile(tmpTokenFile, []byte(os.Getenv("PRIVATE_REPO_IMPORT_PAT")), 0600) // #nosec G703 -- path from MkdirTemp under our control
 	Expect(err).ToNot(HaveOccurred())
 
 	DeferCleanup(func() {

--- a/acceptance/helpers/proc/proc.go
+++ b/acceptance/helpers/proc/proc.go
@@ -29,7 +29,7 @@ func Get(dir, command string, arg ...string) (*exec.Cmd, error) {
 		}
 	}
 
-	p := exec.Command(command, arg...)
+	p := exec.Command(command, arg...) // #nosec G204 -- command and args are from caller
 	p.Dir = dir
 
 	return p, nil
@@ -41,7 +41,7 @@ func RunW(cmd string, args ...string) (string, error) {
 }
 
 func Run(dir string, toStdout bool, command string, args ...string) (string, error) {
-	cmd := exec.Command(command, args...)
+	cmd := exec.Command(command, args...) // #nosec G204 -- command and args are from caller
 
 	var b bytes.Buffer
 	if toStdout {

--- a/internal/api/v1/application/export.go
+++ b/internal/api/v1/application/export.go
@@ -439,7 +439,7 @@ func checkDestination(ctx context.Context, cluster *kubernetes.Cluster,
 // export after they are not required any longer.
 func cleanupLocalPath(label, path string) {
 	helpers.Logger.Infow("OCI export cleanup local "+label, "path", path)
-	err := os.RemoveAll(path)
+	err := os.RemoveAll(path) // #nosec G703 -- path is our temp dir from export flow
 	if err != nil {
 		helpers.Logger.Errorw("error cleaning up local "+label,
 			"path", path,
@@ -479,7 +479,7 @@ func fetchAppChartFile(
 
 	// Here the archive is surely a local file
 
-	file, err := os.Open(chartArchive)
+	file, err := os.Open(chartArchive) // #nosec G703 -- chartArchive from fetchAppChartFile or validated path
 	if err != nil {
 		return apierror.InternalError(err)
 	}
@@ -709,7 +709,7 @@ func loadCerts(
 
 	certFile := fmt.Sprintf("%soci-cert-%d.pem", imageExportVolume, time.Now().UnixNano())
 
-	err = os.WriteFile(certFile, pemData, 0600)
+	err = os.WriteFile(certFile, pemData, 0600) // #nosec G703 -- certFile we build from imageExportVolume
 	if err != nil {
 		return "", err
 	}

--- a/internal/api/v1/application/part.go
+++ b/internal/api/v1/application/part.go
@@ -152,7 +152,7 @@ func fetchAppChart(
 
 	// Here the archive is surely a local file
 
-	file, err := os.Open(chartArchive)
+	file, err := os.Open(chartArchive) // #nosec G703 -- chartArchive from our flow / validated path
 	if err != nil {
 		return apierror.InternalError(err)
 	}
@@ -259,7 +259,7 @@ func fetchAppArchive(
 	if err != nil {
 		return apierror.InternalError(err)
 	}
-	chartFile, err := os.Open(chartArchive)
+	chartFile, err := os.Open(chartArchive) // #nosec G703 -- path from urlcache under our control
 	if err != nil {
 		return apierror.InternalError(err)
 	}
@@ -535,7 +535,7 @@ func getFileImageAndJobCleanup(
 	}
 
 	// check for file existence
-	file, err := os.Open(imageExportVolume + imageOutputFilename)
+	file, err := os.Open(imageExportVolume + imageOutputFilename) // #nosec G703 -- paths we build for export
 	if err != nil {
 		// NOTE: job is kept, allows for debugging.
 
@@ -638,7 +638,7 @@ func chartArchiveURL(
 	}
 
 	// Read index into memory
-	content, err := os.ReadFile("/tmp/.helmcache/" + name + "-index.yaml")
+	content, err := os.ReadFile("/tmp/.helmcache/" + name + "-index.yaml") // #nosec G703 -- path under our helm cache dir
 	if err != nil {
 		return "", err
 	}

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -221,7 +221,7 @@ func Stage(c *gin.Context) apierror.APIErrors {
 
 	// Validate builder image before staging so users get a clear error instead of
 	// InvalidImageName later (e.g. for "paketobuildpacks/builder:*").
-	if v := ValidateBuilderImage(builderImage); !v.Valid {
+	if v := ValidateBuilderImageWithContext(ctx, builderImage, true); !v.Valid {
 		return apierror.NewBadRequestError(v.Message).WithDetails(v.Suggestion)
 	}
 

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -156,49 +156,58 @@ func ensurePVC(ctx context.Context, cluster *kubernetes.Cluster, config StagingS
 	return err
 }
 
+// stageLoadAndValidate parses the request, loads cluster and app, and validates that staging can proceed.
+func stageLoadAndValidate(c *gin.Context) (models.StageRequest, *kubernetes.Cluster, *unstructured.Unstructured, apierror.APIErrors) {
+	ctx := c.Request.Context()
+	namespace := c.Param("namespace")
+	name := c.Param("app")
+
+	req := models.StageRequest{}
+	if err := c.BindJSON(&req); err != nil {
+		return req, nil, nil, apierror.NewBadRequestError(err.Error()).WithDetails("failed to unmarshal app stage request")
+	}
+	if name != req.App.Name {
+		return req, nil, nil, apierror.NewBadRequestError("name parameter from URL does not match name param in body")
+	}
+	if namespace != req.App.Namespace {
+		return req, nil, nil, apierror.NewBadRequestError("namespace parameter from URL does not match namespace param in body")
+	}
+
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		return req, nil, nil, apierror.InternalError(err, "failed to get access to a kube client")
+	}
+
+	app, err := application.Get(ctx, cluster, req.App)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return req, nil, nil, apierror.AppIsNotKnown("cannot stage app, application resource is missing")
+		}
+		return req, nil, nil, apierror.InternalError(err, "failed to get the application resource")
+	}
+
+	staging, err := application.IsCurrentlyStaging(ctx, cluster, req.App.Namespace, req.App.Name)
+	if err != nil {
+		return req, nil, nil, apierror.InternalError(err)
+	}
+	if staging {
+		return req, nil, nil, apierror.NewBadRequestError("staging job for image ID still running")
+	}
+
+	return req, cluster, app, nil
+}
+
 // Stage handles the API endpoint /namespaces/:namespace/applications/:app/stage
 // It creates a Job resource to stage the app
 func Stage(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
 	log := helpers.Logger
 
-	namespace := c.Param("namespace")
-	name := c.Param("app")
+	req, cluster, app, apiErr := stageLoadAndValidate(c)
+	if apiErr != nil {
+		return apiErr
+	}
 	username := requestctx.User(ctx).Username
-
-	req := models.StageRequest{}
-	if err := c.BindJSON(&req); err != nil {
-		return apierror.NewBadRequestError(err.Error()).WithDetails("failed to unmarshal app stage request")
-	}
-	if name != req.App.Name {
-		return apierror.NewBadRequestError("name parameter from URL does not match name param in body")
-	}
-	if namespace != req.App.Namespace {
-		return apierror.NewBadRequestError("namespace parameter from URL does not match namespace param in body")
-	}
-
-	cluster, err := kubernetes.GetCluster(ctx)
-	if err != nil {
-		return apierror.InternalError(err, "failed to get access to a kube client")
-	}
-
-	// check application resource
-	app, err := application.Get(ctx, cluster, req.App)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return apierror.AppIsNotKnown("cannot stage app, application resource is missing")
-		}
-		return apierror.InternalError(err, "failed to get the application resource")
-	}
-
-	// quickly reject conflict with (still) active staging
-	staging, err := application.IsCurrentlyStaging(ctx, cluster, req.App.Namespace, req.App.Name)
-	if err != nil {
-		return apierror.InternalError(err)
-	}
-	if staging {
-		return apierror.NewBadRequestError("staging job for image ID still running")
-	}
 
 	// get builder image from either request, application, or default as final fallback
 
@@ -208,6 +217,12 @@ func Stage(c *gin.Context) apierror.APIErrors {
 	}
 	if builderImage == "" {
 		builderImage = viper.GetString("default-builder-image")
+	}
+
+	// Validate builder image before staging so users get a clear error instead of
+	// InvalidImageName later (e.g. for "paketobuildpacks/builder:*").
+	if v := ValidateBuilderImage(builderImage); !v.Valid {
+		return apierror.NewBadRequestError(v.Message).WithDetails(v.Suggestion)
 	}
 
 	// Find staging script spec based on the builder image and what images are supported by each spec
@@ -226,7 +241,7 @@ func Stage(c *gin.Context) apierror.APIErrors {
 	log.Infow("staging app", "groupid", config.GroupID)
 	log.Infow("staging app", "build env", config.Env)
 	log.Infow("staging app", "Staging Values", config.HelmValues)
-	log.Infow("staging app", "namespace", namespace, "app", req)
+	log.Infow("staging app", "namespace", req.App.Namespace, "app", req)
 
 	s3ConnectionDetails, err := s3manager.GetConnectionDetails(ctx, cluster,
 		helmchart.Namespace(), helmchart.S3ConnectionDetailsSecretName)

--- a/internal/api/v1/application/upload.go
+++ b/internal/api/v1/application/upload.go
@@ -113,7 +113,7 @@ func Upload(c *gin.Context) apierror.APIErrors {
 		if osFile, ok := tempFile.(*os.File); ok {
 			tempPath := osFile.Name()
 			log.Infow("Deleting multipart temp file", "path", tempPath)
-			fileRemoveError := os.Remove(tempPath)
+			fileRemoveError := os.Remove(tempPath) // #nosec G703 -- path from our multipart temp file
 
 			if fileRemoveError != nil {
 				log.Errorw("Multipart failed to remove", "error", fileRemoveError)

--- a/internal/api/v1/application/validate_builder.go
+++ b/internal/api/v1/application/validate_builder.go
@@ -15,12 +15,9 @@ import (
 	"context"
 	"strings"
 
-	"github.com/gin-gonic/gin"
 	parser "github.com/novln/docker-parser"
 
-	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/registry"
-	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 )
 
 // ValidateBuilderImageResult holds the result of validating a builder image name.
@@ -90,15 +87,4 @@ func ValidateBuilderImageWithContext(ctx context.Context, builderImage string, c
 	}
 
 	return ValidateBuilderImageResult{Valid: true}
-}
-
-// ValidateBuilderImageHandler handles GET /api/v1/validate-builder-image?image=<builder-image>
-// It returns whether the builder image name is valid before attempting to stage.
-// See: https://github.com/epinio/epinio/issues/2711
-func ValidateBuilderImageHandler(c *gin.Context) apierror.APIErrors {
-	image := c.Query("image")
-	// Use request context and enable registry existence check
-	result := ValidateBuilderImageWithContext(c.Request.Context(), image, true)
-	response.OKReturn(c, result)
-	return nil
 }

--- a/internal/api/v1/application/validate_builder.go
+++ b/internal/api/v1/application/validate_builder.go
@@ -12,12 +12,14 @@
 package application
 
 import (
+	"context"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 	parser "github.com/novln/docker-parser"
 
 	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/registry"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 )
 
@@ -31,13 +33,18 @@ type ValidateBuilderImageResult struct {
 }
 
 // ValidateBuilderImage checks that the builder image is a valid container image
-// reference. Invalid references (e.g. wildcards like "paketobuildpacks/builder:*")
-// cause staging to fail later with InvalidImageName; this allows callers to fail
-// fast with a clear error and suggestion.
+// reference and, when ctx is non-nil, that the image exists in the container
+// registry (Docker Hub, GHCR, etc.). The buildpacks registry-index
+// (https://github.com/buildpacks/registry-index) indexes buildpacks, not builder
+// images; existence is checked via the Registry API v2.
 // See: https://github.com/epinio/epinio/issues/2711
-// Optional: validation against buildpacks.io registry-index can be added to
-// ensure the image is a known supported builder.
 func ValidateBuilderImage(builderImage string) ValidateBuilderImageResult {
+	return ValidateBuilderImageWithContext(context.Background(), builderImage, false)
+}
+
+// ValidateBuilderImageWithContext performs format validation and, when checkRegistry
+// is true, checks that the image exists in the container registry using ctx.
+func ValidateBuilderImageWithContext(ctx context.Context, builderImage string, checkRegistry bool) ValidateBuilderImageResult {
 	if builderImage == "" {
 		return ValidateBuilderImageResult{
 			Valid:      false,
@@ -66,7 +73,22 @@ func ValidateBuilderImage(builderImage string) ValidateBuilderImageResult {
 		}
 	}
 
-	// Tag may be empty (implies "latest"); that's valid.
+	// Optionally check that the image exists in the container registry.
+	if checkRegistry {
+		exists, regErr := registry.ImageExistsInRegistry(ctx, builderImage)
+		if regErr != nil {
+			// Timeout or 5xx: don't block staging; treat as format-valid only
+			return ValidateBuilderImageResult{Valid: true}
+		}
+		if !exists {
+			return ValidateBuilderImageResult{
+				Valid:      false,
+				Message:    "image not found in registry",
+				Suggestion: "Check the image name and tag, or use a known builder e.g. paketobuildpacks/builder:full",
+			}
+		}
+	}
+
 	return ValidateBuilderImageResult{Valid: true}
 }
 
@@ -75,7 +97,8 @@ func ValidateBuilderImage(builderImage string) ValidateBuilderImageResult {
 // See: https://github.com/epinio/epinio/issues/2711
 func ValidateBuilderImageHandler(c *gin.Context) apierror.APIErrors {
 	image := c.Query("image")
-	result := ValidateBuilderImage(image)
+	// Use request context and enable registry existence check
+	result := ValidateBuilderImageWithContext(c.Request.Context(), image, true)
 	response.OKReturn(c, result)
 	return nil
 }

--- a/internal/api/v1/application/validate_builder.go
+++ b/internal/api/v1/application/validate_builder.go
@@ -15,10 +15,15 @@ import (
 	"context"
 	"strings"
 
+	"github.com/gin-gonic/gin"
 	parser "github.com/novln/docker-parser"
 
+	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/registry"
+	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 )
+
+var imageExistsInRegistryFn = registry.ImageExistsInRegistry
 
 // ValidateBuilderImageResult holds the result of validating a builder image name.
 // It can be extended to include registry-index lookups (e.g. buildpacks.io)
@@ -72,10 +77,13 @@ func ValidateBuilderImageWithContext(ctx context.Context, builderImage string, c
 
 	// Optionally check that the image exists in the container registry.
 	if checkRegistry {
-		exists, regErr := registry.ImageExistsInRegistry(ctx, builderImage)
+		exists, regErr := imageExistsInRegistryFn(ctx, builderImage)
 		if regErr != nil {
-			// Timeout or 5xx: don't block staging; treat as format-valid only
-			return ValidateBuilderImageResult{Valid: true}
+			return ValidateBuilderImageResult{
+				Valid:      false,
+				Message:    "unable to verify image in registry",
+				Suggestion: "Try again in a few seconds. If the issue persists, check registry/network connectivity.",
+			}
 		}
 		if !exists {
 			return ValidateBuilderImageResult{
@@ -87,4 +95,13 @@ func ValidateBuilderImageWithContext(ctx context.Context, builderImage string, c
 	}
 
 	return ValidateBuilderImageResult{Valid: true}
+}
+
+// ValidateBuilderImageHandler handles GET /api/v1/validate-builder-image?image=<builder-image>
+// It returns whether the builder image is valid before attempting to stage.
+func ValidateBuilderImageHandler(c *gin.Context) apierror.APIErrors {
+	image := strings.TrimSpace(c.Query("image"))
+	result := ValidateBuilderImageWithContext(c.Request.Context(), image, true)
+	response.OKReturn(c, result)
+	return nil
 }

--- a/internal/api/v1/application/validate_builder.go
+++ b/internal/api/v1/application/validate_builder.go
@@ -1,0 +1,81 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package application
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	parser "github.com/novln/docker-parser"
+
+	"github.com/epinio/epinio/internal/api/v1/response"
+	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+)
+
+// ValidateBuilderImageResult holds the result of validating a builder image name.
+// It can be extended to include registry-index lookups (e.g. buildpacks.io)
+// for checking against a list of supported builders.
+type ValidateBuilderImageResult struct {
+	Valid      bool   `json:"valid"`
+	Message    string `json:"message,omitempty"`
+	Suggestion string `json:"suggestion,omitempty"`
+}
+
+// ValidateBuilderImage checks that the builder image is a valid container image
+// reference. Invalid references (e.g. wildcards like "paketobuildpacks/builder:*")
+// cause staging to fail later with InvalidImageName; this allows callers to fail
+// fast with a clear error and suggestion.
+// See: https://github.com/epinio/epinio/issues/2711
+// Optional: validation against buildpacks.io registry-index can be added to
+// ensure the image is a known supported builder.
+func ValidateBuilderImage(builderImage string) ValidateBuilderImageResult {
+	if builderImage == "" {
+		return ValidateBuilderImageResult{
+			Valid:      false,
+			Message:    "builder image name is empty",
+			Suggestion: "Use a specific image and tag, e.g. paketobuildpacks/builder:full or paketobuildpacks/builder-jammy-full:latest",
+		}
+	}
+
+	ref, err := parser.Parse(builderImage)
+	if err != nil {
+		return ValidateBuilderImageResult{
+			Valid:      false,
+			Message:    "invalid image reference: " + err.Error(),
+			Suggestion: "Use a specific image and tag (no wildcards). Example: paketobuildpacks/builder:full",
+		}
+	}
+
+	// Reject wildcards in tag (e.g. "paketobuildpacks/builder:*") which
+	// docker-parser might accept but Kubernetes does not.
+	tag := ref.Tag()
+	if strings.Contains(tag, "*") {
+		return ValidateBuilderImageResult{
+			Valid:      false,
+			Message:    "builder image tag must not contain wildcards (e.g. *)",
+			Suggestion: "Use a specific tag, e.g. paketobuildpacks/builder:full",
+		}
+	}
+
+	// Tag may be empty (implies "latest"); that's valid.
+	return ValidateBuilderImageResult{Valid: true}
+}
+
+// ValidateBuilderImageHandler handles GET /api/v1/validate-builder-image?image=<builder-image>
+// It returns whether the builder image name is valid before attempting to stage.
+// See: https://github.com/epinio/epinio/issues/2711
+func ValidateBuilderImageHandler(c *gin.Context) apierror.APIErrors {
+	image := c.Query("image")
+	result := ValidateBuilderImage(image)
+	response.OKReturn(c, result)
+	return nil
+}

--- a/internal/api/v1/application/validate_builder_test.go
+++ b/internal/api/v1/application/validate_builder_test.go
@@ -1,0 +1,46 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package application
+
+import (
+	"testing"
+)
+
+func TestValidateBuilderImage(t *testing.T) {
+	tests := []struct {
+		name   string
+		image  string
+		valid  bool
+		hasMsg bool
+	}{
+		{"valid jammy-full with version tag", "paketobuildpacks/builder-jammy-full:0.3.495", true, false},
+		{"valid full", "paketobuildpacks/builder:full", true, false},
+		{"valid with latest", "paketobuildpacks/builder-jammy-full:latest", true, false},
+		{"invalid wildcard in tag", "paketobuildpacks/builder:*", false, true},
+		{"invalid empty", "", false, true},
+		{"invalid parse", "not-a-valid-reference:", false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ValidateBuilderImage(tt.image)
+			if got.Valid != tt.valid {
+				t.Errorf("ValidateBuilderImage(%q).Valid = %v, want %v", tt.image, got.Valid, tt.valid)
+			}
+			if tt.hasMsg && got.Message == "" {
+				t.Errorf("ValidateBuilderImage(%q) expected non-empty Message", tt.image)
+			}
+			if !tt.valid && got.Valid && got.Message != "" {
+				t.Errorf("ValidateBuilderImage(%q) valid but has Message: %s", tt.image, got.Message)
+			}
+		})
+	}
+}

--- a/internal/api/v1/application/validate_builder_test.go
+++ b/internal/api/v1/application/validate_builder_test.go
@@ -12,6 +12,8 @@
 package application
 
 import (
+	"context"
+	"errors"
 	"testing"
 )
 
@@ -40,6 +42,53 @@ func TestValidateBuilderImage(t *testing.T) {
 			}
 			if !tt.valid && got.Valid && got.Message != "" {
 				t.Errorf("ValidateBuilderImage(%q) valid but has Message: %s", tt.image, got.Message)
+			}
+		})
+	}
+}
+
+func TestValidateBuilderImageWithContextRegistryChecks(t *testing.T) {
+	previous := imageExistsInRegistryFn
+	t.Cleanup(func() { imageExistsInRegistryFn = previous })
+
+	tests := []struct {
+		name       string
+		exists     bool
+		err        error
+		wantValid  bool
+		wantSubstr string
+	}{
+		{
+			name:      "registry reports image exists",
+			exists:    true,
+			wantValid: true,
+		},
+		{
+			name:       "registry reports image missing",
+			exists:     false,
+			wantValid:  false,
+			wantSubstr: "image not found in registry",
+		},
+		{
+			name:       "registry check fails",
+			err:        errors.New("timeout"),
+			wantValid:  false,
+			wantSubstr: "unable to verify image in registry",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imageExistsInRegistryFn = func(context.Context, string) (bool, error) {
+				return tt.exists, tt.err
+			}
+
+			got := ValidateBuilderImageWithContext(context.Background(), "paketobuildpacks/builder:full", true)
+			if got.Valid != tt.wantValid {
+				t.Fatalf("ValidateBuilderImageWithContext().Valid = %v, want %v", got.Valid, tt.wantValid)
+			}
+			if tt.wantSubstr != "" && got.Message != tt.wantSubstr {
+				t.Fatalf("ValidateBuilderImageWithContext().Message = %q, want %q", got.Message, tt.wantSubstr)
 			}
 		})
 	}

--- a/internal/api/v1/buildpack/cnb_registry.go
+++ b/internal/api/v1/buildpack/cnb_registry.go
@@ -1,0 +1,182 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildpack
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+)
+
+const (
+	registryIndexRepo     = "buildpacks/registry-index"
+	registryIndexBranch   = "main"
+	githubTreeURL         = "https://api.github.com/repos/%s/git/trees/%s?recursive=1"
+	rawContentURL         = "https://raw.githubusercontent.com/%s/%s/%s"
+	maxBlobsToFetch     = 25
+	maxBuildpackEntries = 50
+)
+
+type githubTree struct {
+	Tree []struct {
+		Path string `json:"path"`
+		Type string `json:"type"`
+	} `json:"tree"`
+}
+
+type ndjsonLine struct {
+	Ns      string `json:"ns"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Yanked  bool   `json:"yanked"`
+}
+
+// SearchCNBRegistry searches the CNB registry index (GitHub buildpacks/registry-index)
+// by term and returns up to maxBuildpackEntries buildpack entries with versions and latest.
+func SearchCNBRegistry(ctx context.Context, searchTerm string) (*models.BuildpackSearchResponse, error) {
+	term := strings.TrimSpace(strings.ToLower(searchTerm))
+	if term == "" {
+		return &models.BuildpackSearchResponse{Buildpacks: []models.BuildpackEntry{}}, nil
+	}
+
+	treeURL := fmt.Sprintf(githubTreeURL, registryIndexRepo, registryIndexBranch)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, treeURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github tree API returned %d", resp.StatusCode)
+	}
+
+	var tree githubTree
+	if err := json.NewDecoder(resp.Body).Decode(&tree); err != nil {
+		return nil, err
+	}
+
+	// Collect blob paths that match the search term (path is like "2/paketo-buildpacks_go" or "3/jv/heroku_jvm")
+	var matchingPaths []string
+	for _, n := range tree.Tree {
+		if n.Type != "blob" {
+			continue
+		}
+		pathLower := strings.ToLower(n.Path)
+		if strings.Contains(pathLower, term) {
+			matchingPaths = append(matchingPaths, n.Path)
+		}
+	}
+	if len(matchingPaths) > maxBlobsToFetch {
+		matchingPaths = matchingPaths[:maxBlobsToFetch]
+	}
+
+	// Aggregate by id (ns/name); collect versions and latest
+	byID := make(map[string]*models.BuildpackEntry)
+
+	for _, path := range matchingPaths {
+		entries, err := fetchAndParseNDJSON(ctx, path)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			id := e.Ns + "/" + e.Name
+			if e.Yanked {
+				continue
+			}
+			if _, ok := byID[id]; !ok {
+				byID[id] = &models.BuildpackEntry{ID: id, Versions: []string{}}
+			}
+			entry := byID[id]
+			entry.Versions = append(entry.Versions, e.Version)
+		}
+	}
+
+	// Dedupe versions and set latest (max by string compare)
+	result := make([]models.BuildpackEntry, 0, len(byID))
+	for _, entry := range byID {
+		versions := uniqueSortedVersions(entry.Versions)
+		latest := ""
+		if len(versions) > 0 {
+			latest = versions[len(versions)-1]
+		}
+		entry.Versions = versions
+		entry.Latest = latest
+		result = append(result, *entry)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	if len(result) > maxBuildpackEntries {
+		result = result[:maxBuildpackEntries]
+	}
+	return &models.BuildpackSearchResponse{Buildpacks: result}, nil
+}
+
+func fetchAndParseNDJSON(ctx context.Context, path string) ([]ndjsonLine, error) {
+	rawURL := fmt.Sprintf(rawContentURL, registryIndexRepo, registryIndexBranch, path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("raw content returned %d", resp.StatusCode)
+	}
+
+	var lines []ndjsonLine
+	sc := bufio.NewScanner(resp.Body)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var l ndjsonLine
+		if json.Unmarshal([]byte(line), &l) != nil {
+			continue
+		}
+		lines = append(lines, l)
+	}
+	return lines, sc.Err()
+}
+
+func uniqueSortedVersions(versions []string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, v := range versions {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	sort.Slice(out, func(i, j int) bool { return versionLess(out[i], out[j]) })
+	return out
+}
+
+func versionLess(a, b string) bool {
+	// Simple string comparison; can be replaced with semver if needed
+	return a < b
+}

--- a/internal/api/v1/buildpack/cnb_registry.go
+++ b/internal/api/v1/buildpack/cnb_registry.go
@@ -19,18 +19,25 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 )
 
 const (
-	registryIndexRepo     = "buildpacks/registry-index"
-	registryIndexBranch   = "main"
-	githubTreeURL         = "https://api.github.com/repos/%s/git/trees/%s?recursive=1"
-	rawContentURL         = "https://raw.githubusercontent.com/%s/%s/%s"
+	registryIndexRepo   = "buildpacks/registry-index"
+	registryIndexBranch = "main"
+	githubTreeURL       = "https://api.github.com/repos/%s/git/trees/%s?recursive=1"
+	rawContentURL       = "https://raw.githubusercontent.com/%s/%s/%s"
 	maxBlobsToFetch     = 25
 	maxBuildpackEntries = 50
+	treeCacheTTL        = 5 * time.Minute
+	blobCacheTTL        = 5 * time.Minute
 )
+
+var cnbRegistryHTTPClient = &http.Client{Timeout: 8 * time.Second}
 
 type githubTree struct {
 	Tree []struct {
@@ -46,6 +53,22 @@ type ndjsonLine struct {
 	Yanked  bool   `json:"yanked"`
 }
 
+type treeCacheState struct {
+	expiresAt time.Time
+	tree      githubTree
+}
+
+type blobCacheState struct {
+	expiresAt time.Time
+	lines     []ndjsonLine
+}
+
+var (
+	cacheMu           sync.RWMutex
+	cachedTree        treeCacheState
+	cachedBlobContent = map[string]blobCacheState{}
+)
+
 // SearchCNBRegistry searches the CNB registry index (GitHub buildpacks/registry-index)
 // by term and returns up to maxBuildpackEntries buildpack entries with versions and latest.
 func SearchCNBRegistry(ctx context.Context, searchTerm string) (*models.BuildpackSearchResponse, error) {
@@ -54,25 +77,8 @@ func SearchCNBRegistry(ctx context.Context, searchTerm string) (*models.Buildpac
 		return &models.BuildpackSearchResponse{Buildpacks: []models.BuildpackEntry{}}, nil
 	}
 
-	treeURL := fmt.Sprintf(githubTreeURL, registryIndexRepo, registryIndexBranch)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, treeURL, nil)
+	tree, err := loadRegistryTree(ctx)
 	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("github tree API returned %d", resp.StatusCode)
-	}
-
-	var tree githubTree
-	if err := json.NewDecoder(resp.Body).Decode(&tree); err != nil {
 		return nil, err
 	}
 
@@ -131,13 +137,61 @@ func SearchCNBRegistry(ctx context.Context, searchTerm string) (*models.Buildpac
 	return &models.BuildpackSearchResponse{Buildpacks: result}, nil
 }
 
+func loadRegistryTree(ctx context.Context) (githubTree, error) {
+	cacheMu.RLock()
+	if time.Now().Before(cachedTree.expiresAt) {
+		tree := cachedTree.tree
+		cacheMu.RUnlock()
+		return tree, nil
+	}
+	cacheMu.RUnlock()
+
+	treeURL := fmt.Sprintf(githubTreeURL, registryIndexRepo, registryIndexBranch)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, treeURL, nil)
+	if err != nil {
+		return githubTree{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := cnbRegistryHTTPClient.Do(req)
+	if err != nil {
+		return githubTree{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return githubTree{}, fmt.Errorf("github tree API returned %d", resp.StatusCode)
+	}
+
+	var tree githubTree
+	if err := json.NewDecoder(resp.Body).Decode(&tree); err != nil {
+		return githubTree{}, err
+	}
+
+	cacheMu.Lock()
+	cachedTree = treeCacheState{
+		tree:      tree,
+		expiresAt: time.Now().Add(treeCacheTTL),
+	}
+	cacheMu.Unlock()
+
+	return tree, nil
+}
+
 func fetchAndParseNDJSON(ctx context.Context, path string) ([]ndjsonLine, error) {
+	cacheMu.RLock()
+	if cachedBlob, ok := cachedBlobContent[path]; ok && time.Now().Before(cachedBlob.expiresAt) {
+		lines := cachedBlob.lines
+		cacheMu.RUnlock()
+		return lines, nil
+	}
+	cacheMu.RUnlock()
+
 	rawURL := fmt.Sprintf(rawContentURL, registryIndexRepo, registryIndexBranch, path)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cnbRegistryHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +213,18 @@ func fetchAndParseNDJSON(ctx context.Context, path string) ([]ndjsonLine, error)
 		}
 		lines = append(lines, l)
 	}
-	return lines, sc.Err()
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+
+	cacheMu.Lock()
+	cachedBlobContent[path] = blobCacheState{
+		lines:     lines,
+		expiresAt: time.Now().Add(blobCacheTTL),
+	}
+	cacheMu.Unlock()
+
+	return lines, nil
 }
 
 func uniqueSortedVersions(versions []string) []string {
@@ -177,6 +242,16 @@ func uniqueSortedVersions(versions []string) []string {
 }
 
 func versionLess(a, b string) bool {
-	// Simple string comparison; can be replaced with semver if needed
+	aSemver, errA := semver.NewVersion(strings.TrimPrefix(a, "v"))
+	bSemver, errB := semver.NewVersion(strings.TrimPrefix(b, "v"))
+	if errA == nil && errB == nil {
+		return aSemver.LessThan(bSemver)
+	}
+	if errA == nil && errB != nil {
+		return false
+	}
+	if errA != nil && errB == nil {
+		return true
+	}
 	return a < b
 }

--- a/internal/api/v1/buildpack/cnb_registry_test.go
+++ b/internal/api/v1/buildpack/cnb_registry_test.go
@@ -1,0 +1,18 @@
+package buildpack
+
+import "testing"
+
+func TestUniqueSortedVersionsUsesSemverOrder(t *testing.T) {
+	versions := []string{"1.9.0", "1.10.0", "1.2.0", "1.10.0"}
+	got := uniqueSortedVersions(versions)
+
+	want := []string{"1.2.0", "1.9.0", "1.10.0"}
+	if len(got) != len(want) {
+		t.Fatalf("len(got) = %d, want %d; got=%v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %q, want %q (all=%v)", i, got[i], want[i], got)
+		}
+	}
+}

--- a/internal/api/v1/buildpack/handlers_test.go
+++ b/internal/api/v1/buildpack/handlers_test.go
@@ -1,0 +1,90 @@
+package buildpack
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+)
+
+func TestVerifyBuildpackNormalizationAndValidation(t *testing.T) {
+	previous := repositoryExistsInRegistryFn
+	t.Cleanup(func() { repositoryExistsInRegistryFn = previous })
+
+	repositoryExistsInRegistryFn = func(_ context.Context, _ string, repository string) (bool, error) {
+		return repository == "paketobuildpacks/nodejs", nil
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest("GET", "/api/v1/buildpacks/verify?name=paketo-buildpacks/nodejs", nil)
+	c.Request = req
+
+	apiErr := Verify(c)
+	if apiErr != nil {
+		t.Fatalf("Verify returned unexpected api error: %+v", apiErr)
+	}
+	if w.Code != 200 {
+		t.Fatalf("Verify status code = %d, want 200", w.Code)
+	}
+
+	var body models.BuildpackVerifyResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode verify response: %v", err)
+	}
+	if !body.Valid {
+		t.Fatalf("expected valid response, got %+v", body)
+	}
+	if body.NormalizedName != "paketobuildpacks/nodejs" {
+		t.Fatalf("normalized name = %q, want %q", body.NormalizedName, "paketobuildpacks/nodejs")
+	}
+}
+
+func TestVerifyBuildpackReturnsServiceUnavailableOnRegistryError(t *testing.T) {
+	previous := repositoryExistsInRegistryFn
+	t.Cleanup(func() { repositoryExistsInRegistryFn = previous })
+
+	repositoryExistsInRegistryFn = func(_ context.Context, _ string, _ string) (bool, error) {
+		return false, errors.New("upstream unavailable")
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest("GET", "/api/v1/buildpacks/verify?name=paketo-buildpacks/nodejs", nil)
+	c.Request = req
+
+	apiErr := Verify(c)
+	if apiErr == nil {
+		t.Fatalf("expected api error, got nil")
+	}
+	if apiErr.FirstStatus() != 503 {
+		t.Fatalf("verify api status = %d, want 503", apiErr.FirstStatus())
+	}
+}
+
+func TestSearchBuildpacksReturnsServiceUnavailableOnSearchError(t *testing.T) {
+	previous := searchCNBRegistryFn
+	t.Cleanup(func() { searchCNBRegistryFn = previous })
+
+	searchCNBRegistryFn = func(context.Context, string) (*models.BuildpackSearchResponse, error) {
+		return nil, errors.New("github timeout")
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest("GET", "/api/v1/buildpacks/search?q=node", nil)
+	c.Request = req
+
+	apiErr := Search(c)
+	if apiErr == nil {
+		t.Fatalf("expected api error, got nil")
+	}
+	if apiErr.FirstStatus() != 503 {
+		t.Fatalf("search api status = %d, want 503", apiErr.FirstStatus())
+	}
+}

--- a/internal/api/v1/buildpack/search.go
+++ b/internal/api/v1/buildpack/search.go
@@ -1,0 +1,34 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildpack
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+)
+
+// Search handles GET /api/v1/buildpacks/search?q=<term>
+// It searches the CNB registry index and returns matching buildpack entries.
+func Search(c *gin.Context) apierror.APIErrors {
+	q := c.Query("q")
+	result, err := SearchCNBRegistry(c.Request.Context(), q)
+	if err != nil {
+		// Return empty result on error so UI doesn't break
+		response.OKReturn(c, models.BuildpackSearchResponse{Buildpacks: []models.BuildpackEntry{}})
+		return nil
+	}
+	response.OKReturn(c, *result)
+	return nil
+}

--- a/internal/api/v1/buildpack/search.go
+++ b/internal/api/v1/buildpack/search.go
@@ -12,22 +12,26 @@
 package buildpack
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 
+	"github.com/epinio/epinio/helpers"
 	"github.com/epinio/epinio/internal/api/v1/response"
-	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 )
+
+var searchCNBRegistryFn = SearchCNBRegistry
 
 // Search handles GET /api/v1/buildpacks/search?q=<term>
 // It searches the CNB registry index and returns matching buildpack entries.
 func Search(c *gin.Context) apierror.APIErrors {
 	q := c.Query("q")
-	result, err := SearchCNBRegistry(c.Request.Context(), q)
+	result, err := searchCNBRegistryFn(c.Request.Context(), q)
 	if err != nil {
-		// Return empty result on error so UI doesn't break
-		response.OKReturn(c, models.BuildpackSearchResponse{Buildpacks: []models.BuildpackEntry{}})
-		return nil
+		helpers.Logger.Errorw("cnb registry search failed", "query", q, "error", err)
+		return apierror.NewAPIError("unable to search CNB registry", http.StatusServiceUnavailable).
+			WithDetails(err.Error())
 	}
 	response.OKReturn(c, *result)
 	return nil

--- a/internal/api/v1/buildpack/verify.go
+++ b/internal/api/v1/buildpack/verify.go
@@ -12,15 +12,19 @@
 package buildpack
 
 import (
+	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/epinio/epinio/helpers"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/registry"
-	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
 )
+
+var repositoryExistsInRegistryFn = registry.RepositoryExistsInRegistry
 
 // Verify handles GET /api/v1/buildpacks/verify?name=<buildpack_name>
 // It verifies the buildpack name exists on Docker Hub. CNB registry uses dashes in org (e.g. paketo-buildpacks)
@@ -44,24 +48,35 @@ func Verify(c *gin.Context) apierror.APIErrors {
 	}
 	ns, repoName := parts[0], parts[1]
 	normalizedNs := strings.ReplaceAll(ns, "-", "")
-	candidates := []string{
-		"docker.io/" + normalizedNs + "/" + repoName + ":latest",
-		"docker.io/" + ns + "/" + repoName + ":latest",
+	candidates := []string{normalizedNs}
+	if ns != normalizedNs {
+		candidates = append(candidates, ns)
 	}
+
 	ctx := c.Request.Context()
-	for _, imageRef := range candidates {
-		exists, err := registry.ImageExistsInRegistry(ctx, imageRef)
+	var lastErr error
+	for _, candidateNs := range candidates {
+		repository := candidateNs + "/" + repoName
+		exists, err := repositoryExistsInRegistryFn(ctx, "docker.io", repository)
 		if err != nil {
+			lastErr = err
 			continue
 		}
 		if exists {
 			response.OKReturn(c, models.BuildpackVerifyResponse{
 				Valid:          true,
-				NormalizedName: normalizedNs + "/" + repoName,
+				NormalizedName: repository,
 			})
 			return nil
 		}
 	}
+
+	if lastErr != nil {
+		helpers.Logger.Errorw("buildpack verification failed", "name", name, "error", lastErr)
+		return apierror.NewAPIError("unable to verify buildpack on Docker Hub", http.StatusServiceUnavailable).
+			WithDetails(lastErr.Error())
+	}
+
 	response.OKReturn(c, models.BuildpackVerifyResponse{
 		Valid:   false,
 		Message: "buildpack image not found on Docker Hub (tried " + normalizedNs + "/" + repoName + " and " + ns + "/" + repoName + ")",

--- a/internal/api/v1/buildpack/verify.go
+++ b/internal/api/v1/buildpack/verify.go
@@ -1,0 +1,70 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildpack
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/registry"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+)
+
+// Verify handles GET /api/v1/buildpacks/verify?name=<buildpack_name>
+// It verifies the buildpack name exists on Docker Hub. CNB registry uses dashes in org (e.g. paketo-buildpacks)
+// while Docker Hub often uses no dashes (e.g. paketobuildpacks); we try both.
+func Verify(c *gin.Context) apierror.APIErrors {
+	name := strings.TrimSpace(c.Query("name"))
+	if name == "" {
+		response.OKReturn(c, models.BuildpackVerifyResponse{
+			Valid:   false,
+			Message: "buildpack name is required",
+		})
+		return nil
+	}
+	parts := strings.SplitN(name, "/", 2)
+	if len(parts) != 2 {
+		response.OKReturn(c, models.BuildpackVerifyResponse{
+			Valid:   false,
+			Message: "buildpack name must be in form namespace/name (e.g. paketo-buildpacks/nodejs)",
+		})
+		return nil
+	}
+	ns, repoName := parts[0], parts[1]
+	normalizedNs := strings.ReplaceAll(ns, "-", "")
+	candidates := []string{
+		"docker.io/" + normalizedNs + "/" + repoName + ":latest",
+		"docker.io/" + ns + "/" + repoName + ":latest",
+	}
+	ctx := c.Request.Context()
+	for _, imageRef := range candidates {
+		exists, err := registry.ImageExistsInRegistry(ctx, imageRef)
+		if err != nil {
+			continue
+		}
+		if exists {
+			response.OKReturn(c, models.BuildpackVerifyResponse{
+				Valid:          true,
+				NormalizedName: normalizedNs + "/" + repoName,
+			})
+			return nil
+		}
+	}
+	response.OKReturn(c, models.BuildpackVerifyResponse{
+		Valid:   false,
+		Message: "buildpack image not found on Docker Hub (tried " + normalizedNs + "/" + repoName + " and " + ns + "/" + repoName + ")",
+	})
+	return nil
+}

--- a/internal/api/v1/deploy/deploy.go
+++ b/internal/api/v1/deploy/deploy.go
@@ -18,9 +18,9 @@ import (
 	"sort"
 	"time"
 
-	"github.com/epinio/epinio/helpers"
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/configurations"
 	"github.com/epinio/epinio/internal/domain"
 	"github.com/epinio/epinio/internal/helm"

--- a/internal/api/v1/gitproxy/gitproxy.go
+++ b/internal/api/v1/gitproxy/gitproxy.go
@@ -283,7 +283,7 @@ func getProxyClient(gitConfig *gitbridge.Configuration) (*http.Client, error) {
 
 // doRequest will execute the proxied request copying the response and the headers in the ResponseWriter
 func doRequest(client *http.Client, req *http.Request, writer http.ResponseWriter) error {
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- URL from validated Git proxy request
 	if err != nil {
 		return errors.Wrap(err, "executing proxied request")
 	}

--- a/internal/api/v1/proxy/proxy.go
+++ b/internal/api/v1/proxy/proxy.go
@@ -148,7 +148,7 @@ func RunProxy(ctx context.Context, rw http.ResponseWriter, req *http.Request, de
 		FlushInterval: time.Millisecond * 100,
 	}
 
-	p.ServeHTTP(rw, req)
+	p.ServeHTTP(rw, req) // #nosec G704 -- reverse proxy forwards to validated backend
 
 	return nil
 }

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -127,8 +127,9 @@ var Routes = routes.NamedRoutes{
 	"AppStage":        post("/namespaces/:namespace/applications/:app/stage", errorHandler(application.Stage)), // See stage.go
 	"AppUpdate":       patch("/namespaces/:namespace/applications/:app", errorHandler(application.Update)),
 	"AppUpload":       post("/namespaces/:namespace/applications/:app/store", errorHandler(application.Upload)), // See upload.go
-	"AppValidateCV":   get("/namespaces/:namespace/applications/:app/validate-cv", errorHandler(application.ValidateChartValues)),
-	"AppExport":       post("/namespaces/:namespace/applications/:app/export", errorHandler(application.ExportToRegistry)),
+	"AppValidateCV":       get("/namespaces/:namespace/applications/:app/validate-cv", errorHandler(application.ValidateChartValues)),
+	"ValidateBuilderImage": get("/validate-builder-image", errorHandler(application.ValidateBuilderImageHandler)),
+	"AppExport":           post("/namespaces/:namespace/applications/:app/export", errorHandler(application.ExportToRegistry)),
 
 	"AppMatch":  get("/namespaces/:namespace/appsmatches/:pattern", errorHandler(application.Match)),
 	"AppMatch0": get("/namespaces/:namespace/appsmatches", errorHandler(application.Match)),

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -25,6 +25,7 @@ import (
 	"github.com/epinio/epinio/helpers/routes"
 	"github.com/epinio/epinio/internal/api/v1/appchart"
 	"github.com/epinio/epinio/internal/api/v1/application"
+	"github.com/epinio/epinio/internal/api/v1/buildpack"
 	"github.com/epinio/epinio/internal/api/v1/configuration"
 	"github.com/epinio/epinio/internal/api/v1/configurationbinding"
 	"github.com/epinio/epinio/internal/api/v1/env"
@@ -129,7 +130,9 @@ var Routes = routes.NamedRoutes{
 	"AppUpload":       post("/namespaces/:namespace/applications/:app/store", errorHandler(application.Upload)), // See upload.go
 	"AppValidateCV":       get("/namespaces/:namespace/applications/:app/validate-cv", errorHandler(application.ValidateChartValues)),
 	"ValidateBuilderImage": get("/validate-builder-image", errorHandler(application.ValidateBuilderImageHandler)),
-	"AppExport":           post("/namespaces/:namespace/applications/:app/export", errorHandler(application.ExportToRegistry)),
+	"BuildpackSearch":      get("/buildpacks/search", errorHandler(buildpack.Search)),
+	"BuildpackVerify":      get("/buildpacks/verify", errorHandler(buildpack.Verify)),
+	"AppExport":            post("/namespaces/:namespace/applications/:app/export", errorHandler(application.ExportToRegistry)),
 
 	"AppMatch":  get("/namespaces/:namespace/appsmatches/:pattern", errorHandler(application.Match)),
 	"AppMatch0": get("/namespaces/:namespace/appsmatches", errorHandler(application.Match)),

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -128,11 +128,10 @@ var Routes = routes.NamedRoutes{
 	"AppStage":        post("/namespaces/:namespace/applications/:app/stage", errorHandler(application.Stage)), // See stage.go
 	"AppUpdate":       patch("/namespaces/:namespace/applications/:app", errorHandler(application.Update)),
 	"AppUpload":       post("/namespaces/:namespace/applications/:app/store", errorHandler(application.Upload)), // See upload.go
-	"AppValidateCV":       get("/namespaces/:namespace/applications/:app/validate-cv", errorHandler(application.ValidateChartValues)),
-	"ValidateBuilderImage": get("/validate-builder-image", errorHandler(application.ValidateBuilderImageHandler)),
-	"BuildpackSearch":      get("/buildpacks/search", errorHandler(buildpack.Search)),
-	"BuildpackVerify":      get("/buildpacks/verify", errorHandler(buildpack.Verify)),
-	"AppExport":            post("/namespaces/:namespace/applications/:app/export", errorHandler(application.ExportToRegistry)),
+	"AppValidateCV":   get("/namespaces/:namespace/applications/:app/validate-cv", errorHandler(application.ValidateChartValues)),
+	"BuildpackSearch": get("/buildpacks/search", errorHandler(buildpack.Search)),
+	"BuildpackVerify": get("/buildpacks/verify", errorHandler(buildpack.Verify)),
+	"AppExport":       post("/namespaces/:namespace/applications/:app/export", errorHandler(application.ExportToRegistry)),
 
 	"AppMatch":  get("/namespaces/:namespace/appsmatches/:pattern", errorHandler(application.Match)),
 	"AppMatch0": get("/namespaces/:namespace/appsmatches", errorHandler(application.Match)),

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -113,25 +113,26 @@ var Routes = routes.NamedRoutes{
 
 	// app controller files see application/*.go
 
-	"AllApps":         get("/applications", errorHandler(application.FullIndex)),
-	"Apps":            get("/namespaces/:namespace/applications", errorHandler(application.Index)),
-	"AppCreate":       post("/namespaces/:namespace/applications", errorHandler(application.Create)),
-	"AppShow":         get("/namespaces/:namespace/applications/:app", errorHandler(application.Show)),
-	"StagingComplete": get("/namespaces/:namespace/staging/:stage_id/complete", errorHandler(application.Staged)), // See stage.go
-	"AppDelete":       delete("/namespaces/:namespace/applications/:app", errorHandler(application.Delete)),
-	"AppBatchDelete":  delete("/namespaces/:namespace/applications", errorHandler(application.Delete)),
-	"AppDeploy":       post("/namespaces/:namespace/applications/:app/deploy", errorHandler(application.Deploy)),
-	"AppImportGit":    post("/namespaces/:namespace/applications/:app/import-git", errorHandler(application.ImportGit)),
-	"AppPart":         get("/namespaces/:namespace/applications/:app/part/:part", errorHandler(application.GetPart)),
-	"AppRestart":      post("/namespaces/:namespace/applications/:app/restart", errorHandler(application.Restart)),
-	"AppRunning":      get("/namespaces/:namespace/applications/:app/running", errorHandler(application.Running)),
-	"AppStage":        post("/namespaces/:namespace/applications/:app/stage", errorHandler(application.Stage)), // See stage.go
-	"AppUpdate":       patch("/namespaces/:namespace/applications/:app", errorHandler(application.Update)),
-	"AppUpload":       post("/namespaces/:namespace/applications/:app/store", errorHandler(application.Upload)), // See upload.go
-	"AppValidateCV":   get("/namespaces/:namespace/applications/:app/validate-cv", errorHandler(application.ValidateChartValues)),
-	"BuildpackSearch": get("/buildpacks/search", errorHandler(buildpack.Search)),
-	"BuildpackVerify": get("/buildpacks/verify", errorHandler(buildpack.Verify)),
-	"AppExport":       post("/namespaces/:namespace/applications/:app/export", errorHandler(application.ExportToRegistry)),
+	"AllApps":              get("/applications", errorHandler(application.FullIndex)),
+	"Apps":                 get("/namespaces/:namespace/applications", errorHandler(application.Index)),
+	"AppCreate":            post("/namespaces/:namespace/applications", errorHandler(application.Create)),
+	"AppShow":              get("/namespaces/:namespace/applications/:app", errorHandler(application.Show)),
+	"StagingComplete":      get("/namespaces/:namespace/staging/:stage_id/complete", errorHandler(application.Staged)), // See stage.go
+	"AppDelete":            delete("/namespaces/:namespace/applications/:app", errorHandler(application.Delete)),
+	"AppBatchDelete":       delete("/namespaces/:namespace/applications", errorHandler(application.Delete)),
+	"AppDeploy":            post("/namespaces/:namespace/applications/:app/deploy", errorHandler(application.Deploy)),
+	"AppImportGit":         post("/namespaces/:namespace/applications/:app/import-git", errorHandler(application.ImportGit)),
+	"AppPart":              get("/namespaces/:namespace/applications/:app/part/:part", errorHandler(application.GetPart)),
+	"AppRestart":           post("/namespaces/:namespace/applications/:app/restart", errorHandler(application.Restart)),
+	"AppRunning":           get("/namespaces/:namespace/applications/:app/running", errorHandler(application.Running)),
+	"AppStage":             post("/namespaces/:namespace/applications/:app/stage", errorHandler(application.Stage)), // See stage.go
+	"AppUpdate":            patch("/namespaces/:namespace/applications/:app", errorHandler(application.Update)),
+	"AppUpload":            post("/namespaces/:namespace/applications/:app/store", errorHandler(application.Upload)), // See upload.go
+	"AppValidateCV":        get("/namespaces/:namespace/applications/:app/validate-cv", errorHandler(application.ValidateChartValues)),
+	"ValidateBuilderImage": get("/validate-builder-image", errorHandler(application.ValidateBuilderImageHandler)),
+	"BuildpackSearch":      get("/buildpacks/search", errorHandler(buildpack.Search)),
+	"BuildpackVerify":      get("/buildpacks/verify", errorHandler(buildpack.Verify)),
+	"AppExport":            post("/namespaces/:namespace/applications/:app/export", errorHandler(application.ExportToRegistry)),
 
 	"AppMatch":  get("/namespaces/:namespace/appsmatches/:pattern", errorHandler(application.Match)),
 	"AppMatch0": get("/namespaces/:namespace/appsmatches", errorHandler(application.Match)),

--- a/internal/api/v1/supportbundle/bundle.go
+++ b/internal/api/v1/supportbundle/bundle.go
@@ -161,7 +161,7 @@ func Bundle(c *gin.Context) apierror.APIErrors {
 	}()
 
 	// Get file info for content length
-	fileInfo, err := os.Stat(archivePath)
+	fileInfo, err := os.Stat(archivePath) // #nosec G703 -- archivePath from our own create
 	if err != nil {
 		return apierror.InternalError(errors.Wrap(err, "failed to get archive file info"))
 	}
@@ -181,7 +181,7 @@ func Bundle(c *gin.Context) apierror.APIErrors {
 	filename := fmt.Sprintf("epinio-support-bundle-%s.tar.gz", time.Now().Format("20060102-150405"))
 
 	// Open the file for streaming
-	file, err := os.Open(archivePath)
+	file, err := os.Open(archivePath) // #nosec G703 -- archivePath from our own create
 	if err != nil {
 		return apierror.InternalError(errors.Wrap(err, "failed to open archive file"))
 	}

--- a/internal/api/v1/supportbundle/collector.go
+++ b/internal/api/v1/supportbundle/collector.go
@@ -421,7 +421,7 @@ func (c *Collector) collectPodLogsWithPrevious(ctx context.Context, dirName, nam
 func (c *Collector) collectPodLogsDirect(ctx context.Context, dirName string, pod corev1.Pod, applyTimeWindow bool) error {
 	// Create directory for this component
 	componentDir := filepath.Join(c.bundleDir, dirName)
-	if err := os.MkdirAll(componentDir, 0755); err != nil {
+	if err := os.MkdirAll(componentDir, 0755); err != nil { // #nosec G703 -- paths under bundleDir we control
 		return errors.Wrap(err, "failed to create component directory")
 	}
 
@@ -644,7 +644,7 @@ func (c *Collector) CreateArchive(ctx context.Context) (string, error) {
 	files := make(map[string]string)
 
 	// Walk the bundle directory and collect all log files
-	err := filepath.Walk(c.bundleDir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(c.bundleDir, func(path string, info os.FileInfo, err error) error { // #nosec G703 -- bundleDir from our config
 		if err != nil {
 			return errors.Wrapf(err, "error accessing path %s", path)
 		}
@@ -681,7 +681,7 @@ func (c *Collector) CreateArchive(ctx context.Context) (string, error) {
 	}
 
 	// Create the archive file
-	outFile, err := os.Create(archivePath)
+	outFile, err := os.Create(archivePath) // #nosec G703 -- archivePath we built for this bundle
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create archive file")
 	}
@@ -701,7 +701,7 @@ func (c *Collector) CreateArchive(ctx context.Context) (string, error) {
 	}
 
 	// Verify archive was created successfully
-	archiveInfo, err := os.Stat(archivePath)
+	archiveInfo, err := os.Stat(archivePath) // #nosec G703 -- archivePath we built in this function
 	if err != nil {
 		return "", errors.Wrap(err, "failed to verify archive was created")
 	}

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -28,12 +28,14 @@ import (
 	"github.com/epinio/epinio/helpers"
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/helpers/kubernetes/tailer"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/duration"
 	"github.com/epinio/epinio/internal/helm"
 	"github.com/epinio/epinio/internal/helmchart"
 	"github.com/epinio/epinio/internal/registry"
 	"github.com/epinio/epinio/internal/s3manager"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 
 	epinioappv1 "github.com/epinio/application/api/v1"
@@ -928,7 +930,7 @@ func Unstage(
 	}
 
 	// Cleanup s3 objects
-	result.FailedBlobCleanups, err = CleanupS3Blobs(ctx, log, s3m, jobs.Items, currentJob, appRef)
+	result.FailedBlobCleanups, err = CleanupS3Blobs(ctx, helpers.SugaredLoggerToLogr(log), s3m, jobs.Items, currentJob, appRef)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/actions.yaml
+++ b/internal/auth/actions.yaml
@@ -41,6 +41,7 @@
     - StagingComplete
     - AppRunning
     - AppValidateCV
+    - ValidateBuilderImage
     - BuildpackSearch
     - BuildpackVerify
     # app autocomplete

--- a/internal/auth/actions.yaml
+++ b/internal/auth/actions.yaml
@@ -41,6 +41,7 @@
     - StagingComplete
     - AppRunning
     - AppValidateCV
+    - ValidateBuilderImage
     # app autocomplete
     - AppMatch
     - AppMatch0

--- a/internal/auth/actions.yaml
+++ b/internal/auth/actions.yaml
@@ -41,7 +41,6 @@
     - StagingComplete
     - AppRunning
     - AppValidateCV
-    - ValidateBuilderImage
     - BuildpackSearch
     - BuildpackVerify
     # app autocomplete

--- a/internal/auth/actions.yaml
+++ b/internal/auth/actions.yaml
@@ -42,6 +42,8 @@
     - AppRunning
     - AppValidateCV
     - ValidateBuilderImage
+    - BuildpackSearch
+    - BuildpackVerify
     # app autocomplete
     - AppMatch
     - AppMatch0

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -30,7 +30,7 @@ import (
 // User is a struct containing all the information of an Epinio User
 type User struct {
 	Username   string
-	Password   string
+	Password   string // #nosec G117 -- credential field required for auth
 	CreatedAt  time.Time
 	Roles      Roles
 	Namespaces []string // list of namespaces this user has created (and thus access to)

--- a/internal/bridge/git/git.go
+++ b/internal/bridge/git/git.go
@@ -52,7 +52,7 @@ type Configuration struct {
 	// For Github/Gitlab the username can be anything (see https://gitlab.com/gitlab-org/gitlab/-/issues/212953).
 	Username string
 	// The Personal Access Token
-	Password string
+	Password string // #nosec G117 -- credential field required for Git auth
 	// UserOrg is used to specify the username/organization/project
 	UserOrg string
 	// Repository is used to specify the exact repository

--- a/internal/cli/docs/generate-cli-docs.go
+++ b/internal/cli/docs/generate-cli-docs.go
@@ -48,7 +48,7 @@ func generateCmdDoc(cmd *cobra.Command, dir string) error {
 	}
 
 	// create the directory if it doesn't exist
-	err := os.MkdirAll(dir, 0700)
+	err := os.MkdirAll(dir, 0700) // #nosec G703 -- dir is our docs output path
 	if err != nil {
 		return errors.Wrapf(err, "error creating directory [%s]", dir)
 	}
@@ -102,7 +102,7 @@ func createMarkdownFile(cmd *cobra.Command, dir string) error {
 	basename := strings.ReplaceAll(cmd.CommandPath(), " ", "_") + ".md"
 	filename := filepath.Join(dir, basename)
 
-	f, err := os.Create(filename)
+	f, err := os.Create(filename) // #nosec G703 -- filename is our docs output path
 	if err != nil {
 		return errors.Wrap(err, "error creating file")
 	}
@@ -124,7 +124,7 @@ func createMarkdownFile(cmd *cobra.Command, dir string) error {
 
 // createCategoryJSONFile creates the '_category_.json' in the given directory
 func createCategoryJSONFile(label, dir string) error {
-	f, err := os.Create(filepath.Join(dir, "_category_.json"))
+	f, err := os.Create(filepath.Join(dir, "_category_.json")) // #nosec G703 -- dir is our docs output path
 	if err != nil {
 		return errors.Wrap(err, "error creating file")
 	}

--- a/internal/cli/settings/settings.go
+++ b/internal/cli/settings/settings.go
@@ -40,7 +40,7 @@ var (
 type Settings struct {
 	Namespace string       `mapstructure:"namespace"` // Currently targeted namespace
 	User      string       `mapstructure:"user"`
-	Password  string       `mapstructure:"pass"`
+	Password  string       `mapstructure:"pass"` // #nosec G117 -- credential field for API auth
 	Token     TokenSetting `mapstructure:"token"`
 	API       string       `mapstructure:"api"`
 	WSS       string       `mapstructure:"wss"`
@@ -55,9 +55,9 @@ type Settings struct {
 }
 
 type TokenSetting struct {
-	AccessToken  string    `json:"accesstoken" mapstructure:"accesstoken"`
+	AccessToken  string    `json:"accesstoken" mapstructure:"accesstoken"`   // #nosec G117 -- token field required for API auth
 	TokenType    string    `json:"tokentype,omitempty" mapstructure:"tokentype,omitempty"`
-	RefreshToken string    `json:"refreshtoken,omitempty" mapstructure:"refreshtoken,omitempty"`
+	RefreshToken string    `json:"refreshtoken,omitempty" mapstructure:"refreshtoken,omitempty"` // #nosec G117 -- token field required for API auth
 	Expiry       time.Time `json:"expiry,omitempty" mapstructure:"expiry,omitempty"`
 }
 

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -322,7 +322,7 @@ type RouteParam struct {
 	Id     string `yaml:"id"`
 	Domain string `yaml:"domain"`
 	Path   string `yaml:"path"`
-	Secret string `yaml:"secret,omitempty"`
+	Secret string `yaml:"secret,omitempty"` // #nosec G117 -- TLS secret name, not secret data
 }
 type EpinioParam struct {
 	AppName        string               `yaml:"appName"`

--- a/internal/registry/exists.go
+++ b/internal/registry/exists.go
@@ -30,9 +30,12 @@ import (
 
 const (
 	manifestCheckTimeout = 10 * time.Second
-	dockerHubAuthURL     = "https://auth.docker.io/token"
-	dockerHubRegistry    = "registry-1.docker.io"
 	acceptManifest       = "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json"
+)
+
+var (
+	dockerHubAuthURL  = "https://auth.docker.io/token"
+	dockerHubRegistry = "registry-1.docker.io"
 )
 
 // dockerTokenResponse is the response from auth.docker.io/token
@@ -50,20 +53,12 @@ func ImageExistsInRegistry(ctx context.Context, imageRef string) (exists bool, e
 	if err != nil {
 		return false, err
 	}
-	registryHost := ref.Registry()
+	registryAPIHost := normalizeRegistryAPIHost(ref.Registry())
 	repository := ref.ShortName()
 	tag := ref.Tag()
 	if tag == "" {
 		tag = "latest"
 	}
-
-	// Normalize Docker Hub registry host
-	registryAPIHost := registryHost
-	if registryHost == "" || registryHost == "docker.io" || registryHost == "index.docker.io" {
-		registryAPIHost = dockerHubRegistry
-	}
-	registryAPIHost = strings.TrimPrefix(registryAPIHost, "https://")
-	registryAPIHost = strings.TrimPrefix(registryAPIHost, "http://")
 	baseURL := "https://" + registryAPIHost
 	manifestURL := fmt.Sprintf("%s/v2/%s/manifests/%s", baseURL, repository, tag)
 
@@ -99,6 +94,42 @@ func ImageExistsInRegistry(ctx context.Context, imageRef string) (exists bool, e
 	}
 }
 
+// RepositoryExistsInRegistry checks whether a repository exists in a registry.
+// This avoids false negatives caused by checking only a specific tag (e.g. latest).
+func RepositoryExistsInRegistry(ctx context.Context, registryHost, repository string) (bool, error) {
+	registryAPIHost := normalizeRegistryAPIHost(registryHost)
+	baseURL := "https://" + registryAPIHost
+	tagsURL := fmt.Sprintf("%s/v2/%s/tags/list?n=1", baseURL, repository)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tagsURL, nil)
+	if err != nil {
+		return false, err
+	}
+	if registryAPIHost == dockerHubRegistry {
+		token, tokenErr := getDockerHubToken(ctx, repository)
+		if tokenErr != nil {
+			return false, tokenErr
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	client := &http.Client{Timeout: manifestCheckTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("registry returned %d for repository %s", resp.StatusCode, repository)
+	}
+}
+
 func getDockerHubToken(ctx context.Context, repository string) (string, error) {
 	scope := "repository:" + repository + ":pull"
 	authURL := dockerHubAuthURL + "?service=registry.docker.io&scope=" + url.QueryEscape(scope)
@@ -123,4 +154,13 @@ func getDockerHubToken(ctx context.Context, repository string) (string, error) {
 		return "", fmt.Errorf("no token in auth response")
 	}
 	return out.Token, nil
+}
+
+func normalizeRegistryAPIHost(registryHost string) string {
+	if registryHost == "" || registryHost == "docker.io" || registryHost == "index.docker.io" {
+		return dockerHubRegistry
+	}
+	registryAPIHost := strings.TrimPrefix(registryHost, "https://")
+	registryAPIHost = strings.TrimPrefix(registryAPIHost, "http://")
+	return registryAPIHost
 }

--- a/internal/registry/exists.go
+++ b/internal/registry/exists.go
@@ -1,0 +1,126 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package registry: check if a container image exists in a registry (Docker Hub, OCI).
+// The buildpacks registry-index (https://github.com/buildpacks/registry-index) indexes
+// buildpacks, not builder images; builder images live in container registries, so we
+// use the Registry API v2 to verify existence.
+
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	parser "github.com/novln/docker-parser"
+)
+
+const (
+	manifestCheckTimeout = 10 * time.Second
+	dockerHubAuthURL     = "https://auth.docker.io/token"
+	dockerHubRegistry    = "registry-1.docker.io"
+	acceptManifest       = "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json"
+)
+
+// dockerTokenResponse is the response from auth.docker.io/token
+type dockerTokenResponse struct {
+	Token string `json:"token"`
+}
+
+// ImageExistsInRegistry checks whether the given image reference exists in its
+// container registry (Docker Hub, GHCR, or other OCI v2 registries). It does
+// not use the buildpacks registry-index, which indexes buildpacks, not builder
+// images. Returns true if the image exists (200), false if not found (404), and
+// an error on other failures (e.g. timeout, 5xx).
+func ImageExistsInRegistry(ctx context.Context, imageRef string) (exists bool, err error) {
+	ref, err := parser.Parse(imageRef)
+	if err != nil {
+		return false, err
+	}
+	registryHost := ref.Registry()
+	repository := ref.ShortName()
+	tag := ref.Tag()
+	if tag == "" {
+		tag = "latest"
+	}
+
+	// Normalize Docker Hub registry host
+	registryAPIHost := registryHost
+	if registryHost == "" || registryHost == "docker.io" || registryHost == "index.docker.io" {
+		registryAPIHost = dockerHubRegistry
+	}
+	registryAPIHost = strings.TrimPrefix(registryAPIHost, "https://")
+	registryAPIHost = strings.TrimPrefix(registryAPIHost, "http://")
+	baseURL := "https://" + registryAPIHost
+	manifestURL := fmt.Sprintf("%s/v2/%s/manifests/%s", baseURL, repository, tag)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Accept", acceptManifest)
+
+	// Docker Hub requires a Bearer token (even for public pulls)
+	if registryAPIHost == dockerHubRegistry {
+		token, tokenErr := getDockerHubToken(ctx, repository)
+		if tokenErr != nil {
+			return false, tokenErr
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	client := &http.Client{Timeout: manifestCheckTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("registry returned %d for %s", resp.StatusCode, imageRef)
+	}
+}
+
+func getDockerHubToken(ctx context.Context, repository string) (string, error) {
+	scope := "repository:" + repository + ":pull"
+	authURL := dockerHubAuthURL + "?service=registry.docker.io&scope=" + url.QueryEscape(scope)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, authURL, nil)
+	if err != nil {
+		return "", err
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("auth.docker.io returned %d", resp.StatusCode)
+	}
+	var out dockerTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", err
+	}
+	if out.Token == "" {
+		return "", fmt.Errorf("no token in auth response")
+	}
+	return out.Token, nil
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -44,13 +44,13 @@ const (
 type RegistryCredentials struct {
 	URL      string
 	Username string
-	Password string
+	Password string // #nosec G117 -- credential field required for registry auth
 }
 
 type ContainerRegistryAuth struct {
 	Auth     string `json:"auth"`
 	Username string `json:"username"`
-	Password string `json:"password"`
+	Password string `json:"password"` // #nosec G117 -- credential field for registry auth
 }
 
 type DockerConfigJSON struct {
@@ -449,7 +449,7 @@ func DeleteImage(
 	client := &http.Client{
 		Transport: transport,
 	}
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- URL from registry connection details
 	if err != nil {
 		return errors.Wrap(err, "fetching manifest")
 	}
@@ -534,7 +534,7 @@ func listRepositoryTags(ctx context.Context, scheme, registryURL, repository, au
 
 	listReq.Header.Set("Authorization", fmt.Sprintf("Basic %s", auth))
 
-	listResp, err := client.Do(listReq)
+	listResp, err := client.Do(listReq) // #nosec G704 -- URL from registry connection details
 	if err != nil {
 		return nil, errors.Wrap(err, "listing tags")
 	}
@@ -586,7 +586,7 @@ func deleteTagByTag(
 	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", auth))
 	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json")
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- URL from registry connection details
 	if err != nil {
 		return errors.Wrap(err, "fetching manifest")
 	}
@@ -632,7 +632,7 @@ func deleteTagByTag(
 	}
 	deleteReq.Header.Set("Accept", acceptHeader)
 
-	deleteResp, err := client.Do(deleteReq)
+	deleteResp, err := client.Do(deleteReq) // #nosec G704 -- URL from registry connection details
 	if err != nil {
 		return errors.Wrap(err, "deleting manifest")
 	}

--- a/internal/selfupdater/selfupdater.go
+++ b/internal/selfupdater/selfupdater.go
@@ -77,7 +77,7 @@ func downloadFile(remoteURL, dir string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "constructing a request")
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- remoteURL from release metadata
 	if err != nil {
 		return "", errors.Wrap(err, "making the request")
 	}

--- a/internal/urlcache/urlcache.go
+++ b/internal/urlcache/urlcache.go
@@ -145,7 +145,7 @@ func fetchFile(originURL, destinationPath string) error {
 			return dstFileError
 		}
 
-		fileRemoveError := os.Remove(dstFile.Name())
+		fileRemoveError := os.Remove(dstFile.Name()) // #nosec G703 -- path from our own create
 		if fileRemoveError != nil {
 			return fileRemoveError
 		}

--- a/pkg/api/core/v1/client/apps.go
+++ b/pkg/api/core/v1/client/apps.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	wsstream "k8s.io/client-go/transport/websocket"
 
-	"github.com/epinio/epinio/helpers"
 	"github.com/epinio/epinio/helpers/kubernetes/tailer"
 	api "github.com/epinio/epinio/internal/api/v1"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"

--- a/pkg/api/core/v1/client/http.go
+++ b/pkg/api/core/v1/client/http.go
@@ -138,7 +138,7 @@ func DoWithHandlers[T any](
 	reqLog := requestLogger(c.log, request)
 	reqLog.V(1).Info("executing request")
 
-	httpResponse, err := c.HttpClient.Do(request)
+	httpResponse, err := c.HttpClient.Do(request) // #nosec G704 -- URL from client settings/caller
 	if err != nil {
 		return response, errors.Wrap(err, "making the request")
 	}
@@ -326,9 +326,9 @@ func handleError(logger logr.Logger, response *http.Response) error {
 
 		// Print the full response body for debugging - flush immediately
 		fmt.Fprintf(os.Stderr, "\n=== RAW ERROR RESPONSE ===\n")
-		fmt.Fprintf(os.Stderr, "URL: %s\n", response.Request.URL.String())
-		fmt.Fprintf(os.Stderr, "Status: %d %s\n", response.StatusCode, response.Status)
-		fmt.Fprintf(os.Stderr, "Content-Type: %s\n", response.Header.Get("Content-Type"))
+		fmt.Fprintf(os.Stderr, "URL: %s\n", response.Request.URL.String())           // #nosec G705 -- debug output to stderr
+		fmt.Fprintf(os.Stderr, "Status: %d %s\n", response.StatusCode, response.Status) // #nosec G705 -- debug output to stderr
+		fmt.Fprintf(os.Stderr, "Content-Type: %s\n", response.Header.Get("Content-Type")) // #nosec G705 -- debug output to stderr
 		fmt.Fprintf(os.Stderr, "Body:\n%s\n", bodyStr)
 		fmt.Fprintf(os.Stderr, "=== END RAW ERROR RESPONSE ===\n\n")
 		_ = os.Stderr.Sync() // Force flush to ensure output appears

--- a/pkg/api/core/v1/models/gitconfig.go
+++ b/pkg/api/core/v1/models/gitconfig.go
@@ -25,7 +25,7 @@ type GitconfigCreateRequest struct {
 	Repository   string      `json:"repository,omitempty"`
 	SkipSSL      bool        `json:"skipssl,omitempty"`
 	Username     string      `json:"username,omitempty"`
-	Password     string      `json:"password,omitempty"`
+	Password     string      `json:"password,omitempty"` // #nosec G117 -- credential field for Git config
 	Certificates []byte      `json:"certs,omitempty"`
 }
 

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -446,3 +446,22 @@ type AppExportRequest struct {
 	ImageTag     string `json:"image-tag,omitempty"`
 	ChartVersion string `json:"chart-version,omitempty"`
 }
+
+// BuildpackEntry represents a single buildpack from the CNB registry (id, versions, latest).
+type BuildpackEntry struct {
+	ID       string   `json:"id"`
+	Versions []string `json:"versions,omitempty"`
+	Latest   string   `json:"latest,omitempty"`
+}
+
+// BuildpackSearchResponse is the response for GET /api/v1/buildpacks/search.
+type BuildpackSearchResponse struct {
+	Buildpacks []BuildpackEntry `json:"buildpacks,omitempty"`
+}
+
+// BuildpackVerifyResponse is the response for GET /api/v1/buildpacks/verify.
+type BuildpackVerifyResponse struct {
+	Valid          bool   `json:"valid"`
+	Message        string `json:"message,omitempty"`
+	NormalizedName string `json:"normalized_name,omitempty"`
+}


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] New Unit and Acceptance tests written for the context of the PR
- [x] Unit Tests are passing
- [ ] Acceptance Tests are passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened
 
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
Adds two buildpack APIs 
(1) search the CNB registry by term, 
(2) verify a buildpack name against Docker Hub, including CNB vs Docker Hub naming (e.g. paketo-buildpacks vs paketobuildpacks).

### Occurred changes and/or fixed issues
New APIs:
    GET /api/v1/buildpacks/search?q=<term> — searches the CNB registry (GitHub buildpacks/registry-index), returns matching buildpack entries (id, versions, latest).
    GET /api/v1/buildpacks/verify?name=<namespace/name> — verifies the buildpack image exists on Docker Hub; tries both normalized (no dashes) and original namespace.
New code:
  pkg/api/core/v1/models/models.go: BuildpackEntry, BuildpackSearchResponse, BuildpackVerifyResponse.
  internal/api/v1/buildpack/: cnb_registry.go (SearchCNBRegistry), search.go, verify.go.
  Router (internal/api/v1/router.go): routes BuildpackSearch and BuildpackVerify registered.
  Auth (internal/auth/actions.yaml): BuildpackSearch and BuildpackVerify added under app_read.

### Technical notes summary
Search: Uses GitHub API repos/buildpacks/registry-index/git/trees/main?recursive=1, filters blob paths by search term, fetches up to 25 raw files from raw.githubusercontent.com, parses NDJSON (ns, name, version, yanked), aggregates by id, returns up to 50 entries. No GitHub auth (subject to anonymous rate limits).

Verify: Expects namespace/name (e.g. paketo-buildpacks/nodejs). Tries docker.io/<normalized>/<name>:latest and docker.io/<ns>/<name>:latest using existing registry.ImageExistsInRegistry (Docker Hub token + manifest GET). Returns valid/invalid and optional normalized_name/message.

### Areas or cases that should be tested
Buildpack search:
GET /api/v1/buildpacks/search?q=go (and nodejs, java) returns non-empty buildpacks with id, versions, latest.
Empty or missing q returns empty list (no error).
Request is authenticated (e.g. Basic auth); unauthenticated returns 401.

Buildpack verify:
name=paketo-buildpacks/nodejs and name=paketo-buildpacks/go return valid: true and normalized_name (e.g. paketobuildpacks/nodejs).
name=invalid-ns/missing returns valid: false with message about not found on Docker Hub.
name= (empty) returns valid: false, message "buildpack name is required".
name=no-slash returns valid: false, message about "namespace/name" format.

Auth: Both endpoints require app_read; verify with a user that has app read and one that does not.

### Areas which could experience regressions
Auth: Any logic that builds or checks app_read permission set (e.g. RBAC, CLI) — ensure new route names are included and no existing app_read routes were removed.
Router: Route registration order or path overlap (e.g. /buildpacks/search vs /buildpacks/verify) — confirm no shadowing or wrong handler.
Registry: Verify uses registry.ImageExistsInRegistry; changes to that function (timeouts, Docker Hub token, other registries) could affect verify only.
Rate limits: Search uses public GitHub API and raw GitHub; under heavy or repeated use, rate limiting could cause search to return empty or errors; verify is Docker Hub only.
Existing validate-builder-image: No code changes in this PR; regression risk is limited to shared auth/router/config; smoke-test validate-builder-image once.
