### PR TITLE
feat EPINIO-723: service catalog pagination and search

### DIFF
--- a/acceptance/api/v1/services_catalog_test.go
+++ b/acceptance/api/v1/services_catalog_test.go
@@ -83,4 +83,62 @@ var _ = Describe("ServiceCatalog Endpoint", LService, func() {
 		}
 		Expect(serviceNames).ToNot(ContainElement(catalogService.Meta.Name))
 	})
+
+	It("returns a paginated response when page params are provided", func() {
+		catalog.CreateCatalogService(catalogService)
+		defer catalog.DeleteCatalogService(catalogService.Meta.Name)
+
+		response, err := env.Curl("GET", fmt.Sprintf("%s%s/catalogservices?page=1&pageSize=1",
+			serverURL, v1.Root), strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		defer response.Body.Close()
+		bodyBytes, err := io.ReadAll(response.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+		var paged struct {
+			Items      models.CatalogServices `json:"items"`
+			Page       int                    `json:"page"`
+			PageSize   int                    `json:"pageSize"`
+			TotalItems int                    `json:"totalItems"`
+			TotalPages int                    `json:"totalPages"`
+		}
+		err = json.Unmarshal(bodyBytes, &paged)
+		Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+		Expect(paged.Page).To(Equal(1))
+		Expect(paged.PageSize).To(Equal(1))
+		Expect(paged.TotalItems).To(BeNumerically(">=", 1))
+		Expect(paged.TotalPages).To(BeNumerically(">=", 1))
+		Expect(paged.Items).To(HaveLen(1))
+	})
+
+	It("filters catalog services by search term", func() {
+		catalog.CreateCatalogService(catalogService)
+		defer catalog.DeleteCatalogService(catalogService.Meta.Name)
+
+		response, err := env.Curl("GET", fmt.Sprintf("%s%s/catalogservices?search=%s",
+			serverURL, v1.Root, catalogService.Meta.Name), strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+		defer response.Body.Close()
+		bodyBytes, err := io.ReadAll(response.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+		var catalogList models.CatalogServices
+		err = json.Unmarshal(bodyBytes, &catalogList)
+		Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+		Expect(catalogList).ToNot(BeEmpty())
+		found := false
+		for _, svc := range catalogList {
+			Expect(svc.Meta.Name).To(ContainSubstring(catalogService.Meta.Name))
+			if svc.Meta.Name == catalogService.Meta.Name {
+				found = true
+			}
+		}
+		Expect(found).To(BeTrue(), "expected search results to contain %q", catalogService.Meta.Name)
+	})
 })

--- a/internal/api/v1/service/catalog/index.go
+++ b/internal/api/v1/service/catalog/index.go
@@ -12,10 +12,13 @@
 package catalog
 
 import (
+	"strings"
+
 	"github.com/epinio/epinio/helpers/kubernetes"
 	"github.com/epinio/epinio/internal/api/v1/response"
 	"github.com/epinio/epinio/internal/services"
 	apierror "github.com/epinio/epinio/pkg/api/core/v1/errors"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
 	"github.com/gin-gonic/gin"
 )
 
@@ -46,6 +49,27 @@ func Index(c *gin.Context) apierror.APIErrors {
 		svc.BoundServices = inUse[svc.Meta.Name]
 	}
 
+	// Optional name filtering, applied before pagination so the page counts
+	// describe the filtered set.
+	if search := response.GetSearchParam(c); search != "" {
+		lower := strings.ToLower(search)
+		var filtered []*models.CatalogService
+		for _, svc := range serviceList {
+			if strings.Contains(strings.ToLower(svc.Meta.Name), lower) {
+				filtered = append(filtered, svc)
+			}
+		}
+		serviceList = filtered
+	}
+
+	// Apply optional pagination when page parameters are provided.
+	if page, pageSize, ok := response.GetPaginationParams(c, 1, 25); ok {
+		paged := response.PaginateSlice(serviceList, page, pageSize)
+		response.OKReturn(c, paged)
+		return nil
+	}
+
+	// Backwards-compatible: return full list when no page params are set.
 	response.OKReturn(c, serviceList)
 	return nil
 }


### PR DESCRIPTION
### Summary
Fixes #EPINIO-723

On the server only, add optional pagination and name search to `GET /catalogservices`, matching the pattern already used by namespaces and service instances.

### Occurred changes and/or fixed issues
- `GET /catalogservices` now accepts optional `search`, `page`, and `pageSize` query parameters.
- Search filters catalog services by name (case-insensitive substring) before pagination, so page metadata reflects the filtered set.
- When `page`/`pageSize` are provided, the response is a paginated payload (`items`, `page`, `pageSize`, `totalItems`, `totalPages`) via the shared `response.PaginateSlice` helper.
- When page params are omitted, the endpoint still returns the full catalog list for backwards compatibility.
- Acceptance coverage added for pagination metadata and search filtering.

### Technical notes summary
- Implementation mirrors service instance listing (`internal/api/v1/service/list.go`): `response.GetSearchParam` → filter → `response.GetPaginationParams` → `response.PaginateSlice`.
- Defaults match other resources (`page=1`, `pageSize=25` when pagination is requested).
- No UI changes in this PR (server-only scope per ticket).

### Areas or cases that should be tested
1. `GET /catalogservices` with no query params → full list (legacy shape), unchanged behavior for existing clients.
2. `GET /catalogservices?page=1&pageSize=1` → paginated response with correct `page`, `pageSize`, `totalItems`, `totalPages`, and one item.
3. Request a page beyond the last page → empty `items` with correct totals (same helper behavior as other resources).
4. `GET /catalogservices?search=<exact-or-partial-name>` → only matching catalog services; case-insensitive.
5. Combine `search` + `page`/`pageSize` → pagination totals/pages describe the filtered set, not the unfiltered catalog.
6. Empty search / unknown search term → empty list (or empty page), not an error.
7. Regression: catalog show/create/delete and “in use” / bound-service counts on listed items still work.

### Areas which could experience regressions
- Existing CLI/UI/API clients that parse `GET /catalogservices` as a bare array (must remain valid when page params are absent).
- Any client that starts sending `page`/`pageSize` and must handle the paginated response envelope instead of a raw list.
- Shared pagination/search helpers (`GetSearchParam`, `GetPaginationParams`, `PaginateSlice`) used by namespaces and service instances.
- Catalog list fields such as `BoundServices` / in-use counts when filtering or paging the list.