### PR TITLE
Server driven deployment

### DIFF
--- a/internal/api/v1/application/deployments.go
+++ b/internal/api/v1/application/deployments.go
@@ -94,6 +94,8 @@ func DeploymentsStart(c *gin.Context) apierror.APIErrors {
 	username := requestctx.User(ctx).Username
 	go runAsyncDeployment(context.Background(), id, req, username)
 
+	// Help clients recover deployment id even when intermediaries strip 202 bodies.
+	c.Header("Location", c.Request.URL.Path+"/"+id)
 	c.JSON(202, job.status)
 	return nil
 }

--- a/internal/api/v1/application/deployments.go
+++ b/internal/api/v1/application/deployments.go
@@ -1,0 +1,412 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package application
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/helpers/randstr"
+	"github.com/epinio/epinio/internal/api/v1/deploy"
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
+	"github.com/epinio/epinio/internal/helmchart"
+	"github.com/epinio/epinio/internal/s3manager"
+	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+	"github.com/gin-gonic/gin"
+	"github.com/spf13/viper"
+)
+
+type asyncDeployJob struct {
+	status models.AsyncDeployStatus
+}
+
+var (
+	asyncDeployJobsMu sync.RWMutex
+	asyncDeployJobs   = map[string]*asyncDeployJob{}
+)
+
+func asyncDeployJobID() (string, error) {
+	return randstr.Hex16()
+}
+
+// DeploymentsStart handles POST /namespaces/:namespace/applications/:app/deployments
+//
+// It starts a background flow that stages/builds (when BlobUID is provided) and deploys the application,
+// and returns immediately with a deployment id that can be used to query status.
+func DeploymentsStart(c *gin.Context) apierror.APIErrors {
+	ctx := c.Request.Context()
+
+	namespace := c.Param("namespace")
+	name := c.Param("app")
+
+	req := models.AsyncDeployRequest{}
+	if err := c.BindJSON(&req); err != nil {
+		return apierror.NewBadRequestError(err.Error()).WithDetails("failed to unmarshal async deploy request")
+	}
+	if name != req.App.Name {
+		return apierror.NewBadRequestError("name parameter from URL does not match name param in body")
+	}
+	if namespace != req.App.Namespace {
+		return apierror.NewBadRequestError("namespace parameter from URL does not match namespace param in body")
+	}
+	if req.ImageURL == "" && req.BlobUID == "" {
+		return apierror.NewBadRequestError("async deploy requires either `image` or `blobuid`")
+	}
+
+	id, err := asyncDeployJobID()
+	if err != nil {
+		return apierror.InternalError(err, "failed to generate async deploy id")
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	job := &asyncDeployJob{
+		status: models.AsyncDeployStatus{
+			ID:        id,
+			App:       req.App,
+			Status:    "pending",
+			StartedAt: now,
+		},
+	}
+
+	asyncDeployJobsMu.Lock()
+	asyncDeployJobs[id] = job
+	asyncDeployJobsMu.Unlock()
+
+	username := requestctx.User(ctx).Username
+	go runAsyncDeployment(context.Background(), id, req, username)
+
+	c.JSON(202, job.status)
+	return nil
+}
+
+// DeploymentsStatus handles GET /namespaces/:namespace/applications/:app/deployments/:deployment_id
+func DeploymentsStatus(c *gin.Context) apierror.APIErrors {
+	deploymentID := c.Param("deployment_id")
+
+	asyncDeployJobsMu.RLock()
+	job, ok := asyncDeployJobs[deploymentID]
+	asyncDeployJobsMu.RUnlock()
+
+	if !ok {
+		return apierror.NewNotFoundError("deployment", deploymentID)
+	}
+
+	response.OKReturn(c, job.status)
+	return nil
+}
+
+func runAsyncDeployment(ctx context.Context, deploymentID string, req models.AsyncDeployRequest, username string) {
+	log := requestctx.Logger(ctx).With("component", "async-deploy", "deploymentID", deploymentID)
+
+	update := func(mut func(*models.AsyncDeployStatus)) {
+		asyncDeployJobsMu.Lock()
+		defer asyncDeployJobsMu.Unlock()
+
+		job, ok := asyncDeployJobs[deploymentID]
+		if !ok {
+			return
+		}
+		mut(&job.status)
+	}
+
+	failErr := func(err error) {
+		update(func(s *models.AsyncDeployStatus) {
+			s.Status = "failed"
+			s.Error = err.Error()
+			s.FinishedAt = time.Now().UTC().Format(time.RFC3339)
+		})
+	}
+
+	failAPI := func(apiErr apierror.APIErrors) {
+		msg := "request failed"
+		if apiErr != nil {
+			errs := apiErr.Errors()
+			if len(errs) > 0 && errs[0].Title != "" {
+				msg = errs[0].Title
+			}
+		}
+		update(func(s *models.AsyncDeployStatus) {
+			s.Status = "failed"
+			s.Error = msg
+			s.FinishedAt = time.Now().UTC().Format(time.RFC3339)
+		})
+	}
+
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		log.Errorw("failed to get cluster", "error", err)
+		failErr(err)
+		return
+	}
+
+	var stageID string
+	var imageURL string
+
+	// Stage/build when we have a blob uid. Otherwise deploy the provided image.
+	if req.BlobUID != "" {
+		update(func(s *models.AsyncDeployStatus) { s.Status = "staging" })
+
+		stageResp, apiErr := stageForAsyncDeploy(ctx, cluster, req.App, req.BlobUID, req.BuilderImage, username)
+		if apiErr != nil {
+			failAPI(apiErr)
+			return
+		}
+
+		stageID = stageResp.Stage.ID
+		imageURL = stageResp.ImageURL
+		update(func(s *models.AsyncDeployStatus) {
+			s.StageID = stageID
+			s.ImageURL = imageURL
+		})
+
+		jobs, apiErr := stageJobs(ctx, cluster, req.App.Namespace, stageID)
+		if apiErr != nil {
+			failAPI(apiErr)
+			return
+		}
+		success, waitErr := waitForStagingCompletion(ctx, cluster, jobs)
+		if waitErr != nil {
+			log.Errorw("staging completion wait failed", "error", waitErr)
+			failErr(waitErr)
+			return
+		}
+		if !success {
+			failAPI(apierror.NewInternalError("Failed to stage", "staging job failed"))
+			return
+		}
+	} else {
+		imageURL = req.ImageURL
+		update(func(s *models.AsyncDeployStatus) { s.ImageURL = imageURL })
+	}
+
+	update(func(s *models.AsyncDeployStatus) { s.Status = "deploying" })
+
+	applicationCR, err := application.Get(ctx, cluster, req.App)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			failAPI(apierror.AppIsNotKnown("cannot deploy app, application resource is missing"))
+			return
+		}
+		failErr(err)
+		return
+	}
+
+	if err := deploy.UpdateImageURL(ctx, cluster, applicationCR, imageURL); err != nil {
+		failErr(err)
+		return
+	}
+
+	desiredRoutes, found, err := unstructured.NestedStringSlice(applicationCR.Object, "spec", "routes")
+	if err != nil {
+		failErr(err)
+		return
+	}
+	if !found {
+		desiredRoutes = []string{}
+	}
+
+	if apiErr := validateRoutes(ctx, cluster, req.App.Name, req.App.Namespace, desiredRoutes); apiErr != nil {
+		failAPI(apiErr)
+		return
+	}
+
+	deployResult, apiErr := deploy.DeployApp(ctx, cluster, req.App, username, stageID)
+	if apiErr != nil {
+		failAPI(apiErr)
+		return
+	}
+
+	if err := application.SetOrigin(ctx, cluster, req.App, req.Origin); err != nil {
+		failErr(err)
+		return
+	}
+
+	update(func(s *models.AsyncDeployStatus) {
+		s.Status = "succeeded"
+		s.Routes = deployResult.Routes
+		s.Warnings = deployResult.Warnings
+		s.FinishedAt = time.Now().UTC().Format(time.RFC3339)
+	})
+}
+
+// stageForAsyncDeploy performs the same staging operation as Stage() but without a gin context.
+func stageForAsyncDeploy(
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+	appRef models.AppRef,
+	blobUID string,
+	builderImage string,
+	username string,
+) (*models.StageResponse, apierror.APIErrors) {
+	log := requestctx.Logger(ctx).With("component", "async-stage")
+
+	// check application resource
+	app, err := application.Get(ctx, cluster, appRef)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, apierror.AppIsNotKnown("cannot stage app, application resource is missing")
+		}
+		return nil, apierror.InternalError(err, "failed to get the application resource")
+	}
+
+	// quickly reject conflict with (still) active staging
+	staging, err := application.IsCurrentlyStaging(ctx, cluster, appRef.Namespace, appRef.Name)
+	if err != nil {
+		return nil, apierror.InternalError(err)
+	}
+	if staging {
+		return nil, apierror.NewBadRequestError("staging job for image ID still running")
+	}
+
+	// determine builder image (request overrides)
+	stageReq := models.StageRequest{
+		App:         appRef,
+		BlobUID:     blobUID,
+		BuilderImage: builderImage,
+	}
+
+	builder, builderErr := getBuilderImage(stageReq, app)
+	if builderErr != nil {
+		return nil, builderErr
+	}
+	if builder == "" {
+		builder = viper.GetString("default-builder-image")
+		if builder == "" {
+			return nil, apierror.NewBadRequestError("no builder image specified and no default configured")
+		}
+	}
+
+	config, err := DetermineStagingScripts(ctx, cluster, helmchart.Namespace(), builder)
+	if err != nil {
+		return nil, apierror.InternalError(err, "failed to retrieve staging configuration")
+	}
+
+	log.Infow("staging app", "scripts", config.Name, "builder", builder)
+
+	s3ConnectionDetails, err := s3manager.GetConnectionDetails(ctx, cluster,
+		helmchart.Namespace(), helmchart.S3ConnectionDetailsSecretName)
+	if err != nil {
+		return nil, apierror.InternalError(err, "failed to fetch the S3 connection details")
+	}
+
+	// Validate incoming blob id before attempting to stage (reuse existing helper)
+	if apiErr := validateBlob(ctx, blobUID, appRef, s3ConnectionDetails); apiErr != nil {
+		return nil, apiErr
+	}
+
+	uid, err := randstr.Hex16()
+	if err != nil {
+		return nil, apierror.InternalError(err, "failed to generate a uid")
+	}
+
+	environment, err := application.Environment(ctx, cluster, appRef)
+	if err != nil {
+		return nil, apierror.InternalError(err, "failed to access application runtime environment")
+	}
+
+	owner := metav1.OwnerReference{
+		APIVersion: app.GetAPIVersion(),
+		Kind:       app.GetKind(),
+		Name:       app.GetName(),
+		UID:        app.GetUID(),
+	}
+
+	previousID, err := application.StageID(app)
+	if err != nil {
+		return nil, apierror.InternalError(err, "failed to determine application stage id")
+	}
+	if previousID == "" {
+		previousID = uid
+	}
+
+	registryPublicURL, err := getRegistryURL(ctx, cluster)
+	if err != nil {
+		return nil, apierror.InternalError(err, "getting the Epinio registry public URL")
+	}
+
+	registryCertificateSecret := viper.GetString("registry-certificate-secret")
+	registryCertificateHash := ""
+	if registryCertificateSecret != "" {
+		registryCertificateHash, err = getRegistryCertificateHash(ctx, cluster, helmchart.Namespace(), registryCertificateSecret)
+		if err != nil {
+			return nil, apierror.InternalError(err, "cannot calculate Certificate hash")
+		}
+	}
+
+	for name, value := range config.Env {
+		if _, found := environment[name]; found {
+			continue
+		}
+		environment[name] = value
+	}
+
+	params := stageParam{
+		AppRef:              appRef,
+		BuilderImage:        builder,
+		DownloadImage:       config.DownloadImage,
+		UnpackImage:         config.UnpackImage,
+		BlobUID:             blobUID,
+		Environment:         environment.List(),
+		Owner:               owner,
+		RegistryURL:         registryPublicURL,
+		S3ConnectionDetails: s3ConnectionDetails,
+		Stage:               models.NewStage(uid),
+		PreviousStageID:     previousID,
+		Username:            username,
+		RegistryCAHash:      registryCertificateHash,
+		RegistryCASecret:    registryCertificateSecret,
+		UserID:              config.UserID,
+		GroupID:             config.GroupID,
+		Scripts:             config.Name,
+		HelmValues:          config.HelmValues,
+	}
+
+	if !params.HelmValues.Storage.Cache.EmptyDir {
+		if err := ensurePVC(ctx, cluster, params.HelmValues.Storage.Cache, appRef.MakeCachePVCName()); err != nil {
+			return nil, apierror.InternalError(err, "failed to ensure a PersistentVolumeClaim for the application cache")
+		}
+	}
+	if !params.HelmValues.Storage.SourceBlobs.EmptyDir {
+		if err := ensurePVC(ctx, cluster, params.HelmValues.Storage.SourceBlobs, appRef.MakeSourceBlobsPVCName()); err != nil {
+			return nil, apierror.InternalError(err, "failed to ensure a PersistentVolumeClaim for the application source blobs")
+		}
+	}
+
+	job, jobenv := newJobRun(params)
+
+	if err := cluster.CreateSecret(ctx, helmchart.Namespace(), *jobenv); err != nil {
+		return nil, apierror.InternalError(errors.Wrap(err, "failed to create job env secret"))
+	}
+	if err := cluster.CreateJob(ctx, helmchart.Namespace(), job); err != nil {
+		return nil, apierror.InternalError(errors.Wrap(err, "failed to create staging job"))
+	}
+	if err := updateApp(ctx, cluster, app, params); err != nil {
+		return nil, apierror.InternalError(err, "updating application CR with staging information")
+	}
+
+	imageURL := params.ImageURL(params.RegistryURL)
+	return &models.StageResponse{
+		Stage:    models.NewStage(uid),
+		ImageURL: imageURL,
+	}, nil
+}
+

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/epinio/epinio/helpers/cahash"
 	"github.com/epinio/epinio/helpers/kubernetes"
