### PR TITLE
Fix/s3 chart image recovery

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -605,6 +605,54 @@ var _ = Describe("Apps", LApplication, func() {
 			})
 		})
 
+		When("restaging a git-origin app whose S3 blob has been deleted", func() {
+			const gitFallbackURL = "https://github.com/epinio/example-12factor"
+
+			BeforeEach(func() {
+				By("pushing from git to establish origin and blobuid on the app CR")
+				pushLog, err := env.EpinioPush("", appName,
+					"--name", appName,
+					"--git", gitFallbackURL)
+				Expect(err).ToNot(HaveOccurred(), pushLog)
+
+				Eventually(func() string {
+					out, listErr := env.Epinio("", "app", "list")
+					Expect(listErr).ToNot(HaveOccurred(), out)
+					return out
+				}, "5m").Should(
+					HaveATable(
+						WithHeaders("NAME", "CREATED", "STATUS", "ROUTES",
+							"CONFIGURATIONS", "STATUS DETAILS"),
+						WithRow(appName, WithDate(), "1/1", appName+".*", "", ""),
+					),
+				)
+
+				By("reading blobuid from app CR")
+				blobUID, kubectlErr := proc.Kubectl(
+					"get", "apps.application.epinio.io", appName,
+					"--namespace", namespace,
+					"-o", "jsonpath={.spec.blobuid}",
+				)
+				Expect(kubectlErr).ToNot(HaveOccurred(), blobUID)
+				Expect(blobUID).ToNot(BeEmpty())
+
+				By("deleting the S3 blob to simulate storage loss")
+				createS3HelperPod()
+				deleteS3Blob(blobUID)
+			})
+
+			AfterEach(func() {
+				env.DeleteApp(appName)
+			})
+
+			It("re-clones from git and stages successfully", func() {
+				restageLogs, err := env.Epinio("", "app", "restage", appName)
+				Expect(err).ToNot(HaveOccurred(), restageLogs)
+				Expect(restageLogs).To(ContainSubstring("Restaging and restarting application"))
+				Expect(restageLogs).To(ContainSubstring("Restarting application"))
+			})
+		})
+
 	})
 
 	When("pushing as a stateful app", func() {

--- a/acceptance/helpers_test.go
+++ b/acceptance/helpers_test.go
@@ -13,6 +13,7 @@ package acceptance_test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/url"
@@ -20,6 +21,7 @@ import (
 	"time"
 
 	"github.com/epinio/epinio/acceptance/helpers/auth"
+	"github.com/epinio/epinio/acceptance/helpers/proc"
 	. "github.com/epinio/epinio/acceptance/helpers/matchers"
 	"github.com/epinio/epinio/acceptance/testenv"
 
@@ -166,6 +168,58 @@ func waitForServerReady(serverURL string) {
 		}
 		return true
 	}, "2m", "3s").Should(BeTrue(), "API never became ready at %s", readyURL)
+}
+
+const s3HelperPod = "s3cli"
+
+// createS3HelperPod starts a long-lived minio/mc pod used to manipulate S3
+// blobs in acceptance tests. Safe to call multiple times — exits early if the
+// pod already exists and is ready.
+func createS3HelperPod() {
+	out, err := proc.Kubectl("get", "pod", "-o", "name", s3HelperPod)
+	if err != nil {
+		Expect(out).To(MatchRegexp("not found"))
+	}
+	if strings.TrimSpace(out) == "pod/"+s3HelperPod {
+		return
+	}
+
+	out, err = proc.Kubectl("get", "secret",
+		"-n", "epinio",
+		"seaweedfs-creds", "-o", "jsonpath={.data.accesskey}")
+	Expect(err).ToNot(HaveOccurred(), out)
+	accessKey, err := base64.StdEncoding.DecodeString(out)
+	Expect(err).ToNot(HaveOccurred(), out)
+
+	out, err = proc.Kubectl("get", "secret",
+		"-n", "epinio",
+		"seaweedfs-creds", "-o", "jsonpath={.data.secretkey}")
+	Expect(err).ToNot(HaveOccurred(), out)
+	secretKey, err := base64.StdEncoding.DecodeString(out)
+	Expect(err).ToNot(HaveOccurred(), out)
+
+	out, err = proc.Kubectl("run", s3HelperPod,
+		"--image=minio/mc:RELEASE.2022-03-13T22-34-00Z",
+		"--command", "--", "/bin/bash", "-c",
+		"trap : TERM INT; sleep infinity & wait")
+	Expect(err).ToNot(HaveOccurred(), out)
+
+	out, err = proc.Kubectl("wait", "--for=condition=ready", "pod", s3HelperPod)
+	Expect(err).ToNot(HaveOccurred(), out)
+
+	out, err = proc.Kubectl("exec", s3HelperPod, "--",
+		"mc", "--insecure", "alias", "set", "s3",
+		"http://seaweedfs-s3.epinio.svc.cluster.local:8333",
+		string(accessKey), string(secretKey))
+	Expect(err).ToNot(HaveOccurred(), out)
+}
+
+// deleteS3Blob removes a single blob from the epinio S3 bucket. Requires
+// createS3HelperPod to have been called first.
+func deleteS3Blob(blobUID string) {
+	out, err := proc.Kubectl("exec", s3HelperPod, "--",
+		"mc", "--insecure", "rm", "s3/epinio/"+blobUID)
+	Expect(err).ToNot(HaveOccurred(), out)
 }
 
 func isTransientConnectFailure(out string) bool {

--- a/internal/api/v1/application/deployments.go
+++ b/internal/api/v1/application/deployments.go
@@ -347,8 +347,9 @@ func stageForAsyncDeploy(
 
 	registryCertificateSecret := viper.GetString("registry-certificate-secret")
 	registryCertificateHash := ""
+	registryCACertKey := ""
 	if registryCertificateSecret != "" {
-		registryCertificateHash, err = getRegistryCertificateHash(ctx, cluster, helmchart.Namespace(), registryCertificateSecret)
+		registryCACertKey, registryCertificateHash, err = getRegistryCertificateHash(ctx, cluster, helmchart.Namespace(), registryCertificateSecret)
 		if err != nil {
 			return nil, apierror.InternalError(err, "cannot calculate Certificate hash")
 		}
@@ -376,6 +377,7 @@ func stageForAsyncDeploy(
 		Username:            username,
 		RegistryCAHash:      registryCertificateHash,
 		RegistryCASecret:    registryCertificateSecret,
+		RegistryCACertKey:   registryCACertKey,
 		UserID:              config.UserID,
 		GroupID:             config.GroupID,
 		Scripts:             config.Name,

--- a/internal/api/v1/application/importgit.go
+++ b/internal/api/v1/application/importgit.go
@@ -102,108 +102,146 @@ import (
 // of the repo and puts it on S3.
 func ImportGit(c *gin.Context) apierror.APIErrors {
 	ctx := c.Request.Context()
-	log := requestctx.Logger(ctx)
 
 	namespace := c.Param("namespace")
 	name := c.Param("app")
-
 	giturl := c.PostForm("giturl")
 	revision := c.PostForm("gitrev")
 
-	errGitURL := validateGitURL(giturl)
-	if errGitURL != nil {
-		return errGitURL
+	if apiErr := validateGitURL(giturl); apiErr != nil {
+		return apiErr
 	}
 
-	cluster, err := kubernetes.GetCluster(ctx)
-	if err != nil {
-		return apierror.InternalError(err, "failed to get access to a kube client")
+	cluster, clusterError := kubernetes.GetCluster(ctx)
+	if clusterError != nil {
+		return apierror.InternalError(clusterError, "failed to get access to a kube client")
 	}
 
-	gitManager, err := gitbridge.NewManager(cluster.Kubectl.CoreV1().Secrets(helmchart.Namespace()))
-	if err != nil {
-		return apierror.InternalError(err, "creating git configuration manager")
+	username := requestctx.User(ctx).Username
+	blobUID, branch, resolvedRevision, uploadError := cloneAndUpload(
+		ctx, cluster, giturl, revision, namespace, name, username,
+	)
+	if uploadError != nil {
+		return uploadError
 	}
 
-	gitRepo, err := os.MkdirTemp("", "epinio-app")
-	if err != nil {
-		return apierror.InternalError(err, "can't create temp directory")
+	response.OKReturn(c, models.ImportGitResponse{
+		BlobUID:  blobUID,
+		Branch:   branch,
+		Revision: resolvedRevision,
+	})
+	return nil
+}
+
+// cloneAndUpload clones the git repository, tarballs it, uploads to S3,
+// and returns the blobUID plus resolved branch and revision.
+func cloneAndUpload(
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+	gitURL, revision, namespace, appName, username string,
+) (string, string, string, apierror.APIErrors) {
+	log := requestctx.Logger(ctx)
+
+	gitManager, managerError := gitbridge.NewManager(
+		cluster.Kubectl.CoreV1().Secrets(helmchart.Namespace()),
+	)
+	if managerError != nil {
+		return "", "", "", apierror.InternalError(
+			managerError, "creating git configuration manager",
+		)
 	}
 
+	gitRepo, mkdirError := os.MkdirTemp("", "epinio-app")
+	if mkdirError != nil {
+		return "", "", "", apierror.InternalError(mkdirError, "can't create temp directory")
+	}
 	defer func() {
-		if err := os.RemoveAll(gitRepo); err != nil {
-			log.Errorw("failed to remove git repo", "error", err)
+		removeError := os.RemoveAll(gitRepo)
+		if removeError != nil {
+			log.Errorw("failed to remove git repo", "error", removeError)
 		}
 	}()
-	gitConfig, err := gitManager.FindConfiguration(giturl)
-	if err != nil {
-		errMsg := fmt.Sprintf("finding git configuration for gitURL [%s]", giturl)
-		return apierror.InternalError(err, errMsg)
+
+	gitConfig, configError := gitManager.FindConfiguration(gitURL)
+	if configError != nil {
+		return "", "", "", apierror.InternalError(
+			configError,
+			fmt.Sprintf("finding git configuration for gitURL [%s]", gitURL),
+		)
 	}
 
 	if gitConfig != nil {
 		log.Infow("loaded git config", "gitConfig", gitConfig.ID)
 	} else {
-		log.Infow("git config not found for giturl", "giturl", giturl)
+		log.Infow("git config not found for giturl", "giturl", gitURL)
 	}
 
-	// clone/fetch/checkout
-	ref, err := checkoutRepository(ctx, gitRepo, giturl, revision, gitConfig)
-	if err != nil {
-		errMsg := fmt.Sprintf("cloning the git repository: %s @ %s", giturl, revision)
-		return apierror.InternalError(err, errMsg)
+	ref, checkoutError := checkoutRepository(ctx, gitRepo, gitURL, revision, gitConfig)
+	if checkoutError != nil {
+		return "", "", "", apierror.InternalError(
+			checkoutError,
+			fmt.Sprintf("cloning the git repository: %s @ %s", gitURL, revision),
+		)
 	}
 
 	var branch string
+	resolvedRevision := revision
 	if ref != nil {
 		branch = ref.Name().Short()
-		revision = ref.Hash().String()
-		log.Infow("resolved branch and revision", "branch", branch, "revision", revision)
+		resolvedRevision = ref.Hash().String()
+		log.Infow(
+			"resolved branch and revision",
+			"branch", branch,
+			"revision", resolvedRevision,
+		)
 	}
 
-	// Create a tarball
-	tmpDir, tarball, err := helpers.Tar(gitRepo, nil)
+	tmpDir, tarball, tarError := helpers.Tar(gitRepo, nil)
 	defer func() {
 		if tmpDir != "" {
-			_ = os.RemoveAll(tmpDir)
+			cleanupError := os.RemoveAll(tmpDir)
+			if cleanupError != nil {
+				log.Errorw("failed to remove tarball temp dir", "error", cleanupError)
+			}
 		}
 	}()
-	if err != nil {
-		return apierror.InternalError(err, "create a tarball from the git repository")
+	if tarError != nil {
+		return "", "", "", apierror.InternalError(
+			tarError, "create a tarball from the git repository",
+		)
 	}
 
-	// Upload to S3
-	connectionDetails, err := s3manager.GetConnectionDetails(ctx, cluster, helmchart.Namespace(), "epinio-s3-connection-details")
-	if err != nil {
-		return apierror.InternalError(err, "fetching the S3 connection details from the Kubernetes secret")
-	}
-	manager, err := s3manager.New(connectionDetails)
-	if err != nil {
-		return apierror.InternalError(err, "creating an S3 manager")
+	connectionDetails, detailsError := s3manager.GetConnectionDetails(
+		ctx, cluster, helmchart.Namespace(), helmchart.S3ConnectionDetailsSecretName,
+	)
+	if detailsError != nil {
+		return "", "", "", apierror.InternalError(
+			detailsError, "fetching the S3 connection details",
+		)
 	}
 
-	username := requestctx.User(ctx).Username
-	blobUID, err := manager.Upload(ctx, tarball, map[string]string{
-		"app": name, "namespace": namespace, "username": username,
+	s3Manager, s3Error := s3manager.New(connectionDetails)
+	if s3Error != nil {
+		return "", "", "", apierror.InternalError(s3Error, "creating an S3 manager")
+	}
+
+	blobUID, uploadError := s3Manager.Upload(ctx, tarball, map[string]string{
+		"app": appName, "namespace": namespace, "username": username,
 	})
-	if err != nil {
-		// Check if the error is due to quota exhaustion
-		if s3manager.IsQuotaExceededError(err) {
-			return apierror.NewQuotaExceededError("",
-				"uploading the application sources blob: "+err.Error())
+	if uploadError != nil {
+		if s3manager.IsQuotaExceededError(uploadError) {
+			return "", "", "", apierror.NewQuotaExceededError(
+				"",
+				"uploading the application sources blob: "+uploadError.Error(),
+			)
 		}
-		return apierror.InternalError(err, "uploading the application sources blob")
+		return "", "", "", apierror.InternalError(
+			uploadError, "uploading the application sources blob",
+		)
 	}
 
-	log.Infow("uploaded app", "namespace", namespace, "app", name, "blobUID", blobUID)
-
-	// Return the id of the new blob
-	response.OKReturn(c, models.ImportGitResponse{
-		BlobUID:  blobUID,
-		Branch:   branch,
-		Revision: revision,
-	})
-	return nil
+	log.Infow("uploaded app", "namespace", namespace, "app", appName, "blobUID", blobUID)
+	return blobUID, branch, resolvedRevision, nil
 }
 
 func validateGitURL(gitURL string) apierror.APIErrors {

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -234,35 +234,11 @@ func Stage(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err, "failed to fetch the S3 connection details")
 	}
 
-	blobUID, blobError := getBlobUID(ctx, s3ConnectionDetails, req, app)
-	if blobError != nil {
-		log.Infow("blob lookup failed, checking for git origin fallback",
-			"namespace", namespace, "app", name, "error", blobError,
-		)
-		origin, originError := application.Origin(app)
-		if originError == nil && origin.Git != nil {
-			log.Infow("git origin found, re-cloning to S3",
-				"namespace", namespace, "app", name,
-				"url", origin.Git.URL, "revision", origin.Git.Revision,
-			)
-			blobUID, _, _, blobError = cloneAndUpload(
-				ctx, cluster,
-				origin.Git.URL, origin.Git.Revision,
-				namespace, name, username,
-			)
-			if blobError == nil {
-				log.Infow("git fallback clone succeeded",
-					"namespace", namespace, "app", name, "blobUID", blobUID,
-				)
-			}
-		} else {
-			log.Infow("no git origin available for fallback",
-				"namespace", namespace, "app", name,
-			)
-		}
-		if blobError != nil {
-			return blobError
-		}
+	blobUID, blobErr := resolveBlobUID(
+		ctx, cluster, s3ConnectionDetails, req, app, username,
+	)
+	if blobErr != nil {
+		return blobErr
 	}
 
 	// Create uid identifying the staging job to be
@@ -299,13 +275,10 @@ func Stage(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err, "getting the Epinio registry public URL")
 	}
 
-	registryCertificateSecret := viper.GetString("registry-certificate-secret")
-	registryCertificateHash := ""
-	if registryCertificateSecret != "" {
-		registryCertificateHash, err = getRegistryCertificateHash(ctx, cluster, helmchart.Namespace(), registryCertificateSecret)
-		if err != nil {
-			return apierror.InternalError(err, "cannot calculate Certificate hash")
-		}
+	registryCertificateSecret, registryCertificateHash, err :=
+		resolveRegistryCertHash(ctx, cluster)
+	if err != nil {
+		return apierror.InternalError(err, "cannot calculate Certificate hash")
 	}
 
 	// merge buildpack and general EV, i.e. `config.Env`, and `environment`.
@@ -338,32 +311,8 @@ func Stage(c *gin.Context) apierror.APIErrors {
 		HelmValues:          config.HelmValues,
 	}
 
-	if !params.HelmValues.Storage.Cache.EmptyDir {
-		pvcError := ensurePVC(
-			ctx, cluster,
-			params.HelmValues.Storage.Cache,
-			req.App.MakeCachePVCName(),
-		)
-		if pvcError != nil {
-			return apierror.InternalError(
-				pvcError,
-				"failed to ensure a PersistentVolumeClaim for the application cache",
-			)
-		}
-	}
-
-	if !params.HelmValues.Storage.SourceBlobs.EmptyDir {
-		err = ensurePVC(
-			ctx, cluster,
-			params.HelmValues.Storage.SourceBlobs,
-			req.App.MakeSourceBlobsPVCName(),
-		)
-		if err != nil {
-			return apierror.InternalError(
-				err,
-				"failed to ensure a PersistentVolumeClaim for the application source blobs",
-			)
-		}
+	if pvcErr := ensureStagingPVCs(ctx, cluster, req, params.HelmValues); pvcErr != nil {
+		return pvcErr
 	}
 
 	job, jobenv := newJobRun(params)
@@ -1050,6 +999,111 @@ func findPreviousBlobUID(app *unstructured.Unstructured) (string, error) {
 	}
 
 	return blobUID, nil
+}
+
+// resolveBlobUID returns the blob to stage. When the stored blob is missing
+// and the app has a git origin, it re-clones and uploads a fresh blob.
+func resolveBlobUID(
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+	s3ConnectionDetails s3manager.ConnectionDetails,
+	req models.StageRequest,
+	app *unstructured.Unstructured,
+	username string,
+) (string, apierror.APIErrors) {
+	log := requestctx.Logger(ctx)
+	namespace := req.App.Namespace
+	name := req.App.Name
+
+	blobUID, blobError := getBlobUID(ctx, s3ConnectionDetails, req, app)
+	if blobError == nil {
+		return blobUID, nil
+	}
+
+	log.Infow("blob lookup failed, checking for git origin fallback",
+		"namespace", namespace, "app", name, "error", blobError,
+	)
+	origin, originError := application.Origin(app)
+	if originError != nil || origin.Git == nil {
+		log.Infow("no git origin available for fallback",
+			"namespace", namespace, "app", name,
+		)
+		return "", blobError
+	}
+
+	log.Infow("git origin found, re-cloning to S3",
+		"namespace", namespace, "app", name,
+		"url", origin.Git.URL, "revision", origin.Git.Revision,
+	)
+	blobUID, _, _, cloneError := cloneAndUpload(
+		ctx, cluster,
+		origin.Git.URL, origin.Git.Revision,
+		namespace, name, username,
+	)
+	if cloneError != nil {
+		return "", cloneError
+	}
+	log.Infow("git fallback clone succeeded",
+		"namespace", namespace, "app", name, "blobUID", blobUID,
+	)
+	return blobUID, nil
+}
+
+// ensureStagingPVCs creates persistent volume claims for the staging job
+// when the helm values do not use emptyDir for cache or source blobs.
+func ensureStagingPVCs(
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+	req models.StageRequest,
+	helmValues HelmValuesMap,
+) apierror.APIErrors {
+	if !helmValues.Storage.Cache.EmptyDir {
+		cacheErr := ensurePVC(
+			ctx, cluster,
+			helmValues.Storage.Cache,
+			req.App.MakeCachePVCName(),
+		)
+		if cacheErr != nil {
+			return apierror.InternalError(
+				cacheErr,
+				"failed to ensure a PersistentVolumeClaim for the application cache",
+			)
+		}
+	}
+	if !helmValues.Storage.SourceBlobs.EmptyDir {
+		blobsErr := ensurePVC(
+			ctx, cluster,
+			helmValues.Storage.SourceBlobs,
+			req.App.MakeSourceBlobsPVCName(),
+		)
+		if blobsErr != nil {
+			return apierror.InternalError(
+				blobsErr,
+				"failed to ensure a PersistentVolumeClaim for the application source blobs",
+			)
+		}
+	}
+	return nil
+}
+
+// resolveRegistryCertHash reads the registry certificate secret name from
+// config and returns the secret name and its hash. Returns empty strings when
+// no secret is configured.
+func resolveRegistryCertHash(
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+) (string, string, error) {
+	secret := viper.GetString("registry-certificate-secret")
+	if secret == "" {
+		return "", "", nil
+	}
+	hash, hashErr := getRegistryCertificateHash(
+		ctx, cluster, helmchart.Namespace(), secret,
+	)
+	if hashErr != nil {
+		return "", "", hashErr
+	}
+	return secret, hash, nil
 }
 
 func updateApp(ctx context.Context, cluster *kubernetes.Cluster, app *unstructured.Unstructured, params stageParam) error {

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -67,6 +67,7 @@ type stageParam struct {
 	PreviousStageID     string
 	RegistryCASecret    string
 	RegistryCAHash      string
+	RegistryCACertKey   string // "ca.crt" or "tls.crt"
 	UserID              int64
 	GroupID             int64
 	Scripts             string
@@ -275,7 +276,7 @@ func Stage(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err, "getting the Epinio registry public URL")
 	}
 
-	registryCertificateSecret, registryCertificateHash, err :=
+	registryCertificateSecret, registryCACertKey, registryCertificateHash, err :=
 		resolveRegistryCertHash(ctx, cluster)
 	if err != nil {
 		return apierror.InternalError(err, "cannot calculate Certificate hash")
@@ -305,6 +306,7 @@ func Stage(c *gin.Context) apierror.APIErrors {
 		Username:            username,
 		RegistryCAHash:      registryCertificateHash,
 		RegistryCASecret:    registryCertificateSecret,
+		RegistryCACertKey:   registryCACertKey,
 		UserID:              config.UserID,
 		GroupID:             config.GroupID,
 		Scripts:             config.Name,
@@ -919,26 +921,40 @@ func getRegistryURL(ctx context.Context, cluster *kubernetes.Cluster) (string, e
 }
 
 // The equivalent of:
-// kubectl get secret -n (helmchart.Namespace()) epinio-registry-tls -o json | jq -r '.["data"]["tls.crt"]' | base64 -d | openssl x509 -hash -noout
+// kubectl get secret -n (helmchart.Namespace()) epinio-registry-tls -o json | jq -r '.["data"]["ca.crt"]' | base64 -d | openssl x509 -hash -noout
 // written in golang.
-func getRegistryCertificateHash(ctx context.Context, c *kubernetes.Cluster, namespace string, name string) (string, error) {
+// Returns (certKey, hash, error). Prefers ca.crt (the CA root) over tls.crt
+// (the server leaf cert). When cert-manager issues the registry cert with a
+// separate CA, mounting the leaf cert as a trusted CA does not work; the CA
+// cert must be used instead. Falls back to tls.crt for self-signed certs where
+// ca.crt is absent.
+func getRegistryCertificateHash(ctx context.Context, c *kubernetes.Cluster, namespace string, name string) (string, string, error) {
 	secret, err := c.Kubectl.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	// cert-manager doesn't add the CA for ACME certificates:
-	// https://github.com/jetstack/cert-manager/issues/2111
-	if _, found := secret.Data["tls.crt"]; !found {
-		return "", nil
+	// Prefer ca.crt (CA root) so staging jobs trust the registry regardless of
+	// whether the cert is self-signed or issued by an internal CA. Fall back to
+	// tls.crt for self-signed setups where ca.crt is absent.
+	certKey := "ca.crt"
+	certData, found := secret.Data["ca.crt"]
+	if !found || len(certData) == 0 {
+		// cert-manager doesn't add the CA for ACME certificates:
+		// https://github.com/jetstack/cert-manager/issues/2111
+		certKey = "tls.crt"
+		certData, found = secret.Data["tls.crt"]
+		if !found {
+			return "", "", nil
+		}
 	}
 
-	hash, err := cahash.GenerateHash(secret.Data["tls.crt"])
+	hash, err := cahash.GenerateHash(certData)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	return hash, nil
+	return certKey, hash, nil
 }
 
 // getBuilderImage returns the builder image defined on the request. If that
@@ -1092,18 +1108,18 @@ func ensureStagingPVCs(
 func resolveRegistryCertHash(
 	ctx context.Context,
 	cluster *kubernetes.Cluster,
-) (string, string, error) {
+) (string, string, string, error) {
 	secret := viper.GetString("registry-certificate-secret")
 	if secret == "" {
-		return "", "", nil
+		return "", "", "", nil
 	}
-	hash, hashErr := getRegistryCertificateHash(
+	certKey, hash, hashErr := getRegistryCertificateHash(
 		ctx, cluster, helmchart.Namespace(), secret,
 	)
 	if hashErr != nil {
-		return "", "", hashErr
+		return "", "", "", hashErr
 	}
-	return secret, hash, nil
+	return secret, certKey, hash, nil
 }
 
 func updateApp(ctx context.Context, cluster *kubernetes.Cluster, app *unstructured.Unstructured, params stageParam) error {
@@ -1181,7 +1197,7 @@ func mountRegistryCerts(app stageParam, volumes []corev1.Volume, volumeMounts []
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "registry-certs",
 			MountPath: fmt.Sprintf("/etc/ssl/certs/%s", app.RegistryCAHash),
-			SubPath:   "tls.crt",
+			SubPath:   app.RegistryCACertKey,
 			ReadOnly:  true,
 		})
 	}

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -70,7 +70,7 @@ type stageParam struct {
 	UserID              int64
 	GroupID             int64
 	Scripts             string
-	HelmValues          HelmValuesMap // Helm Values configuring the staging workload
+	HelmValues          HelmValuesMap
 }
 
 type HelmValuesMap struct {
@@ -234,9 +234,35 @@ func Stage(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err, "failed to fetch the S3 connection details")
 	}
 
-	blobUID, blobErr := getBlobUID(ctx, s3ConnectionDetails, req, app)
-	if blobErr != nil {
-		return blobErr
+	blobUID, blobError := getBlobUID(ctx, s3ConnectionDetails, req, app)
+	if blobError != nil {
+		log.Infow("blob lookup failed, checking for git origin fallback",
+			"namespace", namespace, "app", name, "error", blobError,
+		)
+		origin, originError := application.Origin(app)
+		if originError == nil && origin.Git != nil {
+			log.Infow("git origin found, re-cloning to S3",
+				"namespace", namespace, "app", name,
+				"url", origin.Git.URL, "revision", origin.Git.Revision,
+			)
+			blobUID, _, _, blobError = cloneAndUpload(
+				ctx, cluster,
+				origin.Git.URL, origin.Git.Revision,
+				namespace, name, username,
+			)
+			if blobError == nil {
+				log.Infow("git fallback clone succeeded",
+					"namespace", namespace, "app", name, "blobUID", blobUID,
+				)
+			}
+		} else {
+			log.Infow("no git origin available for fallback",
+				"namespace", namespace, "app", name,
+			)
+		}
+		if blobError != nil {
+			return blobError
+		}
 	}
 
 	// Create uid identifying the staging job to be
@@ -294,9 +320,9 @@ func Stage(c *gin.Context) apierror.APIErrors {
 	params := stageParam{
 		AppRef:              req.App,
 		BuilderImage:        builderImage,
+		BlobUID:             blobUID,
 		DownloadImage:       config.DownloadImage,
 		UnpackImage:         config.UnpackImage,
-		BlobUID:             blobUID,
 		Environment:         environment.List(),
 		Owner:               owner,
 		RegistryURL:         registryPublicURL,
@@ -313,16 +339,30 @@ func Stage(c *gin.Context) apierror.APIErrors {
 	}
 
 	if !params.HelmValues.Storage.Cache.EmptyDir {
-		err = ensurePVC(ctx, cluster, params.HelmValues.Storage.Cache, req.App.MakeCachePVCName())
-		if err != nil {
-			return apierror.InternalError(err, "failed to ensure a PersistentVolumeClaim for the application cache")
+		pvcError := ensurePVC(
+			ctx, cluster,
+			params.HelmValues.Storage.Cache,
+			req.App.MakeCachePVCName(),
+		)
+		if pvcError != nil {
+			return apierror.InternalError(
+				pvcError,
+				"failed to ensure a PersistentVolumeClaim for the application cache",
+			)
 		}
 	}
 
 	if !params.HelmValues.Storage.SourceBlobs.EmptyDir {
-		err = ensurePVC(ctx, cluster, params.HelmValues.Storage.SourceBlobs, req.App.MakeSourceBlobsPVCName())
+		err = ensurePVC(
+			ctx, cluster,
+			params.HelmValues.Storage.SourceBlobs,
+			req.App.MakeSourceBlobsPVCName(),
+		)
 		if err != nil {
-			return apierror.InternalError(err, "failed to ensure a PersistentVolumeClaim for the application source blobs")
+			return apierror.InternalError(
+				err,
+				"failed to ensure a PersistentVolumeClaim for the application source blobs",
+			)
 		}
 	}
 
@@ -798,6 +838,31 @@ func newJobRun(app stageParam) (*batchv1.Job, *corev1.Secret) {
 		},
 	}
 
+	initContainers := []corev1.Container{
+		{
+			Name:         "download-s3-blob",
+			Image:        app.DownloadImage,
+			VolumeMounts: volumeMounts,
+			Command:      []string{"/bin/bash"},
+			Args: []string{
+				"-c",
+				awsScript,
+			},
+			Env: stageEnv,
+		},
+		{
+			Name:         "unpack-blob",
+			Image:        app.UnpackImage,
+			VolumeMounts: volumeMounts,
+			Command:      []string{"bash"},
+			Args: []string{
+				"-c",
+				unpackScript,
+			},
+			Env: stageEnv,
+		},
+	}
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: jobName,
@@ -836,30 +901,7 @@ func newJobRun(app stageParam) (*batchv1.Job, *corev1.Secret) {
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: app.HelmValues.ServiceAccountName,
-					InitContainers: []corev1.Container{
-						{
-							Name:         "download-s3-blob",
-							Image:        app.DownloadImage,
-							VolumeMounts: volumeMounts,
-							Command:      []string{"/bin/bash"},
-							Args: []string{
-								"-c",
-								awsScript,
-							},
-							Env: stageEnv,
-						},
-						{
-							Name:         "unpack-blob",
-							Image:        app.UnpackImage,
-							VolumeMounts: volumeMounts,
-							Command:      []string{"bash"},
-							Args: []string{
-								"-c",
-								unpackScript,
-							},
-							Env: stageEnv,
-						},
-					},
+					InitContainers:     initContainers,
 					Containers: []corev1.Container{
 						{
 							Name:    "buildpack",
@@ -969,30 +1011,33 @@ func getBuilderImage(req models.StageRequest, app *unstructured.Unstructured) (s
 	return builderImage, nil
 }
 
-func getBlobUID(ctx context.Context, s3ConnectionDetails s3manager.ConnectionDetails, req models.StageRequest, app *unstructured.Unstructured) (string, apierror.APIErrors) {
+func getBlobUID(
+	ctx context.Context,
+	s3ConnectionDetails s3manager.ConnectionDetails,
+	req models.StageRequest,
+	app *unstructured.Unstructured,
+) (string, apierror.APIErrors) {
 	var blobUID string
-	var err error
-	var returnErr apierror.APIErrors
 
 	if req.BlobUID != "" {
 		blobUID = req.BlobUID
 	} else {
-		blobUID, err = findPreviousBlobUID(app)
-		if err != nil {
-			returnErr = apierror.InternalError(err, "looking up the previous blod UID")
-			return "", returnErr
+		previousUID, lookupError := findPreviousBlobUID(app)
+		if lookupError != nil {
+			return "", apierror.InternalError(lookupError, "looking up the previous blob UID")
 		}
+		blobUID = previousUID
 	}
 
 	if blobUID == "" {
-		returnErr = apierror.NewBadRequestError("request didn't provide a blobUID and a previous one doesn't exist")
-		return "", returnErr
+		return "", apierror.NewBadRequestError(
+			"request didn't provide a blobUID and a previous one doesn't exist",
+		)
 	}
 
-	// Validate incoming blob id before attempting to stage
-	apierr := validateBlob(ctx, blobUID, req.App, s3ConnectionDetails)
-	if apierr != nil {
-		return "", apierr
+	validateError := validateBlob(ctx, blobUID, req.App, s3ConnectionDetails)
+	if validateError != nil {
+		return "", validateError
 	}
 
 	return blobUID, nil
@@ -1022,14 +1067,14 @@ func updateApp(ctx context.Context, cluster *kubernetes.Cluster, app *unstructur
 		return err
 	}
 
+	specPatch := map[string]any{
+		"stageid":      params.Stage.ID,
+		"builderimage": params.BuilderImage,
+		"blobuid":      params.BlobUID,
+	}
+
 	// Merge patch avoids resourceVersion update conflicts for these spec fields.
-	patchBody, err := json.Marshal(map[string]any{
-		"spec": map[string]any{
-			"blobuid":      params.BlobUID,
-			"stageid":      params.Stage.ID,
-			"builderimage": params.BuilderImage,
-		},
-	})
+	patchBody, err := json.Marshal(map[string]any{"spec": specPatch})
 	if err != nil {
 		return err
 	}
@@ -1099,7 +1144,7 @@ type StagingScriptConfig struct {
 	Name          string                // config name. Needed to mount the resource in the pod
 	Builder       string                // glob pattern for builders supported by this resource
 	UserID        int64                 // user id to run the build phase with (`cnb` user)
-	GroupID       int64                 // group id to run the build hase with
+	GroupID       int64                 // group id to run the build phase with
 	Base          string                // optional, name of resource to pull the other parts from
 	DownloadImage string                // image to run the download phase with
 	UnpackImage   string                // image to run the unpack phase with

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -29,11 +29,10 @@ import (
 	"github.com/epinio/epinio/internal/version"
 	"github.com/gin-gonic/gin"
 
-	"k8s.io/client-go/rest"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/client-go/rest"
 )
 
 func init() {


### PR DESCRIPTION
### PR Checklist
  - [x] Linting Test is passing
  - [x] Unit Tests are passing
  - [ ] Acceptance Tests are passing (new tests added, pending CI run)
  - [x] Code is well documented
  - [ ] epinio/docs PR (internal API change, no user-facing command changes)

### Summary

Related PR for the [UI 588](https://github.com/epinio/ui/pull/588)

  Fixes the case where an application deployed from a git source loses its S3 staging blob (e.g. S3
  storage reset, PVC loss, or cluster migration). Without this fix, `epinio app restage` would fail with a
   blob-not-found error even though the original git source is still available and the app could be
  rebuilt.

  ### Occurred changes and/or fixed issues

  **`internal/api/v1/application/importgit.go`**
  - Extracted the blob upload logic from `ImportGit()` into a new exported helper `cloneAndUpload()`. This
   allows the staging path to invoke a git clone + S3 upload without going through the full HTTP handler,
  which was not designed to be called internally.
  - Improved variable naming and error message clarity throughout.

  **`internal/api/v1/application/stage.go`**
  - `Stage` now calls `resolveBlobUID()` instead of `getBlobUID()` directly. If blob lookup fails and the
  app has a `spec.origin.git` set, `resolveBlobUID` re-clones from the git URL/revision and uploads a new
  blob to S3 before continuing staging. The fallback is fully logged at each step.
  - Extracted three helpers to bring cyclomatic complexity within the linter threshold (was 34, now 26):
    - `resolveBlobUID`: blob lookup with git fallback
    - `ensureStagingPVCs`: PVC provisioning for cache and source blobs
    - `resolveRegistryCertHash`: registry certificate hash resolution

  **`internal/cli/server.go`**
  - Minor route wiring to support the refactored import handler.

  **`acceptance/helpers_test.go`**
  - `createS3HelperPod()`: launches a `minio/mc` pod in-cluster, reads SeaweedFS credentials from the
  `seaweedfs-creds` secret, and configures an S3 alias. Idempotent, skips creation if the pod already
  exists.
  - `deleteS3Blob(blobUID string)`: executes `mc rm` against the epinio bucket for a given blob UID via
  the helper pod.

  **`acceptance/apps_test.go`**
  - New `When("the S3 blob is deleted after a git push", ...)` block inside the `restage` describe:
    1. Push an app from a public git URL
    2. Wait for `1/1` running
    3. Read `spec.blobuid` from the `apps.application.epinio.io` CRD via kubectl
    4. Delete the blob from S3 using the helper
    5. Call `epinio app restage`
    6. Verify the app returns to `1/1` running (confirms git fallback rebuilt and deployed)

  ### Technical notes summary

  The git fallback only activates in `Stage` (the `POST .../stage` endpoint), which is the path used by
  `epinio app restage`. It does NOT run in `stageForAsyncDeploy` (the async push path) because that path
  always has a fresh blob from the upload step immediately before it.

  The fallback requires `spec.origin.git` to be set on the app. This field is written by `SetOrigin` after
   a successful full deployment. Apps pushed via archive/tarball upload will not have a git origin and
  will receive the original blob-not-found error unchanged.

  `cloneAndUpload` is the same code path used by `ImportGit` during initial git push. Re-using it for the
  fallback means the recovery produces an identical staging artifact to the original deploy.

  ### Areas or cases that should be tested

  1. Push an app from a git source, confirm it runs, delete its S3 blob, then `restage` -- should recover
  and reach `1/1` running
  2. `restage` on an app pushed via file upload with a missing blob -- should fail with blob-not-found (no
   git fallback)
  3. `restage` on a git app with an invalid/unreachable git URL in `spec.origin` -- should fail with a
  descriptive clone error
  4. Normal `restage` with blob intact -- should be unaffected (fallback never triggers)
  5. Server logs during fallback: confirm the sequence `blob lookup failed` → `git origin found` → `git
  fallback clone succeeded` is present

  ### Areas which could experience regressions

  - `epinio app restage` for all app source types
  - `epinio app push` from git source (touches `importgit.go` refactor)
  - Staging PVC provisioning (`ensureStagingPVCs` extracted -- same logic, different call site)
  - Registry certificate handling (`resolveRegistryCertHash` extracted -- same logic)