### PR TITLE
Clarify buildpack/builder wording in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The [developer documentation](./docs) explains how to build and run Epinio from 
 
 - Rails: https://github.com/epinio/example-rails
 - Java: https://github.com/spring-projects/spring-petclinic/
-- Paketo Buildpack example apps: https://github.com/paketo-buildpacks/samples
+- Buildpack example apps (e.g. Paketo samples): https://github.com/paketo-buildpacks/samples. Epinio supports any Cloud Native Buildpack builder; see [buildpack customization](https://docs.epinio.io/references/customization/staging/#using-non-paketo-buildpacks).
 
 ## License
 

--- a/docs/explanations/architecture/container-registry.md
+++ b/docs/explanations/architecture/container-registry.md
@@ -5,12 +5,12 @@ specified everything needed to work with an external registry.
 
 The current setup of this registry evolved under the following constraints:
 
-  1. The paketo lifecycle creator used by our staging accesses the registry using a TLS-secured
+  1. The buildpack lifecycle (e.g. Paketo or other CNB builders) used by our staging accesses the registry using a TLS-secured
   channel.
 
      It cannot be configured to use an unsecured channel.
 
-     See [Paketo Ticket #524](https://github.com/buildpacks/lifecycle/issues/524)
+     See [buildpacks/lifecycle #524](https://github.com/buildpacks/lifecycle/issues/524)
      for a request to change this.
 
   2. For the application pods to use a TLS-secured channel for access to the registry it is necesssary to either


### PR DESCRIPTION


### PR Checklist
- [x] Linting Test is passing
- [x] New Unit and Acceptance tests written for the context of the PR
- [x] Unit Tests are passing
- [x] Acceptance Tests are passing
- [x] Code is well documented
- [x] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened
 
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
Update README and container-registry docs to generalize references to Paketo and clarify support for any Cloud Native Buildpack (CNB) builder. README now labels the samples as "Buildpack example apps (e.g. Paketo samples)" and points to the buildpack customization docs. container-registry wording was changed from "paketo lifecycle creator" to "buildpack lifecycle (e.g. Paketo or other CNB builders)" and the issue link text was adjusted to reference the buildpacks/lifecycle repo. These changes improve accuracy and reduce Paketo-specific wording.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as a requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if they have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed, which may be affected by the changes, which would require prior research to avoid regressions. -->