@@ -1007,16 +1008,6 @@ func findPreviousBlobUID(app *unstructured.Unstructured) (string, error) {
 }
 
 func updateApp(ctx context.Context, cluster *kubernetes.Cluster, app *unstructured.Unstructured, params stageParam) error {
-	if err := unstructured.SetNestedField(app.Object, params.BlobUID, "spec", "blobuid"); err != nil {
-		return err
-	}
-	if err := unstructured.SetNestedField(app.Object, params.Stage.ID, "spec", "stageid"); err != nil {
-		return err
-	}
-	if err := unstructured.SetNestedField(app.Object, params.BuilderImage, "spec", "builderimage"); err != nil {
-		return err
-	}
-
 	client, err := cluster.ClientApp()
 	if err != nil {
 		return err
@@ -1026,9 +1017,30 @@ func updateApp(ctx context.Context, cluster *kubernetes.Cluster, app *unstructur
 	if err != nil {
 		return err
 	}
+	name, _, err := unstructured.NestedString(app.UnstructuredContent(), "metadata", "name")
+	if err != nil {
+		return err
+	}
 
-	_, err = client.Namespace(namespace).Update(ctx, app, metav1.UpdateOptions{})
+	// Merge patch avoids resourceVersion update conflicts for these spec fields.
+	patchBody, err := json.Marshal(map[string]any{
+		"spec": map[string]any{
+			"blobuid":      params.BlobUID,
+			"stageid":      params.Stage.ID,
+			"builderimage": params.BuilderImage,
+		},
+	})
+	if err != nil {
+		return err
+	}
 
+	_, err = client.Namespace(namespace).Patch(
+		ctx,
+		name,
+		types.MergePatchType,
+		patchBody,
+		metav1.PatchOptions{},
+	)
 	return err
 }
 

--- a/internal/api/v1/deploy/deploy.go
+++ b/internal/api/v1/deploy/deploy.go
@@ -27,6 +27,7 @@ import (
 	"github.com/epinio/epinio/internal/helmchart"
 	"github.com/epinio/epinio/internal/registry"
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -236,10 +237,6 @@ func replaceInternalRegistry(ctx context.Context, cluster *kubernetes.Cluster, i
 }
 
 func UpdateImageURL(ctx context.Context, cluster *kubernetes.Cluster, app *unstructured.Unstructured, imageURL string) error {
-	if err := unstructured.SetNestedField(app.Object, imageURL, "spec", "imageurl"); err != nil {
-		return err
-	}
-
 	client, err := cluster.ClientApp()
 	if err != nil {
 		return err
@@ -249,8 +246,32 @@ func UpdateImageURL(ctx context.Context, cluster *kubernetes.Cluster, app *unstr
 	if err != nil {
 		return err
 	}
+	name, _, err := unstructured.NestedString(app.UnstructuredContent(), "metadata", "name")
+	if err != nil {
+		return err
+	}
 
-	_, err = client.Namespace(namespace).Update(ctx, app, metav1.UpdateOptions{})
+	// App status and staging updates can race with this write.
+	// Retry with the latest resource version on conflict.
+	current := app
+	for i := 0; i < 3; i++ {
+		if err := unstructured.SetNestedField(current.Object, imageURL, "spec", "imageurl"); err != nil {
+			return err
+		}
 
-	return err
+		_, err = client.Namespace(namespace).Update(ctx, current, metav1.UpdateOptions{})
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsConflict(err) || i == 2 {
+			return err
+		}
+
+		current, err = client.Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -116,6 +116,8 @@ var Routes = routes.NamedRoutes{
 	"AppDelete":       delete("/namespaces/:namespace/applications/:app", errorHandler(application.Delete)),
 	"AppBatchDelete":  delete("/namespaces/:namespace/applications", errorHandler(application.Delete)),
 	"AppDeploy":       post("/namespaces/:namespace/applications/:app/deploy", errorHandler(application.Deploy)),
+	"AppDeployments":  post("/namespaces/:namespace/applications/:app/deployments", errorHandler(application.DeploymentsStart)),
+	"AppDeployment":   get("/namespaces/:namespace/applications/:app/deployments/:deployment_id", errorHandler(application.DeploymentsStatus)),
 	"AppImportGit":    post("/namespaces/:namespace/applications/:app/import-git", errorHandler(application.ImportGit)),
 	"AppPart":         get("/namespaces/:namespace/applications/:app/part/:part", errorHandler(application.GetPart)),
 	"AppRestart":      post("/namespaces/:namespace/applications/:app/restart", errorHandler(application.Restart)),

--- a/internal/auth/actions.yaml
+++ b/internal/auth/actions.yaml
@@ -39,6 +39,7 @@
     - Apps
     - AppShow
     - StagingComplete
+    - AppDeployment
     - AppRunning
     - AppValidateCV
     # app autocomplete
@@ -75,6 +76,7 @@
     - AppDelete
     - AppBatchDelete
     - AppDeploy
+    - AppDeployments
     - AppImportGit
     - AppRestart
     - AppStage

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -58,6 +58,8 @@ type APIClient interface {
 	AppImportGit(namespace string, name string, gitRef models.GitRef) (models.ImportGitResponse, error)
 	AppStage(req models.StageRequest) (*models.StageResponse, error)
 	AppDeploy(req models.DeployRequest) (*models.DeployResponse, error)
+	AppDeploymentsStart(req models.AsyncDeployRequest) (*models.AsyncDeployStatus, error)
+	AppDeploymentStatus(namespace, appName, deploymentID string) (models.AsyncDeployStatus, error)
 	AppLogs(namespace, appName, stageID string, follow bool, options *client.LogOptions, callback func(tailer.ContainerLogLine)) error
 	StagingComplete(namespace string, id string) (models.Response, error)
 	StagingCompleteStream(ctx context.Context, namespace, id string, callback func(models.StageCompleteEvent) error) error

--- a/internal/cli/usercmd/push.go
+++ b/internal/cli/usercmd/push.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -195,74 +196,88 @@ func (c *EpinioClient) AppPush(ctx context.Context, manifest models.ApplicationM
 		// Nothing to upload (nor stage)
 	}
 
-	// AppStage
-	stageID := ""
-	var stageResponse *models.StageResponse
-	if manifest.Origin.Kind != models.OriginContainer {
-		c.ui.Normal().Msg("Staging application with code...")
-		c.ui.ProgressNote().Msg("Running staging")
-
-		req := models.StageRequest{
-			App:          appRef,
-			BlobUID:      blobUID,
-			BuilderImage: manifest.Staging.Builder,
-		}
-		details.Info("staging code", "Blob", blobUID)
-		stageResponse, err = c.API.AppStage(req)
-		if err != nil {
-			return err
-		}
-		stageID = stageResponse.Stage.ID
-		log.V(3).Info("stage response", "response", stageResponse)
-
-		details.Info("start tailing logs", "StageID", stageResponse.Stage.ID)
-		c.stageLogs(appRef, stageResponse.Stage.ID)
-
-		details.Info("wait for job", "StageID", stageID)
-
-		// blocking function that wait until the staging is done
-		err = stagingWithRetry(log.V(1), c.API, appRef.Namespace, stageID)
-		if err != nil {
-			c.ui.Note().Msgf(
-				"You can access the staging logs at any time, either in the UI or with the CLI using this command:\n\nepinio app logs --staging %s",
-				appRef.Name)
-			return errors.Wrap(err, "waiting for staging failed")
-		}
-	}
-
-	// AppDeploy
-	c.ui.Normal().Msg("Deploying application ...")
-	deployRequest := models.DeployRequest{
+	// Async stage/build/deploy (same endpoint as the UI) — avoids long blocking POST timeouts.
+	asyncReq := models.AsyncDeployRequest{
 		App:    appRef,
 		Origin: manifest.Origin,
 	}
-	// If container param is specified, then we just take it into ImageURL
-	// If not, we take the one from the staging response
 	if manifest.Origin.Kind == models.OriginContainer {
-		deployRequest.ImageURL = manifest.Origin.Container
+		asyncReq.ImageURL = manifest.Origin.Container
 	} else {
-		deployRequest.ImageURL = stageResponse.ImageURL
-		deployRequest.Stage = models.StageRef{ID: stageID}
+		asyncReq.BlobUID = blobUID
+		asyncReq.BuilderImage = manifest.Staging.Builder
+	}
+
+	c.ui.Normal().Msg("Building and deploying application on the server ...")
+	c.ui.ProgressNote().Msg("Build and deploy")
+
+	details.Info("async deploy start", "app", appRef)
+	startStatus, err := c.API.AppDeploymentsStart(asyncReq)
+	if err != nil {
+		return errors.Wrap(err, "starting async deployment")
+	}
+	if startStatus == nil || startStatus.ID == "" {
+		return errors.New("async deployment did not return a deployment id")
 	}
 
 	s := c.ui.Progress("Waiting for deployment")
 	defer s.Stop()
 
-	deployResponse, err := c.API.AppDeploy(deployRequest)
+	finalStatus, err := c.waitAsyncDeployment(ctx, appRef, startStatus.ID, details)
 	if err != nil {
-		return err
+		c.ui.Note().Msgf(
+			"You can access the staging logs at any time, either in the UI or with the CLI using this command:\n\nepinio app logs --staging %s",
+			appRef.Name)
+		return errors.Wrap(err, "async deployment failed")
 	}
 
-	details.Info("wait for application resources")
-	c.ui.ProgressNote().KeeplineUnder(1).Msg("Creating application resources")
+	details.Info("deployment finished", "status", finalStatus.Status)
 
 	routes := []string{}
-	for _, d := range deployResponse.Routes {
+	for _, d := range finalStatus.Routes {
 		routes = append(routes, fmt.Sprintf("https://%s", d))
 	}
 
 	c.reportOK(appRef, manifest.Staging.Builder, routes)
 	return nil
+}
+
+func (c *EpinioClient) waitAsyncDeployment(ctx context.Context, appRef models.AppRef, deploymentID string, details logr.Logger) (*models.AsyncDeployStatus, error) {
+	deadline := time.Now().Add(duration.ToAppBuilt())
+	stagingLogsStarted := false
+
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		status, err := c.API.AppDeploymentStatus(appRef.Namespace, appRef.Name, deploymentID)
+		if err != nil {
+			return nil, err
+		}
+
+		if status.StageID != "" && !stagingLogsStarted {
+			stagingLogsStarted = true
+			details.Info("start tailing logs", "StageID", status.StageID)
+			c.stageLogs(appRef, status.StageID)
+		}
+
+		switch status.Status {
+		case "succeeded":
+			return &status, nil
+		case "failed":
+			if status.Error != "" {
+				return nil, errors.New(status.Error)
+			}
+			return nil, errors.New("async deployment failed")
+		}
+
+		time.Sleep(2 * time.Second)
+	}
+
+	return nil, errors.New("timed out waiting for async deployment")
 }
 
 func (c *EpinioClient) uploadSources(log logr.Logger, appRef models.AppRef, source string, manifest models.ApplicationManifest) (string, error) {

--- a/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
+++ b/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
@@ -103,6 +103,34 @@ type FakeAPIClient struct {
 		result1 *models.DeployResponse
 		result2 error
 	}
+	AppDeploymentStatusStub        func(string, string, string) (models.AsyncDeployStatus, error)
+	appDeploymentStatusMutex       sync.RWMutex
+	appDeploymentStatusArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}
+	appDeploymentStatusReturns struct {
+		result1 models.AsyncDeployStatus
+		result2 error
+	}
+	appDeploymentStatusReturnsOnCall map[int]struct {
+		result1 models.AsyncDeployStatus
+		result2 error
+	}
+	AppDeploymentsStartStub        func(models.AsyncDeployRequest) (*models.AsyncDeployStatus, error)
+	appDeploymentsStartMutex       sync.RWMutex
+	appDeploymentsStartArgsForCall []struct {
+		arg1 models.AsyncDeployRequest
+	}
+	appDeploymentsStartReturns struct {
+		result1 *models.AsyncDeployStatus
+		result2 error
+	}
+	appDeploymentsStartReturnsOnCall map[int]struct {
+		result1 *models.AsyncDeployStatus
+		result2 error
+	}
 	AppExecStub        func(context.Context, string, string, string, term.TTY) error
 	appExecMutex       sync.RWMutex
 	appExecArgsForCall []struct {
@@ -1368,6 +1396,136 @@ func (fake *FakeAPIClient) AppDeployReturnsOnCall(i int, result1 *models.DeployR
 	}
 	fake.appDeployReturnsOnCall[i] = struct {
 		result1 *models.DeployResponse
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeAPIClient) AppDeploymentStatus(arg1 string, arg2 string, arg3 string) (models.AsyncDeployStatus, error) {
+	fake.appDeploymentStatusMutex.Lock()
+	ret, specificReturn := fake.appDeploymentStatusReturnsOnCall[len(fake.appDeploymentStatusArgsForCall)]
+	fake.appDeploymentStatusArgsForCall = append(fake.appDeploymentStatusArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.AppDeploymentStatusStub
+	fakeReturns := fake.appDeploymentStatusReturns
+	fake.recordInvocation("AppDeploymentStatus", []interface{}{arg1, arg2, arg3})
+	fake.appDeploymentStatusMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeAPIClient) AppDeploymentStatusCallCount() int {
+	fake.appDeploymentStatusMutex.RLock()
+	defer fake.appDeploymentStatusMutex.RUnlock()
+	return len(fake.appDeploymentStatusArgsForCall)
+}
+
+func (fake *FakeAPIClient) AppDeploymentStatusCalls(stub func(string, string, string) (models.AsyncDeployStatus, error)) {
+	fake.appDeploymentStatusMutex.Lock()
+	defer fake.appDeploymentStatusMutex.Unlock()
+	fake.AppDeploymentStatusStub = stub
+}
+
+func (fake *FakeAPIClient) AppDeploymentStatusArgsForCall(i int) (string, string, string) {
+	fake.appDeploymentStatusMutex.RLock()
+	defer fake.appDeploymentStatusMutex.RUnlock()
+	argsForCall := fake.appDeploymentStatusArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeAPIClient) AppDeploymentStatusReturns(result1 models.AsyncDeployStatus, result2 error) {
+	fake.appDeploymentStatusMutex.Lock()
+	defer fake.appDeploymentStatusMutex.Unlock()
+	fake.AppDeploymentStatusStub = nil
+	fake.appDeploymentStatusReturns = struct {
+		result1 models.AsyncDeployStatus
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeAPIClient) AppDeploymentStatusReturnsOnCall(i int, result1 models.AsyncDeployStatus, result2 error) {
+	fake.appDeploymentStatusMutex.Lock()
+	defer fake.appDeploymentStatusMutex.Unlock()
+	fake.AppDeploymentStatusStub = nil
+	if fake.appDeploymentStatusReturnsOnCall == nil {
+		fake.appDeploymentStatusReturnsOnCall = make(map[int]struct {
+			result1 models.AsyncDeployStatus
+			result2 error
+		})
+	}
+	fake.appDeploymentStatusReturnsOnCall[i] = struct {
+		result1 models.AsyncDeployStatus
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeAPIClient) AppDeploymentsStart(arg1 models.AsyncDeployRequest) (*models.AsyncDeployStatus, error) {
+	fake.appDeploymentsStartMutex.Lock()
+	ret, specificReturn := fake.appDeploymentsStartReturnsOnCall[len(fake.appDeploymentsStartArgsForCall)]
+	fake.appDeploymentsStartArgsForCall = append(fake.appDeploymentsStartArgsForCall, struct {
+		arg1 models.AsyncDeployRequest
+	}{arg1})
+	stub := fake.AppDeploymentsStartStub
+	fakeReturns := fake.appDeploymentsStartReturns
+	fake.recordInvocation("AppDeploymentsStart", []interface{}{arg1})
+	fake.appDeploymentsStartMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeAPIClient) AppDeploymentsStartCallCount() int {
+	fake.appDeploymentsStartMutex.RLock()
+	defer fake.appDeploymentsStartMutex.RUnlock()
+	return len(fake.appDeploymentsStartArgsForCall)
+}
+
+func (fake *FakeAPIClient) AppDeploymentsStartCalls(stub func(models.AsyncDeployRequest) (*models.AsyncDeployStatus, error)) {
+	fake.appDeploymentsStartMutex.Lock()
+	defer fake.appDeploymentsStartMutex.Unlock()
+	fake.AppDeploymentsStartStub = stub
+}
+
+func (fake *FakeAPIClient) AppDeploymentsStartArgsForCall(i int) models.AsyncDeployRequest {
+	fake.appDeploymentsStartMutex.RLock()
+	defer fake.appDeploymentsStartMutex.RUnlock()
+	argsForCall := fake.appDeploymentsStartArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeAPIClient) AppDeploymentsStartReturns(result1 *models.AsyncDeployStatus, result2 error) {
+	fake.appDeploymentsStartMutex.Lock()
+	defer fake.appDeploymentsStartMutex.Unlock()
+	fake.AppDeploymentsStartStub = nil
+	fake.appDeploymentsStartReturns = struct {
+		result1 *models.AsyncDeployStatus
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeAPIClient) AppDeploymentsStartReturnsOnCall(i int, result1 *models.AsyncDeployStatus, result2 error) {
+	fake.appDeploymentsStartMutex.Lock()
+	defer fake.appDeploymentsStartMutex.Unlock()
+	fake.AppDeploymentsStartStub = nil
+	if fake.appDeploymentsStartReturnsOnCall == nil {
+		fake.appDeploymentsStartReturnsOnCall = make(map[int]struct {
+			result1 *models.AsyncDeployStatus
+			result2 error
+		})
+	}
+	fake.appDeploymentsStartReturnsOnCall[i] = struct {
+		result1 *models.AsyncDeployStatus
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/api/core/v1/client/apps.go
+++ b/pkg/api/core/v1/client/apps.go
@@ -209,6 +209,23 @@ func (c *Client) AppDeploy(request models.DeployRequest) (*models.DeployResponse
 	return Post(c, endpoint, request, response)
 }
 
+// AppDeploymentsStart starts an asynchronous stage/build/deploy (or image-only deploy).
+// The server returns 202 Accepted with an AsyncDeployStatus containing the deployment id.
+func (c *Client) AppDeploymentsStart(request models.AsyncDeployRequest) (*models.AsyncDeployStatus, error) {
+	response := &models.AsyncDeployStatus{}
+	endpoint := api.Routes.Path("AppDeployments", request.App.Namespace, request.App.Name)
+
+	return Post(c, endpoint, request, response)
+}
+
+// AppDeploymentStatus returns the current status of an asynchronous deployment.
+func (c *Client) AppDeploymentStatus(namespace, appName, deploymentID string) (models.AsyncDeployStatus, error) {
+	response := models.AsyncDeployStatus{}
+	endpoint := api.Routes.Path("AppDeployment", namespace, appName, deploymentID)
+
+	return Get(c, endpoint, response)
+}
+
 // LogOptions represents the optional filters for retrieving application logs.
 type LogOptions struct {
 	Tail              *int64

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -303,6 +303,32 @@ type DeployResponse struct {
 	Warnings []string `json:"warnings,omitempty"`
 }
 
+// AsyncDeployRequest represents and contains the data needed to stage/build and deploy an application asynchronously.
+//
+// For "source-based" deploys, the client should provide `BlobUID` (from /store or /import-git) and optionally
+// `BuilderImage` to run staging. For "image-based" deploys, the client can provide `ImageURL` directly.
+type AsyncDeployRequest struct {
+	App         AppRef            `json:"app,omitempty"`
+	BlobUID     string            `json:"blobuid,omitempty"`
+	BuilderImage string           `json:"builderimage,omitempty"`
+	ImageURL    string            `json:"image,omitempty"`
+	Origin      ApplicationOrigin `json:"origin,omitempty"`
+}
+
+// AsyncDeployStatus represents the status of an asynchronous deploy operation.
+type AsyncDeployStatus struct {
+	ID         string   `json:"id"`
+	App        AppRef   `json:"app"`
+	Status     string   `json:"status"` // pending, staging, deploying, succeeded, failed
+	StageID    string   `json:"stage_id,omitempty"`
+	ImageURL   string   `json:"image,omitempty"`
+	Error      string   `json:"error,omitempty"`
+	Routes     []string `json:"routes,omitempty"`
+	Warnings   []string `json:"warnings,omitempty"`
+	StartedAt  string   `json:"startedAt,omitempty"`
+	FinishedAt string   `json:"finishedAt,omitempty"`
+}
+
 // ApplicationDeleteRequest represents and contains the data needed to delete an application
 type ApplicationDeleteRequest struct {
 	DeleteImage bool `json:"deleteImage"`


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [ ] New Unit and Acceptance tests written for the context of the PR
- [x] Unit Tests are passing
- [ ] Acceptance Tests are passing
- [x] Code is well documented
- [x] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened
 
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
Added asynchronous application deployment endpoints so deploy is no longer UI-driven:
POST /api/v1/namespaces/:namespace/applications/:app/deployments
GET /api/v1/namespaces/:namespace/applications/:app/deployments/:deployment_id
Implemented backend async orchestration for stage/build/deploy with status tracking (pending, staging, deploying, succeeded, failed).
Added new API models for async deploy request/status payloads.

### Occurred changes and/or fixed issues
Occurred changes and/or fixed issues
Added async deployment API endpoints:
POST /api/v1/namespaces/:namespace/applications/:app/deployments
GET /api/v1/namespaces/:namespace/applications/:app/deployments/:deployment_id
Added async deploy request/response models:
AsyncDeployRequest
AsyncDeployStatus
Implemented backend async stage/build/deploy orchestration with status lifecycle:
pending -> staging -> deploying -> succeeded|failed
Updated route registration and auth action mapping for new endpoints.

### Technical notes summary
New async handler lives in internal/api/v1/application/deployments.go.
Async flow supports:
source-based deploy (blobuid + optional builderimage) -> stage/build -> deploy
image-based deploy (image) -> deploy directly
Status is currently maintained in-memory per API process (deployment_id keyed map).
Existing synchronous endpoints remain in place for compatibility.
Stage metadata update moved to JSON merge patch for spec.blobuid, spec.stageid, spec.builderimage, avoiding resourceVersion races from full object updates.

### Areas or cases that should be tested
Async deploy happy path (source app):
Create app and upload source.
Call async deploy start (via UI flow or API).
Verify status progression via GET .../deployments/:deployment_id.
Confirm final app is running and routes are available.
Failure path:
Trigger a staging/build failure and verify status becomes failed with error message.


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed, which may be affected by the changes, which would require prior research to avoid regressions. -->
