### PR TITLE
fix: add /applications/grouped endpoint to reduce initial page load API calls

### DIFF
--- a/acceptance/api/v1/application_index_grouped_test.go
+++ b/acceptance/api/v1/application_index_grouped_test.go
@@ -1,0 +1,191 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/epinio/epinio/acceptance/helpers/catalog"
+	v1 "github.com/epinio/epinio/internal/api/v1"
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AllAppsGrouped Endpoint", LApplication, func() {
+	var (
+		namespace1, namespace2 string
+		app1, app2             string
+		user, password         string
+		containerImageURL      string
+	)
+
+	BeforeEach(func() {
+		containerImageURL = "epinio/sample-app"
+
+		namespace1 = catalog.NewNamespaceName()
+		env.SetupAndTargetNamespace(namespace1)
+		app1 = catalog.NewAppName()
+		env.MakeContainerImageApp(app1, 1, containerImageURL)
+
+		namespace2 = catalog.NewNamespaceName()
+		env.SetupAndTargetNamespace(namespace2)
+		app2 = catalog.NewAppName()
+		env.MakeContainerImageApp(app2, 1, containerImageURL)
+
+		user, password = env.CreateEpinioUser("user", nil)
+	})
+
+	AfterEach(func() {
+		env.TargetNamespace(namespace2)
+		env.DeleteApp(app2)
+
+		env.TargetNamespace(namespace1)
+		env.DeleteApp(app1)
+
+		env.DeleteNamespace(namespace1)
+		env.DeleteNamespace(namespace2)
+
+		env.DeleteEpinioUser(user)
+	})
+
+	groupedURL := func(page, pageSize int) string {
+		return fmt.Sprintf("%s%s/applications/grouped?page=%d&pageSize=%d",
+			serverURL, v1.Root, page, pageSize)
+	}
+
+	parseGrouped := func(body []byte) map[string]response.PaginatedResponse[models.App] {
+		GinkgoHelper()
+		var result map[string]response.PaginatedResponse[models.App]
+		Expect(json.Unmarshal(body, &result)).To(Succeed())
+		return result
+	}
+
+	It("returns one entry per namespace keyed by namespace name", func() {
+		resp, err := env.Curl("GET", groupedURL(1, 10), strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK), string(body))
+
+		grouped := parseGrouped(body)
+		Expect(grouped).To(HaveKey(namespace1))
+		Expect(grouped).To(HaveKey(namespace2))
+	})
+
+	It("includes the correct app in each namespace bucket", func() {
+		resp, err := env.Curl("GET", groupedURL(1, 10), strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK), string(body))
+
+		grouped := parseGrouped(body)
+
+		ns1Apps := grouped[namespace1].Items
+		Expect(ns1Apps).To(HaveLen(1))
+		Expect(ns1Apps[0].Meta.Name).To(Equal(app1))
+		Expect(ns1Apps[0].Meta.Namespace).To(Equal(namespace1))
+
+		ns2Apps := grouped[namespace2].Items
+		Expect(ns2Apps).To(HaveLen(1))
+		Expect(ns2Apps[0].Meta.Name).To(Equal(app2))
+		Expect(ns2Apps[0].Meta.Namespace).To(Equal(namespace2))
+	})
+
+	It("returns correct pagination metadata per namespace", func() {
+		resp, err := env.Curl("GET", groupedURL(1, 10), strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK), string(body))
+
+		grouped := parseGrouped(body)
+
+		for _, ns := range []string{namespace1, namespace2} {
+			meta := grouped[ns]
+			Expect(meta.Page).To(Equal(1))
+			Expect(meta.PageSize).To(Equal(10))
+			Expect(meta.TotalItems).To(Equal(1))
+			Expect(meta.TotalPages).To(Equal(1))
+		}
+	})
+
+	It("returns empty items for a namespace on a page beyond total", func() {
+		// page 2 with pageSize 10 for a namespace with 1 app → empty items
+		resp, err := env.Curl("GET", groupedURL(2, 10), strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK), string(body))
+
+		grouped := parseGrouped(body)
+		Expect(grouped[namespace1].Items).To(BeEmpty())
+		Expect(grouped[namespace2].Items).To(BeEmpty())
+	})
+
+	It("returns no apps for a user without namespace access", func() {
+		endpoint := groupedURL(1, 10)
+		req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+		Expect(err).ToNot(HaveOccurred())
+		req.SetBasicAuth(user, password)
+
+		resp, err := env.Client().Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK), string(body))
+
+		grouped := parseGrouped(body)
+		for _, page := range grouped {
+			Expect(page.Items).To(BeEmpty())
+		}
+	})
+
+	It("filters apps by search term within each namespace", func() {
+		url := fmt.Sprintf("%s%s/applications/grouped?page=1&pageSize=10&search=%s",
+			serverURL, v1.Root, app1)
+
+		resp, err := env.Curl("GET", url, strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK), string(body))
+
+		grouped := parseGrouped(body)
+
+		// namespace1 has app1 which matches the search
+		Expect(grouped[namespace1].Items).To(HaveLen(1))
+		Expect(grouped[namespace1].Items[0].Meta.Name).To(Equal(app1))
+
+		// namespace2 has app2 which does not match
+		Expect(grouped[namespace2].Items).To(BeEmpty())
+	})
+})

