### PR TITLE
Feat/builderimage cr as default source

### DIFF
--- a/acceptance/api/v1/application_stage_test.go
+++ b/acceptance/api/v1/application_stage_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/epinio/epinio/acceptance/helpers/catalog"
@@ -210,6 +211,123 @@ var _ = Describe("AppStage Endpoint", LApplication, func() {
 			Expect(stagingBuilderImage).To(Equal(builderImage))
 		})
 	})
+
+	It("uses the default BuilderImage CR and follows a default change", Serial, func() {
+		firstImage := "paketobuildpacks/builder-jammy-full:0.3.495"
+		secondImage := "paketobuildpacks/builder-jammy-full:0.3.290"
+		firstName := catalog.NewTmpName("00-builderimage-default-a-")
+		secondName := catalog.NewTmpName("00-builderimage-default-b-")
+		manifest := fmt.Sprintf(`apiVersion: application.epinio.io/v1
+kind: BuilderImage
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  image: %s
+  default: true
+  shortDescription: Acceptance test builder
+  description: Acceptance test builder
+---
+apiVersion: application.epinio.io/v1
+kind: BuilderImage
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  image: %s
+  default: false
+  shortDescription: Acceptance test builder
+  description: Acceptance test builder
+`, firstName, testenv.Namespace, firstImage, secondName, testenv.Namespace, secondImage)
+
+		manifestFile, err := os.CreateTemp("", "epinio-builderimages-*.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = manifestFile.WriteString(manifest)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(manifestFile.Close()).To(Succeed())
+		DeferCleanup(os.Remove, manifestFile.Name())
+
+		out, err := proc.Kubectl("apply", "-f", manifestFile.Name())
+		Expect(err).NotTo(HaveOccurred(), out)
+		DeferCleanup(func() {
+			_, _ = proc.Kubectl(
+				"delete", "builderimage", firstName, secondName,
+				"--namespace", testenv.Namespace,
+				"--ignore-not-found",
+			)
+		})
+
+		By("staging a new application with the initial CR-derived default")
+		uploadResponse := uploadApplication(appName, namespace)
+		stageResponse := stageApplication(appName, namespace, models.StageRequest{
+			App: models.AppRef{
+				Meta: models.Meta{Name: appName, Namespace: namespace},
+			},
+			BlobUID: uploadResponse.BlobUID,
+		})
+		stagingBuilderImage, err := proc.Kubectl(
+			"get", "pods",
+			"--namespace", testenv.Namespace,
+			"-l", fmt.Sprintf("epinio.io/stage-id=%s", stageResponse.Stage.ID),
+			"-o", "jsonpath={.items[*].spec.containers[0].image}",
+		)
+		Expect(err).NotTo(HaveOccurred(), stagingBuilderImage)
+		Expect(stagingBuilderImage).To(Equal(firstImage))
+
+		By("switching the default BuilderImage CR")
+		out, err = proc.Kubectl(
+			"patch", "builderimage", firstName,
+			"--namespace", testenv.Namespace,
+			"--type", "merge",
+			"--patch", `{"spec":{"default":false}}`,
+		)
+		Expect(err).NotTo(HaveOccurred(), out)
+		out, err = proc.Kubectl(
+			"patch", "builderimage", secondName,
+			"--namespace", testenv.Namespace,
+			"--type", "merge",
+			"--patch", `{"spec":{"default":true}}`,
+		)
+		Expect(err).NotTo(HaveOccurred(), out)
+
+		By("reporting the changed CR-derived default from the info endpoint")
+		infoResponse, err := env.Curl(
+			"GET",
+			fmt.Sprintf("%s%s/info", serverURL, v1.Root),
+			strings.NewReader(""),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		infoBody, err := io.ReadAll(infoResponse.Body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(infoResponse.Body.Close()).To(Succeed())
+		Expect(infoResponse.StatusCode).To(Equal(http.StatusOK), string(infoBody))
+		var info models.InfoResponse
+		Expect(json.Unmarshal(infoBody, &info)).To(Succeed())
+		Expect(info.DefaultBuilderImage).To(Equal(secondImage))
+
+		By("staging another new application with the changed default")
+		secondAppName := catalog.NewAppName()
+		appCreateRequest := models.ApplicationCreateRequest{Name: secondAppName}
+		bodyBytes, statusCode := appCreate(namespace, toJSON(appCreateRequest))
+		Expect(statusCode).To(Equal(http.StatusCreated), string(bodyBytes))
+
+		secondUpload := uploadApplication(secondAppName, namespace)
+		secondStage := stageApplication(secondAppName, namespace, models.StageRequest{
+			App: models.AppRef{
+				Meta: models.Meta{Name: secondAppName, Namespace: namespace},
+			},
+			BlobUID: secondUpload.BlobUID,
+		})
+		stagingBuilderImage, err = proc.Kubectl(
+			"get", "pods",
+			"--namespace", testenv.Namespace,
+			"-l", fmt.Sprintf("epinio.io/stage-id=%s", secondStage.Stage.ID),
+			"-o", "jsonpath={.items[*].spec.containers[0].image}",
+		)
+		Expect(err).NotTo(HaveOccurred(), stagingBuilderImage)
+		Expect(stagingBuilderImage).To(Equal(secondImage))
+	})
+
 	When("staging and deploying a new app", func() {
 		It("returns a success for a tarball", func() {
 			By("uploading the code")

--- a/internal/api/v1/application/deployments.go
+++ b/internal/api/v1/application/deployments.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/helpers/randstr"
@@ -291,8 +291,8 @@ func stageForAsyncDeploy(
 
 	// determine builder image (request overrides)
 	stageReq := models.StageRequest{
-		App:         appRef,
-		BlobUID:     blobUID,
+		App:          appRef,
+		BlobUID:      blobUID,
 		BuilderImage: builderImage,
 	}
 
@@ -301,7 +301,10 @@ func stageForAsyncDeploy(
 		return nil, builderErr
 	}
 	if builder == "" {
-		builder = viper.GetString("default-builder-image")
+		builder, err = resolveDefaultBuilderImage(ctx, cluster)
+		if err != nil {
+			return nil, apierror.InternalError(err, "failed to resolve the default builder image")
+		}
 		if builder == "" {
 			return nil, apierror.NewBadRequestError("no builder image specified and no default configured")
 		}
@@ -423,4 +426,3 @@ func stageForAsyncDeploy(
 		ImageURL: imageURL,
 	}, nil
 }
-

--- a/internal/api/v1/application/sourcepatch.go
+++ b/internal/api/v1/application/sourcepatch.go
@@ -22,7 +22,6 @@ import (
 	"github.com/epinio/epinio/internal/registry"
 	"github.com/epinio/epinio/internal/s3manager"
 	"github.com/gin-gonic/gin"
-	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -264,7 +263,14 @@ func buildAndPatch(
 		return models.StageResponse{}, stageParam{}, builderError
 	}
 	if builderImage == "" {
-		builderImage = viper.GetString("default-builder-image")
+		resolvedBuilderImage, resolveError := resolveDefaultBuilderImage(ctx, cluster)
+		if resolveError != nil {
+			return models.StageResponse{}, stageParam{}, apierror.InternalError(
+				resolveError,
+				"failed to resolve the default builder image",
+			)
+		}
+		builderImage = resolvedBuilderImage
 	}
 
 	config, determineStagingError := DetermineStagingScripts(

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -45,6 +45,7 @@ import (
 	"github.com/epinio/epinio/internal/application"
 	"github.com/epinio/epinio/internal/auth"
 	gitbridge "github.com/epinio/epinio/internal/bridge/git"
+	"github.com/epinio/epinio/internal/builderimage"
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/epinio/epinio/internal/duration"
 	"github.com/epinio/epinio/internal/helmchart"
@@ -75,6 +76,29 @@ type stageParam struct {
 	GroupID             int64
 	Scripts             string
 	HelmValues          HelmValuesMap
+}
+
+// resolveDefaultBuilderImage returns the BuilderImage CR selected as the
+// cluster default, falling back to the legacy environment configuration when
+// no CR is marked as default.
+func resolveDefaultBuilderImage(
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+) (string, error) {
+	client, err := cluster.ClientBuilderImage()
+	if err != nil {
+		return "", err
+	}
+
+	defaultBuilder, err := builderimage.Default(ctx, client)
+	if err != nil {
+		return "", err
+	}
+	if defaultBuilder != nil {
+		return defaultBuilder.Image, nil
+	}
+
+	return viper.GetString("default-builder-image"), nil
 }
 
 type HelmValuesMap struct {
@@ -211,7 +235,10 @@ func Stage(c *gin.Context) apierror.APIErrors {
 		return builderErr
 	}
 	if builderImage == "" {
-		builderImage = viper.GetString("default-builder-image")
+		builderImage, err = resolveDefaultBuilderImage(ctx, cluster)
+		if err != nil {
+			return apierror.InternalError(err, "failed to resolve the default builder image")
+		}
 	}
 
 	// Find staging script spec based on the builder image and what images are supported by each spec

--- a/internal/api/v1/application/stage.go
+++ b/internal/api/v1/application/stage.go
@@ -80,7 +80,7 @@ type stageParam struct {
 
 // resolveDefaultBuilderImage returns the BuilderImage CR selected as the
 // cluster default, falling back to the legacy environment configuration when
-// no CR is marked as default.
+// no CR is marked as default, or when listing BuilderImage CRs is forbidden.
 func resolveDefaultBuilderImage(
 	ctx context.Context,
 	cluster *kubernetes.Cluster,

--- a/internal/api/v1/info.go
+++ b/internal/api/v1/info.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
+	"github.com/epinio/epinio/internal/builderimage"
 	"github.com/epinio/epinio/internal/version"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/spf13/viper"
@@ -45,7 +46,20 @@ func Info(c *gin.Context) APIErrors {
 
 	platform := cluster.GetPlatform()
 
+	builderImageClient, err := cluster.ClientBuilderImage()
+	if err != nil {
+		return InternalError(err)
+	}
+
+	defaultBuilder, err := builderimage.Default(ctx, builderImageClient)
+	if err != nil {
+		return InternalError(err)
+	}
+
 	defaultBuilderImage := viper.GetString("default-builder-image")
+	if defaultBuilder != nil {
+		defaultBuilderImage = defaultBuilder.Image
+	}
 
 	_, dexError := os.Stat(DexPEMPath)
 

--- a/internal/api/v1/info.go
+++ b/internal/api/v1/info.go
@@ -51,6 +51,8 @@ func Info(c *gin.Context) APIErrors {
 		return InternalError(err)
 	}
 
+	// builderimage.Default returns nil (no error) when listing is forbidden,
+	// so we fall back to DEFAULT_BUILDER_IMAGE in that case as well.
 	defaultBuilder, err := builderimage.Default(ctx, builderImageClient)
 	if err != nil {
 		return InternalError(err)

--- a/internal/builderimage/builderimage.go
+++ b/internal/builderimage/builderimage.go
@@ -16,6 +16,7 @@ package builderimage
 import (
 	"context"
 	"errors"
+	"sort"
 
 	"github.com/epinio/epinio/internal/helmchart"
 	"github.com/epinio/epinio/pkg/api/core/v1/models"
@@ -24,6 +25,36 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 )
+
+// Default returns the default BuilderImage. If more than one resource is
+// marked as default, the one with the lexicographically smallest name wins.
+// It returns nil when no default is configured.
+func Default(
+	ctx context.Context,
+	client dynamic.NamespaceableResourceInterface,
+) (*models.BuilderImage, error) {
+	builderimages, err := List(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	defaults := make(models.BuilderImageList, 0)
+	for _, candidate := range builderimages {
+		if candidate.Default {
+			defaults = append(defaults, candidate)
+		}
+	}
+
+	if len(defaults) == 0 {
+		return nil, nil
+	}
+
+	sort.Slice(defaults, func(i, j int) bool {
+		return defaults[i].Meta.Name < defaults[j].Meta.Name
+	})
+
+	return &defaults[0], nil
+}
 
 // List returns a slice of all known builderimage CRs.
 func List(

--- a/internal/builderimage/builderimage.go
+++ b/internal/builderimage/builderimage.go
@@ -29,12 +29,18 @@ import (
 // Default returns the default BuilderImage. If more than one resource is
 // marked as default, the one with the lexicographically smallest name wins.
 // It returns nil when no default is configured.
+//
+// Permission errors (Forbidden / Unauthorized) while listing also return
+// nil so callers can fall back to DEFAULT_BUILDER_IMAGE.
 func Default(
 	ctx context.Context,
 	client dynamic.NamespaceableResourceInterface,
 ) (*models.BuilderImage, error) {
 	builderimages, err := List(ctx, client)
 	if err != nil {
+		if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/internal/builderimage/builderimage_test.go
+++ b/internal/builderimage/builderimage_test.go
@@ -52,6 +52,62 @@ var _ = Describe("BuilderImage CRUD", func() {
 		}
 	}
 
+	Describe("Default", func() {
+		It("returns nil when no builder image is marked as default", func() {
+			fakeRI.ListReturns(&unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					makeCR("standard", "paketo:jammy", "", ""),
+				},
+			}, nil)
+
+			found, defaultError := builderimage.Default(ctx, fakeNS)
+
+			Expect(defaultError).ToNot(HaveOccurred())
+			Expect(found).To(BeNil())
+		})
+
+		It("returns the builder image marked as default", func() {
+			standard := makeCR("standard", "paketo:jammy", "", "")
+			standard.Object["spec"].(map[string]interface{})["default"] = true
+			fakeRI.ListReturns(&unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{standard},
+			}, nil)
+
+			found, defaultError := builderimage.Default(ctx, fakeNS)
+
+			Expect(defaultError).ToNot(HaveOccurred())
+			Expect(found).ToNot(BeNil())
+			Expect(found.Meta.Name).To(Equal("standard"))
+			Expect(found.Image).To(Equal("paketo:jammy"))
+		})
+
+		It("chooses deterministically when multiple builder images are default", func() {
+			zulu := makeCR("zulu", "zulu:latest", "", "")
+			zulu.Object["spec"].(map[string]interface{})["default"] = true
+			alpha := makeCR("alpha", "alpha:latest", "", "")
+			alpha.Object["spec"].(map[string]interface{})["default"] = true
+			fakeRI.ListReturns(&unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{zulu, alpha},
+			}, nil)
+
+			found, defaultError := builderimage.Default(ctx, fakeNS)
+
+			Expect(defaultError).ToNot(HaveOccurred())
+			Expect(found).ToNot(BeNil())
+			Expect(found.Meta.Name).To(Equal("alpha"))
+			Expect(found.Image).To(Equal("alpha:latest"))
+		})
+
+		It("propagates list errors", func() {
+			fakeRI.ListReturns(nil, errors.New("boom"))
+
+			found, defaultError := builderimage.Default(ctx, fakeNS)
+
+			Expect(defaultError).To(MatchError("boom"))
+			Expect(found).To(BeNil())
+		})
+	})
+
 	Describe("List", func() {
 		It("returns all known builder images", func() {
 			fakeRI.ListReturns(&unstructured.UnstructuredList{

--- a/internal/builderimage/builderimage_test.go
+++ b/internal/builderimage/builderimage_test.go
@@ -106,6 +106,37 @@ var _ = Describe("BuilderImage CRUD", func() {
 			Expect(defaultError).To(MatchError("boom"))
 			Expect(found).To(BeNil())
 		})
+
+		It("returns nil when listing is forbidden so callers can fall back to env", func() {
+			fakeRI.ListReturns(
+				nil,
+				k8sapierrors.NewForbidden(
+					schema.GroupResource{
+						Group:    "application.epinio.io",
+						Resource: "builderimages",
+					},
+					"list",
+					errors.New("no rights"),
+				),
+			)
+
+			found, defaultError := builderimage.Default(ctx, fakeNS)
+
+			Expect(defaultError).ToNot(HaveOccurred())
+			Expect(found).To(BeNil())
+		})
+
+		It("returns nil when listing is unauthorized so callers can fall back to env", func() {
+			fakeRI.ListReturns(
+				nil,
+				k8sapierrors.NewUnauthorized("not authenticated"),
+			)
+
+			found, defaultError := builderimage.Default(ctx, fakeNS)
+
+			Expect(defaultError).ToNot(HaveOccurred())
+			Expect(found).To(BeNil())
+		})
 	})
 
 	Describe("List", func() {


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] New Unit and Acceptance tests written for the context of the PR
- [ ] Unit Tests are passing
- [ ] Acceptance Tests are passing
- [x] Code is well documented
- [ ] Does the [MCP](https://github.com/epinio/mcp) server need an update?
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened
 
<!-- This template is for Devs to give the reviewer and QA details -->
### Summary
Fixes #
Use the BuilderImage custom resource as the source of truth for the default builder image, with the existing DEFAULT_BUILDER_IMAGE environment variable retained only as a fallback when no CR is marked as default.


### Occurred changes and/or fixed issues

- Added builderimage.Default() to resolve the cluster default from BuilderImage CRs (spec.default: true), with lexicographic name tie-breaking when multiple defaults exist, and nil when none are configured.
- Added resolveDefaultBuilderImage() and wired it into:
- internal/api/v1/application/stage.go
- internal/api/v1/application/sourcepatch.go
- internal/api/v1/application/deployments.go
- Updated /info to report the CR-derived default builder image, falling back to the env var when no default CR exists.
- Replaced direct viper.GetString("default-builder-image") lookups in the above paths with CR-first resolution.
- Added unit tests for builderimage.Default.
- Added an acceptance test verifying staging uses the CR default and that changing the default CR updates both staging behavior and the /info response.

### Technical notes summary

- Resolution order is: explicit request value → application CR spec.builderimage → default BuilderImage CR → DEFAULT_BUILDER_IMAGE env fallback.
- builderimage.Default() reuses the existing List() helper and sorts matching CRs by name for deterministic selection.
- List/client failures are surfaced as internal API errors instead of silently falling back.
- Async deploys retain the existing guard that returns a bad request when no builder can be resolved from any source.
- 

### Areas or cases that should be tested
<!-- Areas that should be tested. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if they have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

-  Stage an app without specifying a builder image and confirm the default BuilderImage CR image is used in the staging pod.
-  Patch a different BuilderImage CR to spec.default: true (and unset the previous default), then stage a new app and confirm the new default is used.
-  Call GET /api/v1/info and confirm default_builder_image reflects the CR default.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed, which may be affected by the changes, which would require prior research to avoid regressions. -->

- Staging when no builder is explicitly provided (previously env-only; now CR-first).
- Source patch rebuilds for apps without a stored builder image.
- Async deploy staging path when builder is not specified in the request or app CR.
