### PR TITLE
fix(Fixes timing/transient issues with user rights)

### DIFF
--- a/acceptance/helpers/machine/machine.go
+++ b/acceptance/helpers/machine/machine.go
@@ -178,6 +178,18 @@ func isTransientPushError(out string) bool {
 	return isTransientAPIError(out)
 }
 
+// isTransient403 detects the "user unauthorized for namespace X" 403 that
+// intermittently appears under parallel CI load when concurrent writes to the
+// admin user secret briefly clobber its role annotation. It clears on its own
+// once a subsequent mutation rewrites the secret, so retry rather than fail.
+func isTransient403(out string) bool {
+	if out == "" {
+		return false
+	}
+	return strings.Contains(out, "user unauthorized") &&
+		strings.Contains(out, "403")
+}
+
 // EpinioPush shows the staging log if the error indicates that staging
 // failed
 func (m *Machine) EpinioPush(dir string, name string, arg ...string) (string, error) {
@@ -234,6 +246,9 @@ func (m *Machine) SetupNamespace(namespace string) {
 			if strings.Contains(out, "EOF") || strings.Contains(out, "making the request") {
 				_, _ = fmt.Fprintf(GinkgoWriter, "[SetupNamespace] root cause: API connection closed (EOF) - often under parallel load\n")
 			}
+			if isTransient403(out) {
+				_, _ = fmt.Fprintf(GinkgoWriter, "[SetupNamespace] root cause: transient 403 - admin role annotation temporarily clobbered by concurrent UpdateUser, will retry\n")
+			}
 			return errors.New(out)
 		}
 
@@ -262,13 +277,23 @@ func (m *Machine) SetupNamespace(namespace string) {
 func (m *Machine) TargetNamespace(namespace string) {
 	By(fmt.Sprintf("targeting a namespace: %s", namespace))
 
-	out, err := m.Epinio(m.nodeTmpDir, "target", namespace)
-	if err != nil {
-		_, _ = fmt.Fprintf(GinkgoWriter, "[TargetNamespace] epinio target %s failed: err=%v out=%s\n", namespace, err, out)
-	}
-	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "epinio target %s: out=%s", namespace, out)
+	var attempt int
+	var lastOut string
+	// Retry transient 403 "user unauthorized" errors that appear under parallel
+	// CI load when concurrent writes to the admin user secret briefly clobber
+	// its role annotation. Also retries transient API errors (see isTransientAPIError).
+	EventuallyWithOffset(1, func() error {
+		attempt++
+		out, err := m.Epinio(m.nodeTmpDir, "target", namespace)
+		lastOut = out
+		if err != nil {
+			_, _ = fmt.Fprintf(GinkgoWriter, "[TargetNamespace] attempt %d epinio target %s failed: err=%v out=%s\n", attempt, namespace, err, out)
+			return errors.New(out)
+		}
+		return nil
+	}, "6m", "5s").Should(Succeed(), "epinio target %s: out=%s", namespace, lastOut)
 
-	out, err = m.Epinio(m.nodeTmpDir, "target")
+	out, err := m.Epinio(m.nodeTmpDir, "target")
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "[TargetNamespace] epinio target (show) failed: err=%v out=%s\n", err, out)
 	}

--- a/acceptance/helpers/machine/machine.go
+++ b/acceptance/helpers/machine/machine.go
@@ -192,12 +192,22 @@ func isTransient403(out string) bool {
 
 // EpinioPush shows the staging log if the error indicates that staging
 // failed
-func (m *Machine) EpinioPush(dir string, name string, arg ...string) (string, error) {
+func (m *Machine) EpinioPush(
+	dir string,
+	name string,
+	arg ...string,
+) (string, error) {
 	var out string
 	var err error
 
 	for attempt := 1; attempt <= 3; attempt++ {
-		out, err = proc.Run(dir, false, m.epinioBinaryPath, append([]string{"apps", "push"}, arg...)...)
+		out, err = proc.Run(
+			dir,
+			false,
+			m.epinioBinaryPath,
+			append([]string{"apps", "push"}, arg...)...,
+		)
+
 		if err == nil {
 			return out, nil
 		}
@@ -206,7 +216,15 @@ func (m *Machine) EpinioPush(dir string, name string, arg ...string) (string, er
 			break
 		}
 
-		_, _ = fmt.Fprintf(GinkgoWriter, "[EpinioPush] transient push error for app=%s attempt=%d/3, retrying: %v\nout=%s\n", name, attempt, err, out)
+		_, _ = fmt.Fprintf(
+			GinkgoWriter,
+			"[EpinioPush] transient push error for app=%s attempt=%d/3, retrying: %v\nout=%s\n",
+			name,
+			attempt,
+			err,
+			out,
+		)
+
 		time.Sleep(time.Duration(attempt) * 2 * time.Second)
 	}
 
@@ -279,15 +297,21 @@ func (m *Machine) TargetNamespace(namespace string) {
 
 	var attempt int
 	var lastOut string
-	// Retry transient 403 "user unauthorized" errors that appear under parallel
-	// CI load when concurrent writes to the admin user secret briefly clobber
-	// its role annotation. Also retries transient API errors (see isTransientAPIError).
+	// Retries any error, primary motivation is the transient 403 role-annotation
+	// race under parallel CI load.
 	EventuallyWithOffset(1, func() error {
 		attempt++
 		out, err := m.Epinio(m.nodeTmpDir, "target", namespace)
 		lastOut = out
 		if err != nil {
-			_, _ = fmt.Fprintf(GinkgoWriter, "[TargetNamespace] attempt %d epinio target %s failed: err=%v out=%s\n", attempt, namespace, err, out)
+			_, _ = fmt.Fprintf(
+				GinkgoWriter,
+				"[TargetNamespace] attempt %d epinio target %s failed: err=%v out=%s\n",
+				attempt,
+				namespace,
+				err,
+				out,
+			)
 			return errors.New(out)
 		}
 		return nil


### PR DESCRIPTION
Under parallel CI load, concurrent writes to the admin user secret can briefly clobber its role annotation, producing transient 403 errors in TargetNamespace.

Also adds isTransient403 detection with diagnostic logging for any future debugging. 