### PR TITLE
feat EPINIO-726: optional PVC deletion on application delete

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -1088,7 +1088,7 @@ var _ = Describe("Apps", LApplication, func() {
 			})
 		})
 		When("deleting the app", func() {
-			It("deletes the cache PVC too", func() {
+			It("deletes the cache PVC when --delete-pvc is set", func() {
 				pvcName := names.GenerateResourceName(namespace, "cache", appName)
 				// Wait for build cache PVC to appear.
 				var found bool
@@ -1105,6 +1105,31 @@ var _ = Describe("Apps", LApplication, func() {
 				out, err := proc.Kubectl("get", "pvc", "--namespace", testenv.Namespace, pvcName)
 				Expect(err).To(HaveOccurred(), out)
 				Expect(out).To(ContainSubstring(`persistentvolumeclaims "%s" not found`, pvcName))
+			})
+
+			It("keeps the cache PVC when --delete-pvc is not set", func() {
+				pvcName := names.GenerateResourceName(namespace, "cache", appName)
+				var found bool
+				for deadline := time.Now().Add(2 * time.Minute); time.Now().Before(deadline); time.Sleep(5 * time.Second) {
+					_, err := proc.Kubectl("get", "pvc", "--namespace", testenv.Namespace, pvcName)
+					if err == nil {
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeTrue(), "build cache PVC %q was not present in namespace %q after waiting 2m", pvcName, testenv.Namespace)
+
+				out, err := env.Epinio("", "app", "delete", appName)
+				Expect(err).ToNot(HaveOccurred(), out)
+
+				out, err = proc.Kubectl("get", "pvc", "--namespace", testenv.Namespace, pvcName)
+				Expect(err).ToNot(HaveOccurred(), out)
+				Expect(out).To(ContainSubstring(pvcName))
+
+				// Cleanup leftover staging PVCs
+				_, _ = proc.Kubectl("delete", "pvc", "--namespace", testenv.Namespace, pvcName, "--ignore-not-found=true")
+				sourcePVC := names.GenerateResourceName(namespace, "sourceblobs", appName)
+				_, _ = proc.Kubectl("delete", "pvc", "--namespace", testenv.Namespace, sourcePVC, "--ignore-not-found=true")
 			})
 		})
 	})

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -1088,7 +1088,7 @@ var _ = Describe("Apps", LApplication, func() {
 			})
 		})
 		When("deleting the app", func() {
-			It("deletes the cache PVC when --delete-pvc is set", func() {
+			It("deletes the cache PVC too", func() {
 				pvcName := names.GenerateResourceName(namespace, "cache", appName)
 				// Wait for build cache PVC to appear.
 				var found bool
@@ -1107,30 +1107,6 @@ var _ = Describe("Apps", LApplication, func() {
 				Expect(out).To(ContainSubstring(`persistentvolumeclaims "%s" not found`, pvcName))
 			})
 
-			It("keeps the cache PVC when --delete-pvc is not set", func() {
-				pvcName := names.GenerateResourceName(namespace, "cache", appName)
-				var found bool
-				for deadline := time.Now().Add(2 * time.Minute); time.Now().Before(deadline); time.Sleep(5 * time.Second) {
-					_, err := proc.Kubectl("get", "pvc", "--namespace", testenv.Namespace, pvcName)
-					if err == nil {
-						found = true
-						break
-					}
-				}
-				Expect(found).To(BeTrue(), "build cache PVC %q was not present in namespace %q after waiting 2m", pvcName, testenv.Namespace)
-
-				out, err := env.Epinio("", "app", "delete", appName)
-				Expect(err).ToNot(HaveOccurred(), out)
-
-				out, err = proc.Kubectl("get", "pvc", "--namespace", testenv.Namespace, pvcName)
-				Expect(err).ToNot(HaveOccurred(), out)
-				Expect(out).To(ContainSubstring(pvcName))
-
-				// Cleanup leftover staging PVCs
-				_, _ = proc.Kubectl("delete", "pvc", "--namespace", testenv.Namespace, pvcName, "--ignore-not-found=true")
-				sourcePVC := names.GenerateResourceName(namespace, "sourceblobs", appName)
-				_, _ = proc.Kubectl("delete", "pvc", "--namespace", testenv.Namespace, sourcePVC, "--ignore-not-found=true")
-			})
 		})
 	})
 

--- a/acceptance/helpers/machine/apps.go
+++ b/acceptance/helpers/machine/apps.go
@@ -144,7 +144,7 @@ func (m *Machine) MakeAppWithDirSimple(appName string, deployFromCurrentDir bool
 func (m *Machine) DeleteApp(appName string) {
 	By("deleting app " + appName)
 
-	out, err := m.Epinio("", "app", "delete", appName)
+	out, err := m.Epinio("", "app", "delete", "--delete-pvc", appName)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)
 
 	EventuallyWithOffset(1, func() string {
@@ -155,7 +155,7 @@ func (m *Machine) DeleteApp(appName string) {
 }
 
 func (m *Machine) CleanupApp(appName string) {
-	out, err := m.Epinio("", "app", "delete", appName)
+	out, err := m.Epinio("", "app", "delete", "--delete-pvc", appName)
 	if err != nil {
 		fmt.Printf("deleting app failed : %s\n%s", err.Error(), out)
 	}

--- a/acceptance/helpers/machine/apps.go
+++ b/acceptance/helpers/machine/apps.go
@@ -144,7 +144,7 @@ func (m *Machine) MakeAppWithDirSimple(appName string, deployFromCurrentDir bool
 func (m *Machine) DeleteApp(appName string) {
 	By("deleting app " + appName)
 
-	out, err := m.Epinio("", "app", "delete", "--delete-pvc", appName)
+	out, err := m.Epinio("", "app", "delete", appName)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), out)
 
 	EventuallyWithOffset(1, func() string {
@@ -155,7 +155,7 @@ func (m *Machine) DeleteApp(appName string) {
 }
 
 func (m *Machine) CleanupApp(appName string) {
-	out, err := m.Epinio("", "app", "delete", "--delete-pvc", appName)
+	out, err := m.Epinio("", "app", "delete", appName)
 	if err != nil {
 		fmt.Printf("deleting app failed : %s\n%s", err.Error(), out)
 	}

--- a/internal/api/v1/application/delete.go
+++ b/internal/api/v1/application/delete.go
@@ -67,7 +67,7 @@ func Delete(c *gin.Context) apierror.APIErrors {
 		}
 		boundConfigurations = append(boundConfigurations, configurations...)
 
-		deleteResult, err := application.Delete(ctx, cluster, appRef, deleteRequest.DeleteImage)
+		deleteResult, err := application.Delete(ctx, cluster, appRef, deleteRequest.DeleteImage, deleteRequest.DeletePVC)
 		if err != nil {
 			return apierror.InternalError(err)
 		}

--- a/internal/api/v1/namespace/delete.go
+++ b/internal/api/v1/namespace/delete.go
@@ -116,10 +116,7 @@ func deleteApps(ctx context.Context, cluster *kubernetes.Cluster, namespace stri
 	}()
 
 	p, err := ants.NewPoolWithFunc(maxConcurrent, func(i interface{}) {
-		// Namespaces are deleted without an explicit request body. Keep matching
-		// existing behavior for images (do not delete), but remove PVCs so
-		// staging storage in the epinio namespace is not left behind.
-		_, err := application.Delete(ctx, cluster, i.(models.AppRef), false, true)
+		_, err := application.Delete(ctx, cluster, i.(models.AppRef), false, false)
 		if err != nil {
 			errChan <- err
 		}

--- a/internal/api/v1/namespace/delete.go
+++ b/internal/api/v1/namespace/delete.go
@@ -116,9 +116,10 @@ func deleteApps(ctx context.Context, cluster *kubernetes.Cluster, namespace stri
 	}()
 
 	p, err := ants.NewPoolWithFunc(maxConcurrent, func(i interface{}) {
-		// Namespaces are deleted without an explicit request body, so default to
-		// not deleting the built image to match existing behavior.
-		_, err := application.Delete(ctx, cluster, i.(models.AppRef), false)
+		// Namespaces are deleted without an explicit request body. Keep matching
+		// existing behavior for images (do not delete), but remove PVCs so
+		// staging storage in the epinio namespace is not left behind.
+		_, err := application.Delete(ctx, cluster, i.(models.AppRef), false, true)
 		if err != nil {
 			errChan <- err
 		}

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -730,6 +730,10 @@ Delete removes the named application, its workload (if active), bindings
 application was staged (if active). Waits for the application's deployment's
 pods to disappear (if active).
 
+When deletePVC is true, staging PVCs (cache/source blobs) and application data
+PVCs (e.g. from StatefulSet volumeClaimTemplates) are removed as well.
+When deletePVC is false (the default), PVCs are preserved.
+
 Returns a DeleteResult containing any warnings (e.g., incomplete blob cleanup).
 */
 func Delete(
@@ -737,6 +741,7 @@ func Delete(
 	cluster *kubernetes.Cluster,
 	appRef models.AppRef,
 	deleteImage bool,
+	deletePVC bool,
 ) (*DeleteResult, error) {
 	result := &DeleteResult{}
 
@@ -760,6 +765,15 @@ func Delete(
 			} else if imageURL == "" {
 				log.Infow("No image URL found in application, skipping image deletion", "app", appRef.Name)
 			}
+		}
+	}
+
+	// Collect app data PVC names before helm uninstall removes the StatefulSet.
+	var appDataPVCs []string
+	if deletePVC {
+		appDataPVCs, err = listAppDataPVCNames(ctx, cluster, appRef)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -805,15 +819,22 @@ func Delete(
 		log.Info("warning: "+warning, "failedBlobs", unstageResult.FailedBlobCleanups)
 	}
 
-	// delete staging PVC (the one that holds the "source" and "cache" workspaces)
-	err = deleteCacheStagePVC(ctx, cluster, appRef)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, err
-	}
+	if deletePVC {
+		// delete staging PVC (the one that holds the "source" and "cache" workspaces)
+		err = deleteCacheStagePVC(ctx, cluster, appRef)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, err
+		}
 
-	err = deleteSourceBlobsStagePVC(ctx, cluster, appRef)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, err
+		err = deleteSourceBlobsStagePVC(ctx, cluster, appRef)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+
+		err = deleteAppDataPVCs(ctx, cluster, appRef.Namespace, appDataPVCs)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	err = cluster.WaitForPodBySelectorMissing(ctx,
@@ -990,6 +1011,58 @@ func deleteSourceBlobsStagePVC(
 		PersistentVolumeClaims(
 			helmchart.Namespace(),
 		).Delete(ctx, appRef.MakeSourceBlobsPVCName(), metav1.DeleteOptions{})
+}
+
+// listAppDataPVCNames finds PersistentVolumeClaims owned by the application's
+// StatefulSets via volumeClaimTemplates. Must be called before the workload is
+// removed so the StatefulSet still exists.
+func listAppDataPVCNames(
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+	appRef models.AppRef,
+) ([]string, error) {
+	stsList, err := cluster.Kubectl.AppsV1().StatefulSets(appRef.Namespace).List(
+		ctx,
+		metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", appRef.Name),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var pvcNames []string
+	for _, sts := range stsList.Items {
+		replicas := int32(1)
+		if sts.Spec.Replicas != nil {
+			replicas = *sts.Spec.Replicas
+		}
+		for _, vct := range sts.Spec.VolumeClaimTemplates {
+			for i := int32(0); i < replicas; i++ {
+				pvcNames = append(pvcNames, fmt.Sprintf("%s-%s-%d", vct.Name, sts.Name, i))
+			}
+		}
+	}
+	return pvcNames, nil
+}
+
+func deleteAppDataPVCs(
+	ctx context.Context,
+	cluster *kubernetes.Cluster,
+	namespace string,
+	pvcNames []string,
+) error {
+	for _, pvcName := range pvcNames {
+		err := cluster.Kubectl.CoreV1().PersistentVolumeClaims(namespace).Delete(
+			ctx,
+			pvcName,
+			metav1.DeleteOptions{},
+		)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
 }
 
 /*

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -730,9 +730,12 @@ Delete removes the named application, its workload (if active), bindings
 application was staged (if active). Waits for the application's deployment's
 pods to disappear (if active).
 
-When deletePVC is true, staging PVCs (cache/source blobs) and application data
-PVCs (e.g. from StatefulSet volumeClaimTemplates) are removed as well.
-When deletePVC is false (the default), PVCs are preserved.
+Staging PVCs (build cache and source blobs) are always removed; they hold only
+data rebuilt from S3 on the next stage, and nothing else ever reaps them.
+
+When deletePVC is true, application data PVCs (e.g. from StatefulSet
+volumeClaimTemplates) are removed as well. When it is false (the default) that
+data is preserved.
 
 Returns a DeleteResult containing any warnings (e.g., incomplete blob cleanup).
 */
@@ -768,7 +771,7 @@ func Delete(
 		}
 	}
 
-	// Collect app data PVC names up front (label-selected; independent of workload).
+	// Collect app data PVC names up front, while the StatefulSet still exists.
 	var appDataPVCs []string
 	if deletePVC {
 		appDataPVCs, err = listAppDataPVCNames(ctx, cluster, appRef)
@@ -819,18 +822,18 @@ func Delete(
 		log.Info("warning: "+warning, "failedBlobs", unstageResult.FailedBlobCleanups)
 	}
 
+	// delete staging PVC (the one that holds the "source" and "cache" workspaces)
+	err = deleteCacheStagePVC(ctx, cluster, appRef)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	err = deleteSourceBlobsStagePVC(ctx, cluster, appRef)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+
 	if deletePVC {
-		// delete staging PVC (the one that holds the "source" and "cache" workspaces)
-		err = deleteCacheStagePVC(ctx, cluster, appRef)
-		if err != nil && !apierrors.IsNotFound(err) {
-			return nil, err
-		}
-
-		err = deleteSourceBlobsStagePVC(ctx, cluster, appRef)
-		if err != nil && !apierrors.IsNotFound(err) {
-			return nil, err
-		}
-
 		err = deleteAppDataPVCs(ctx, cluster, appRef.Namespace, appDataPVCs)
 		if err != nil {
 			return nil, err
@@ -1014,18 +1017,21 @@ func deleteSourceBlobsStagePVC(
 }
 
 // listAppDataPVCNames finds application data PersistentVolumeClaims by label
-// selector. PVCs from StatefulSet volumeClaimTemplates should carry
-// app.kubernetes.io/name and app.kubernetes.io/component=application.
-// Listing by labels (instead of reconstructing names from the current replica
-// count) also finds PVCs left behind after scale-down.
+// selector. Listing by label (instead of reconstructing names from the current
+// replica count) also finds PVCs left behind after scale-down.
+//
+// Only app.kubernetes.io/name is matched. A claim built from a StatefulSet
+// volumeClaimTemplate inherits spec.selector.matchLabels, which the app charts
+// set to that one label; app.kubernetes.io/component lives on the StatefulSet
+// and its pod template, neither of which reaches the claim. Matching on a
+// subset also keeps working if a chart later adds labels of its own.
 func listAppDataPVCNames(
 	ctx context.Context,
 	cluster *kubernetes.Cluster,
 	appRef models.AppRef,
 ) ([]string, error) {
 	selector := labels.Set{
-		"app.kubernetes.io/name":      appRef.Name,
-		"app.kubernetes.io/component": "application",
+		"app.kubernetes.io/name": appRef.Name,
 	}.AsSelector().String()
 
 	pvcList, err := cluster.Kubectl.CoreV1().PersistentVolumeClaims(appRef.Namespace).List(

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -768,7 +768,7 @@ func Delete(
 		}
 	}
 
-	// Collect app data PVC names before helm uninstall removes the StatefulSet.
+	// Collect app data PVC names up front (label-selected; independent of workload).
 	var appDataPVCs []string
 	if deletePVC {
 		appDataPVCs, err = listAppDataPVCNames(ctx, cluster, appRef)
@@ -1013,35 +1013,32 @@ func deleteSourceBlobsStagePVC(
 		).Delete(ctx, appRef.MakeSourceBlobsPVCName(), metav1.DeleteOptions{})
 }
 
-// listAppDataPVCNames finds PersistentVolumeClaims owned by the application's
-// StatefulSets via volumeClaimTemplates. Must be called before the workload is
-// removed so the StatefulSet still exists.
+// listAppDataPVCNames finds application data PersistentVolumeClaims by label
+// selector. PVCs from StatefulSet volumeClaimTemplates should carry
+// app.kubernetes.io/name and app.kubernetes.io/component=application.
+// Listing by labels (instead of reconstructing names from the current replica
+// count) also finds PVCs left behind after scale-down.
 func listAppDataPVCNames(
 	ctx context.Context,
 	cluster *kubernetes.Cluster,
 	appRef models.AppRef,
 ) ([]string, error) {
-	stsList, err := cluster.Kubectl.AppsV1().StatefulSets(appRef.Namespace).List(
+	selector := labels.Set{
+		"app.kubernetes.io/name":      appRef.Name,
+		"app.kubernetes.io/component": "application",
+	}.AsSelector().String()
+
+	pvcList, err := cluster.Kubectl.CoreV1().PersistentVolumeClaims(appRef.Namespace).List(
 		ctx,
-		metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", appRef.Name),
-		},
+		metav1.ListOptions{LabelSelector: selector},
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	var pvcNames []string
-	for _, sts := range stsList.Items {
-		replicas := int32(1)
-		if sts.Spec.Replicas != nil {
-			replicas = *sts.Spec.Replicas
-		}
-		for _, vct := range sts.Spec.VolumeClaimTemplates {
-			for i := int32(0); i < replicas; i++ {
-				pvcNames = append(pvcNames, fmt.Sprintf("%s-%s-%d", vct.Name, sts.Name, i))
-			}
-		}
+	pvcNames := make([]string, 0, len(pvcList.Items))
+	for _, pvc := range pvcList.Items {
+		pvcNames = append(pvcNames, pvc.Name)
 	}
 	return pvcNames, nil
 }

--- a/internal/application/export_test.go
+++ b/internal/application/export_test.go
@@ -1,0 +1,15 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package application
+
+// ListAppDataPVCNames exports listAppDataPVCNames for white-box tests.
+var ListAppDataPVCNames = listAppDataPVCNames

--- a/internal/application/list_app_data_pvc_test.go
+++ b/internal/application/list_app_data_pvc_test.go
@@ -1,0 +1,110 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package application_test
+
+import (
+	"context"
+
+	kubernetesPkg "github.com/epinio/epinio/helpers/kubernetes"
+	"github.com/epinio/epinio/internal/application"
+	"github.com/epinio/epinio/pkg/api/core/v1/models"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("listAppDataPVCNames", func() {
+	const (
+		namespace = "workspace"
+		appName   = "myapp"
+	)
+
+	var ctx context.Context
+
+	appLabels := map[string]string{
+		"app.kubernetes.io/name":      appName,
+		"app.kubernetes.io/component": "application",
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	makePVC := func(name string, labels map[string]string) *v1.PersistentVolumeClaim {
+		return &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    labels,
+			},
+		}
+	}
+
+	It("returns PVCs matching the app label selector", func() {
+		cluster := &kubernetesPkg.Cluster{
+			Kubectl: k8sfake.NewSimpleClientset(
+				makePVC("stateful-myapp-0", appLabels),
+				makePVC("stateful-myapp-1", appLabels),
+			),
+		}
+
+		names, err := application.ListAppDataPVCNames(ctx, cluster, models.NewAppRef(appName, namespace))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(names).To(ConsistOf("stateful-myapp-0", "stateful-myapp-1"))
+	})
+
+	It("finds scaled-down orphan PVCs that still carry the app labels", func() {
+		// Replica count may be 1, but ordinal-1 PVC remains after scale-down.
+		cluster := &kubernetesPkg.Cluster{
+			Kubectl: k8sfake.NewSimpleClientset(
+				makePVC("stateful-myapp-0", appLabels),
+				makePVC("stateful-myapp-1", appLabels),
+			),
+		}
+
+		names, err := application.ListAppDataPVCNames(ctx, cluster, models.NewAppRef(appName, namespace))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(names).To(ConsistOf("stateful-myapp-0", "stateful-myapp-1"))
+	})
+
+	It("ignores PVCs for other apps and unlabeled claims", func() {
+		otherAppLabels := map[string]string{
+			"app.kubernetes.io/name":      "other",
+			"app.kubernetes.io/component": "application",
+		}
+		cluster := &kubernetesPkg.Cluster{
+			Kubectl: k8sfake.NewSimpleClientset(
+				makePVC("stateful-myapp-0", appLabels),
+				makePVC("stateful-other-0", otherAppLabels),
+				makePVC("unlabeled-pvc", nil),
+			),
+		}
+
+		names, err := application.ListAppDataPVCNames(ctx, cluster, models.NewAppRef(appName, namespace))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(names).To(ConsistOf("stateful-myapp-0"))
+	})
+
+	It("returns an empty list when no matching PVCs exist", func() {
+		cluster := &kubernetesPkg.Cluster{
+			Kubectl: k8sfake.NewSimpleClientset(),
+		}
+
+		names, err := application.ListAppDataPVCNames(ctx, cluster, models.NewAppRef(appName, namespace))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(names).To(BeEmpty())
+	})
+})

--- a/internal/application/list_app_data_pvc_test.go
+++ b/internal/application/list_app_data_pvc_test.go
@@ -35,8 +35,7 @@ var _ = Describe("listAppDataPVCNames", func() {
 	var ctx context.Context
 
 	appLabels := map[string]string{
-		"app.kubernetes.io/name":      appName,
-		"app.kubernetes.io/component": "application",
+		"app.kubernetes.io/name": appName,
 	}
 
 	BeforeEach(func() {
@@ -53,7 +52,7 @@ var _ = Describe("listAppDataPVCNames", func() {
 		}
 	}
 
-	It("returns PVCs matching the app label selector", func() {
+	It("returns every PVC for the app, including ordinals left by a scale-down", func() {
 		cluster := &kubernetesPkg.Cluster{
 			Kubectl: k8sfake.NewSimpleClientset(
 				makePVC("stateful-myapp-0", appLabels),
@@ -66,18 +65,23 @@ var _ = Describe("listAppDataPVCNames", func() {
 		Expect(names).To(ConsistOf("stateful-myapp-0", "stateful-myapp-1"))
 	})
 
-	It("finds scaled-down orphan PVCs that still carry the app labels", func() {
-		// Replica count may be 1, but ordinal-1 PVC remains after scale-down.
+	It("still matches when a claim carries extra labels", func() {
+		// Guards the subset match: a chart that adds labels of its own must not
+		// fall out of the selector.
+		extraLabels := map[string]string{
+			"app.kubernetes.io/name":       appName,
+			"app.kubernetes.io/component":  "application",
+			"app.kubernetes.io/managed-by": "epinio",
+		}
 		cluster := &kubernetesPkg.Cluster{
 			Kubectl: k8sfake.NewSimpleClientset(
-				makePVC("stateful-myapp-0", appLabels),
-				makePVC("stateful-myapp-1", appLabels),
+				makePVC("stateful-myapp-0", extraLabels),
 			),
 		}
 
 		names, err := application.ListAppDataPVCNames(ctx, cluster, models.NewAppRef(appName, namespace))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(names).To(ConsistOf("stateful-myapp-0", "stateful-myapp-1"))
+		Expect(names).To(ConsistOf("stateful-myapp-0"))
 	})
 
 	It("ignores PVCs for other apps and unlabeled claims", func() {

--- a/internal/cli/cmd/apps.go
+++ b/internal/cli/cmd/apps.go
@@ -171,7 +171,7 @@ func NewAppDeleteCmd(client ApplicationsService) *cobra.Command {
 
 	cmd.Flags().BoolVar(&cfg.all, "all", false, "Delete all applications")
 	cmd.Flags().BoolVar(&cfg.deleteImage, "delete-image", false, "Delete the application's container image from the registry")
-	cmd.Flags().BoolVar(&cfg.deletePVC, "delete-pvc", false, "Delete the application's staging and data PersistentVolumeClaims")
+	cmd.Flags().BoolVar(&cfg.deletePVC, "delete-pvc", false, "Delete the application's data PersistentVolumeClaims (e.g. StatefulSet volumes)")
 
 	return cmd
 }

--- a/internal/cli/cmd/apps.go
+++ b/internal/cli/cmd/apps.go
@@ -27,7 +27,7 @@ import (
 //counterfeiter:generate -header ../../../LICENSE_HEADER . ApplicationsService
 type ApplicationsService interface {
 	AppCreate(name string, updateRequest models.ApplicationUpdateRequest) error
-	AppDelete(ctx context.Context, appNames []string, all, deleteImage bool) error
+	AppDelete(ctx context.Context, appNames []string, all, deleteImage, deletePVC bool) error
 	AppExec(ctx context.Context, name, instance string) error
 	AppExport(name string, toRegistry bool, exportRequest models.AppExportRequest) error
 	AppLogs(name, stageID string, follow bool, options *client.LogOptions) error
@@ -140,6 +140,7 @@ func NewAppCreateCmd(client ApplicationsService) *cobra.Command {
 type AppDeleteConfig struct {
 	all         bool
 	deleteImage bool
+	deletePVC   bool
 }
 
 // NewAppDeleteCmd returns a new `epinio apps delete` command
@@ -159,7 +160,7 @@ func NewAppDeleteCmd(client ApplicationsService) *cobra.Command {
 				return errors.New("No applications specified for deletion")
 			}
 
-			err := client.AppDelete(cmd.Context(), args, cfg.all, cfg.deleteImage)
+			err := client.AppDelete(cmd.Context(), args, cfg.all, cfg.deleteImage, cfg.deletePVC)
 			if err != nil {
 				return errors.Wrap(err, "error deleting app")
 			}
@@ -170,6 +171,7 @@ func NewAppDeleteCmd(client ApplicationsService) *cobra.Command {
 
 	cmd.Flags().BoolVar(&cfg.all, "all", false, "Delete all applications")
 	cmd.Flags().BoolVar(&cfg.deleteImage, "delete-image", false, "Delete the application's container image from the registry")
+	cmd.Flags().BoolVar(&cfg.deletePVC, "delete-pvc", false, "Delete the application's staging and data PersistentVolumeClaims")
 
 	return cmd
 }

--- a/internal/cli/cmd/cmdfakes/fake_applications_service.go
+++ b/internal/cli/cmd/cmdfakes/fake_applications_service.go
@@ -35,13 +35,14 @@ type FakeApplicationsService struct {
 	appCreateReturnsOnCall map[int]struct {
 		result1 error
 	}
-	AppDeleteStub        func(context.Context, []string, bool, bool) error
+	AppDeleteStub        func(context.Context, []string, bool, bool, bool) error
 	appDeleteMutex       sync.RWMutex
 	appDeleteArgsForCall []struct {
 		arg1 context.Context
 		arg2 []string
 		arg3 bool
 		arg4 bool
+		arg5 bool
 	}
 	appDeleteReturns struct {
 		result1 error
@@ -491,7 +492,7 @@ func (fake *FakeApplicationsService) AppCreateReturnsOnCall(i int, result1 error
 	}{result1}
 }
 
-func (fake *FakeApplicationsService) AppDelete(arg1 context.Context, arg2 []string, arg3 bool, arg4 bool) error {
+func (fake *FakeApplicationsService) AppDelete(arg1 context.Context, arg2 []string, arg3 bool, arg4 bool, arg5 bool) error {
 	var arg2Copy []string
 	if arg2 != nil {
 		arg2Copy = make([]string, len(arg2))
@@ -504,13 +505,14 @@ func (fake *FakeApplicationsService) AppDelete(arg1 context.Context, arg2 []stri
 		arg2 []string
 		arg3 bool
 		arg4 bool
-	}{arg1, arg2Copy, arg3, arg4})
+		arg5 bool
+	}{arg1, arg2Copy, arg3, arg4, arg5})
 	stub := fake.AppDeleteStub
 	fakeReturns := fake.appDeleteReturns
-	fake.recordInvocation("AppDelete", []interface{}{arg1, arg2Copy, arg3, arg4})
+	fake.recordInvocation("AppDelete", []interface{}{arg1, arg2Copy, arg3, arg4, arg5})
 	fake.appDeleteMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
@@ -524,17 +526,17 @@ func (fake *FakeApplicationsService) AppDeleteCallCount() int {
 	return len(fake.appDeleteArgsForCall)
 }
 
-func (fake *FakeApplicationsService) AppDeleteCalls(stub func(context.Context, []string, bool, bool) error) {
+func (fake *FakeApplicationsService) AppDeleteCalls(stub func(context.Context, []string, bool, bool, bool) error) {
 	fake.appDeleteMutex.Lock()
 	defer fake.appDeleteMutex.Unlock()
 	fake.AppDeleteStub = stub
 }
 
-func (fake *FakeApplicationsService) AppDeleteArgsForCall(i int) (context.Context, []string, bool, bool) {
+func (fake *FakeApplicationsService) AppDeleteArgsForCall(i int) (context.Context, []string, bool, bool, bool) {
 	fake.appDeleteMutex.RLock()
 	defer fake.appDeleteMutex.RUnlock()
 	argsForCall := fake.appDeleteArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeApplicationsService) AppDeleteReturns(result1 error) {

--- a/internal/cli/usercmd/app.go
+++ b/internal/cli/usercmd/app.go
@@ -557,7 +557,7 @@ func (c *EpinioClient) AppPortForward(ctx context.Context, appName, instance str
 }
 
 // Delete removes one or more applications, specified by name
-func (c *EpinioClient) AppDelete(ctx context.Context, appNames []string, all, deleteImage bool) error {
+func (c *EpinioClient) AppDelete(ctx context.Context, appNames []string, all, deleteImage, deletePVC bool) error {
 	if all {
 		c.ui.Note().
 			WithStringValue("Namespace", c.Settings.Namespace).
@@ -626,7 +626,7 @@ func (c *EpinioClient) AppDelete(ctx context.Context, appNames []string, all, de
 		return match.Names
 	})
 
-	response, err := c.API.AppDelete(c.Settings.Namespace, appNames, deleteImage)
+	response, err := c.API.AppDelete(c.Settings.Namespace, appNames, deleteImage, deletePVC)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/usercmd/client.go
+++ b/internal/cli/usercmd/client.go
@@ -53,7 +53,7 @@ type APIClient interface {
 	AllApps() (models.AppList, error)
 	AppShow(namespace string, appName string) (models.App, error)
 	AppUpdate(req models.ApplicationUpdateRequest, namespace string, appName string) (models.Response, error)
-	AppDelete(namespace string, names []string, deleteImage bool) (models.ApplicationDeleteResponse, error)
+	AppDelete(namespace string, names []string, deleteImage, deletePVC bool) (models.ApplicationDeleteResponse, error)
 	AppUpload(namespace string, name string, file client.FormFile) (models.UploadResponse, error)
 	AppSourcePatch(namespace, name string, file client.FormFile, processCmd string) (*models.StageResponse, error)
 	AppSync(namespace, name string, file client.FormFile, mode, dest, binaryName string) (models.Response, error)

--- a/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
+++ b/internal/cli/usercmd/usercmdfakes/fake_apiclient.go
@@ -75,12 +75,13 @@ type FakeAPIClient struct {
 		result1 models.Response
 		result2 error
 	}
-	AppDeleteStub        func(string, []string, bool) (models.ApplicationDeleteResponse, error)
+	AppDeleteStub        func(string, []string, bool, bool) (models.ApplicationDeleteResponse, error)
 	appDeleteMutex       sync.RWMutex
 	appDeleteArgsForCall []struct {
 		arg1 string
 		arg2 []string
 		arg3 bool
+		arg4 bool
 	}
 	appDeleteReturns struct {
 		result1 models.ApplicationDeleteResponse
@@ -1457,7 +1458,7 @@ func (fake *FakeAPIClient) AppCreateReturnsOnCall(i int, result1 models.Response
 	}{result1, result2}
 }
 
-func (fake *FakeAPIClient) AppDelete(arg1 string, arg2 []string, arg3 bool) (models.ApplicationDeleteResponse, error) {
+func (fake *FakeAPIClient) AppDelete(arg1 string, arg2 []string, arg3 bool, arg4 bool) (models.ApplicationDeleteResponse, error) {
 	var arg2Copy []string
 	if arg2 != nil {
 		arg2Copy = make([]string, len(arg2))
@@ -1469,13 +1470,14 @@ func (fake *FakeAPIClient) AppDelete(arg1 string, arg2 []string, arg3 bool) (mod
 		arg1 string
 		arg2 []string
 		arg3 bool
-	}{arg1, arg2Copy, arg3})
+		arg4 bool
+	}{arg1, arg2Copy, arg3, arg4})
 	stub := fake.AppDeleteStub
 	fakeReturns := fake.appDeleteReturns
-	fake.recordInvocation("AppDelete", []interface{}{arg1, arg2Copy, arg3})
+	fake.recordInvocation("AppDelete", []interface{}{arg1, arg2Copy, arg3, arg4})
 	fake.appDeleteMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1489,17 +1491,17 @@ func (fake *FakeAPIClient) AppDeleteCallCount() int {
 	return len(fake.appDeleteArgsForCall)
 }
 
-func (fake *FakeAPIClient) AppDeleteCalls(stub func(string, []string, bool) (models.ApplicationDeleteResponse, error)) {
+func (fake *FakeAPIClient) AppDeleteCalls(stub func(string, []string, bool, bool) (models.ApplicationDeleteResponse, error)) {
 	fake.appDeleteMutex.Lock()
 	defer fake.appDeleteMutex.Unlock()
 	fake.AppDeleteStub = stub
 }
 
-func (fake *FakeAPIClient) AppDeleteArgsForCall(i int) (string, []string, bool) {
+func (fake *FakeAPIClient) AppDeleteArgsForCall(i int) (string, []string, bool, bool) {
 	fake.appDeleteMutex.RLock()
 	defer fake.appDeleteMutex.RUnlock()
 	argsForCall := fake.appDeleteArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeAPIClient) AppDeleteReturns(result1 models.ApplicationDeleteResponse, result2 error) {

--- a/pkg/api/core/v1/client/apps.go
+++ b/pkg/api/core/v1/client/apps.go
@@ -191,7 +191,7 @@ func (c *Client) AppMatch(namespace, prefix string) (models.AppMatchResponse, er
 }
 
 // AppDelete deletes an app
-func (c *Client) AppDelete(namespace string, names []string, deleteImage bool) (models.ApplicationDeleteResponse, error) {
+func (c *Client) AppDelete(namespace string, names []string, deleteImage, deletePVC bool) (models.ApplicationDeleteResponse, error) {
 	response := models.ApplicationDeleteResponse{}
 
 	queryParams := url.Values{}
@@ -207,6 +207,7 @@ func (c *Client) AppDelete(namespace string, names []string, deleteImage bool) (
 
 	request := models.ApplicationDeleteRequest{
 		DeleteImage: deleteImage,
+		DeletePVC:   deletePVC,
 	}
 
 	return Delete(c, endpoint, request, response)

--- a/pkg/api/core/v1/client/apps_test.go
+++ b/pkg/api/core/v1/client/apps_test.go
@@ -87,7 +87,7 @@ func DescribeAppsErrors() {
 				return epinioClient.AppUpdate(models.ApplicationUpdateRequest{}, "namespace", "appname")
 			}),
 			Entry("app delete", func() (any, error) {
-				return epinioClient.AppDelete("namespace", []string{"appname"}, false)
+				return epinioClient.AppDelete("namespace", []string{"appname"}, false, false)
 			}),
 			Entry("app upload", func() (any, error) {
 				return epinioClient.AppUpload("namespace", "appname", nil)

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -333,9 +333,10 @@ type AsyncDeployStatus struct {
 // ApplicationDeleteRequest represents and contains the data needed to delete an application
 type ApplicationDeleteRequest struct {
 	DeleteImage bool `json:"deleteImage"`
-	// DeletePVC when true removes staging PVCs (cache/source blobs) and
-	// application data PVCs (e.g. StatefulSet volumeClaimTemplates).
-	// Defaults to false so PVCs are preserved unless explicitly requested.
+	// DeletePVC when true also removes application data PVCs (e.g. from
+	// StatefulSet volumeClaimTemplates). Defaults to false so application data
+	// is preserved unless explicitly requested. Staging PVCs (build cache and
+	// source blobs) are always removed and are not governed by this flag.
 	DeletePVC bool `json:"deletePVC"`
 }
 

--- a/pkg/api/core/v1/models/models.go
+++ b/pkg/api/core/v1/models/models.go
@@ -333,6 +333,10 @@ type AsyncDeployStatus struct {
 // ApplicationDeleteRequest represents and contains the data needed to delete an application
 type ApplicationDeleteRequest struct {
 	DeleteImage bool `json:"deleteImage"`
+	// DeletePVC when true removes staging PVCs (cache/source blobs) and
+	// application data PVCs (e.g. StatefulSet volumeClaimTemplates).
+	// Defaults to false so PVCs are preserved unless explicitly requested.
+	DeletePVC bool `json:"deletePVC"`
 }
 
 // ApplicationDeleteResponse represents the server's response to a successful app deletion


### PR DESCRIPTION
### Summary
Fixes #EPINIO-726

Add an optional `deletePVC` flag to the application delete endpoint (and CLI `--delete-pvc`). Default remains `false` so staging/app-data PVCs are preserved unless explicitly requested.

Companion UI PR: https://github.com/epinio/ui/pull/639

### Occurred changes and/or fixed issues
- `ApplicationDeleteRequest` gains `deletePVC` (JSON `deletePVC`, default false).
- `application.Delete` only removes staging PVCs (cache/source blobs) and app-data PVCs (StatefulSet `volumeClaimTemplates`) when `deletePVC` is true.
- App-data PVC names are collected **before** helm uninstall so StatefulSets still exist.
- CLI: `epinio app delete --delete-pvc`.
- API client / usercmd / fakes updated for the new parameter.
- Acceptance: existing cache-PVC deletion test now requires `--delete-pvc`; new test asserts PVC is kept when the flag is omitted.
- Test helpers `DeleteApp`/`CleanupApp` pass `--delete-pvc` so leftover staging PVCs do not accumulate.
- Namespace delete now removes app PVCs when cascading app deletion (`deletePVC=true`) so staging storage is not left behind after namespace removal.

### Technical notes summary
- Behavior change vs older unconditional staging-PVC deletion on app delete: PVCs are now kept by default; callers must opt in.
- Staging PVC deletion still uses existing `deleteCacheStagePVC` / `deleteSourceBlobsStagePVC`.
- App-data PVC deletion uses label-selected StatefulSets (`app.kubernetes.io/name`) and the standard `{vct}-{sts}-{ordinal}` naming.
- Namespace cascade intentionally opts in to PVC cleanup even though single-app delete defaults to false.

### Areas or cases that should be tested
1. `epinio app delete <app>` (no flags) → app gone, cache/source/data PVCs still present.
2. `epinio app delete --delete-pvc <app>` → staging PVCs removed; StatefulSet data PVCs removed when present.
3. API delete with body `{deletePVC:false}` / omitted → same as default keep.
4. API delete with `{deletePVC:true}` (alone and with `deleteImage`) → PVCs removed as expected.
5. Delete namespace containing staged apps → apps and their staging PVCs cleaned up.
6. Acceptance apps suite covering the new keep-vs-delete PVC cases.
7. App with no PVCs / already-missing PVCs → delete still succeeds (NotFound ignored).

### Areas which could experience regressions
- Any automation that assumed app delete always removed staging PVCs (now must pass `--delete-pvc` / `deletePVC: true`).
- Bulk/API clients that construct `ApplicationDeleteRequest` (new field is optional/false by default).
- Namespace deletion cleanup volume/cost behavior (now deletes PVCs).
- Helm uninstall ordering vs PVC collection for StatefulSet-backed apps.
- Acceptance helpers always cleaning PVCs may hide accidental PVC leaks in other tests if they relied on leftover volumes.