### PR TITLE
populate meta.createdAt for gitconfigs

### DIFF
--- a/internal/api/v1/gitconfig/index.go
+++ b/internal/api/v1/gitconfig/index.go
@@ -49,8 +49,8 @@ func Index(c *gin.Context) apierror.APIErrors {
 	for _, gitconfig := range gitconfigList {
 		gitconfigs = append(gitconfigs, models.Gitconfig{
 			Meta: models.MetaLite{
-				Name: gitconfig.ID,
-				// CreatedAt: -- Not tracked by gitconfig
+				Name:      gitconfig.ID,
+				CreatedAt: gitconfig.CreatedAt,
 			},
 			URL:        gitconfig.URL,
 			Provider:   gitconfig.Provider,

--- a/internal/api/v1/gitconfig/show.go
+++ b/internal/api/v1/gitconfig/show.go
@@ -47,8 +47,8 @@ func Show(c *gin.Context) apierror.APIErrors {
 
 		response.OKReturn(c, models.Gitconfig{
 			Meta: models.MetaLite{
-				Name: gitconfig.ID,
-				// CreatedAt: -- Not tracked by gitconfig
+				Name:      gitconfig.ID,
+				CreatedAt: gitconfig.CreatedAt,
 			},
 			URL:        gitconfig.URL,
 			Provider:   gitconfig.Provider,

--- a/internal/bridge/git/git.go
+++ b/internal/bridge/git/git.go
@@ -45,6 +45,8 @@ type Configuration struct {
 
 	// ID of the configuration (it maps to the kubernetes secret)
 	ID string
+	// CreatedAt is when the gitconfig (Secret) was created (from Secret.CreationTimestamp).
+	CreatedAt metav1.Time
 	// URL is the full url (schema/host/port) used to match a particular instance
 	URL      string
 	Provider models.GitProvider
@@ -106,6 +108,7 @@ func NewConfigurationsFromSecrets(secrets []v1.Secret) []Configuration {
 	for _, sec := range secrets {
 		config := &Configuration{
 			ID:          string(sec.Name),
+			CreatedAt:   sec.CreationTimestamp,
 			URL:         string(sec.Data["url"]),
 			Username:    string(sec.Data["username"]),
 			Password:    string(sec.Data["password"]),

--- a/internal/bridge/git/git_test.go
+++ b/internal/bridge/git/git_test.go
@@ -198,9 +198,14 @@ var _ = Describe("Manager", func() {
 	Describe("NewSecretFromConfiguration", func() {
 		When("some secrets exists", func() {
 			It("returns the expected configurations", func() {
-				configs := git.NewConfigurationsFromSecrets([]v1.Secret{
+				createdAt := metav1.Now()
+
+				secrets := []v1.Secret{
 					{
-						ObjectMeta: metav1.ObjectMeta{Name: "my-config"},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "my-config",
+							CreationTimestamp: createdAt,
+						},
 						Data: map[string][]byte{
 							"url":         []byte("giturl"),
 							"provider":    []byte("github"),
@@ -231,7 +236,9 @@ var _ = Describe("Manager", func() {
 							"provider": []byte("sdjnksd"),
 						},
 					},
-				})
+				}
+
+				configs := git.NewConfigurationsFromSecrets(secrets)
 
 				Expect(configs).ToNot(BeNil())
 				Expect(configs).To(HaveLen(4))
@@ -244,6 +251,7 @@ var _ = Describe("Manager", func() {
 				Expect(configs[0].Repository).To(Equal("myrepo"))
 				Expect(configs[0].SkipSSL).To(BeTrue())
 				Expect(configs[0].Certificate).To(Equal([]byte("----CERT----")))
+				Expect(configs[0].CreatedAt).To(Equal(createdAt))
 
 				Expect(configs[1].ID).To(Equal("my-config-skipssl-false"))
 				Expect(configs[1].SkipSSL).To(BeFalse())


### PR DESCRIPTION
- Add CreatedAt to bridge/git Configuration and set it from Secret.CreationTimestamp in NewConfigurationsFromSecrets.
- Return CreatedAt in gitconfig list and show API responses so meta.createdAt is no longer always null.

### PR Checklist
- [x] Linting Test is passing
- [x] New Unit and Acceptance tests written for the context of the PR
- [x] Unit Tests are passing
- [ ] Acceptance Tests are passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened
 
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
The meta.createdAt field for gitconfigs is now correctly populated from the underlying Kubernetes Secret creation timestamp, instead of always being null.

### Occurred changes and/or fixed issues

- Bridge layer

Extended internal/bridge/git.Configuration with a CreatedAt metav1.Time field.
In NewConfigurationsFromSecrets, set Configuration.CreatedAt from Secret.CreationTimestamp.

- API layer

In internal/api/v1/gitconfig/index.go, return MetaLite.CreatedAt for each gitconfig from Configuration.CreatedAt.
In internal/api/v1/gitconfig/show.go, return MetaLite.CreatedAt for the requested gitconfig from Configuration.CreatedAt.

- Behavioral change

GET /api/v1/gitconfigs and GET /api/v1/gitconfigs/:name now return a non-null meta.createdAt for existing gitconfigs (e.g. "2026-03-03T05:00:15Z").

### Technical notes summary

- Gitconfigs are modeled as Kubernetes Secrets labeled for Epinio. Those Secrets already have a CreationTimestamp, which was previously ignored for gitconfigs.
- The bridge Configuration struct is the single source of truth for gitconfig metadata; propagating CreationTimestamp there ensures any consumer (current or future) can use it without re-touching the Secret.
- The API models already exposed MetaLite.CreatedAt, so no wire-format or client-facing schema changes were needed—only population of the existing field.
- Existing selection/filtering logic for gitconfigs is unchanged; only an additional field is carried along and serialized.

### Areas or cases that should be tested

- Gitconfig listing
-- Create at least one gitconfig (e.g. via CLI or an HTTP POST to /api/v1/gitconfigs).
-- Call GET /api/v1/gitconfigs and verify:
-- Each returned object has meta.name set correctly.
-- Each returned object has meta.createdAt set to an RFC3339 timestamp (not null).
- Gitconfig show
-- Call GET /api/v1/gitconfigs/:name for an existing gitconfig and verify meta.createdAt is populated and matches the list response.
- CLI / UI integration
-- If the CLI or dashboard surface gitconfig metadata, verify that any “Created”/“Age” displays work as expected and no views break due to the new non-null value.
- Error handling
-- Attempt to create a duplicate gitconfig ID and verify the API still returns a 409 conflict and the existing meta.createdAt remains unchanged.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed, which may be affected by the changes, which would require prior research to avoid regressions. -->
