### PR TITLE
Ingress error no rule found

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -12,7 +12,6 @@
 package routes
 
 import (
-	"errors"
 	"strings"
 
 	networkingv1 "k8s.io/api/networking/v1"
@@ -79,7 +78,7 @@ func FromString(routeStr string) Route {
 // Ingress, ingoring all other rules if they exist.
 func FromIngress(ingress networkingv1.Ingress) ([]Route, error) {
 	if len(ingress.Spec.Rules) == 0 {
-		return nil, errors.New("no Rules found on Ingress")
+		return []Route{}, nil
 	}
 
 	result := []Route{}

--- a/internal/routes/routes_test.go
+++ b/internal/routes/routes_test.go
@@ -84,10 +84,10 @@ var _ = Describe("Route", func() {
 			BeforeEach(func() {
 				routeIngress.Spec.Rules = []networkingv1.IngressRule{}
 			})
-			It("returns an error", func() {
-				_, err := FromIngress(routeIngress)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError("no Rules found on Ingress"))
+			It("returns an empty list of routes", func() {
+				result, err := FromIngress(routeIngress)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeEmpty())
 			})
 		})
 		When("the Ingress has multiple rules defined", func() {


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] New Unit and Acceptance tests written for the context of the PR
- [x] Unit Tests are passing
- [ ] Acceptance Tests are passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened
 
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
When the cluster contained any Ingress with no `spec.rules` (e.g., only `defaultBackend`, or empty rules), creating an application with a route failed with "no Rules found on Ingress". The fix makes `FromIngress` treat such Ingresses as having no routes instead of returning an error, so route validation can safely ignore them.


### Occurred changes and/or fixed issues
- **internal/routes/routes.go**: `FromIngress()` now returns an empty slice and `nil` when `ingress.Spec.Rules` is empty, instead of returning an error. Unused `errors` import removed.
- **internal/routes/routes_test.go**: The case "the Ingress has no rules defined" now expects an empty list of routes and no error, instead of an error.

### Technical notes summary
- Route validation (e.g. in `internal/api/v1/application/create.go` and `internal/application/ingresses.go`) lists all Ingresses and calls `routes.FromIngress()` to detect route conflicts. Previously, any Ingress with zero rules caused `FromIngress` to error and abort the whole request. Now those Ingresses contribute zero routes to the check, so validation continues and only fails on real conflicts.
- Kubernetes allows Ingress resources with no rules (e.g. only `defaultBackend`). Epinio does not create such Ingresses, but they can exist from other controllers or platforms (e.g. GKE, Traefik), so tolerating them avoids unnecessary failures.


### Areas or cases that should be tested
- **Push with route when cluster has Ingress with no rules**: Create an Ingress with no `spec.rules` , then run `epinio push -n <app> -p . --route <app>.<domain>/`. Push should succeed (no "no Rules found on Ingress" error).
- **Push with route when cluster has no such Ingress**: Same push without the empty-rules Ingress; behavior unchanged (should still succeed).
- **Route conflict**: Create an app A with route `foo.domain/`, then try to create app B with the same route; should still get a conflict error. Empty-rules Ingresses should not affect this.
- **Unit**: `go test ./internal/routes/...` — all specs pass, including "the Ingress has no rules defined" returning an empty list.

### Areas which could experience regressions
- **Route conflict detection**: Code paths that use `FromIngress()` and depend on it failing for invalid/empty Ingresses could be affected. Current call sites only use the returned route list; none rely on an error for empty rules. Quick audit: `validateIngress` (create), `AddActualApplicationRoutes` (list), `ListRoutes` — all only need a list of routes; an empty list is correct for no rules.
- **Listing app routes / actual routes**: `AddActualApplicationRoutes` and `ListRoutes` now get an empty list instead of an error for rule-less Ingresses. That reduces spurious failures when such Ingresses exist; no intentional behavior change for Epinio-managed Ingresses (which always have rules).