### PR TITLE
Epnio 467 use pack

### DIFF
--- a/docs/explanations/architecture/container-registry.md
+++ b/docs/explanations/architecture/container-registry.md
@@ -5,12 +5,12 @@ specified everything needed to work with an external registry.
 
 The current setup of this registry evolved under the following constraints:
 
-  1. The paketo lifecycle creator used by our staging accesses the registry using a TLS-secured
-  channel.
+  1. The build tooling used by staging (pack/lifecycle, depending on profile) accesses the
+  registry using a TLS-secured channel.
 
      It cannot be configured to use an unsecured channel.
 
-     See [Paketo Ticket #524](https://github.com/buildpacks/lifecycle/issues/524)
+     See [Buildpacks lifecycle issue #524](https://github.com/buildpacks/lifecycle/issues/524)
      for a request to change this.
 
   2. For the application pods to use a TLS-secured channel for access to the registry it is necesssary to either

--- a/docs/explanations/architecture/container-registry.md
+++ b/docs/explanations/architecture/container-registry.md
@@ -5,7 +5,7 @@ specified everything needed to work with an external registry.
 
 The current setup of this registry evolved under the following constraints:
 
-  1. The build tooling used by staging (pack/lifecycle, depending on profile) accesses the
+  1. The build tooling used by staging (pack) accesses the
   registry using a TLS-secured channel.
 
      It cannot be configured to use an unsecured channel.

--- a/internal/api/v1/application/restart.go
+++ b/internal/api/v1/application/restart.go
@@ -12,6 +12,7 @@
 package application
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -20,6 +21,8 @@ import (
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
+	"github.com/epinio/epinio/internal/helmchart"
+	"github.com/epinio/epinio/internal/registry"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/gin-gonic/gin"
@@ -58,9 +61,23 @@ func Restart(c *gin.Context) apierror.APIErrors {
 		// Recompute the image url, by replacing the old image tag (= old stage id) with the
 		// new stage id.
 
-		pieces := strings.Split(app.ImageURL, ":")
-		pieces[len(pieces)-1] = app.StageID
-		newImageURL := strings.Join(pieces, ":")
+		newImageURL := app.ImageURL
+		// If there is no prior image, or it's malformed, reconstruct the full image URL.
+		if app.ImageURL == "" || !strings.Contains(app.ImageURL, ":") {
+			details, err := registry.GetConnectionDetails(ctx, cluster, helmchart.Namespace(), registry.CredentialsSecretName)
+			if err != nil {
+				return apierror.InternalError(err, "getting registry connection details")
+			}
+			publicURL, err := details.PublicRegistryURL()
+			if err != nil {
+				return apierror.InternalError(err, "getting public registry URL")
+			}
+			newImageURL = fmt.Sprintf("%s/%s-%s:%s", publicURL, app.Meta.Namespace, app.Meta.Name, app.StageID)
+		} else {
+			pieces := strings.Split(app.ImageURL, ":")
+			pieces[len(pieces)-1] = app.StageID
+			newImageURL = strings.Join(pieces, ":")
+		}
 
 		// .. and save it for `DeployApp` to find.
 

--- a/internal/api/v1/application/restart.go
+++ b/internal/api/v1/application/restart.go
@@ -59,25 +59,20 @@ func Restart(c *gin.Context) apierror.APIErrors {
 		// version up.
 
 		// Recompute the image url, by replacing the old image tag (= old stage id) with the
-		// new stage id.
-
-		newImageURL := app.ImageURL
-		// If there is no prior image, or it's malformed, reconstruct the full image URL.
+		// new stage id. If the current image is empty/malformed, reconstruct the full URL
+		// from the registry public URL.
+		publicURL := ""
 		if app.ImageURL == "" || !strings.Contains(app.ImageURL, ":") {
 			details, err := registry.GetConnectionDetails(ctx, cluster, helmchart.Namespace(), registry.CredentialsSecretName)
 			if err != nil {
 				return apierror.InternalError(err, "getting registry connection details")
 			}
-			publicURL, err := details.PublicRegistryURL()
+			publicURL, err = details.PublicRegistryURL()
 			if err != nil {
 				return apierror.InternalError(err, "getting public registry URL")
 			}
-			newImageURL = fmt.Sprintf("%s/%s-%s:%s", publicURL, app.Meta.Namespace, app.Meta.Name, app.StageID)
-		} else {
-			pieces := strings.Split(app.ImageURL, ":")
-			pieces[len(pieces)-1] = app.StageID
-			newImageURL = strings.Join(pieces, ":")
 		}
+		newImageURL := computeRestartImageURL(app.ImageURL, app.StageID, app.Meta.Namespace, app.Meta.Name, publicURL)
 
 		// .. and save it for `DeployApp` to find.
 
@@ -99,4 +94,14 @@ func Restart(c *gin.Context) apierror.APIErrors {
 
 	response.OK(c)
 	return nil
+}
+
+func computeRestartImageURL(currentImageURL, stageID, namespace, appName, publicRegistryURL string) string {
+	if currentImageURL == "" || !strings.Contains(currentImageURL, ":") {
+		return fmt.Sprintf("%s/%s-%s:%s", publicRegistryURL, namespace, appName, stageID)
+	}
+
+	pieces := strings.Split(currentImageURL, ":")
+	pieces[len(pieces)-1] = stageID
+	return strings.Join(pieces, ":")
 }

--- a/internal/api/v1/application/restart_test.go
+++ b/internal/api/v1/application/restart_test.go
@@ -1,0 +1,33 @@
+package application
+
+import "testing"
+
+func TestComputeRestartImageURLReplacesTag(t *testing.T) {
+	got := computeRestartImageURL(
+		"192.168.49.2:30500/apps/workspace-sample:oldstage",
+		"newstage",
+		"workspace",
+		"sample",
+		"",
+	)
+
+	expected := "192.168.49.2:30500/apps/workspace-sample:newstage"
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestComputeRestartImageURLReconstructsWhenMalformed(t *testing.T) {
+	got := computeRestartImageURL(
+		"c244aea3d59859ad",
+		"c244aea3d59859ad",
+		"workspace",
+		"sdsdsxzxasdwsd",
+		"192.168.49.2:30500/apps",
+	)
+
+	expected := "192.168.49.2:30500/apps/workspace-sdsdsxzxasdwsd:c244aea3d59859ad"
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -326,11 +326,6 @@ func Stage(c *gin.Context) apierror.APIErrors {
 	if params.BuildImage == "" {
 		params.BuildImage = params.BuilderImage
 	}
-	// buildpacksio/pack is distroless (no /bin/sh or /bin/bash); the build script needs a shell
-	// and /cnb/lifecycle/creator, which live in the builder image. Use builder for the build container.
-	if strings.Contains(params.BuildImage, "buildpacksio/pack") {
-		params.BuildImage = params.BuilderImage
-	}
 
 	if !params.HelmValues.Storage.Cache.EmptyDir {
 		err = ensurePVC(ctx, cluster, params.HelmValues.Storage.Cache, req.App.MakeCachePVCName())
@@ -883,10 +878,10 @@ func newJobRun(app stageParam) (*batchv1.Job, *corev1.Secret) {
 								"-c",
 								buildpackScript,
 							},
-							Env:          stageEnv,
-							VolumeMounts: volumeMounts,
+							Env:             stageEnv,
+							VolumeMounts:    volumeMounts,
 							SecurityContext: buildpackSecurityContext(app),
-							Resources: app.HelmValues.Resources,
+							Resources:       app.HelmValues.Resources,
 						},
 					},
 					RestartPolicy: corev1.RestartPolicyNever,

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -56,6 +56,8 @@ type stageParam struct {
 	models.AppRef
 	BlobUID             string
 	BuilderImage        string
+	BuildImage          string
+	BuildEngine         string
 	DownloadImage       string
 	UnpackImage         string
 	Environment         models.EnvVariableList
@@ -220,6 +222,8 @@ func Stage(c *gin.Context) apierror.APIErrors {
 
 	log.Infow("staging app", "scripts", config.Name)
 	log.Infow("staging app", "builder", builderImage)
+	log.Infow("staging app", "build image", config.BuildImage)
+	log.Infow("staging app", "build engine", config.BuildEngine)
 	log.Infow("staging app", "download", config.DownloadImage)
 	log.Infow("staging app", "unpack", config.UnpackImage)
 	log.Infow("staging app", "userid", config.UserID)
@@ -294,6 +298,8 @@ func Stage(c *gin.Context) apierror.APIErrors {
 	params := stageParam{
 		AppRef:              req.App,
 		BuilderImage:        builderImage,
+		BuildImage:          config.BuildImage,
+		BuildEngine:         config.BuildEngine,
 		DownloadImage:       config.DownloadImage,
 		UnpackImage:         config.UnpackImage,
 		BlobUID:             blobUID,
@@ -310,6 +316,10 @@ func Stage(c *gin.Context) apierror.APIErrors {
 		GroupID:             config.GroupID,
 		Scripts:             config.Name,
 		HelmValues:          config.HelmValues,
+	}
+
+	if params.BuildImage == "" {
+		params.BuildImage = params.BuilderImage
 	}
 
 	if !params.HelmValues.Storage.Cache.EmptyDir {
@@ -642,7 +652,7 @@ func newJobRun(app stageParam) (*batchv1.Job, *corev1.Secret) {
 	// runtime: BashImage
 	unpackScript := fmt.Sprintf(`source /stage-support/%s`, helmchart.EpinioStageUnpack)
 
-	// runtime: app.BuilderImage
+	// runtime: app.BuildImage
 	buildpackScript := fmt.Sprintf(`source /stage-support/%s`, helmchart.EpinioStageBuild)
 
 	// build configuration
@@ -856,7 +866,7 @@ func newJobRun(app stageParam) (*batchv1.Job, *corev1.Secret) {
 					Containers: []corev1.Container{
 						{
 							Name:    "buildpack",
-							Image:   app.BuilderImage,
+							Image:   app.BuildImage,
 							Command: []string{"/bin/bash"},
 							Args: []string{
 								"-c",
@@ -898,6 +908,8 @@ func assembleStageEnv(app, previous stageParam) []corev1.EnvVar {
 	stageEnv = appendEnvVar(stageEnv, "BLOBID", app.BlobUID)
 	stageEnv = appendEnvVar(stageEnv, "PREIMAGE", previous.ImageURL(previous.RegistryURL))
 	stageEnv = appendEnvVar(stageEnv, "APPIMAGE", app.ImageURL(app.RegistryURL))
+	stageEnv = appendEnvVar(stageEnv, "BUILDERIMAGE", app.BuilderImage)
+	stageEnv = appendEnvVar(stageEnv, "BUILDENGINE", app.BuildEngine)
 	stageEnv = appendEnvVar(stageEnv, "USERID", strconv.FormatInt(app.UserID, 10))
 	stageEnv = appendEnvVar(stageEnv, "GROUPID", strconv.FormatInt(app.GroupID, 10))
 
@@ -1080,6 +1092,8 @@ func appendEnvVar(envs []corev1.EnvVar, name, value string) []corev1.EnvVar {
 type StagingScriptConfig struct {
 	Name          string                // config name. Needed to mount the resource in the pod
 	Builder       string                // glob pattern for builders supported by this resource
+	BuildImage    string                // image to run the build phase with
+	BuildEngine   string                // build command family, e.g. pack or lifecycle
 	UserID        int64                 // user id to run the build phase with (`cnb` user)
 	GroupID       int64                 // group id to run the build hase with
 	Base          string                // optional, name of resource to pull the other parts from
@@ -1199,8 +1213,18 @@ func StagingScriptConfigResolve(ctx context.Context, cluster *kubernetes.Cluster
 	// BEWARE: Keep environment data of the incoming config.
 
 	config.Name = base.Name
-	config.DownloadImage = base.Data["downloadImage"]
-	config.UnpackImage = base.Data["unpackImage"]
+	if config.BuildImage == "" {
+		config.BuildImage = base.Data["buildImage"]
+	}
+	if config.BuildEngine == "" {
+		config.BuildEngine = base.Data["buildEngine"]
+	}
+	if config.DownloadImage == "" {
+		config.DownloadImage = base.Data["downloadImage"]
+	}
+	if config.UnpackImage == "" {
+		config.UnpackImage = base.Data["unpackImage"]
+	}
 
 	return nil
 }
@@ -1209,10 +1233,19 @@ func NewStagingScriptConfig(config corev1.ConfigMap) (*StagingScriptConfig, erro
 	stagingScript := &StagingScriptConfig{
 		Name:          config.Name,
 		Builder:       config.Data["builder"],
+		BuildImage:    config.Data["buildImage"],
+		BuildEngine:   config.Data["buildEngine"],
 		Base:          config.Data["base"],
 		DownloadImage: config.Data["downloadImage"],
 		UnpackImage:   config.Data["unpackImage"],
 		// env, user, group id, Helm Values, see below.
+	}
+
+	if stagingScript.BuildEngine == "" {
+		stagingScript.BuildEngine = "lifecycle"
+	}
+	if stagingScript.BuildImage == "" {
+		stagingScript.BuildImage = config.Data["builderImage"] // backward compatible key
 	}
 
 	userID, err := strconv.ParseInt(config.Data["userID"], 10, 64)

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -1093,7 +1093,7 @@ type StagingScriptConfig struct {
 	Name          string                // config name. Needed to mount the resource in the pod
 	Builder       string                // glob pattern for builders supported by this resource
 	BuildImage    string                // image to run the build phase with
-	BuildEngine   string                // build command family, e.g. pack or lifecycle
+	BuildEngine   string                // build command family, normalized to pack
 	UserID        int64                 // user id to run the build phase with (`cnb` user)
 	GroupID       int64                 // group id to run the build hase with
 	Base          string                // optional, name of resource to pull the other parts from
@@ -1241,9 +1241,8 @@ func NewStagingScriptConfig(config corev1.ConfigMap) (*StagingScriptConfig, erro
 		// env, user, group id, Helm Values, see below.
 	}
 
-	if stagingScript.BuildEngine == "" {
-		stagingScript.BuildEngine = "lifecycle"
-	}
+	// Engine is normalized to pack for all profiles.
+	stagingScript.BuildEngine = "pack"
 	if stagingScript.BuildImage == "" {
 		stagingScript.BuildImage = config.Data["builderImage"] // backward compatible key
 	}

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -1016,16 +1016,7 @@ func findPreviousBlobUID(app *unstructured.Unstructured) (string, error) {
 }
 
 func updateApp(ctx context.Context, cluster *kubernetes.Cluster, app *unstructured.Unstructured, params stageParam) error {
-	if err := unstructured.SetNestedField(app.Object, params.BlobUID, "spec", "blobuid"); err != nil {
-		return err
-	}
-	if err := unstructured.SetNestedField(app.Object, params.Stage.ID, "spec", "stageid"); err != nil {
-		return err
-	}
-	if err := unstructured.SetNestedField(app.Object, params.ImageURL(params.RegistryURL), "spec", "imageurl"); err != nil {
-		return err
-	}
-	if err := unstructured.SetNestedField(app.Object, params.BuilderImage, "spec", "builderimage"); err != nil {
+	if err := setAppStagingFields(app, params); err != nil {
 		return err
 	}
 
@@ -1042,6 +1033,23 @@ func updateApp(ctx context.Context, cluster *kubernetes.Cluster, app *unstructur
 	_, err = client.Namespace(namespace).Update(ctx, app, metav1.UpdateOptions{})
 
 	return err
+}
+
+func setAppStagingFields(app *unstructured.Unstructured, params stageParam) error {
+	if err := unstructured.SetNestedField(app.Object, params.BlobUID, "spec", "blobuid"); err != nil {
+		return err
+	}
+	if err := unstructured.SetNestedField(app.Object, params.Stage.ID, "spec", "stageid"); err != nil {
+		return err
+	}
+	if err := unstructured.SetNestedField(app.Object, params.ImageURL(params.RegistryURL), "spec", "imageurl"); err != nil {
+		return err
+	}
+	if err := unstructured.SetNestedField(app.Object, params.BuilderImage, "spec", "builderimage"); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func mountS3Certs(volumes []corev1.Volume, volumeMounts []corev1.VolumeMount) ([]corev1.Volume, []corev1.VolumeMount) {

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -1022,6 +1022,9 @@ func updateApp(ctx context.Context, cluster *kubernetes.Cluster, app *unstructur
 	if err := unstructured.SetNestedField(app.Object, params.Stage.ID, "spec", "stageid"); err != nil {
 		return err
 	}
+	if err := unstructured.SetNestedField(app.Object, params.ImageURL(params.RegistryURL), "spec", "imageurl"); err != nil {
+		return err
+	}
 	if err := unstructured.SetNestedField(app.Object, params.BuilderImage, "spec", "builderimage"); err != nil {
 		return err
 	}

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -82,6 +82,8 @@ type HelmValuesMap struct {
 	Affinity                corev1.Affinity             `json:"affinity,omitempty"`
 	Resources               corev1.ResourceRequirements `json:"resources,omitempty"`
 	TTLSecondsAfterFinished int32                       `json:"ttlSecondsAfterFinished,omitempty"`
+	DockerSocketPath        string                      `json:"dockerSocketPath,omitempty"` // e.g. /var/run/docker.sock for pack build (minikube)
+	RegistryHostOverride    string                      `json:"registryHostOverride,omitempty"`
 	Storage                 struct {
 		SourceBlobs StagingStorageValues `json:"sourceBlobs,omitempty"`
 		Cache       StagingStorageValues `json:"cache,omitempty"`
@@ -317,8 +319,16 @@ func Stage(c *gin.Context) apierror.APIErrors {
 		Scripts:             config.Name,
 		HelmValues:          config.HelmValues,
 	}
+	if params.HelmValues.DockerSocketPath != "" && params.HelmValues.RegistryHostOverride != "" {
+		params.RegistryURL = overrideRegistryHost(params.RegistryURL, params.HelmValues.RegistryHostOverride)
+	}
 
 	if params.BuildImage == "" {
+		params.BuildImage = params.BuilderImage
+	}
+	// buildpacksio/pack is distroless (no /bin/sh or /bin/bash); the build script needs a shell
+	// and /cnb/lifecycle/creator, which live in the builder image. Use builder for the build container.
+	if strings.Contains(params.BuildImage, "buildpacksio/pack") {
 		params.BuildImage = params.BuilderImage
 	}
 
@@ -652,8 +662,8 @@ func newJobRun(app stageParam) (*batchv1.Job, *corev1.Secret) {
 	// runtime: BashImage
 	unpackScript := fmt.Sprintf(`source /stage-support/%s`, helmchart.EpinioStageUnpack)
 
-	// runtime: app.BuildImage
-	buildpackScript := fmt.Sprintf(`source /stage-support/%s`, helmchart.EpinioStageBuild)
+	// runtime: app.BuildImage (use . for POSIX sh; many build images have only /bin/sh)
+	buildpackScript := fmt.Sprintf(". /stage-support/%s", helmchart.EpinioStageBuild)
 
 	// build configuration
 	// - shared between all the phases, even if each phase uses only part of the set
@@ -775,6 +785,7 @@ func newJobRun(app stageParam) (*batchv1.Job, *corev1.Secret) {
 
 	volumes, volumeMounts = mountS3Certs(volumes, volumeMounts)
 	volumes, volumeMounts = mountRegistryCerts(app, volumes, volumeMounts)
+	volumes, volumeMounts = mountDockerSocket(app, volumes, volumeMounts)
 
 	// Create job environment as a copy of the app environment
 	env := make(map[string][]byte)
@@ -867,17 +878,14 @@ func newJobRun(app stageParam) (*batchv1.Job, *corev1.Secret) {
 						{
 							Name:    "buildpack",
 							Image:   app.BuildImage,
-							Command: []string{"/bin/bash"},
+							Command: []string{"/bin/sh"},
 							Args: []string{
 								"-c",
 								buildpackScript,
 							},
 							Env:          stageEnv,
 							VolumeMounts: volumeMounts,
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser:  ptr.To[int64](app.UserID),
-								RunAsGroup: ptr.To[int64](app.GroupID),
-							},
+							SecurityContext: buildpackSecurityContext(app),
 							Resources: app.HelmValues.Resources,
 						},
 					},
@@ -1084,8 +1092,55 @@ func mountRegistryCerts(app stageParam, volumes []corev1.Volume, volumeMounts []
 	return volumes, volumeMounts
 }
 
+// buildpackSecurityContext returns SecurityContext for the buildpack container.
+// When Docker socket is mounted, run as root so the container can access the host Docker daemon.
+func buildpackSecurityContext(app stageParam) *corev1.SecurityContext {
+	userID, groupID := app.UserID, app.GroupID
+	if app.HelmValues.DockerSocketPath != "" {
+		userID, groupID = 0, 0
+	}
+	return &corev1.SecurityContext{
+		RunAsUser:  ptr.To[int64](userID),
+		RunAsGroup: ptr.To[int64](groupID),
+	}
+}
+
+func mountDockerSocket(app stageParam, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount) ([]corev1.Volume, []corev1.VolumeMount) {
+	if app.HelmValues.DockerSocketPath == "" {
+		return volumes, volumeMounts
+	}
+	volumes = append(volumes, corev1.Volume{
+		Name: "docker-socket",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: app.HelmValues.DockerSocketPath,
+				Type: ptr.To(corev1.HostPathSocket),
+			},
+		},
+	})
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      "docker-socket",
+		MountPath: "/var/run/docker.sock",
+		ReadOnly:  false,
+	})
+	return volumes, volumeMounts
+}
+
 func appendEnvVar(envs []corev1.EnvVar, name, value string) []corev1.EnvVar {
 	return append(envs, corev1.EnvVar{Name: name, Value: value})
+}
+
+func overrideRegistryHost(registryURL, hostOverride string) string {
+	hostOverride = strings.Trim(hostOverride, "/")
+	if hostOverride == "" {
+		return registryURL
+	}
+
+	parts := strings.SplitN(strings.Trim(registryURL, "/"), "/", 2)
+	if len(parts) == 1 {
+		return hostOverride
+	}
+	return fmt.Sprintf("%s/%s", hostOverride, parts[1])
 }
 
 // StagingScriptConfig holds all the information for using a (set of) buildpack(s)

--- a/internal/api/v1/application/stage_test.go
+++ b/internal/api/v1/application/stage_test.go
@@ -10,6 +10,43 @@ import (
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 )
 
+func TestOverrideRegistryHost(t *testing.T) {
+	tests := []struct {
+		name         string
+		registryURL  string
+		hostOverride string
+		expected     string
+	}{
+		{
+			name:         "replace host keep namespace path",
+			registryURL:  "registry.epinio.svc.cluster.local:5000/apps",
+			hostOverride: "192.168.49.2:30500",
+			expected:     "192.168.49.2:30500/apps",
+		},
+		{
+			name:         "trim trailing slashes",
+			registryURL:  "registry.epinio.svc.cluster.local:5000/apps",
+			hostOverride: "192.168.49.2:30500/",
+			expected:     "192.168.49.2:30500/apps",
+		},
+		{
+			name:         "empty override keeps original",
+			registryURL:  "registry.epinio.svc.cluster.local:5000/apps",
+			hostOverride: "",
+			expected:     "registry.epinio.svc.cluster.local:5000/apps",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := overrideRegistryHost(tc.registryURL, tc.hostOverride)
+			if got != tc.expected {
+				t.Fatalf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
 func TestJobDoneStateSuccess(t *testing.T) {
 	job := batchv1.Job{
 		Status: batchv1.JobStatus{
@@ -69,6 +106,30 @@ func TestNewStagingScriptConfigPackFields(t *testing.T) {
 	}
 	if cfg.BuildImage != "buildpacksio/pack:0.38.2" {
 		t.Fatalf("expected build image buildpacksio/pack:0.38.2, got %q", cfg.BuildImage)
+	}
+}
+
+func TestNewStagingScriptConfigReadsRegistryHostOverride(t *testing.T) {
+	cfg, err := NewStagingScriptConfig(corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "epinio-stage-scripts"},
+		Data: map[string]string{
+			"builder":   "*",
+			"userID":    "1001",
+			"groupID":   "1000",
+			"env":       "CNB_PLATFORM_API: \"0.11\"",
+			"buildImage": "paketobuildpacks/builder-jammy-full:latest",
+			"staging-values.json": `{
+				"serviceAccountName": "epinio-server",
+				"dockerSocketPath": "/var/run/docker.sock",
+				"registryHostOverride": "192.168.49.2:30500"
+			}`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.HelmValues.RegistryHostOverride != "192.168.49.2:30500" {
+		t.Fatalf("expected registryHostOverride to be parsed, got %q", cfg.HelmValues.RegistryHostOverride)
 	}
 }
 

--- a/internal/api/v1/application/stage_test.go
+++ b/internal/api/v1/application/stage_test.go
@@ -6,6 +6,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 )
@@ -166,5 +167,42 @@ func TestNewJobRunUsesBuildImageAndBuilderEnv(t *testing.T) {
 	}
 	if !foundBuilderImage {
 		t.Fatalf("expected BUILDERIMAGE to be passed to build container env")
+	}
+}
+
+func TestSetAppStagingFieldsSetsImageURL(t *testing.T) {
+	app := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "my-app",
+				"namespace": "workspace",
+			},
+			"spec": map[string]interface{}{},
+		},
+	}
+
+	params := stageParam{
+		AppRef:       models.NewAppRef("my-app", "workspace"),
+		BlobUID:      "blob-1",
+		BuilderImage: "paketobuildpacks/builder-jammy-full:0.3.495",
+		RegistryURL:  "192.168.49.2:30500/apps",
+		Stage:        models.NewStage("c244aea3d59859ad"),
+	}
+
+	if err := setAppStagingFields(app, params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	imageURL, found, err := unstructured.NestedString(app.Object, "spec", "imageurl")
+	if err != nil {
+		t.Fatalf("unexpected error reading imageurl: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected spec.imageurl to be set")
+	}
+
+	expected := "192.168.49.2:30500/apps/workspace-my-app:c244aea3d59859ad"
+	if imageURL != expected {
+		t.Fatalf("expected imageurl %q, got %q", expected, imageURL)
 	}
 }

--- a/internal/api/v1/application/stage_test.go
+++ b/internal/api/v1/application/stage_test.go
@@ -5,6 +5,9 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
 )
 
 func TestJobDoneStateSuccess(t *testing.T) {
@@ -43,5 +46,64 @@ func TestJobDoneStatePending(t *testing.T) {
 	done, success := jobDoneState([]batchv1.Job{job})
 	if done || success {
 		t.Fatalf("expected done=false, success=false got done=%v success=%v", done, success)
+	}
+}
+
+func TestNewStagingScriptConfigPackFields(t *testing.T) {
+	cfg, err := NewStagingScriptConfig(corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "epinio-stage-scripts"},
+		Data: map[string]string{
+			"builder":     "*",
+			"buildEngine": "pack",
+			"buildImage":  "buildpacksio/pack:0.38.2",
+			"userID":      "1001",
+			"groupID":     "1000",
+			"env":         "CNB_PLATFORM_API: \"0.11\"",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.BuildEngine != "pack" {
+		t.Fatalf("expected build engine pack, got %q", cfg.BuildEngine)
+	}
+	if cfg.BuildImage != "buildpacksio/pack:0.38.2" {
+		t.Fatalf("expected build image buildpacksio/pack:0.38.2, got %q", cfg.BuildImage)
+	}
+}
+
+func TestNewJobRunUsesBuildImageAndBuilderEnv(t *testing.T) {
+	app := stageParam{
+		AppRef:          models.NewAppRef("my-app", "my-space"),
+		BlobUID:         "blob-1",
+		BuilderImage:    "paketobuildpacks/builder-jammy-full:latest",
+		BuildImage:      "buildpacksio/pack:0.38.2",
+		BuildEngine:     "pack",
+		DownloadImage:   "amazon/aws-cli:2.13.26",
+		UnpackImage:     "ghcr.io/epinio/epinio-unpacker:latest",
+		RegistryURL:     "registry.example.com/apps",
+		Stage:           models.NewStage("stage-1"),
+		PreviousStageID: "prev-stage",
+		UserID:          1001,
+		GroupID:         1000,
+		Scripts:         "epinio-stage-scripts",
+	}
+
+	job, _ := newJobRun(app)
+	buildContainer := job.Spec.Template.Spec.Containers[0]
+
+	if buildContainer.Image != "buildpacksio/pack:0.38.2" {
+		t.Fatalf("expected build container image buildpacksio/pack:0.38.2, got %q", buildContainer.Image)
+	}
+
+	foundBuilderImage := false
+	for _, ev := range buildContainer.Env {
+		if ev.Name == "BUILDERIMAGE" && ev.Value == "paketobuildpacks/builder-jammy-full:latest" {
+			foundBuilderImage = true
+			break
+		}
+	}
+	if !foundBuilderImage {
+		t.Fatalf("expected BUILDERIMAGE to be passed to build container env")
 	}
 }

--- a/internal/cli/cmd/apps.go
+++ b/internal/cli/cmd/apps.go
@@ -469,7 +469,7 @@ func NewAppPushCmd(client ApplicationsService) *cobra.Command {
 	cmd.Flags().String("container-image-url", "", "Container image url for the app workload image")
 	cmd.Flags().StringP("name", "n", "", "Application name. (mandatory if no manifest is provided)")
 	cmd.Flags().StringP("path", "p", "", "Path to application sources.")
-	cmd.Flags().String("builder-image", "", "Paketo builder image to use for staging")
+	cmd.Flags().String("builder-image", "", "Builder image to use for staging")
 
 	gitProviderOption(cmd)
 	routeOption(cmd)
@@ -564,7 +564,7 @@ func NewAppUpdateCmd(client ApplicationsService) *cobra.Command {
 
 	// It scales the named app
 	var noRestart bool
-	
+
 	cmd := &cobra.Command{
 		Use:               "update NAME",
 		Short:             "Update the named application",
@@ -603,7 +603,7 @@ func NewAppUpdateCmd(client ApplicationsService) *cobra.Command {
 				AppChart:       manifestConfig.AppChart,
 				Settings:       manifestConfig.Settings,
 			}
-			
+
 			// Set restart flag based on --no-restart option
 			restart := !noRestart
 			updateRequest.Restart = &restart
@@ -626,7 +626,7 @@ func NewAppUpdateCmd(client ApplicationsService) *cobra.Command {
 	cmd.Flags().String("app-chart", "", "App chart to use for deployment")
 	bindFlag(cmd, "app-chart")
 	bindFlagCompletionFunc(cmd, "app-chart", NewAppChartMatcherValueFunc(client))
-	
+
 	cmd.Flags().BoolVar(&noRestart, "no-restart", false, "Prevent restarting the application after update")
 
 	return cmd

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -49,6 +49,13 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
+const (
+	// Helm readiness checks can throttle on small clusters under load.
+	// Keep a conservative minimum so deploy waits don't fail due to client-side rate limits.
+	minHelmKubeAPIQPS   = float32(50)
+	minHelmKubeAPIBurst = 100
+)
+
 type PostDeployFunction func(ctx context.Context) error
 
 type ServiceParameters struct {
@@ -394,7 +401,7 @@ func Deploy(parameters ChartParameters) error {
 		Wait:        true,
 		Atomic:      true, // implies `Wait true`
 		ValuesYaml:  params,
-		Timeout:     duration.ToDeployment(),
+		Timeout:     maxDuration(duration.ToDeployment(), 8*time.Minute),
 		ReuseValues: true,
 	}
 
@@ -511,8 +518,16 @@ func GetHelmClient(
 	restConfig *rest.Config,
 	namespace string,
 ) (*SynchronizedClient, error) {
+	helmRestConfig := rest.CopyConfig(restConfig)
+	if helmRestConfig.QPS < minHelmKubeAPIQPS {
+		helmRestConfig.QPS = minHelmKubeAPIQPS
+	}
+	if helmRestConfig.Burst < minHelmKubeAPIBurst {
+		helmRestConfig.Burst = minHelmKubeAPIBurst
+	}
+
 	options := &hc.RestConfClientOptions{
-		RestConfig: restConfig,
+		RestConfig: helmRestConfig,
 		Options: &hc.Options{
 			Namespace:        namespace,         // Match chart spec
 			RepositoryCache:  "/tmp/.helmcache", // Hopefully reduces chart downloads.
@@ -674,6 +689,13 @@ func installOrUpgradeChartWithRetry(ctx context.Context, client hc.Client,
 		}
 		return err
 	})
+}
+
+func maxDuration(a, b time.Duration) time.Duration {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func getChartReference(ctx context.Context, client hc.Client, appChart *models.AppChartFull) (string, string, error) {


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] New Unit and Acceptance tests written for the context of the PR
- [x] Unit Tests are passing
- [x] Acceptance Tests are passing
- [x] Code is well documented
- [x] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened
 
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
Enables Pack as an optional staging path in Epinio and fixes blocking issues so Pack-based staging works end-to-end. Staging clearly indicates whether it used Pack or the classic buildpack (lifecycle) path.

### Occurred changes and/or fixed issues
Pack image must provide a shell: Build container uses /bin/sh for Pack; the staging script does not install Docker. Documented that the Pack image must be a -base (or similar) image that includes /bin/sh; the minimal image fails with exec: "/bin/sh": no such file or directory.

mountDockerSocket, mountNodeCerts, podSecurityContextForStaging, buildContainerShell (Pack → /bin/sh, lifecycle → /bin/bash), and staging job spec use buildOnlyMounts and the new security context. Debug log added for “Pack docker socket” params when creating the job.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if they have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed, which may be affected by the changes, which would require prior research to avoid regressions. -->
