### PR TITLE
Fix/pagination layer move

### DIFF
--- a/acceptance/api/v1/application_index_test.go
+++ b/acceptance/api/v1/application_index_test.go
@@ -110,6 +110,41 @@ var _ = Describe("Apps Endpoint", LApplication, func() {
 		Expect(paged.Items).To(HaveLen(1))
 	})
 
+	It("filters applications by search term", func() {
+		app1 := catalog.NewAppName()
+		env.MakeContainerImageApp(app1, 1, containerImageURL)
+		defer env.DeleteApp(app1)
+		app2 := catalog.NewAppName()
+		env.MakeContainerImageApp(app2, 1, containerImageURL)
+		defer env.DeleteApp(app2)
+
+		response, err := env.Curl("GET", fmt.Sprintf("%s%s/namespaces/%s/applications?search=%s",
+			serverURL, v1.Root, namespace, app1), strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		defer response.Body.Close()
+		bodyBytes, err := io.ReadAll(response.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+		var paged struct {
+			Items []models.App `json:"items"`
+		}
+		err = json.Unmarshal(bodyBytes, &paged)
+		Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+		Expect(paged.Items).ToNot(BeEmpty())
+		for _, app := range paged.Items {
+			Expect(strings.Contains(app.Meta.Name, app1)).To(BeTrue(),
+				"expected app name %q to contain search term %q", app.Meta.Name, app1)
+		}
+		names := make([]string, 0, len(paged.Items))
+		for _, app := range paged.Items {
+			names = append(names, app.Meta.Name)
+		}
+		Expect(names).To(ContainElement(app1))
+	})
+
 	It("returns a 404 when the namespace does not exist", func() {
 		response, err := env.Curl("GET", fmt.Sprintf("%s%s/namespaces/idontexist/applications",
 			serverURL, v1.Root), strings.NewReader(""))

--- a/acceptance/api/v1/application_index_test.go
+++ b/acceptance/api/v1/application_index_test.go
@@ -76,6 +76,40 @@ var _ = Describe("Apps Endpoint", LApplication, func() {
 		Expect(apps[0].Status).To(BeEquivalentTo("running"))
 	})
 
+	It("returns a paginated response when page params are provided", func() {
+		app1 := catalog.NewAppName()
+		env.MakeContainerImageApp(app1, 1, containerImageURL)
+		defer env.DeleteApp(app1)
+		app2 := catalog.NewAppName()
+		env.MakeContainerImageApp(app2, 1, containerImageURL)
+		defer env.DeleteApp(app2)
+
+		response, err := env.Curl("GET", fmt.Sprintf("%s%s/namespaces/%s/applications?page=1&pageSize=1",
+			serverURL, v1.Root, namespace), strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		defer response.Body.Close()
+		bodyBytes, err := io.ReadAll(response.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+		var paged struct {
+			Items      []models.App `json:"items"`
+			Page       int          `json:"page"`
+			PageSize   int          `json:"pageSize"`
+			TotalItems int          `json:"totalItems"`
+			TotalPages int          `json:"totalPages"`
+		}
+		err = json.Unmarshal(bodyBytes, &paged)
+		Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+		Expect(paged.Page).To(Equal(1))
+		Expect(paged.PageSize).To(Equal(1))
+		Expect(paged.TotalItems).To(Equal(2))
+		Expect(paged.TotalPages).To(Equal(2))
+		Expect(paged.Items).To(HaveLen(1))
+	})
+
 	It("returns a 404 when the namespace does not exist", func() {
 		response, err := env.Curl("GET", fmt.Sprintf("%s%s/namespaces/idontexist/applications",
 			serverURL, v1.Root), strings.NewReader(""))

--- a/acceptance/api/v1/configurations_test.go
+++ b/acceptance/api/v1/configurations_test.go
@@ -198,6 +198,24 @@ var _ = Describe("Configurations API Application Endpoints", LConfiguration, fun
 			Expect(paged.Items).To(HaveLen(1))
 		})
 
+		It("filters configurations by search term", func() {
+			response, err := env.Curl("GET", fmt.Sprintf("%s%s/configurations?search=%s",
+				serverURL, api.Root, configuration2), strings.NewReader(""))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			defer response.Body.Close()
+			bodyBytes, err := io.ReadAll(response.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+			var configurations models.ConfigurationResponseList
+			err = json.Unmarshal(bodyBytes, &configurations)
+			Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+			Expect(configurations).To(HaveLen(1))
+			Expect(configurations[0].Meta.Name).To(Equal(configuration2))
+		})
+
 		It("doesn't list configurations belonging to non-accessible namespaces", func() {
 			endpoint := fmt.Sprintf("%s%s/configurations", serverURL, api.Root)
 			request, err := http.NewRequest(http.MethodGet, endpoint, nil)

--- a/acceptance/api/v1/configurations_test.go
+++ b/acceptance/api/v1/configurations_test.go
@@ -171,6 +171,33 @@ var _ = Describe("Configurations API Application Endpoints", LConfiguration, fun
 			))
 		})
 
+		It("returns a paginated response when page params are provided", func() {
+			response, err := env.Curl("GET", fmt.Sprintf("%s%s/configurations?page=1&pageSize=1",
+				serverURL, api.Root), strings.NewReader(""))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			defer response.Body.Close()
+			bodyBytes, err := io.ReadAll(response.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+			var paged struct {
+				Items      models.ConfigurationResponseList `json:"items"`
+				Page       int                              `json:"page"`
+				PageSize   int                              `json:"pageSize"`
+				TotalItems int                              `json:"totalItems"`
+				TotalPages int                              `json:"totalPages"`
+			}
+			err = json.Unmarshal(bodyBytes, &paged)
+			Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+			Expect(paged.Page).To(Equal(1))
+			Expect(paged.PageSize).To(Equal(1))
+			Expect(paged.TotalItems).To(BeNumerically(">=", 3))
+			Expect(paged.TotalPages).To(BeNumerically(">=", 3))
+			Expect(paged.Items).To(HaveLen(1))
+		})
+
 		It("doesn't list configurations belonging to non-accessible namespaces", func() {
 			endpoint := fmt.Sprintf("%s%s/configurations", serverURL, api.Root)
 			request, err := http.NewRequest(http.MethodGet, endpoint, nil)

--- a/acceptance/api/v1/namespaces_test.go
+++ b/acceptance/api/v1/namespaces_test.go
@@ -71,6 +71,37 @@ var _ = Describe("Namespaces API Application Endpoints", LNamespace, func() {
 				// See global BeforeEach for where this namespace is set up.
 				Expect(namespaceNames).Should(ContainElements(namespace))
 			})
+			It("returns a paginated response when page params are provided", func() {
+				ns2 := catalog.NewNamespaceName()
+				env.SetupAndTargetNamespace(ns2)
+				defer env.DeleteNamespace(ns2)
+
+				response, err := env.Curl("GET", fmt.Sprintf("%s%s/namespaces?page=1&pageSize=1",
+					serverURL, api.Root), strings.NewReader(""))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				defer response.Body.Close()
+				bodyBytes, err := io.ReadAll(response.Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+				var paged struct {
+					Items      models.NamespaceList `json:"items"`
+					Page       int                  `json:"page"`
+					PageSize   int                  `json:"pageSize"`
+					TotalItems int                  `json:"totalItems"`
+					TotalPages int                  `json:"totalPages"`
+				}
+				err = json.Unmarshal(bodyBytes, &paged)
+				Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+				Expect(paged.Page).To(Equal(1))
+				Expect(paged.PageSize).To(Equal(1))
+				Expect(paged.TotalItems).To(BeNumerically(">=", 2))
+				Expect(paged.TotalPages).To(BeNumerically(">=", 2))
+				Expect(paged.Items).To(HaveLen(1))
+			})
+
 			When("basic auth credentials are not provided", func() {
 				It("returns a 401 response", func() {
 					request, err := http.NewRequest("GET", fmt.Sprintf("%s%s/namespaces",

--- a/acceptance/api/v1/namespaces_test.go
+++ b/acceptance/api/v1/namespaces_test.go
@@ -102,6 +102,31 @@ var _ = Describe("Namespaces API Application Endpoints", LNamespace, func() {
 				Expect(paged.Items).To(HaveLen(1))
 			})
 
+			It("filters namespaces by search term", func() {
+				response, err := env.Curl("GET", fmt.Sprintf("%s%s/namespaces?search=%s",
+					serverURL, api.Root, namespace), strings.NewReader(""))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				defer response.Body.Close()
+				bodyBytes, err := io.ReadAll(response.Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+				var namespaceList models.NamespaceList
+				err = json.Unmarshal(bodyBytes, &namespaceList)
+				Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+				Expect(namespaceList).ToNot(BeEmpty())
+				found := false
+				for _, ns := range namespaceList {
+					Expect(ns.Meta.Name).To(ContainSubstring(namespace))
+					if ns.Meta.Name == namespace {
+						found = true
+					}
+				}
+				Expect(found).To(BeTrue(), "expected search results to contain %q", namespace)
+			})
+
 			When("basic auth credentials are not provided", func() {
 				It("returns a 401 response", func() {
 					request, err := http.NewRequest("GET", fmt.Sprintf("%s%s/namespaces",

--- a/acceptance/api/v1/service_list_test.go
+++ b/acceptance/api/v1/service_list_test.go
@@ -239,4 +239,45 @@ var _ = Describe("ServiceList Endpoint", LService, func() {
 			})
 		})
 	})
+
+	Describe("GET /api/v1/services search", func() {
+		var serviceName1, serviceName2 string
+
+		BeforeEach(func() {
+			serviceName1 = catalog.NewServiceName()
+			serviceName2 = catalog.NewServiceName()
+
+			env.TargetNamespace(namespace1)
+			env.MakeServiceInstance(serviceName1, catalogService.Meta.Name)
+
+			env.TargetNamespace(namespace2)
+			env.MakeServiceInstance(serviceName2, catalogService.Meta.Name)
+		})
+
+		AfterEach(func() {
+			catalog.DeleteService(serviceName1, namespace1)
+			catalog.DeleteService(serviceName2, namespace2)
+		})
+
+		It("filters services by search term", func() {
+			endpoint := fmt.Sprintf("%s%s/services?search=%s", serverURL, v1.Root, serviceName1)
+			response, err := env.Curl("GET", endpoint, strings.NewReader(""))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+			var serviceListResponse models.ServiceList
+			err = json.NewDecoder(response.Body).Decode(&serviceListResponse)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(serviceListResponse).ToNot(BeEmpty())
+			found := false
+			for _, svc := range serviceListResponse {
+				Expect(svc.Meta.Name).To(ContainSubstring(serviceName1))
+				if svc.Meta.Name == serviceName1 {
+					found = true
+				}
+			}
+			Expect(found).To(BeTrue(), "expected search results to contain %q", serviceName1)
+		})
+	})
 })

--- a/internal/api/v1/application/fullindex.go
+++ b/internal/api/v1/application/fullindex.go
@@ -12,12 +12,15 @@
 package application
 
 import (
+	"strings"
+
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/auth"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
 
 	"github.com/gin-gonic/gin"
 )
@@ -39,6 +42,17 @@ func FullIndex(c *gin.Context) apierror.APIErrors {
 	}
 
 	filteredApps := auth.FilterResources(user, allApps)
+
+	if search := response.GetSearchParam(c); search != "" {
+		lower := strings.ToLower(search)
+		var searched models.AppList
+		for _, a := range filteredApps {
+			if strings.Contains(strings.ToLower(a.Meta.Name), lower) {
+				searched = append(searched, a)
+			}
+		}
+		filteredApps = searched
+	}
 
 	// Apply optional pagination when page parameters are provided.
 	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {

--- a/internal/api/v1/application/index.go
+++ b/internal/api/v1/application/index.go
@@ -30,8 +30,12 @@ func Index(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
-		apps, total, err := application.ListPaginated(ctx, cluster, namespace, page, pageSize)
+	search := response.GetSearchParam(c)
+	page, pageSize, paginated := response.GetPaginationParams(c, 1, 25)
+	if paginated || search != "" {
+		apps, total, err := application.ListPaginated(
+			ctx, cluster, namespace, page, pageSize, search,
+		)
 		if err != nil {
 			return apierror.InternalError(err)
 		}

--- a/internal/api/v1/application/index.go
+++ b/internal/api/v1/application/index.go
@@ -30,15 +30,18 @@ func Index(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
+	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
+		apps, total, err := application.ListPaginated(ctx, cluster, namespace, page, pageSize)
+		if err != nil {
+			return apierror.InternalError(err)
+		}
+		response.OKReturn(c, response.BuildPaginatedResponse(apps, page, pageSize, total))
+		return nil
+	}
+
 	apps, err := application.List(ctx, cluster, namespace)
 	if err != nil {
 		return apierror.InternalError(err)
-	}
-
-	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
-		paged := response.PaginateSlice(apps, page, pageSize)
-		response.OKReturn(c, paged)
-		return nil
 	}
 
 	response.OKReturn(c, apps)

--- a/internal/api/v1/configuration/fullindex.go
+++ b/internal/api/v1/configuration/fullindex.go
@@ -40,6 +40,43 @@ func FullIndex(c *gin.Context) apierror.APIErrors {
 	}
 	filteredConfigurations := auth.FilterResources(user, allConfigurations)
 
+	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
+		total := len(filteredConfigurations)
+		start := (page - 1) * pageSize
+		if start >= total {
+			start = total
+		}
+		end := start + pageSize
+		if end > total {
+			end = total
+		}
+		pageConfigurations := filteredConfigurations[start:end]
+
+		// Scope the binding lookup to just the namespaces on this page.
+		nsSet := map[string]struct{}{}
+		for _, cfg := range pageConfigurations {
+			nsSet[cfg.Namespace()] = struct{}{}
+		}
+		pageNamespaces := make([]string, 0, len(nsSet))
+		for ns := range nsSet {
+			pageNamespaces = append(pageNamespaces, ns)
+		}
+
+		appsOf, err := application.BoundAppsNamesForNamespaces(ctx, cluster, pageNamespaces)
+		if err != nil {
+			return apierror.InternalError(err)
+		}
+
+		// Use all filtered configs for sibling map; Details() called only for page configs.
+		responseData, err := makeResponseFrom(ctx, appsOf, filteredConfigurations, pageConfigurations)
+		if err != nil {
+			return apierror.InternalError(err)
+		}
+
+		response.OKReturn(c, response.BuildPaginatedResponse(responseData, page, pageSize, total))
+		return nil
+	}
+
 	appsOf, err := application.BoundAppsNames(ctx, cluster, "")
 	if err != nil {
 		return apierror.InternalError(err)
@@ -50,14 +87,6 @@ func FullIndex(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	// Apply optional pagination when page parameters are provided.
-	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
-		paged := response.PaginateSlice(responseData, page, pageSize)
-		response.OKReturn(c, paged)
-		return nil
-	}
-
-	// Backwards-compatible: return full list when no page params are set.
 	response.OKReturn(c, responseData)
 	return nil
 }

--- a/internal/api/v1/configuration/fullindex.go
+++ b/internal/api/v1/configuration/fullindex.go
@@ -12,6 +12,8 @@
 package configuration
 
 import (
+	"strings"
+
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
@@ -39,6 +41,17 @@ func FullIndex(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 	filteredConfigurations := auth.FilterResources(user, allConfigurations)
+
+	if search := response.GetSearchParam(c); search != "" {
+		lower := strings.ToLower(search)
+		var searched configurations.ConfigurationList
+		for _, cfg := range filteredConfigurations {
+			if strings.Contains(strings.ToLower(cfg.Name), lower) {
+				searched = append(searched, cfg)
+			}
+		}
+		filteredConfigurations = searched
+	}
 
 	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
 		total := len(filteredConfigurations)

--- a/internal/api/v1/configuration/index.go
+++ b/internal/api/v1/configuration/index.go
@@ -14,6 +14,7 @@ package configuration
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
@@ -52,6 +53,24 @@ func Index(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
+	if search := response.GetSearchParam(c); search != "" {
+		lower := strings.ToLower(search)
+		var filtered models.ConfigurationResponseList
+		for _, cfg := range responseData {
+			if strings.Contains(strings.ToLower(cfg.Meta.Name), lower) {
+				filtered = append(filtered, cfg)
+			}
+		}
+		responseData = filtered
+	}
+
+	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
+		paged := response.PaginateSlice(responseData, page, pageSize)
+		response.OKReturn(c, paged)
+		return nil
+	}
+
+	// Backwards-compatible: return full list when no page params are set.
 	response.OKReturn(c, responseData)
 	return nil
 }

--- a/internal/api/v1/configuration/index.go
+++ b/internal/api/v1/configuration/index.go
@@ -56,21 +56,36 @@ func Index(c *gin.Context) apierror.APIErrors {
 	return nil
 }
 
-func makeResponse(ctx context.Context, appsOf map[application.ConfigurationKey][]string, configs configurations.ConfigurationList) (models.ConfigurationResponseList, error) {
+func makeResponse(
+	ctx context.Context,
+	appsOf map[application.ConfigurationKey][]string,
+	configs configurations.ConfigurationList,
+) (models.ConfigurationResponseList, error) {
 	return makeResponseFrom(ctx, appsOf, configs, configs)
 }
 
-// makeResponseFrom builds the sibling map from allConfigs (so cross-page siblings remain visible)
-// but only calls Details() for processConfigs. Paginated callers pass the full filtered list as
-// allConfigs and only the current page as processConfigs.
-func makeResponseFrom(ctx context.Context, appsOf map[application.ConfigurationKey][]string, allConfigs configurations.ConfigurationList, processConfigs configurations.ConfigurationList) (models.ConfigurationResponseList, error) {
+// makeResponseFrom builds the sibling map from allConfigs
+// (so cross-page siblings remain visible) but only calls Details() for
+// processConfigs. Paginated callers pass the full filtered list as allConfigs
+// and only the current page as processConfigs.
+func makeResponseFrom(
+	ctx context.Context,
+	appsOf map[application.ConfigurationKey][]string,
+	allConfigs configurations.ConfigurationList,
+	processConfigs configurations.ConfigurationList,
+) (models.ConfigurationResponseList, error) {
 	result := models.ConfigurationResponseList{}
 
-	// Build sibling map from all configs so service-based siblings on other pages are visible.
+	// Build sibling map from all configs so service-based siblings on other
+	// pages are visible.
 	siblingMap := map[string][]string{}
 	for _, configuration := range allConfigs {
 		if configuration.Origin != "" {
-			key := fmt.Sprintf("n%s/o%s", configuration.Namespace(), configuration.Origin)
+			key := fmt.Sprintf(
+				"n%s/o%s",
+				configuration.Namespace(),
+				configuration.Origin,
+			)
 			siblingMap[key] = append(siblingMap[key], configuration.Name)
 		}
 	}

--- a/internal/api/v1/configuration/index.go
+++ b/internal/api/v1/configuration/index.go
@@ -56,27 +56,29 @@ func Index(c *gin.Context) apierror.APIErrors {
 	return nil
 }
 
-func makeResponse(ctx context.Context, appsOf map[application.ConfigurationKey][]string, configurations configurations.ConfigurationList) (models.ConfigurationResponseList, error) {
+func makeResponse(ctx context.Context, appsOf map[application.ConfigurationKey][]string, configs configurations.ConfigurationList) (models.ConfigurationResponseList, error) {
+	return makeResponseFrom(ctx, appsOf, configs, configs)
+}
 
-	response := models.ConfigurationResponseList{}
+// makeResponseFrom builds the sibling map from allConfigs (so cross-page siblings remain visible)
+// but only calls Details() for processConfigs. Paginated callers pass the full filtered list as
+// allConfigs and only the current page as processConfigs.
+func makeResponseFrom(ctx context.Context, appsOf map[application.ConfigurationKey][]string, allConfigs configurations.ConfigurationList, processConfigs configurations.ConfigurationList) (models.ConfigurationResponseList, error) {
+	result := models.ConfigurationResponseList{}
 
-	// All the possible siblings of a configuration are present in the configuration list.
-	//
-	// Simply iterate and sort them into buckets by service origin. Note that the namespace has
-	// to be part of the key. Non-service configurations are ignored.
-
+	// Build sibling map from all configs so service-based siblings on other pages are visible.
 	siblingMap := map[string][]string{}
-	for _, configuration := range configurations {
+	for _, configuration := range allConfigs {
 		if configuration.Origin != "" {
 			key := fmt.Sprintf("n%s/o%s", configuration.Namespace(), configuration.Origin)
 			siblingMap[key] = append(siblingMap[key], configuration.Name)
 		}
 	}
 
-	// Fetch details for each configuration concurrently.
-	results := make([]*models.ConfigurationResponse, len(configurations))
+	// Fetch details concurrently for processConfigs only.
+	results := make([]*models.ConfigurationResponse, len(processConfigs))
 	group, groupCtx := errgroup.WithContext(ctx)
-	for i, configuration := range configurations {
+	for i, configuration := range processConfigs {
 		i, configuration := i, configuration
 		group.Go(func() error {
 			configurationDetails, err := configuration.Details(groupCtx)
@@ -93,7 +95,6 @@ func makeResponse(ctx context.Context, appsOf map[application.ConfigurationKey][
 			)
 			appNames := appsOf[key]
 
-			// For service-based configuration, pull siblings out of the map
 			siblings := []string{}
 			if configuration.Origin != "" {
 				key := fmt.Sprintf(
@@ -101,7 +102,6 @@ func makeResponse(ctx context.Context, appsOf map[application.ConfigurationKey][
 					configuration.Namespace(),
 					configuration.Origin,
 				)
-
 				for _, maybeSibling := range siblingMap[key] {
 					if maybeSibling != configuration.Name {
 						siblings = append(siblings, maybeSibling)
@@ -136,9 +136,9 @@ func makeResponse(ctx context.Context, appsOf map[application.ConfigurationKey][
 
 	for _, r := range results {
 		if r != nil {
-			response = append(response, *r)
+			result = append(result, *r)
 		}
 	}
 
-	return response, nil
+	return result, nil
 }

--- a/internal/api/v1/namespace/index.go
+++ b/internal/api/v1/namespace/index.go
@@ -46,6 +46,59 @@ func Index(c *gin.Context) apierror.APIErrors {
 	}
 	namespaceList = auth.FilterResources(user, namespaceList)
 
+	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
+		total := len(namespaceList)
+		start := (page - 1) * pageSize
+		if start >= total {
+			start = total
+		}
+		end := start + pageSize
+		if end > total {
+			end = total
+		}
+		pageNsList := namespaceList[start:end]
+
+		// Single cross-namespace API calls; filter in-memory to page namespaces.
+		pageNsSet := make(map[string]bool, len(pageNsList))
+		for _, ns := range pageNsList {
+			pageNsSet[ns.Name] = true
+		}
+
+		allAppRefs, err := application.ListAppRefs(ctx, cluster, "")
+		if err != nil {
+			return apierror.InternalError(err)
+		}
+		appNamesMap := map[string][]string{}
+		for _, ref := range allAppRefs {
+			if pageNsSet[ref.Namespace] {
+				appNamesMap[ref.Namespace] = append(appNamesMap[ref.Namespace], ref.Name)
+			}
+		}
+
+		allConfigs, err := configurations.List(ctx, cluster, "")
+		if err != nil {
+			return apierror.InternalError(err)
+		}
+		configNamesMap := map[string][]string{}
+		for _, cfg := range allConfigs {
+			if pageNsSet[cfg.Namespace()] {
+				configNamesMap[cfg.Namespace()] = append(configNamesMap[cfg.Namespace()], cfg.Name)
+			}
+		}
+
+		nsModels := make(models.NamespaceList, 0, len(pageNsList))
+		for _, ns := range pageNsList {
+			nsModels = append(nsModels, models.Namespace{
+				Meta:           models.MetaLite{Name: ns.Name, CreatedAt: ns.CreatedAt},
+				Apps:           appNamesMap[ns.Name],
+				Configurations: configNamesMap[ns.Name],
+			})
+		}
+
+		response.OKReturn(c, response.BuildPaginatedResponse(nsModels, page, pageSize, total))
+		return nil
+	}
+
 	appNamesMap, err := getAppNamesByNamespaceMap(ctx, cluster)
 	if err != nil {
 		return apierror.InternalError(err)
@@ -56,9 +109,9 @@ func Index(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	namespaces := make(models.NamespaceList, 0, len(namespaceList))
+	nsList := make(models.NamespaceList, 0, len(namespaceList))
 	for _, namespace := range namespaceList {
-		namespaces = append(namespaces, models.Namespace{
+		nsList = append(nsList, models.Namespace{
 			Meta: models.MetaLite{
 				Name:      namespace.Name,
 				CreatedAt: namespace.CreatedAt,
@@ -68,15 +121,7 @@ func Index(c *gin.Context) apierror.APIErrors {
 		})
 	}
 
-	// Apply optional pagination when page parameters are provided.
-	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
-		paged := response.PaginateSlice(namespaces, page, pageSize)
-		response.OKReturn(c, paged)
-		return nil
-	}
-
-	// Backwards-compatible: return full list when no page params are set.
-	response.OKReturn(c, namespaces)
+	response.OKReturn(c, nsList)
 	return nil
 }
 

--- a/internal/api/v1/namespace/index.go
+++ b/internal/api/v1/namespace/index.go
@@ -71,7 +71,10 @@ func Index(c *gin.Context) apierror.APIErrors {
 		appNamesMap := map[string][]string{}
 		for _, ref := range allAppRefs {
 			if pageNsSet[ref.Namespace] {
-				appNamesMap[ref.Namespace] = append(appNamesMap[ref.Namespace], ref.Name)
+				appNamesMap[ref.Namespace] = append(
+					appNamesMap[ref.Namespace],
+					ref.Name,
+				)
 			}
 		}
 
@@ -82,7 +85,10 @@ func Index(c *gin.Context) apierror.APIErrors {
 		configNamesMap := map[string][]string{}
 		for _, cfg := range allConfigs {
 			if pageNsSet[cfg.Namespace()] {
-				configNamesMap[cfg.Namespace()] = append(configNamesMap[cfg.Namespace()], cfg.Name)
+				configNamesMap[cfg.Namespace()] = append(
+					configNamesMap[cfg.Namespace()],
+					cfg.Name,
+				)
 			}
 		}
 
@@ -95,7 +101,12 @@ func Index(c *gin.Context) apierror.APIErrors {
 			})
 		}
 
-		response.OKReturn(c, response.BuildPaginatedResponse(nsModels, page, pageSize, total))
+		response.OKReturn(c, response.BuildPaginatedResponse(
+			nsModels,
+			page,
+			pageSize,
+			total,
+		))
 		return nil
 	}
 
@@ -125,7 +136,10 @@ func Index(c *gin.Context) apierror.APIErrors {
 	return nil
 }
 
-func getAppNamesByNamespaceMap(ctx context.Context, cluster *kubernetes.Cluster) (map[string][]string, error) {
+func getAppNamesByNamespaceMap(
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+) (map[string][]string, error) {
 	// Retrieve app references for all namespaces, and map their name by namespace
 	allAppNamesMap := make(map[string][]string)
 
@@ -138,13 +152,19 @@ func getAppNamesByNamespaceMap(ctx context.Context, cluster *kubernetes.Cluster)
 		if _, ok := allAppNamesMap[appRef.Namespace]; !ok {
 			allAppNamesMap[appRef.Namespace] = make([]string, 0)
 		}
-		allAppNamesMap[appRef.Namespace] = append(allAppNamesMap[appRef.Namespace], appRef.Name)
+		allAppNamesMap[appRef.Namespace] = append(
+			allAppNamesMap[appRef.Namespace],
+			appRef.Name,
+		)
 	}
 
 	return allAppNamesMap, nil
 }
 
-func getConfigurationNamesByNamespaceMap(ctx context.Context, cluster *kubernetes.Cluster) (map[string][]string, error) {
+func getConfigurationNamesByNamespaceMap(
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+) (map[string][]string, error) {
 	configurationNamesMap := make(map[string][]string)
 
 	// Retrieve configurations for all namespaces, and map their name by namespace
@@ -157,7 +177,10 @@ func getConfigurationNamesByNamespaceMap(ctx context.Context, cluster *kubernete
 		if _, ok := configurationNamesMap[config.Namespace()]; !ok {
 			configurationNamesMap[config.Namespace()] = make([]string, 0)
 		}
-		configurationNamesMap[config.Namespace()] = append(configurationNamesMap[config.Namespace()], config.Name)
+		configurationNamesMap[config.Namespace()] = append(
+			configurationNamesMap[config.Namespace()],
+			config.Name,
+		)
 	}
 
 	return configurationNamesMap, nil

--- a/internal/api/v1/namespace/index.go
+++ b/internal/api/v1/namespace/index.go
@@ -13,6 +13,7 @@ package namespace
 
 import (
 	"context"
+	"strings"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
@@ -45,6 +46,17 @@ func Index(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 	namespaceList = auth.FilterResources(user, namespaceList)
+
+	if search := response.GetSearchParam(c); search != "" {
+		lower := strings.ToLower(search)
+		var filtered []namespaces.Namespace
+		for _, ns := range namespaceList {
+			if strings.Contains(strings.ToLower(ns.Name), lower) {
+				filtered = append(filtered, ns)
+			}
+		}
+		namespaceList = filtered
+	}
 
 	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
 		total := len(namespaceList)

--- a/internal/api/v1/response/response.go
+++ b/internal/api/v1/response/response.go
@@ -107,6 +107,26 @@ func GetPaginationParams(c *gin.Context, defaultPage, defaultPageSize int) (page
 	return page, pageSize, enabled
 }
 
+// BuildPaginatedResponse builds a PaginatedResponse from an already-paged slice and total count.
+// Use this when pagination happened before enrichment (e.g. ListPaginated), so the caller
+// already holds only the page items and knows the total independently.
+func BuildPaginatedResponse[T any](items []T, page, pageSize, totalItems int) PaginatedResponse[T] {
+	totalPages := 1
+	if pageSize > 0 {
+		totalPages = int(math.Ceil(float64(totalItems) / float64(pageSize)))
+	}
+	if totalPages == 0 {
+		totalPages = 1
+	}
+	return PaginatedResponse[T]{
+		Items:      items,
+		Page:       page,
+		PageSize:   pageSize,
+		TotalItems: totalItems,
+		TotalPages: totalPages,
+	}
+}
+
 // PaginateSlice applies simple page/pageSize slicing over a slice and returns
 // a PaginatedResponse with metadata.
 func PaginateSlice[T any](items []T, page, pageSize int) PaginatedResponse[T] {

--- a/internal/api/v1/response/response.go
+++ b/internal/api/v1/response/response.go
@@ -67,6 +67,11 @@ func OKReturn(c *gin.Context, response interface{}) {
 	c.JSON(http.StatusOK, response)
 }
 
+// GetSearchParam returns the optional "search" query parameter for name filtering.
+func GetSearchParam(c *gin.Context) string {
+	return c.Query("search")
+}
+
 // PaginatedResponse represents a generic paginated response payload.
 // It wraps a slice of items with pagination metadata.
 type PaginatedResponse[T any] struct {

--- a/internal/api/v1/response/response_test.go
+++ b/internal/api/v1/response/response_test.go
@@ -1,0 +1,170 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package response_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/gin-gonic/gin"
+)
+
+func TestBuildPaginatedResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name         string
+		items        []string
+		page         int
+		pageSize     int
+		totalItems   int
+		wantPage     int
+		wantPageSize int
+		wantTotal    int
+		wantPages    int
+		wantItemsLen int
+	}{
+		{
+			name:         "first page of three",
+			items:        []string{"a", "b"},
+			page: 1, pageSize: 2, totalItems: 5,
+			wantPage: 1, wantPageSize: 2, wantTotal: 5, wantPages: 3, wantItemsLen: 2,
+		},
+		{
+			name:         "last partial page",
+			items:        []string{"e"},
+			page: 3, pageSize: 2, totalItems: 5,
+			wantPage: 3, wantPageSize: 2, wantTotal: 5, wantPages: 3, wantItemsLen: 1,
+		},
+		{
+			name:         "empty result set floors totalPages to 1",
+			items:        []string{},
+			page: 1, pageSize: 10, totalItems: 0,
+			wantPage: 1, wantPageSize: 10, wantTotal: 0, wantPages: 1, wantItemsLen: 0,
+		},
+		{
+			name:         "pageSize zero returns totalPages 1",
+			items:        []string{},
+			page: 1, pageSize: 0, totalItems: 5,
+			wantPage: 1, wantPageSize: 0, wantTotal: 5, wantPages: 1, wantItemsLen: 0,
+		},
+		{
+			name:         "exact fit — single full page",
+			items:        []string{"a", "b", "c"},
+			page: 1, pageSize: 3, totalItems: 3,
+			wantPage: 1, wantPageSize: 3, wantTotal: 3, wantPages: 1, wantItemsLen: 3,
+		},
+		{
+			name:         "single item per page",
+			items:        []string{"x"},
+			page: 2, pageSize: 1, totalItems: 4,
+			wantPage: 2, wantPageSize: 1, wantTotal: 4, wantPages: 4, wantItemsLen: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := response.BuildPaginatedResponse(tc.items, tc.page, tc.pageSize, tc.totalItems)
+			if got.Page != tc.wantPage {
+				t.Errorf("Page: got %d want %d", got.Page, tc.wantPage)
+			}
+			if got.PageSize != tc.wantPageSize {
+				t.Errorf("PageSize: got %d want %d", got.PageSize, tc.wantPageSize)
+			}
+			if got.TotalItems != tc.wantTotal {
+				t.Errorf("TotalItems: got %d want %d", got.TotalItems, tc.wantTotal)
+			}
+			if got.TotalPages != tc.wantPages {
+				t.Errorf("TotalPages: got %d want %d", got.TotalPages, tc.wantPages)
+			}
+			if len(got.Items) != tc.wantItemsLen {
+				t.Errorf("len(Items): got %d want %d", len(got.Items), tc.wantItemsLen)
+			}
+		})
+	}
+}
+
+func TestGetPaginationParams(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	makeCtx := func(query string) *gin.Context {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		req, _ := http.NewRequest("GET", "/test?"+query, nil)
+		c.Request = req
+		return c
+	}
+
+	tests := []struct {
+		name            string
+		query           string
+		defaultPage     int
+		defaultPageSize int
+		wantPage        int
+		wantPageSize    int
+		wantEnabled     bool
+	}{
+		{
+			name: "no params — disabled",
+			query: "", defaultPage: 1, defaultPageSize: 25,
+			wantPage: 0, wantPageSize: 0, wantEnabled: false,
+		},
+		{
+			name: "both params present",
+			query: "page=2&pageSize=10", defaultPage: 1, defaultPageSize: 25,
+			wantPage: 2, wantPageSize: 10, wantEnabled: true,
+		},
+		{
+			name: "only page present — uses default pageSize",
+			query: "page=3", defaultPage: 1, defaultPageSize: 25,
+			wantPage: 3, wantPageSize: 25, wantEnabled: true,
+		},
+		{
+			name: "only pageSize present — uses default page",
+			query: "pageSize=5", defaultPage: 1, defaultPageSize: 25,
+			wantPage: 1, wantPageSize: 5, wantEnabled: true,
+		},
+		{
+			name: "invalid page value — falls back to default",
+			query: "page=bad&pageSize=10", defaultPage: 1, defaultPageSize: 25,
+			wantPage: 1, wantPageSize: 10, wantEnabled: true,
+		},
+		{
+			name: "zero page value — falls back to default",
+			query: "page=0&pageSize=10", defaultPage: 1, defaultPageSize: 25,
+			wantPage: 1, wantPageSize: 10, wantEnabled: true,
+		},
+		{
+			name: "negative pageSize — falls back to default",
+			query: "page=1&pageSize=-5", defaultPage: 1, defaultPageSize: 25,
+			wantPage: 1, wantPageSize: 25, wantEnabled: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := makeCtx(tc.query)
+			page, pageSize, enabled := response.GetPaginationParams(c, tc.defaultPage, tc.defaultPageSize)
+			if enabled != tc.wantEnabled {
+				t.Errorf("enabled: got %v want %v", enabled, tc.wantEnabled)
+			}
+			if page != tc.wantPage {
+				t.Errorf("page: got %d want %d", page, tc.wantPage)
+			}
+			if pageSize != tc.wantPageSize {
+				t.Errorf("pageSize: got %d want %d", pageSize, tc.wantPageSize)
+			}
+		})
+	}
+}

--- a/internal/api/v1/response/response_test.go
+++ b/internal/api/v1/response/response_test.go
@@ -95,6 +95,38 @@ func TestBuildPaginatedResponse(t *testing.T) {
 	}
 }
 
+func TestGetSearchParam(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	makeCtx := func(query string) *gin.Context {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		req, _ := http.NewRequest("GET", "/test?"+query, nil)
+		c.Request = req
+		return c
+	}
+
+	tests := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{name: "no search param", query: "", want: ""},
+		{name: "search param with value", query: "search=foo", want: "foo"},
+		{name: "empty search param", query: "search=", want: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := makeCtx(tc.query)
+			got := response.GetSearchParam(c)
+			if got != tc.want {
+				t.Errorf("GetSearchParam: got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestGetPaginationParams(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/api/v1/service/fullindex.go
+++ b/internal/api/v1/service/fullindex.go
@@ -43,24 +43,45 @@ func FullIndex(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
+	filteredServices := auth.FilterResources(user, serviceList)
+
+	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
+		total := len(filteredServices)
+		start := (page - 1) * pageSize
+		if start >= total {
+			start = total
+		}
+		end := start + pageSize
+		if end > total {
+			end = total
+		}
+		pageServices := filteredServices[start:end]
+
+		// Scope the binding lookup to just the namespaces on this page.
+		nsSet := map[string]struct{}{}
+		for _, svc := range pageServices {
+			nsSet[svc.Meta.Namespace] = struct{}{}
+		}
+		pageNamespaces := make([]string, 0, len(nsSet))
+		for ns := range nsSet {
+			pageNamespaces = append(pageNamespaces, ns)
+		}
+
+		appsOf, err := application.ServicesBoundAppsNamesForNamespaces(ctx, cluster, pageNamespaces)
+		if err != nil {
+			return apierror.InternalError(err)
+		}
+
+		response.OKReturn(c, response.BuildPaginatedResponse(extendWithBoundApps(pageServices, appsOf), page, pageSize, total))
+		return nil
+	}
+
 	appsOf, err := application.ServicesBoundAppsNames(ctx, cluster, "")
 	if err != nil {
 		return apierror.InternalError(err)
 	}
 
-	filteredServices := auth.FilterResources(user, serviceList)
-
-	servicesWithApps := extendWithBoundApps(filteredServices, appsOf)
-
-	// Apply optional pagination when page parameters are provided.
-	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
-		paged := response.PaginateSlice(servicesWithApps, page, pageSize)
-		response.OKReturn(c, paged)
-		return nil
-	}
-
-	// Backwards-compatible: return full list when no page params are set.
-	response.OKReturn(c, servicesWithApps)
+	response.OKReturn(c, extendWithBoundApps(filteredServices, appsOf))
 	return nil
 }
 

--- a/internal/api/v1/service/fullindex.go
+++ b/internal/api/v1/service/fullindex.go
@@ -12,6 +12,8 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
@@ -44,6 +46,17 @@ func FullIndex(c *gin.Context) apierror.APIErrors {
 	}
 
 	filteredServices := auth.FilterResources(user, serviceList)
+
+	if search := response.GetSearchParam(c); search != "" {
+		lower := strings.ToLower(search)
+		var searched models.ServiceList
+		for _, svc := range filteredServices {
+			if strings.Contains(strings.ToLower(svc.Meta.Name), lower) {
+				searched = append(searched, svc)
+			}
+		}
+		filteredServices = searched
+	}
 
 	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
 		total := len(filteredServices)

--- a/internal/api/v1/service/fullindex.go
+++ b/internal/api/v1/service/fullindex.go
@@ -67,12 +67,21 @@ func FullIndex(c *gin.Context) apierror.APIErrors {
 			pageNamespaces = append(pageNamespaces, ns)
 		}
 
-		appsOf, err := application.ServicesBoundAppsNamesForNamespaces(ctx, cluster, pageNamespaces)
+		appsOf, err := application.ServicesBoundAppsNamesForNamespaces(
+			ctx,
+			cluster,
+			pageNamespaces,
+		)
 		if err != nil {
 			return apierror.InternalError(err)
 		}
 
-		response.OKReturn(c, response.BuildPaginatedResponse(extendWithBoundApps(pageServices, appsOf), page, pageSize, total))
+		response.OKReturn(c, response.BuildPaginatedResponse(
+			extendWithBoundApps(pageServices, appsOf),
+			page,
+			pageSize,
+			total,
+		))
 		return nil
 	}
 
@@ -85,7 +94,10 @@ func FullIndex(c *gin.Context) apierror.APIErrors {
 	return nil
 }
 
-func extendWithBoundApps(services models.ServiceList, appsOf map[string][]string) models.ServiceList {
+func extendWithBoundApps(
+	services models.ServiceList,
+	appsOf map[string][]string,
+) models.ServiceList {
 	theServices := models.ServiceList{}
 	for _, service := range services {
 		key := application.ServiceKey(service.Meta.Name, service.Meta.Namespace)

--- a/internal/api/v1/service/list.go
+++ b/internal/api/v1/service/list.go
@@ -12,11 +12,14 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/services"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
 
 	"github.com/gin-gonic/gin"
 )
@@ -45,6 +48,26 @@ func List(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
-	response.OKReturn(c, extendWithBoundApps(serviceList, appsOf))
+	servicesWithApps := extendWithBoundApps(serviceList, appsOf)
+
+	if search := response.GetSearchParam(c); search != "" {
+		lower := strings.ToLower(search)
+		var filtered models.ServiceList
+		for _, svc := range servicesWithApps {
+			if strings.Contains(strings.ToLower(svc.Meta.Name), lower) {
+				filtered = append(filtered, svc)
+			}
+		}
+		servicesWithApps = filtered
+	}
+
+	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
+		paged := response.PaginateSlice(servicesWithApps, page, pageSize)
+		response.OKReturn(c, paged)
+		return nil
+	}
+
+	// Backwards-compatible: return full list when no page params are set.
+	response.OKReturn(c, servicesWithApps)
 	return nil
 }

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -553,12 +553,24 @@ func ListPaginated(
 
 	appAuxiliary := makeAuxiliaryMap(secrets.Items)
 
-	appAuxiliary, err = AddApplicationPods(appAuxiliary, ctx, cluster, namespace, pageAppNames)
+	appAuxiliary, err = AddApplicationPods(
+		appAuxiliary,
+		ctx,
+		cluster,
+		namespace,
+		pageAppNames,
+	)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	appAuxiliary, err = AddActualApplicationRoutes(appAuxiliary, ctx, cluster, namespace, pageAppNames)
+	appAuxiliary, err = AddActualApplicationRoutes(
+		appAuxiliary,
+		ctx,
+		cluster,
+		namespace,
+		pageAppNames,
+	)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -568,11 +580,19 @@ func ListPaginated(
 		helpers.Logger.Errorw("metrics not available", "error", err)
 	}
 
-	stagingStatuses, err := StagingStatusesForApps(ctx, cluster, namespace, pageAppNames)
+	stagingStatuses, err := StagingStatusesForApps(
+		ctx,
+		cluster,
+		namespace,
+		pageAppNames,
+	)
 	if err != nil {
 		return nil, 0, err
 	}
-	appAuxiliary = updateAppDataMapWithStagingJobStatus(appAuxiliary, stagingStatuses)
+	appAuxiliary = updateAppDataMapWithStagingJobStatus(
+		appAuxiliary,
+		stagingStatuses,
+	)
 
 	result := models.AppList{}
 	for _, appCR := range pageCRs {

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -507,6 +507,7 @@ func ListPaginated(
 	cluster *kubernetes.Cluster,
 	namespace string,
 	page, pageSize int,
+	search string,
 ) (models.AppList, int, error) {
 	client, err := cluster.ClientApp()
 	if err != nil {
@@ -518,7 +519,19 @@ func ListPaginated(
 		return nil, 0, err
 	}
 
-	totalCount := len(appCRList.Items)
+	allCRs := appCRList.Items
+	if search != "" {
+		lower := strings.ToLower(search)
+		var matched []unstructured.Unstructured
+		for _, cr := range allCRs {
+			if strings.Contains(strings.ToLower(cr.GetName()), lower) {
+				matched = append(matched, cr)
+			}
+		}
+		allCRs = matched
+	}
+
+	totalCount := len(allCRs)
 
 	if page < 1 {
 		page = 1
@@ -534,7 +547,7 @@ func ListPaginated(
 	if end > totalCount {
 		end = totalCount
 	}
-	pageCRs := appCRList.Items[start:end]
+	pageCRs := allCRs[start:end]
 
 	pageAppNames := make([]string, 0, len(pageCRs))
 	for _, cr := range pageCRs {

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -53,6 +53,19 @@ import (
 
 const EpinioApplicationAreaLabel = "epinio.io/area"
 
+// appNamesInSelector appends an "in" label requirement for app names to a base selector string.
+// Returns base unchanged when names is empty.
+func appNamesInSelector(base string, names []string) string {
+	if len(names) == 0 {
+		return base
+	}
+	in := "app.kubernetes.io/name in (" + strings.Join(names, ",") + ")"
+	if base == "" {
+		return in
+	}
+	return base + "," + in
+}
+
 type JobLister interface {
 	ListJobs(
 		ctx context.Context,
@@ -219,7 +232,7 @@ func IsCurrentlyStaging(
 	namespace,
 	appName string,
 ) (bool, error) {
-	staging, err := stagingStatus(ctx, cluster, namespace, appName)
+	staging, err := stagingStatus(ctx, cluster, namespace, []string{appName})
 	if err != nil {
 		return false, err
 	}
@@ -233,35 +246,48 @@ func StagingStatuses(
 	cluster JobLister,
 	namespace string,
 ) (map[ConfigurationKey]models.ApplicationStagingStatus, error) {
-	return stagingStatus(ctx, cluster, namespace, "")
+	return stagingStatus(ctx, cluster, namespace, nil)
+}
+
+// StagingStatusesForApps returns staging statuses scoped to the given app names.
+func StagingStatusesForApps(
+	ctx context.Context,
+	cluster JobLister,
+	namespace string,
+	appNames []string,
+) (map[ConfigurationKey]models.ApplicationStagingStatus, error) {
+	return stagingStatus(ctx, cluster, namespace, appNames)
 }
 
 /*
 stagingStatus is a utility function loading a map of the status of the
-application's staging jobs (active, done, error).  If no appName is specified
-it will load a complete map, otherwise the map will contain only the status
-of the job of the specified app
+application's staging jobs (active, done, error). If appNames is empty it loads
+a complete map for the namespace; otherwise it scopes the query to the named apps.
 */
 func stagingStatus(
 	ctx context.Context,
 	cluster JobLister,
-	namespace,
-	appName string,
+	namespace string,
+	appNames []string,
 ) (map[ConfigurationKey]models.ApplicationStagingStatus, error) {
 	stagingJobsMap := make(map[ConfigurationKey]models.ApplicationStagingStatus)
 
-	// filter the jobs in the namespace
 	labelsMap := make(map[string]string)
-
 	if namespace != "" {
 		labelsMap["app.kubernetes.io/part-of"] = namespace
 	}
 
-	if appName != "" {
-		labelsMap["app.kubernetes.io/name"] = appName
+	base := labels.Set(labelsMap).AsSelector().String()
+	var selector string
+	switch len(appNames) {
+	case 0:
+		selector = base
+	case 1:
+		labelsMap["app.kubernetes.io/name"] = appNames[0]
+		selector = labels.Set(labelsMap).AsSelector().String()
+	default:
+		selector = appNamesInSelector(base, appNames)
 	}
-
-	selector := labels.Set(labelsMap).AsSelector().String()
 	jobList, err := cluster.ListJobs(ctx, helmchart.Namespace(), selector)
 	if err != nil {
 		return nil, err
@@ -417,7 +443,7 @@ func List(
 
 	// III. The pods for the deployed apps.
 
-	appAuxiliary, err = AddApplicationPods(appAuxiliary, ctx, cluster, namespace)
+	appAuxiliary, err = AddApplicationPods(appAuxiliary, ctx, cluster, namespace, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -429,6 +455,7 @@ func List(
 		ctx,
 		cluster,
 		namespace,
+		nil,
 	)
 	if err != nil {
 		return nil, err
@@ -436,7 +463,7 @@ func List(
 
 	// V. Pod metrics and replica information
 
-	metrics, err := GetPodMetrics(ctx, cluster, namespace)
+	metrics, err := GetPodMetrics(ctx, cluster, namespace, nil)
 	if err != nil {
 		// While the error is ignored, as the server can operate without metrics, and while
 		// the missing metrics will be noted in the data shown to the user, it is logged so
@@ -470,6 +497,95 @@ func List(
 	}
 
 	return result, nil
+}
+
+// ListPaginated fetches only the apps for the requested page, scoping the expensive
+// Kubernetes queries (pods, ingresses, metrics, staging jobs) to just those app names.
+// Returns the paged app list and the total app count (for building pagination metadata).
+func ListPaginated(
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+	namespace string,
+	page, pageSize int,
+) (models.AppList, int, error) {
+	client, err := cluster.ClientApp()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	appCRList, err := client.Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	totalCount := len(appCRList.Items)
+
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 {
+		pageSize = 25
+	}
+	start := (page - 1) * pageSize
+	if start >= totalCount {
+		return models.AppList{}, totalCount, nil
+	}
+	end := start + pageSize
+	if end > totalCount {
+		end = totalCount
+	}
+	pageCRs := appCRList.Items[start:end]
+
+	pageAppNames := make([]string, 0, len(pageCRs))
+	for _, cr := range pageCRs {
+		pageAppNames = append(pageAppNames, cr.GetName())
+	}
+
+	secrets, err := cluster.Kubectl.CoreV1().Secrets(namespace).List(
+		ctx,
+		metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/managed-by=epinio",
+		},
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	appAuxiliary := makeAuxiliaryMap(secrets.Items)
+
+	appAuxiliary, err = AddApplicationPods(appAuxiliary, ctx, cluster, namespace, pageAppNames)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	appAuxiliary, err = AddActualApplicationRoutes(appAuxiliary, ctx, cluster, namespace, pageAppNames)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	pageMetrics, err := GetPodMetrics(ctx, cluster, namespace, pageAppNames)
+	if err != nil {
+		helpers.Logger.Errorw("metrics not available", "error", err)
+	}
+
+	stagingStatuses, err := StagingStatusesForApps(ctx, cluster, namespace, pageAppNames)
+	if err != nil {
+		return nil, 0, err
+	}
+	appAuxiliary = updateAppDataMapWithStagingJobStatus(appAuxiliary, stagingStatuses)
+
+	result := models.AppList{}
+	for _, appCR := range pageCRs {
+		app, err := aggregate(ctx, cluster, appCR, appAuxiliary, pageMetrics)
+		if err != nil {
+			return result, totalCount, err
+		}
+		if app != nil {
+			result = append(result, *app)
+		}
+	}
+
+	return result, totalCount, nil
 }
 
 // DeleteResult contains the result of a delete operation, including
@@ -1581,7 +1697,7 @@ func fetch(ctx context.Context, cluster *kubernetes.Cluster, app *models.App) er
 		return err
 	}
 
-	staging, err := stagingStatus(ctx, cluster, app.Meta.Namespace, app.Meta.Name)
+	staging, err := stagingStatus(ctx, cluster, app.Meta.Namespace, []string{app.Meta.Name})
 	if err != nil {
 		err = errors.Wrap(err, "staging app")
 		app.StatusMessage = err.Error()

--- a/internal/application/application_test.go
+++ b/internal/application/application_test.go
@@ -201,6 +201,77 @@ var _ = Describe("application", func() {
 		})
 	})
 
+	Describe("StagingStatusesForApps", func() {
+		When("called with a single app name", func() {
+			It("returns the staging status for that app", func() {
+				app := appName()
+
+				stagingJobs := &apibatchv1.JobList{
+					Items: []apibatchv1.Job{
+						makeJob(app, namespace, v1.ConditionFalse, apibatchv1.JobComplete),
+					},
+				}
+				fake.ListJobsReturns(stagingJobs, nil)
+
+				isStagingMap, err := application.StagingStatusesForApps(context.Background(), fake, namespace, []string{app})
+				Expect(err).To(BeNil())
+				Expect(isStagingMap).To(HaveLen(1))
+				Expect(string(isStagingMap[application.EncodeConfigurationKey(app, namespace)])).To(Equal(models.ApplicationStagingActive))
+			})
+		})
+
+		When("called with multiple app names", func() {
+			It("uses an in-selector and returns a status for each app", func() {
+				app1, app2 := appName(), appName()
+
+				stagingJobs := &apibatchv1.JobList{
+					Items: []apibatchv1.Job{
+						makeJob(app1, namespace, v1.ConditionFalse, apibatchv1.JobComplete),
+						makeJob(app2, namespace, v1.ConditionTrue, apibatchv1.JobComplete),
+					},
+				}
+				fake.ListJobsReturns(stagingJobs, nil)
+
+				isStagingMap, err := application.StagingStatusesForApps(context.Background(), fake, namespace, []string{app1, app2})
+				Expect(err).To(BeNil())
+				Expect(isStagingMap).To(HaveLen(2))
+
+				_, _, selector := fake.ListJobsArgsForCall(0)
+				Expect(selector).To(ContainSubstring("app.kubernetes.io/name in ("))
+			})
+		})
+
+		When("called with empty app names", func() {
+			It("returns statuses for all apps in the namespace", func() {
+				app1, app2 := appName(), appName()
+
+				stagingJobs := &apibatchv1.JobList{
+					Items: []apibatchv1.Job{
+						makeJob(app1, namespace, v1.ConditionFalse, apibatchv1.JobComplete),
+						makeJob(app2, namespace, v1.ConditionTrue, apibatchv1.JobComplete),
+					},
+				}
+				fake.ListJobsReturns(stagingJobs, nil)
+
+				isStagingMap, err := application.StagingStatusesForApps(context.Background(), fake, namespace, nil)
+				Expect(err).To(BeNil())
+				Expect(isStagingMap).To(HaveLen(2))
+
+				_, _, selector := fake.ListJobsArgsForCall(0)
+				Expect(selector).ToNot(ContainSubstring("in ("))
+			})
+		})
+
+		When("ListJobs returns an error", func() {
+			It("propagates the error", func() {
+				fake.ListJobsReturns(nil, errors.New("k8s unavailable"))
+
+				_, err := application.StagingStatusesForApps(context.Background(), fake, namespace, []string{appName()})
+				Expect(err).NotTo(BeNil())
+			})
+		})
+	})
+
 	Describe("UnstageResult", func() {
 		Describe("HasIncompleteCleanup", func() {
 			When("no failed blob cleanups", func() {

--- a/internal/application/configurations.go
+++ b/internal/application/configurations.go
@@ -101,7 +101,11 @@ func BoundAppsNamesFor(ctx context.Context, cluster *kubernetes.Cluster, namespa
 // BoundAppsNamesForNamespaces is a scoped variant of BoundAppsNames that limits the binding
 // secret lookup to a specific set of namespaces. Used by paginated list handlers to avoid loading
 // binding data for namespaces not on the current page.
-func BoundAppsNamesForNamespaces(ctx context.Context, cluster *kubernetes.Cluster, namespaces []string) (map[ConfigurationKey][]string, error) {
+func BoundAppsNamesForNamespaces(
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+	namespaces []string,
+) (map[ConfigurationKey][]string, error) {
 	result := map[ConfigurationKey][]string{}
 	if len(namespaces) == 0 {
 		return result, nil

--- a/internal/application/configurations.go
+++ b/internal/application/configurations.go
@@ -98,6 +98,38 @@ func BoundAppsNamesFor(ctx context.Context, cluster *kubernetes.Cluster, namespa
 	return result, nil
 }
 
+// BoundAppsNamesForNamespaces is a scoped variant of BoundAppsNames that limits the binding
+// secret lookup to a specific set of namespaces. Used by paginated list handlers to avoid loading
+// binding data for namespaces not on the current page.
+func BoundAppsNamesForNamespaces(ctx context.Context, cluster *kubernetes.Cluster, namespaces []string) (map[ConfigurationKey][]string, error) {
+	result := map[ConfigurationKey][]string{}
+	if len(namespaces) == 0 {
+		return result, nil
+	}
+
+	selector := EpinioApplicationAreaLabel + "=configuration"
+	selector += ",app.kubernetes.io/component=application"
+	selector += ",app.kubernetes.io/managed-by=epinio"
+	selector += ",app.kubernetes.io/part-of in (" + strings.Join(namespaces, ",") + ")"
+
+	appBindings, err := cluster.Kubectl.CoreV1().Secrets("").List(ctx,
+		metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return result, err
+	}
+
+	for _, binding := range appBindings.Items {
+		appName := binding.Labels["app.kubernetes.io/name"]
+		namespace := binding.Labels["app.kubernetes.io/part-of"]
+		for configurationName := range binding.Data {
+			key := EncodeConfigurationKey(configurationName, namespace)
+			result[key] = append(result[key], appName)
+		}
+	}
+
+	return result, nil
+}
+
 // BoundAppsNames returns a map from the names of configurations in the specified namespace, to the
 // names of the applications they are bound to. The keys of the map are always a combination of
 // namespace name and configuration name, to distinguish same-named configurations in different

--- a/internal/application/ingresses.go
+++ b/internal/application/ingresses.go
@@ -44,11 +44,9 @@ func DesiredRoutes(appCR *unstructured.Unstructured) ([]string, error) {
 // the namespace into memory, indexes their routes by namespace and application, and returns the
 // resulting map of route lists.  ATTENTION: Using an empty string for the namespace loads the
 // information from all namespaces.
-func AddActualApplicationRoutes(auxiliary map[ConfigurationKey]AppData, ctx context.Context, cluster *kubernetes.Cluster, namespace string) (map[ConfigurationKey]AppData, error) {
+func AddActualApplicationRoutes(auxiliary map[ConfigurationKey]AppData, ctx context.Context, cluster *kubernetes.Cluster, namespace string, appNames []string) (map[ConfigurationKey]AppData, error) {
 	ingressList, err := cluster.Kubectl.NetworkingV1().Ingresses(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labels.Set(map[string]string{
-			"app.kubernetes.io/component": "application",
-		}).AsSelector().String(),
+		LabelSelector: appNamesInSelector("app.kubernetes.io/component=application", appNames),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/application/ingresses.go
+++ b/internal/application/ingresses.go
@@ -44,10 +44,22 @@ func DesiredRoutes(appCR *unstructured.Unstructured) ([]string, error) {
 // the namespace into memory, indexes their routes by namespace and application, and returns the
 // resulting map of route lists.  ATTENTION: Using an empty string for the namespace loads the
 // information from all namespaces.
-func AddActualApplicationRoutes(auxiliary map[ConfigurationKey]AppData, ctx context.Context, cluster *kubernetes.Cluster, namespace string, appNames []string) (map[ConfigurationKey]AppData, error) {
-	ingressList, err := cluster.Kubectl.NetworkingV1().Ingresses(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: appNamesInSelector("app.kubernetes.io/component=application", appNames),
-	})
+func AddActualApplicationRoutes(
+	auxiliary map[ConfigurationKey]AppData,
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+	namespace string,
+	appNames []string,
+) (map[ConfigurationKey]AppData, error) {
+	ingressList, err := cluster.Kubectl.NetworkingV1().Ingresses(namespace).List(
+		ctx,
+		metav1.ListOptions{
+			LabelSelector: appNamesInSelector(
+				"app.kubernetes.io/component=application",
+				appNames,
+			),
+		},
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/application/services.go
+++ b/internal/application/services.go
@@ -97,10 +97,15 @@ func ServicesBoundAppsNamesFor(ctx context.Context, cluster *kubernetes.Cluster,
 	return result, nil
 }
 
-// ServicesBoundAppsNamesForNamespaces is a scoped variant of ServicesBoundAppsNames that limits
-// the binding secret lookup to a specific set of namespaces. Used by paginated list handlers to
-// avoid loading binding data for namespaces not on the current page.
-func ServicesBoundAppsNamesForNamespaces(ctx context.Context, cluster *kubernetes.Cluster, namespaces []string) (map[string][]string, error) {
+// ServicesBoundAppsNamesForNamespaces is a scoped variant of
+// ServicesBoundAppsNames that limits the binding secret lookup to a specific
+// set of namespaces. Used by paginated list handlers to avoid loading binding
+// data for namespaces not on the current page.
+func ServicesBoundAppsNamesForNamespaces(
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+	namespaces []string,
+) (map[string][]string, error) {
 	result := map[string][]string{}
 	if len(namespaces) == 0 {
 		return result, nil

--- a/internal/application/services.go
+++ b/internal/application/services.go
@@ -97,6 +97,38 @@ func ServicesBoundAppsNamesFor(ctx context.Context, cluster *kubernetes.Cluster,
 	return result, nil
 }
 
+// ServicesBoundAppsNamesForNamespaces is a scoped variant of ServicesBoundAppsNames that limits
+// the binding secret lookup to a specific set of namespaces. Used by paginated list handlers to
+// avoid loading binding data for namespaces not on the current page.
+func ServicesBoundAppsNamesForNamespaces(ctx context.Context, cluster *kubernetes.Cluster, namespaces []string) (map[string][]string, error) {
+	result := map[string][]string{}
+	if len(namespaces) == 0 {
+		return result, nil
+	}
+
+	selector := EpinioApplicationAreaLabel + "=service"
+	selector += ",app.kubernetes.io/component=application"
+	selector += ",app.kubernetes.io/managed-by=epinio"
+	selector += ",app.kubernetes.io/part-of in (" + strings.Join(namespaces, ",") + ")"
+
+	appBindings, err := cluster.Kubectl.CoreV1().Secrets("").List(ctx,
+		metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return result, err
+	}
+
+	for _, binding := range appBindings.Items {
+		appName := binding.Labels["app.kubernetes.io/name"]
+		namespace := binding.Labels["app.kubernetes.io/part-of"]
+		for serviceName := range binding.Data {
+			key := ServiceKey(serviceName, namespace)
+			result[key] = append(result[key], appName)
+		}
+	}
+
+	return result, nil
+}
+
 // ServicesBoundAppsNames returns a map from the names of services in the specified namespace, to
 // the names of the applications they are bound to. The keys of the map are always a combination of
 // namespace name and service name, to distinguish same-named services in different namespaces (See

--- a/internal/application/workload.go
+++ b/internal/application/workload.go
@@ -115,12 +115,10 @@ func (b AppConfigurationBindList) ToNames() []string {
 // namespace into memory, indexes them by namespace and application, and returns the resulting map
 // of pod lists.
 // ATTENTION: Using an empty string for the namespace loads the information from all namespaces.
-func AddApplicationPods(auxiliary map[ConfigurationKey]AppData, ctx context.Context, cluster *kubernetes.Cluster, namespace string) (map[ConfigurationKey]AppData, error) {
+func AddApplicationPods(auxiliary map[ConfigurationKey]AppData, ctx context.Context, cluster *kubernetes.Cluster, namespace string, appNames []string) (map[ConfigurationKey]AppData, error) {
 	podList, err := cluster.Kubectl.CoreV1().Pods(namespace).List(
 		ctx, metav1.ListOptions{
-			LabelSelector: labels.Set(map[string]string{
-				"app.kubernetes.io/component": "application",
-			}).String(),
+			LabelSelector: appNamesInSelector("app.kubernetes.io/component=application", appNames),
 		})
 	if err != nil {
 		return nil, err
@@ -301,7 +299,7 @@ func (a *Workload) AssembleFromParts(
 // lists. The user, List, selects the metrics it needs for an application based on the application's
 // pods.
 // ATTENTION: Using an empty string for the namespace loads the information from all namespaces.
-func GetPodMetrics(ctx context.Context, cluster *kubernetes.Cluster, namespace string) (map[string]metricsv1beta1.PodMetrics, error) {
+func GetPodMetrics(ctx context.Context, cluster *kubernetes.Cluster, namespace string, appNames []string) (map[string]metricsv1beta1.PodMetrics, error) {
 	result := make(map[string]metricsv1beta1.PodMetrics)
 
 	metricsClient, err := metrics.NewForConfig(cluster.RestConfig)
@@ -311,7 +309,7 @@ func GetPodMetrics(ctx context.Context, cluster *kubernetes.Cluster, namespace s
 
 	podMetrics, err := metricsClient.MetricsV1beta1().PodMetricses(namespace).
 		List(ctx, metav1.ListOptions{
-			LabelSelector: "app.kubernetes.io/managed-by=epinio",
+			LabelSelector: appNamesInSelector("app.kubernetes.io/managed-by=epinio", appNames),
 		})
 	if err != nil {
 		return nil, err

--- a/internal/application/workload.go
+++ b/internal/application/workload.go
@@ -115,10 +115,19 @@ func (b AppConfigurationBindList) ToNames() []string {
 // namespace into memory, indexes them by namespace and application, and returns the resulting map
 // of pod lists.
 // ATTENTION: Using an empty string for the namespace loads the information from all namespaces.
-func AddApplicationPods(auxiliary map[ConfigurationKey]AppData, ctx context.Context, cluster *kubernetes.Cluster, namespace string, appNames []string) (map[ConfigurationKey]AppData, error) {
+func AddApplicationPods(
+	auxiliary map[ConfigurationKey]AppData,
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+	namespace string,
+	appNames []string,
+) (map[ConfigurationKey]AppData, error) {
 	podList, err := cluster.Kubectl.CoreV1().Pods(namespace).List(
 		ctx, metav1.ListOptions{
-			LabelSelector: appNamesInSelector("app.kubernetes.io/component=application", appNames),
+			LabelSelector: appNamesInSelector(
+				"app.kubernetes.io/component=application",
+				appNames,
+			),
 		})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] New Unit and Acceptance tests written for the context of the PR
- [x] Unit Tests are passing
- [ ] Acceptance Tests are passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

### Summary
Fixes EPINIO-619: moves pagination to happen before enrichment so expensive Kubernetes queries (pods, ingresses, metrics, staging jobs) are scoped to only the apps/configs/services on the current page, rather than loading everything and slicing after.

### Occurred changes and/or fixed issues
- `application/index.go`: paginated path now calls `ListPaginated` instead of `List` + post-slice
- `namespace/index.go`, `configuration/fullindex.go`, `service/fullindex.go`: same pattern, paginate first, then scope binding/app lookups to page namespaces only
- New `ListPaginated` function scopes pods, ingresses, metrics, and staging queries to page app names via a new `appNamesInSelector` helper (builds `in (...)` label selectors for multi-app queries)
- New `BuildPaginatedResponse[T]` helper in `response` package, builds pagination metadata from a pre-sliced result + known total
- New scoped variants: `StagingStatusesForApps`, `BoundAppsNamesForNamespaces`, `ServicesBoundAppsNamesForNamespaces`
- `AddApplicationPods`, `AddActualApplicationRoutes`, `GetPodMetrics` extended with `appNames []string` parameter (nil = fetch all, unchanged behavior)

### Technical notes summary
The previous approach called `PaginateSlice` on a fully-enriched list. For large namespaces this was wasteful, every pod, ingress, and metric for the entire namespace was fetched to serve a single page. The new approach fetches only the CRs to determine the page, then scopes all downstream Kubernetes queries to just those app names. Non-paginated callers pass `nil` and get the original behavior.

### Areas or cases that should be tested
- `GET /namespaces/:ns/applications?page=1&pageSize=N` returns `PaginatedResponse` with correct `totalItems`, `totalPages`, and `len(items) == pageSize`
- Same for `GET /namespaces`, `GET /configurations`, `GET /services` with page params
- All four endpoints without page params still return the full flat list (backwards-compatible)
- Page beyond total returns empty `items` with correct `totalItems`

### Areas which could experience regressions
- Any client parsing the list response as a flat array will break when page params are passed, response shape changes from `[]T` to `{items, page, pageSize, totalItems, totalPages}`
- The non-paginated path is unchanged, so existing clients not sending page params are unaffected