### PR TITLE
Server-side search for apps, namespaces, services, and configurations

### DIFF
--- a/acceptance/api/v1/application_index_test.go
+++ b/acceptance/api/v1/application_index_test.go
@@ -110,6 +110,41 @@ var _ = Describe("Apps Endpoint", LApplication, func() {
 		Expect(paged.Items).To(HaveLen(1))
 	})
 
+	It("filters applications by search term", func() {
+		app1 := catalog.NewAppName()
+		env.MakeContainerImageApp(app1, 1, containerImageURL)
+		defer env.DeleteApp(app1)
+		app2 := catalog.NewAppName()
+		env.MakeContainerImageApp(app2, 1, containerImageURL)
+		defer env.DeleteApp(app2)
+
+		response, err := env.Curl("GET", fmt.Sprintf("%s%s/namespaces/%s/applications?search=%s",
+			serverURL, v1.Root, namespace, app1), strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		defer response.Body.Close()
+		bodyBytes, err := io.ReadAll(response.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+		var paged struct {
+			Items []models.App `json:"items"`
+		}
+		err = json.Unmarshal(bodyBytes, &paged)
+		Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+		Expect(paged.Items).ToNot(BeEmpty())
+		for _, app := range paged.Items {
+			Expect(strings.Contains(app.Meta.Name, app1)).To(BeTrue(),
+				"expected app name %q to contain search term %q", app.Meta.Name, app1)
+		}
+		names := make([]string, 0, len(paged.Items))
+		for _, app := range paged.Items {
+			names = append(names, app.Meta.Name)
+		}
+		Expect(names).To(ContainElement(app1))
+	})
+
 	It("returns a 404 when the namespace does not exist", func() {
 		response, err := env.Curl("GET", fmt.Sprintf("%s%s/namespaces/idontexist/applications",
 			serverURL, v1.Root), strings.NewReader(""))

--- a/acceptance/api/v1/configurations_test.go
+++ b/acceptance/api/v1/configurations_test.go
@@ -198,6 +198,24 @@ var _ = Describe("Configurations API Application Endpoints", LConfiguration, fun
 			Expect(paged.Items).To(HaveLen(1))
 		})
 
+		It("filters configurations by search term", func() {
+			response, err := env.Curl("GET", fmt.Sprintf("%s%s/configurations?search=%s",
+				serverURL, api.Root, configuration2), strings.NewReader(""))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			defer response.Body.Close()
+			bodyBytes, err := io.ReadAll(response.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+			var configurations models.ConfigurationResponseList
+			err = json.Unmarshal(bodyBytes, &configurations)
+			Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+			Expect(configurations).To(HaveLen(1))
+			Expect(configurations[0].Meta.Name).To(Equal(configuration2))
+		})
+
 		It("doesn't list configurations belonging to non-accessible namespaces", func() {
 			endpoint := fmt.Sprintf("%s%s/configurations", serverURL, api.Root)
 			request, err := http.NewRequest(http.MethodGet, endpoint, nil)

--- a/acceptance/api/v1/namespaces_test.go
+++ b/acceptance/api/v1/namespaces_test.go
@@ -102,6 +102,31 @@ var _ = Describe("Namespaces API Application Endpoints", LNamespace, func() {
 				Expect(paged.Items).To(HaveLen(1))
 			})
 
+			It("filters namespaces by search term", func() {
+				response, err := env.Curl("GET", fmt.Sprintf("%s%s/namespaces?search=%s",
+					serverURL, api.Root, namespace), strings.NewReader(""))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				defer response.Body.Close()
+				bodyBytes, err := io.ReadAll(response.Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+				var namespaceList models.NamespaceList
+				err = json.Unmarshal(bodyBytes, &namespaceList)
+				Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+				Expect(namespaceList).ToNot(BeEmpty())
+				found := false
+				for _, ns := range namespaceList {
+					Expect(ns.Meta.Name).To(ContainSubstring(namespace))
+					if ns.Meta.Name == namespace {
+						found = true
+					}
+				}
+				Expect(found).To(BeTrue(), "expected search results to contain %q", namespace)
+			})
+
 			When("basic auth credentials are not provided", func() {
 				It("returns a 401 response", func() {
 					request, err := http.NewRequest("GET", fmt.Sprintf("%s%s/namespaces",

--- a/acceptance/api/v1/service_list_test.go
+++ b/acceptance/api/v1/service_list_test.go
@@ -239,4 +239,45 @@ var _ = Describe("ServiceList Endpoint", LService, func() {
 			})
 		})
 	})
+
+	Describe("GET /api/v1/services search", func() {
+		var serviceName1, serviceName2 string
+
+		BeforeEach(func() {
+			serviceName1 = catalog.NewServiceName()
+			serviceName2 = catalog.NewServiceName()
+
+			env.TargetNamespace(namespace1)
+			env.MakeServiceInstance(serviceName1, catalogService.Meta.Name)
+
+			env.TargetNamespace(namespace2)
+			env.MakeServiceInstance(serviceName2, catalogService.Meta.Name)
+		})
+
+		AfterEach(func() {
+			catalog.DeleteService(serviceName1, namespace1)
+			catalog.DeleteService(serviceName2, namespace2)
+		})
+
+		It("filters services by search term", func() {
+			endpoint := fmt.Sprintf("%s%s/services?search=%s", serverURL, v1.Root, serviceName1)
+			response, err := env.Curl("GET", endpoint, strings.NewReader(""))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+			var serviceListResponse models.ServiceList
+			err = json.NewDecoder(response.Body).Decode(&serviceListResponse)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(serviceListResponse).ToNot(BeEmpty())
+			found := false
+			for _, svc := range serviceListResponse {
+				Expect(svc.Meta.Name).To(ContainSubstring(serviceName1))
+				if svc.Meta.Name == serviceName1 {
+					found = true
+				}
+			}
+			Expect(found).To(BeTrue(), "expected search results to contain %q", serviceName1)
+		})
+	})
 })

--- a/internal/api/v1/application/fullindex.go
+++ b/internal/api/v1/application/fullindex.go
@@ -12,12 +12,15 @@
 package application
 
 import (
+	"strings"
+
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/auth"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
 
 	"github.com/gin-gonic/gin"
 )
@@ -39,6 +42,17 @@ func FullIndex(c *gin.Context) apierror.APIErrors {
 	}
 
 	filteredApps := auth.FilterResources(user, allApps)
+
+	if search := response.GetSearchParam(c); search != "" {
+		lower := strings.ToLower(search)
+		var searched models.AppList
+		for _, a := range filteredApps {
+			if strings.Contains(strings.ToLower(a.Meta.Name), lower) {
+				searched = append(searched, a)
+			}
+		}
+		filteredApps = searched
+	}
 
 	// Apply optional pagination when page parameters are provided.
 	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {

--- a/internal/api/v1/application/index.go
+++ b/internal/api/v1/application/index.go
@@ -30,8 +30,12 @@ func Index(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
-		apps, total, err := application.ListPaginated(ctx, cluster, namespace, page, pageSize)
+	search := response.GetSearchParam(c)
+	page, pageSize, paginated := response.GetPaginationParams(c, 1, 25)
+	if paginated || search != "" {
+		apps, total, err := application.ListPaginated(
+			ctx, cluster, namespace, page, pageSize, search,
+		)
 		if err != nil {
 			return apierror.InternalError(err)
 		}

--- a/internal/api/v1/configuration/fullindex.go
+++ b/internal/api/v1/configuration/fullindex.go
@@ -12,6 +12,8 @@
 package configuration
 
 import (
+	"strings"
+
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
@@ -39,6 +41,17 @@ func FullIndex(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 	filteredConfigurations := auth.FilterResources(user, allConfigurations)
+
+	if search := response.GetSearchParam(c); search != "" {
+		lower := strings.ToLower(search)
+		var searched configurations.ConfigurationList
+		for _, cfg := range filteredConfigurations {
+			if strings.Contains(strings.ToLower(cfg.Name), lower) {
+				searched = append(searched, cfg)
+			}
+		}
+		filteredConfigurations = searched
+	}
 
 	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
 		total := len(filteredConfigurations)

--- a/internal/api/v1/configuration/index.go
+++ b/internal/api/v1/configuration/index.go
@@ -14,6 +14,7 @@ package configuration
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
@@ -52,6 +53,24 @@ func Index(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
+	if search := response.GetSearchParam(c); search != "" {
+		lower := strings.ToLower(search)
+		var filtered models.ConfigurationResponseList
+		for _, cfg := range responseData {
+			if strings.Contains(strings.ToLower(cfg.Meta.Name), lower) {
+				filtered = append(filtered, cfg)
+			}
+		}
+		responseData = filtered
+	}
+
+	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
+		paged := response.PaginateSlice(responseData, page, pageSize)
+		response.OKReturn(c, paged)
+		return nil
+	}
+
+	// Backwards-compatible: return full list when no page params are set.
 	response.OKReturn(c, responseData)
 	return nil
 }

--- a/internal/api/v1/namespace/index.go
+++ b/internal/api/v1/namespace/index.go
@@ -13,6 +13,7 @@ package namespace
 
 import (
 	"context"
+	"strings"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
@@ -45,6 +46,17 @@ func Index(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 	namespaceList = auth.FilterResources(user, namespaceList)
+
+	if search := response.GetSearchParam(c); search != "" {
+		lower := strings.ToLower(search)
+		var filtered []namespaces.Namespace
+		for _, ns := range namespaceList {
+			if strings.Contains(strings.ToLower(ns.Name), lower) {
+				filtered = append(filtered, ns)
+			}
+		}
+		namespaceList = filtered
+	}
 
 	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
 		total := len(namespaceList)

--- a/internal/api/v1/response/response.go
+++ b/internal/api/v1/response/response.go
@@ -67,6 +67,11 @@ func OKReturn(c *gin.Context, response interface{}) {
 	c.JSON(http.StatusOK, response)
 }
 
+// GetSearchParam returns the optional "search" query parameter for name filtering.
+func GetSearchParam(c *gin.Context) string {
+	return c.Query("search")
+}
+
 // PaginatedResponse represents a generic paginated response payload.
 // It wraps a slice of items with pagination metadata.
 type PaginatedResponse[T any] struct {

--- a/internal/api/v1/response/response_test.go
+++ b/internal/api/v1/response/response_test.go
@@ -95,6 +95,38 @@ func TestBuildPaginatedResponse(t *testing.T) {
 	}
 }
 
+func TestGetSearchParam(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	makeCtx := func(query string) *gin.Context {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		req, _ := http.NewRequest("GET", "/test?"+query, nil)
+		c.Request = req
+		return c
+	}
+
+	tests := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{name: "no search param", query: "", want: ""},
+		{name: "search param with value", query: "search=foo", want: "foo"},
+		{name: "empty search param", query: "search=", want: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := makeCtx(tc.query)
+			got := response.GetSearchParam(c)
+			if got != tc.want {
+				t.Errorf("GetSearchParam: got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestGetPaginationParams(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/api/v1/service/fullindex.go
+++ b/internal/api/v1/service/fullindex.go
@@ -12,6 +12,8 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
@@ -44,6 +46,17 @@ func FullIndex(c *gin.Context) apierror.APIErrors {
 	}
 
 	filteredServices := auth.FilterResources(user, serviceList)
+
+	if search := response.GetSearchParam(c); search != "" {
+		lower := strings.ToLower(search)
+		var searched models.ServiceList
+		for _, svc := range filteredServices {
+			if strings.Contains(strings.ToLower(svc.Meta.Name), lower) {
+				searched = append(searched, svc)
+			}
+		}
+		filteredServices = searched
+	}
 
 	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
 		total := len(filteredServices)

--- a/internal/api/v1/service/list.go
+++ b/internal/api/v1/service/list.go
@@ -12,11 +12,14 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/services"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
 
 	"github.com/gin-gonic/gin"
 )
@@ -45,6 +48,26 @@ func List(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	response.OKReturn(c, extendWithBoundApps(serviceList, appsOf))
+	servicesWithApps := extendWithBoundApps(serviceList, appsOf)
+
+	if search := response.GetSearchParam(c); search != "" {
+		lower := strings.ToLower(search)
+		var filtered models.ServiceList
+		for _, svc := range servicesWithApps {
+			if strings.Contains(strings.ToLower(svc.Meta.Name), lower) {
+				filtered = append(filtered, svc)
+			}
+		}
+		servicesWithApps = filtered
+	}
+
+	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
+		paged := response.PaginateSlice(servicesWithApps, page, pageSize)
+		response.OKReturn(c, paged)
+		return nil
+	}
+
+	// Backwards-compatible: return full list when no page params are set.
+	response.OKReturn(c, servicesWithApps)
 	return nil
 }

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -507,6 +507,7 @@ func ListPaginated(
 	cluster *kubernetes.Cluster,
 	namespace string,
 	page, pageSize int,
+	search string,
 ) (models.AppList, int, error) {
 	client, err := cluster.ClientApp()
 	if err != nil {
@@ -518,7 +519,19 @@ func ListPaginated(
 		return nil, 0, err
 	}
 
-	totalCount := len(appCRList.Items)
+	allCRs := appCRList.Items
+	if search != "" {
+		lower := strings.ToLower(search)
+		var matched []unstructured.Unstructured
+		for _, cr := range allCRs {
+			if strings.Contains(strings.ToLower(cr.GetName()), lower) {
+				matched = append(matched, cr)
+			}
+		}
+		allCRs = matched
+	}
+
+	totalCount := len(allCRs)
 
 	if page < 1 {
 		page = 1
@@ -534,7 +547,7 @@ func ListPaginated(
 	if end > totalCount {
 		end = totalCount
 	}
-	pageCRs := appCRList.Items[start:end]
+	pageCRs := allCRs[start:end]
 
 	pageAppNames := make([]string, 0, len(pageCRs))
 	for _, cr := range pageCRs {


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] New Unit and Acceptance tests written for the context of the PR
- [x] Unit Tests are passing
- [ ] Acceptance Tests are passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

### Summary
Fixes EPINIO-603

### Occurred changes and/or fixed issues

Added `?search=` query parameter to all resource list endpoints (applications, namespaces, services, configurations) both namespace-scoped and global variants. Case-insensitive substring match on resource name, applied before pagination. Also added missing pagination to the namespace-scoped service and configuration list endpoints. A `GetSearchParam` helper was added to the `response` package alongside the existing pagination helpers.

### Technical notes summary

Search is opt-in via `?search=<term>` and composes with existing pagination params (`?page=`, `?pageSize=`). Omitting `?search` returns the full list, no change to existing behavior.

### Areas or cases that should be tested

- `GET /api/v1/applications?search=foo` — only matching apps returned
- `GET /api/v1/namespaces?search=foo` — only matching namespaces returned
- `GET /api/v1/services?search=foo` — only matching services returned
- `GET /api/v1/configurations?search=foo` — only matching configurations returned
- Composed: `?search=foo&page=1&pageSize=10` — search filters first, pagination applies to filtered set
- No `?search` param — full list returned (backwards-compatible)

### Areas which could experience regressions

Search param is opt-in and all existing callers omit it.