### PR TITLE
Update token.go

### DIFF
--- a/internal/api/v1/middleware/token.go
+++ b/internal/api/v1/middleware/token.go
@@ -62,12 +62,24 @@ func TokenAuth(ctx *gin.Context) {
 	}
 
 	// find the user and add it to the context
-
 	user, err := authService.GetUserByUsername(ctx, claims.Username)
 	if err != nil {
 		response.Error(ctx, apierrors.InternalError(err))
 		ctx.Abort()
 		return
+	}
+
+	// Match Authentication middleware: merge namespaces from namespaced roles into the user
+	// and persist when needed. Websocket routes skip Authentication, so without this,
+	// NamespaceAuthorization can deny App Shell even when HTTP API calls work.
+	updatedUser, needsUpdate := auth.IsUpdateUserNeeded(user)
+	if needsUpdate {
+		user, err = authService.UpdateUser(ctx, updatedUser)
+		if err != nil {
+			response.Error(ctx, apierrors.InternalError(err, "updating user"))
+			ctx.Abort()
+			return
+		}
 	}
 
 	newCtx := ctx.Request.Context()


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [ ] New Unit and Acceptance tests written for the context of the PR
- [ ] Unit Tests are passing
- [ ] Acceptance Tests are passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened
 
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
Fixes websocket App Shell (and other /wapi/v1 routes) failing with namespace authorization errors when the user’s allowed namespaces were only implied by namespaced roles and had not yet been merged into the user Secret—something REST auth already did, but TokenAuth did not.

### Occurred changes and/or fixed issues
epinio/internal/api/v1/middleware/token.go: After loading the user for websocket requests, run the same auth.IsUpdateUserNeeded + authService.UpdateUser path as Authentication, so namespaces derived from roles (e.g. role:workspace) are merged and persisted before NamespaceAuthorization runs.
create_epinio_user.py (helper in repo root): Script to create Epinio API users via kubectl apply of a Secret; fixed kubectl_apply when using text=True (pass string input, not bytes) so apply does not crash.

### Technical notes summary
Epinio HTTP API uses Authentication middleware, which already refreshed user records when role/namespace annotations were out of sync with resolved roles.
Websocket API uses TokenAuth only; it previously skipped that refresh, so user.Namespaces could stay empty while namespaced roles granted access on paper—NamespaceAuthorization then returned 403 for /wapi/v1/.../exec (App Shell).
Aligning TokenAuth with Authentication removes the REST vs websocket inconsistency without changing RBAC rules or UI.

### Areas or cases that should be tested
App Shell (UI): User with namespaced role + app_exec (e.g. application_manager:workspace), before any prior HTTP call that would have updated the Secret—open App Shell; should connect.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed, which may be affected by the changes, which would require prior research to avoid regressions. -->
