### PR TITLE
Unit test for git provider

### DIFF
--- a/internal/cli/cmd/flags_test.go
+++ b/internal/cli/cmd/flags_test.go
@@ -1,0 +1,70 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd_test
+
+import (
+	"github.com/epinio/epinio/internal/cli/cmd"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+var _ = Describe("--git-provider completion", func() {
+	var completionFunc func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective)
+
+	BeforeEach(func() {
+		completionFunc = cmd.NewStaticFlagsCompletionFunc(models.ValidProviders)
+	})
+
+	It("returns all valid providers when toComplete is empty", func() {
+		matches, directive := completionFunc(nil, nil, "")
+		Expect(matches).To(ConsistOf("git", "github", "github_enterprise", "gitlab", "gitlab_enterprise"))
+		Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
+	})
+
+	It("returns providers matching prefix 'git'", func() {
+		matches, directive := completionFunc(nil, nil, "git")
+		Expect(matches).To(ConsistOf("git", "github", "github_enterprise", "gitlab", "gitlab_enterprise"))
+		Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
+	})
+
+	It("returns only github and github_enterprise for prefix 'github'", func() {
+		matches, directive := completionFunc(nil, nil, "github")
+		Expect(matches).To(ConsistOf("github", "github_enterprise"))
+		Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
+	})
+
+	It("returns only github_enterprise for prefix 'github_en'", func() {
+		matches, directive := completionFunc(nil, nil, "github_en")
+		Expect(matches).To(Equal([]string{"github_enterprise"}))
+		Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
+	})
+
+	It("returns only gitlab and gitlab_enterprise for prefix 'gitlab'", func() {
+		matches, directive := completionFunc(nil, nil, "gitlab")
+		Expect(matches).To(ConsistOf("gitlab", "gitlab_enterprise"))
+		Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
+	})
+
+	It("returns no matches for unknown prefix 'bogus'", func() {
+		matches, directive := completionFunc(nil, nil, "bogus")
+		Expect(matches).To(BeEmpty())
+		Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
+	})
+
+	It("returns single match for full provider name 'git'", func() {
+		matches, directive := completionFunc(nil, nil, "git")
+		Expect(matches).To(ContainElement("git"))
+		Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
+	})
+})

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
 )
 
 var _ = Describe("Manifest", func() {
@@ -143,6 +144,41 @@ configuration:
 					},
 				}))
 
+			})
+		})
+	})
+
+	Describe("UpdateSources", func() {
+		When("--git is set with an invalid --git-provider", func() {
+			It("returns an error with message Bad --git-provider `...`", func() {
+				c := &cobra.Command{}
+				c.Flags().String("path", "", "")
+				c.Flags().String("git", "", "")
+				c.Flags().String("git-provider", "", "")
+				c.Flags().String("container-image-url", "", "")
+				Expect(c.Flags().Set("git", "https://github.com/org/repo")).To(Succeed())
+				Expect(c.Flags().Set("git-provider", "bogus")).To(Succeed())
+
+				_, err := manifest.UpdateSources(models.ApplicationManifest{}, c)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Bad --git-provider `bogus`"))
+			})
+		})
+
+		When("--git is set with a valid --git-provider", func() {
+			It("succeeds and sets the provider on the manifest origin", func() {
+				c := &cobra.Command{}
+				c.Flags().String("path", "", "")
+				c.Flags().String("git", "", "")
+				c.Flags().String("git-provider", "", "")
+				c.Flags().String("container-image-url", "", "")
+				Expect(c.Flags().Set("git", "https://github.com/org/repo")).To(Succeed())
+				Expect(c.Flags().Set("git-provider", "github")).To(Succeed())
+
+				m, err := manifest.UpdateSources(models.ApplicationManifest{}, c)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(m.Origin.Git).ToNot(BeNil())
+				Expect(m.Origin.Git.Provider).To(Equal(models.ProviderGithub))
 			})
 		})
 	})


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] New Unit and Acceptance tests written for the context of the PR
- [x] Unit Tests are passing
- [ ] Acceptance Tests are passing
- [ ] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened
 
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
Adds unit tests for --git-provider shell completion and for provider validation when using --git with --git-provider

### Occurred changes and/or fixed issues
New file: internal/cli/cmd/flags_test.go

Unit tests for --git-provider completion: exercises NewStaticFlagsCompletionFunc(models.ValidProviders) with empty prefix, prefixes (git, github, github_en, gitlab), unknown prefix (bogus), and verifies cobra.ShellCompDirectiveNoFileComp.

Updated: internal/manifest/manifest_test.go
New Describe("UpdateSources") with:

Invalid --git-provider: --git + --git-provider bogus → expects error "Bad --git-provider \bogus\".

Valid --git-provider: --git + --git-provider github → expects success and m.Origin.Git.Provider == models.ProviderGithub.
No production code changed; only test coverage was added. Existing tests in pkg/api/core/v1/models/app_test.go for GitProviderFromString and ValidateURL are unchanged.

### Technical notes summary
Completion is implemented in internal/cli/cmd/flags.go via NewStaticFlagsCompletionFunc and is already wired for --git-provider in args.go and gitconfigs.go. The new tests call that completion function directly with different toComplete values and assert returned matches and shell directive.

Provider validation is in internal/manifest/manifest.go in UpdateSources, which uses models.GitProviderFromString and returns "Bad --git-provider \...\" on invalid input. The new manifest tests build a minimal cobra.Command with --path, --git, --git-provider, and --container-image-url, set flags, call manifest.UpdateSources, and assert error message or manifest content.
Tests use the existing Ginkgo/Gomega style and cmd_test package for the CLI tests.

### Areas or cases that should be tested
Unit tests
Run completion tests:
go test ./internal/cli/cmd -v -- -ginkgo.focus "git-provider"

Run manifest UpdateSources tests:
go test ./internal/manifest -v -- -ginkgo.focus "UpdateSources"

Optional: run full packages:
go test ./internal/cli/cmd/... ./internal/manifest/...

CLI (manual/smoke)
In a shell with completion enabled, run e.g. epinio app create myapp --git-provider <TAB> and confirm completions: git, github, github_enterprise, gitlab, gitlab_enterprise.
Run epinio push --name foo --git https://github.com/org/repo --git-provider bogus and confirm error contains Bad --git-provider 'bogus'.
Run with valid provider, e.g. --git-provider github, and confirm push/stage proceeds without that error.
No browser testing; CLI and unit tests only.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed, which may be affected by the changes, which would require prior research to avoid regressions. -->