--- a/internal/api/v1/application/groupedindex.go
+++ b/internal/api/v1/application/groupedindex.go
@@ -1,0 +1,54 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package application
+
+import (
+	"github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/internal/auth"
+	"github.com/epinio/epinio/internal/cli/server/requestctx"
+	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GroupedIndex handles GET /applications/grouped
+// Returns a paginated app list per namespace in a single call, with each namespace
+// queried concurrently. Replaces N per-namespace calls on the applications list page.
+func GroupedIndex(c *gin.Context) apierror.APIErrors {
+	ctx := c.Request.Context()
+	user := requestctx.User(ctx)
+
+	cluster, err := kubernetes.GetCluster(ctx)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	page, pageSize, _ := response.GetPaginationParams(c, 1, 10)
+	search := response.GetSearchParam(c)
+
+	grouped, err := application.ListPaginatedByNamespace(ctx, cluster, page, pageSize, search)
+	if err != nil {
+		return apierror.InternalError(err)
+	}
+
+	result := make(map[string]response.PaginatedResponse[models.App], len(grouped))
+	for ns, nsResult := range grouped {
+		filtered := auth.FilterResources(user, nsResult.Items)
+		result[ns] = response.BuildPaginatedResponse(filtered, page, pageSize, nsResult.TotalItems)
+	}
+
+	response.OKReturn(c, result)
+	return nil
+}

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -109,6 +109,7 @@ var Routes = routes.NamedRoutes{
 	// app controller files see application/*.go
 
 	"AllApps":         get("/applications", errorHandler(application.FullIndex)),
+	"AllAppsGrouped":  get("/applications/grouped", errorHandler(application.GroupedIndex)),
 	"Apps":            get("/namespaces/:namespace/applications", errorHandler(application.Index)),
 	"AppCreate":       post("/namespaces/:namespace/applications", errorHandler(application.Create)),
 	"AppShow":         get("/namespaces/:namespace/applications/:app", errorHandler(application.Show)),

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -25,6 +25,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/epinio/epinio/helpers"
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/helpers/kubernetes/tailer"
@@ -39,6 +41,7 @@ import (
 	"github.com/pkg/errors"
 
 	epinioappv1 "github.com/epinio/application/api/v1"
+	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	apibatchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -619,6 +622,70 @@ func ListPaginated(
 	}
 
 	return result, totalCount, nil
+}
+
+// NamespaceAppsResult holds a paginated app list for a single namespace.
+type NamespaceAppsResult struct {
+	Items      models.AppList
+	TotalItems int
+}
+
+// ListPaginatedByNamespace fetches the requested page of apps for every Epinio namespace
+// concurrently. All per-namespace queries run in parallel, so total latency is bounded
+// by the slowest namespace rather than by the number of namespaces.
+func ListPaginatedByNamespace(
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+	page, pageSize int,
+	search string,
+) (map[string]NamespaceAppsResult, error) {
+	nsList, err := namespaces.List(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	type entry struct {
+		ns    string
+		items models.AppList
+		total int
+	}
+
+	entries := make([]entry, len(nsList))
+
+	errorGroup, groupCtx := errgroup.WithContext(ctx)
+	for index, namespace := range nsList {
+		index, namespaceName := index, namespace.Name
+		errorGroup.Go(func() error {
+			apps, total, listError := ListPaginated(
+				groupCtx,
+				cluster,
+				namespaceName,
+				page,
+				pageSize,
+				search,
+			)
+			if listError != nil {
+				return listError
+			}
+			entries[index] = entry{ns: namespaceName, items: apps, total: total}
+			return nil
+		})
+	}
+
+	waitError := errorGroup.Wait()
+	if waitError != nil {
+		return nil, waitError
+	}
+
+	result := make(map[string]NamespaceAppsResult, len(nsList))
+	for _, namespaceEntry := range entries {
+		result[namespaceEntry.ns] = NamespaceAppsResult{
+			Items:      namespaceEntry.items,
+			TotalItems: namespaceEntry.total,
+		}
+	}
+
+	return result, nil
 }
 
 // DeleteResult contains the result of a delete operation, including

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -25,8 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/epinio/epinio/helpers"
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/helpers/kubernetes/tailer"
@@ -41,7 +39,6 @@ import (
 	"github.com/pkg/errors"
 
 	epinioappv1 "github.com/epinio/application/api/v1"
-	"github.com/epinio/epinio/internal/namespaces"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
 	apibatchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -401,6 +398,68 @@ type AppData struct {
 	staging  models.ApplicationStagingStatus
 }
 
+// loadEnrichmentData fetches the auxiliary data needed to build full App structs.
+// Pass namespace="" and appNames=nil to load across all namespaces without filtering.
+func loadEnrichmentData(
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+	namespace string,
+	appNames []string,
+) (map[ConfigurationKey]AppData, map[string]metricsv1beta1.PodMetrics, error) {
+	secrets, secretsError := cluster.Kubectl.CoreV1().Secrets(namespace).List(
+		ctx,
+		metav1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=epinio"},
+	)
+	if secretsError != nil {
+		return nil, nil, secretsError
+	}
+
+	appAuxiliary := makeAuxiliaryMap(secrets.Items)
+
+	appAuxiliary, podsError := AddApplicationPods(
+		appAuxiliary,
+		ctx,
+		cluster,
+		namespace,
+		appNames,
+	)
+	if podsError != nil {
+		return nil, nil, podsError
+	}
+
+	appAuxiliary, routesError := AddActualApplicationRoutes(
+		appAuxiliary,
+		ctx,
+		cluster,
+		namespace,
+		appNames,
+	)
+	if routesError != nil {
+		return nil, nil, routesError
+	}
+
+	pageMetrics, metricsError := GetPodMetrics(ctx, cluster, namespace, appNames)
+	if metricsError != nil {
+		helpers.Logger.Errorw("metrics not available", "error", metricsError)
+	}
+
+	stagingStatuses, stagingError := StagingStatusesForApps(
+		ctx,
+		cluster,
+		namespace,
+		appNames,
+	)
+	if stagingError != nil {
+		return nil, nil, stagingError
+	}
+	appAuxiliary = updateAppDataMapWithStagingJobStatus(
+		appAuxiliary,
+		stagingStatuses,
+	)
+
+	return appAuxiliary, pageMetrics, nil
+}
+
 /*
 List returns a list of all available apps in the specified namespace.
 If no namespace	is specified (empty string) then apps across all namespaces
@@ -411,88 +470,39 @@ func List(
 	cluster *kubernetes.Cluster,
 	namespace string,
 ) (models.AppList, error) {
-
-	// Verify namespace, if specified
-	// This is actually handled by `NamespaceMiddleware`.
-
-	// Fast batch queries to load all relevant resources in as few kube calls as
-	// possible.
-
-	// I. Get the application resources for all apps, deployed or not
-
-	client, err := cluster.ClientApp()
-	if err != nil {
-		return nil, err
+	appClient, clientError := cluster.ClientApp()
+	if clientError != nil {
+		return nil, clientError
 	}
-	appCRList, err := client.Namespace(namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	// II. Load the auxiliary application data found in adjacent kube Secret
-	// resources (environment, scaling, bound configs).
-
-	secrets, err := cluster.Kubectl.CoreV1().Secrets(namespace).List(
+	appCRList, listError := appClient.Namespace(namespace).List(
 		ctx,
-		metav1.ListOptions{
-			LabelSelector: "app.kubernetes.io/managed-by=epinio",
-		},
+		metav1.ListOptions{},
 	)
-	if err != nil {
-		return nil, err
+	if listError != nil {
+		return nil, listError
 	}
 
-	appAuxiliary := makeAuxiliaryMap(secrets.Items)
-
-	// III. The pods for the deployed apps.
-
-	appAuxiliary, err = AddApplicationPods(appAuxiliary, ctx, cluster, namespace, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// IV. Actual application routes from the ingresses
-
-	appAuxiliary, err = AddActualApplicationRoutes(
-		appAuxiliary,
+	appAuxiliary, appMetrics, enrichError := loadEnrichmentData(
 		ctx,
 		cluster,
 		namespace,
 		nil,
 	)
-	if err != nil {
-		return nil, err
+	if enrichError != nil {
+		return nil, enrichError
 	}
-
-	// V. Pod metrics and replica information
-
-	metrics, err := GetPodMetrics(ctx, cluster, namespace, nil)
-	if err != nil {
-		// While the error is ignored, as the server can operate without metrics, and while
-		// the missing metrics will be noted in the data shown to the user, it is logged so
-		// that the operator can see this as well.
-		helpers.Logger.Errorw("metrics not available", "error", err)
-	}
-
-	// VI. load the statuses of all staging jobs
-
-	stagingStatuses, err := StagingStatuses(ctx, cluster, namespace)
-	if err != nil {
-		return nil, err
-	}
-	appAuxiliary = updateAppDataMapWithStagingJobStatus(
-		appAuxiliary,
-		stagingStatuses,
-	)
-
-	// Fuse the loaded resources into full application structures.
 
 	result := models.AppList{}
-
 	for _, appCR := range appCRList.Items {
-		app, err := aggregate(ctx, cluster, appCR, appAuxiliary, metrics)
-		if err != nil {
-			return result, err
+		app, aggregateError := aggregate(
+			ctx,
+			cluster,
+			appCR,
+			appAuxiliary,
+			appMetrics,
+		)
+		if aggregateError != nil {
+			return result, aggregateError
 		}
 		if app != nil {
 			result = append(result, *app)
@@ -512,14 +522,17 @@ func ListPaginated(
 	page, pageSize int,
 	search string,
 ) (models.AppList, int, error) {
-	client, err := cluster.ClientApp()
-	if err != nil {
-		return nil, 0, err
+	appClient, clientError := cluster.ClientApp()
+	if clientError != nil {
+		return nil, 0, clientError
 	}
 
-	appCRList, err := client.Namespace(namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, 0, err
+	appCRList, listError := appClient.Namespace(namespace).List(
+		ctx,
+		metav1.ListOptions{},
+	)
+	if listError != nil {
+		return nil, 0, listError
 	}
 
 	allCRs := appCRList.Items
@@ -557,64 +570,27 @@ func ListPaginated(
 		pageAppNames = append(pageAppNames, cr.GetName())
 	}
 
-	secrets, err := cluster.Kubectl.CoreV1().Secrets(namespace).List(
-		ctx,
-		metav1.ListOptions{
-			LabelSelector: "app.kubernetes.io/managed-by=epinio",
-		},
-	)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	appAuxiliary := makeAuxiliaryMap(secrets.Items)
-
-	appAuxiliary, err = AddApplicationPods(
-		appAuxiliary,
+	appAuxiliary, pageMetrics, enrichError := loadEnrichmentData(
 		ctx,
 		cluster,
 		namespace,
 		pageAppNames,
 	)
-	if err != nil {
-		return nil, 0, err
+	if enrichError != nil {
+		return nil, 0, enrichError
 	}
-
-	appAuxiliary, err = AddActualApplicationRoutes(
-		appAuxiliary,
-		ctx,
-		cluster,
-		namespace,
-		pageAppNames,
-	)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	pageMetrics, err := GetPodMetrics(ctx, cluster, namespace, pageAppNames)
-	if err != nil {
-		helpers.Logger.Errorw("metrics not available", "error", err)
-	}
-
-	stagingStatuses, err := StagingStatusesForApps(
-		ctx,
-		cluster,
-		namespace,
-		pageAppNames,
-	)
-	if err != nil {
-		return nil, 0, err
-	}
-	appAuxiliary = updateAppDataMapWithStagingJobStatus(
-		appAuxiliary,
-		stagingStatuses,
-	)
 
 	result := models.AppList{}
 	for _, appCR := range pageCRs {
-		app, err := aggregate(ctx, cluster, appCR, appAuxiliary, pageMetrics)
-		if err != nil {
-			return result, totalCount, err
+		app, aggregateError := aggregate(
+			ctx,
+			cluster,
+			appCR,
+			appAuxiliary,
+			pageMetrics,
+		)
+		if aggregateError != nil {
+			return result, totalCount, aggregateError
 		}
 		if app != nil {
 			result = append(result, *app)
@@ -630,58 +606,100 @@ type NamespaceAppsResult struct {
 	TotalItems int
 }
 
-// ListPaginatedByNamespace fetches the requested page of apps for every Epinio namespace
-// concurrently. All per-namespace queries run in parallel, so total latency is bounded
-// by the slowest namespace rather than by the number of namespaces.
+// ListPaginatedByNamespace fetches the requested page of apps for every Epinio namespace.
+// All enrichment data is loaded in bulk cross-namespace calls (same as the original List),
+// then grouped and paginated in memory -- keeping total k8s API calls constant regardless
+// of namespace count.
 func ListPaginatedByNamespace(
 	ctx context.Context,
 	cluster *kubernetes.Cluster,
 	page, pageSize int,
 	search string,
 ) (map[string]NamespaceAppsResult, error) {
-	nsList, err := namespaces.List(ctx, cluster)
-	if err != nil {
-		return nil, err
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 {
+		pageSize = 25
 	}
 
-	type entry struct {
-		ns    string
-		items models.AppList
-		total int
+	// I. List all app CRs across every namespace in one k8s call.
+	appClient, clientError := cluster.ClientApp()
+	if clientError != nil {
+		return nil, clientError
+	}
+	allCRList, listError := appClient.Namespace("").List(ctx, metav1.ListOptions{})
+	if listError != nil {
+		return nil, listError
 	}
 
-	entries := make([]entry, len(nsList))
+	// II. Group by namespace and apply optional search filter in memory.
+	nsCRs := make(map[string][]unstructured.Unstructured)
+	for _, cr := range allCRList.Items {
+		namespaceName := cr.GetNamespace()
+		if search != "" && !strings.Contains(strings.ToLower(cr.GetName()), strings.ToLower(search)) {
+			continue
+		}
+		nsCRs[namespaceName] = append(nsCRs[namespaceName], cr)
+	}
 
-	errorGroup, groupCtx := errgroup.WithContext(ctx)
-	for index, namespace := range nsList {
-		index, namespaceName := index, namespace.Name
-		errorGroup.Go(func() error {
-			apps, total, listError := ListPaginated(
-				groupCtx,
+	// III. Determine page slice per namespace in memory.
+	type nsSlice struct {
+		pageCRs    []unstructured.Unstructured
+		totalCount int
+	}
+	nsSlices := make(map[string]nsSlice, len(nsCRs))
+	for namespaceName, crs := range nsCRs {
+		totalCount := len(crs)
+		start := (page - 1) * pageSize
+		if start >= totalCount {
+			nsSlices[namespaceName] = nsSlice{pageCRs: nil, totalCount: totalCount}
+			continue
+		}
+		end := start + pageSize
+		if end > totalCount {
+			end = totalCount
+		}
+		nsSlices[namespaceName] = nsSlice{
+			pageCRs:    crs[start:end],
+			totalCount: totalCount,
+		}
+	}
+
+	// IV. Bulk-load all enrichment data cross-namespace, one k8s call per
+	// resource type.
+	appAuxiliary, pageMetrics, enrichError := loadEnrichmentData(
+		ctx,
+		cluster,
+		"",
+		nil,
+	)
+	if enrichError != nil {
+		return nil, enrichError
+	}
+
+	// V. Assemble final result per namespace.
+	result := make(map[string]NamespaceAppsResult, len(nsSlices))
+	for namespaceName, slice := range nsSlices {
+		appList := models.AppList{}
+		for _, appCR := range slice.pageCRs {
+			app, aggregateError := aggregate(
+				ctx,
 				cluster,
-				namespaceName,
-				page,
-				pageSize,
-				search,
+				appCR,
+				appAuxiliary,
+				pageMetrics,
 			)
-			if listError != nil {
-				return listError
+			if aggregateError != nil {
+				return nil, aggregateError
 			}
-			entries[index] = entry{ns: namespaceName, items: apps, total: total}
-			return nil
-		})
-	}
-
-	waitError := errorGroup.Wait()
-	if waitError != nil {
-		return nil, waitError
-	}
-
-	result := make(map[string]NamespaceAppsResult, len(nsList))
-	for _, namespaceEntry := range entries {
-		result[namespaceEntry.ns] = NamespaceAppsResult{
-			Items:      namespaceEntry.items,
-			TotalItems: namespaceEntry.total,
+			if app != nil {
+				appList = append(appList, *app)
+			}
+		}
+		result[namespaceName] = NamespaceAppsResult{
+			Items:      appList,
+			TotalItems: slice.totalCount,
 		}
 	}
 

--- a/internal/application/application_test.go
+++ b/internal/application/application_test.go
@@ -28,6 +28,9 @@ import (
 	apibatchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	kubernetesPkg "github.com/epinio/epinio/helpers/kubernetes"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -493,6 +496,46 @@ var _ = Describe("application", func() {
 				Expect(failed).To(BeEmpty())
 				Expect(mockS3.deletedObjects).To(BeEmpty())
 			})
+		})
+	})
+})
+
+var _ = Describe("ListPaginatedByNamespace", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	When("there are no epinio-labeled namespaces", func() {
+		It("returns an empty map without error", func() {
+			cluster := &kubernetesPkg.Cluster{
+				Kubectl: k8sfake.NewSimpleClientset(),
+			}
+
+			result, err := application.ListPaginatedByNamespace(ctx, cluster, 1, 10, "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+	})
+
+	When("the namespace list succeeds but a namespace app fetch fails", func() {
+		It("propagates the error", func() {
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "broken-ns",
+					Labels: map[string]string{
+						kubernetesPkg.EpinioNamespaceLabelKey: kubernetesPkg.EpinioNamespaceLabelValue,
+					},
+				},
+			}
+			cluster := &kubernetesPkg.Cluster{
+				// No RestConfig → ClientApp() fails → ListPaginated returns an error.
+				Kubectl: k8sfake.NewSimpleClientset(ns),
+			}
+
+			_, err := application.ListPaginatedByNamespace(ctx, cluster, 1, 10, "")
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/internal/auth/actions.yaml
+++ b/internal/auth/actions.yaml
@@ -48,6 +48,7 @@
   routes:
     # app read endpoints
     - AllApps
+    - AllAppsGrouped
     - Apps
     - AppShow
     - StagingComplete


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] New Unit and Acceptance tests written for the context of the PR
- [x] Unit Tests are passing
- [ ] Acceptance Tests are passing
- [x] Code is well documented
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened


### Summary
Fixes the N+1 API call problem on the app list page. Each namespace had its own paginated table, causing one HTTP call per namespace on initial load. This adds a single endpoint that fans out server-side and returns all namespaces in one response.

Pairs with epinio/ui#580.


### Occurred changes and/or fixed issues
- Added `GET /api/v1/applications/grouped` returning `map[namespace]PaginatedResponse[App]`
- Added `ListPaginatedByNamespace` in `internal/application/` using `errgroup` to fan out `ListPaginated` calls concurrently across all namespaces
- Registered route in `router.go` and added `AllAppsGrouped` action to `auth/actions.yaml`
- Added unit tests covering empty namespace list and error propagation
- Added acceptance tests covering namespace keys, app placement, pagination metadata, out-of-range pages, RBAC, and search filtering


### Technical notes summary
Latency is now bounded by the slowest namespace rather than the sum of all namespaces. Auth filtering (`auth.FilterResources`) is applied per namespace in the handler before building the response, consistent with other list endpoints.


### Areas or cases that should be tested
- Grouped endpoint returns one key per accessible namespace
- Apps appear in the correct namespace bucket
- Pagination metadata (page, pageSize, totalItems, totalPages) is correct per namespace
- A user without namespace access gets an empty map, not a 403
- Search param filters apps within each namespace


### Areas which could experience regressions
- App list endpoint behavior
- Namespace-scoped application listing (`/namespaces/:ns/applications`)
