### PR TITLE
feat(Add namespace scoping to endpoints): For namespace related resou…

### DIFF
--- a/acceptance/api/v1/application_index_all_test.go
+++ b/acceptance/api/v1/application_index_all_test.go
@@ -95,6 +95,122 @@ var _ = Describe("AllApps Endpoints", LApplication, func() {
 			[]string{app2, namespace2}))
 	})
 
+	// listApps GETs /applications with the given query string and returns the
+	// plain, non-paginated list.
+	listApps := func(query string) models.AppList {
+		url := fmt.Sprintf("%s%s/applications?%s", serverURL, v1.Root, query)
+
+		response, err := env.Curl("GET", url, strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+
+		defer response.Body.Close()
+		bodyBytes, err := io.ReadAll(response.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+		var apps models.AppList
+		err = json.Unmarshal(bodyBytes, &apps)
+		Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+		return apps
+	}
+
+	appRefsOf := func(apps models.AppList) [][]string {
+		var appRefs [][]string
+		for _, a := range apps {
+			appRefs = append(appRefs, []string{a.Meta.Name, a.Meta.Namespace})
+		}
+
+		return appRefs
+	}
+
+	It("filters applications to a single namespace", func() {
+		apps := listApps("namespaces=" + namespace1)
+
+		Expect(appRefsOf(apps)).To(ConsistOf([]string{app1, namespace1}))
+	})
+
+	It("filters applications to several namespaces", func() {
+		query := fmt.Sprintf("namespaces=%s,%s", namespace1, namespace2)
+
+		apps := listApps(query)
+
+		Expect(appRefsOf(apps)).To(ConsistOf(
+			[]string{app1, namespace1},
+			[]string{app2, namespace2}))
+	})
+
+	It("ignores a requested namespace that does not exist", func() {
+		query := fmt.Sprintf("namespaces=%s,does-not-exist", namespace1)
+
+		apps := listApps(query)
+
+		Expect(appRefsOf(apps)).To(ConsistOf([]string{app1, namespace1}))
+	})
+
+	It("combines the namespace filter with the search term", func() {
+		query := fmt.Sprintf("namespaces=%s,%s&search=%s",
+			namespace1, namespace2, app1)
+
+		apps := listApps(query)
+
+		Expect(appRefsOf(apps)).To(ConsistOf([]string{app1, namespace1}))
+	})
+
+	It("paginates within the filtered namespaces", func() {
+		url := fmt.Sprintf(
+			"%s%s/applications?namespaces=%s,%s&page=1&pageSize=1",
+			serverURL, v1.Root, namespace1, namespace2)
+
+		response, err := env.Curl("GET", url, strings.NewReader(""))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+
+		defer response.Body.Close()
+		bodyBytes, err := io.ReadAll(response.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+		var paged struct {
+			Items      []models.App `json:"items"`
+			Page       int          `json:"page"`
+			PageSize   int          `json:"pageSize"`
+			TotalItems int          `json:"totalItems"`
+			TotalPages int          `json:"totalPages"`
+		}
+		err = json.Unmarshal(bodyBytes, &paged)
+		Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+		// The namespace filter makes the totals deterministic despite apps
+		// left over from other specs running concurrently.
+		Expect(paged.TotalItems).To(Equal(2))
+		Expect(paged.TotalPages).To(Equal(2))
+		Expect(paged.Items).To(HaveLen(1))
+	})
+
+	It("cannot widen access beyond the user's namespaces", func() {
+		endpoint := fmt.Sprintf("%s%s/applications?namespaces=%s",
+			serverURL, v1.Root, namespace1)
+		request, err := http.NewRequest(http.MethodGet, endpoint, nil)
+		Expect(err).ToNot(HaveOccurred())
+		request.SetBasicAuth(user, password)
+
+		response, err := env.Client().Do(request)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).ToNot(BeNil())
+
+		defer response.Body.Close()
+		bodyBytes, err := io.ReadAll(response.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+		var apps models.AppList
+		err = json.Unmarshal(bodyBytes, &apps)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(apps).To(BeEmpty())
+	})
+
 	It("doesn't list applications belonging to non-accessible namespaces", func() {
 		endpoint := fmt.Sprintf("%s%s/applications", serverURL, v1.Root)
 		request, err := http.NewRequest(http.MethodGet, endpoint, nil)

--- a/acceptance/api/v1/configurations_test.go
+++ b/acceptance/api/v1/configurations_test.go
@@ -171,6 +171,130 @@ var _ = Describe("Configurations API Application Endpoints", LConfiguration, fun
 			))
 		})
 
+		// listConfigurations GETs /configurations with the given query string
+		// and returns the plain, non-paginated list.
+		listConfigurations := func(
+			query string,
+		) models.ConfigurationResponseList {
+			url := fmt.Sprintf("%s%s/configurations?%s",
+				serverURL, api.Root, query)
+
+			response, err := env.Curl("GET", url, strings.NewReader(""))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+
+			defer response.Body.Close()
+			bodyBytes, err := io.ReadAll(response.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+			var configurations models.ConfigurationResponseList
+			err = json.Unmarshal(bodyBytes, &configurations)
+			Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+			return configurations
+		}
+
+		configurationRefsOf := func(
+			configurations models.ConfigurationResponseList,
+		) [][]string {
+			var configurationRefs [][]string
+			for _, s := range configurations {
+				configurationRefs = append(configurationRefs, []string{
+					s.Meta.Name,
+					s.Meta.Namespace,
+					strings.Join(s.Configuration.BoundApps, ", "),
+				})
+			}
+
+			return configurationRefs
+		}
+
+		It("filters configurations to a single namespace", func() {
+			configurations := listConfigurations("namespaces=" + namespace1)
+
+			// Bound apps must survive the filter: the enrichment lookup is
+			// scoped to the namespaces that remain.
+			Expect(configurationRefsOf(configurations)).To(ConsistOf(
+				[]string{configuration1, namespace1, app1},
+			))
+		})
+
+		It("filters configurations to several namespaces", func() {
+			query := fmt.Sprintf("namespaces=%s,%s", namespace1, namespace2)
+
+			configurations := listConfigurations(query)
+
+			Expect(configurationRefsOf(configurations)).To(ConsistOf(
+				[]string{configuration1, namespace1, app1},
+				[]string{configuration1, namespace2, ""},
+				[]string{configuration2, namespace2, ""},
+			))
+		})
+
+		It("ignores a requested namespace that does not exist", func() {
+			query := fmt.Sprintf("namespaces=%s,does-not-exist", namespace1)
+
+			configurations := listConfigurations(query)
+
+			Expect(configurationRefsOf(configurations)).To(ConsistOf(
+				[]string{configuration1, namespace1, app1},
+			))
+		})
+
+		It("paginates within the filtered namespaces", func() {
+			url := fmt.Sprintf(
+				"%s%s/configurations?namespaces=%s,%s&page=1&pageSize=2",
+				serverURL, api.Root, namespace1, namespace2)
+
+			response, err := env.Curl("GET", url, strings.NewReader(""))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+
+			defer response.Body.Close()
+			bodyBytes, err := io.ReadAll(response.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+			var paged struct {
+				Items      models.ConfigurationResponseList `json:"items"`
+				Page       int                              `json:"page"`
+				PageSize   int                              `json:"pageSize"`
+				TotalItems int                              `json:"totalItems"`
+				TotalPages int                              `json:"totalPages"`
+			}
+			err = json.Unmarshal(bodyBytes, &paged)
+			Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+			// The namespace filter makes the totals deterministic despite
+			// configurations left over from other specs running concurrently.
+			Expect(paged.TotalItems).To(Equal(3))
+			Expect(paged.TotalPages).To(Equal(2))
+			Expect(paged.Items).To(HaveLen(2))
+		})
+
+		It("cannot widen access beyond the user's namespaces", func() {
+			endpoint := fmt.Sprintf("%s%s/configurations?namespaces=%s",
+				serverURL, api.Root, namespace1)
+			request, err := http.NewRequest(http.MethodGet, endpoint, nil)
+			Expect(err).ToNot(HaveOccurred())
+			request.SetBasicAuth(user, password)
+
+			response, err := env.Client().Do(request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+
+			defer response.Body.Close()
+			bodyBytes, err := io.ReadAll(response.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+			var configurations models.ConfigurationResponseList
+			err = json.Unmarshal(bodyBytes, &configurations)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(configurations).To(BeEmpty())
+		})
+
 		It("returns a paginated response when page params are provided", func() {
 			response, err := env.Curl("GET", fmt.Sprintf("%s%s/configurations?page=1&pageSize=1",
 				serverURL, api.Root), strings.NewReader(""))

--- a/acceptance/api/v1/namespaces_test.go
+++ b/acceptance/api/v1/namespaces_test.go
@@ -127,6 +127,57 @@ var _ = Describe("Namespaces API Application Endpoints", LNamespace, func() {
 				Expect(found).To(BeTrue(), "expected search results to contain %q", namespace)
 			})
 
+			It("filters namespaces by name", func() {
+				ns2 := catalog.NewNamespaceName()
+				env.SetupAndTargetNamespace(ns2)
+				defer env.DeleteNamespace(ns2)
+
+				listNames := func(query string) []string {
+					response, err := env.Curl("GET",
+						fmt.Sprintf("%s%s/namespaces?%s", serverURL, api.Root, query),
+						strings.NewReader(""))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(response).ToNot(BeNil())
+
+					defer response.Body.Close()
+					bodyBytes, err := io.ReadAll(response.Body)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(response.StatusCode).To(Equal(http.StatusOK), string(bodyBytes))
+
+					var namespaceList models.NamespaceList
+					err = json.Unmarshal(bodyBytes, &namespaceList)
+					Expect(err).ToNot(HaveOccurred(), string(bodyBytes))
+
+					names := []string{}
+					for _, ns := range namespaceList {
+						names = append(names, ns.Meta.Name)
+					}
+
+					return names
+				}
+
+				By("keeping only the requested namespace")
+				Expect(listNames("namespaces=" + namespace)).To(ConsistOf(namespace))
+
+				By("keeping the union of several namespaces")
+				query := fmt.Sprintf("namespaces=%s,%s", namespace, ns2)
+				Expect(listNames(query)).To(ConsistOf(namespace, ns2))
+
+				By("ignoring a requested namespace that does not exist")
+				query = fmt.Sprintf("namespaces=%s,does-not-exist", namespace)
+				Expect(listNames(query)).To(ConsistOf(namespace))
+
+				By("returning an empty list when nothing matches")
+				Expect(listNames("namespaces=does-not-exist")).To(BeEmpty())
+
+				// The distinction that matters on this endpoint: namespaces
+				// matches the name exactly, search matches a substring.
+				By("matching the name exactly, unlike search")
+				partial := namespace[:len(namespace)-2]
+				Expect(listNames("namespaces=" + partial)).To(BeEmpty())
+				Expect(listNames("search=" + partial)).To(ContainElement(namespace))
+			})
+
 			When("basic auth credentials are not provided", func() {
 				It("returns a 401 response", func() {
 					request, err := http.NewRequest("GET", fmt.Sprintf("%s%s/namespaces",

--- a/acceptance/api/v1/service_list_test.go
+++ b/acceptance/api/v1/service_list_test.go
@@ -280,4 +280,111 @@ var _ = Describe("ServiceList Endpoint", LService, func() {
 			Expect(found).To(BeTrue(), "expected search results to contain %q", serviceName1)
 		})
 	})
+
+	Describe("GET /api/v1/services namespaces", func() {
+		var serviceName1, serviceName2 string
+		var user, password string
+
+		BeforeEach(func() {
+			serviceName1 = catalog.NewServiceName()
+			serviceName2 = catalog.NewServiceName()
+
+			env.TargetNamespace(namespace1)
+			env.MakeServiceInstance(serviceName1, catalogService.Meta.Name)
+
+			env.TargetNamespace(namespace2)
+			env.MakeServiceInstance(serviceName2, catalogService.Meta.Name)
+
+			user, password = env.CreateEpinioUser("user", nil)
+		})
+
+		AfterEach(func() {
+			catalog.DeleteService(serviceName1, namespace1)
+			catalog.DeleteService(serviceName2, namespace2)
+
+			env.DeleteEpinioUser(user)
+		})
+
+		listServices := func(query string) models.ServiceList {
+			endpoint := fmt.Sprintf("%s%s/services?%s",
+				serverURL, v1.Root, query)
+
+			response, err := env.Curl("GET", endpoint, strings.NewReader(""))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+			defer response.Body.Close()
+
+			var services models.ServiceList
+			err = json.NewDecoder(response.Body).Decode(&services)
+			Expect(err).ToNot(HaveOccurred())
+
+			return services
+		}
+
+		serviceRefsOf := func(services models.ServiceList) [][]string {
+			var serviceRefs [][]string
+			for _, svc := range services {
+				serviceRefs = append(serviceRefs, []string{
+					svc.Meta.Name,
+					svc.Meta.Namespace,
+				})
+			}
+
+			return serviceRefs
+		}
+
+		// Every filter case shares one fixture: provisioning two service
+		// instances is far more expensive than the reads themselves.
+		It("filters services by namespace", func() {
+			By("keeping only the requested namespace")
+			services := listServices("namespaces=" + namespace1)
+			Expect(serviceRefsOf(services)).To(ConsistOf(
+				[]string{serviceName1, namespace1}))
+
+			By("keeping the union of several namespaces")
+			query := fmt.Sprintf("namespaces=%s,%s", namespace1, namespace2)
+			services = listServices(query)
+			Expect(serviceRefsOf(services)).To(ConsistOf(
+				[]string{serviceName1, namespace1},
+				[]string{serviceName2, namespace2}))
+
+			By("ignoring a requested namespace that does not exist")
+			query = fmt.Sprintf("namespaces=%s,does-not-exist", namespace1)
+			services = listServices(query)
+			Expect(serviceRefsOf(services)).To(ConsistOf(
+				[]string{serviceName1, namespace1}))
+
+			By("returning an empty list when nothing matches")
+			services = listServices("namespaces=does-not-exist")
+			Expect(services).To(BeEmpty())
+
+			By("combining the namespace filter with the search term")
+			query = fmt.Sprintf("namespaces=%s,%s&search=%s",
+				namespace1, namespace2, serviceName2)
+			services = listServices(query)
+			Expect(serviceRefsOf(services)).To(ConsistOf(
+				[]string{serviceName2, namespace2}))
+		})
+
+		It("cannot widen access beyond the user's namespaces", func() {
+			endpoint := fmt.Sprintf("%s%s/services?namespaces=%s",
+				serverURL, v1.Root, namespace1)
+			request, err := http.NewRequest(http.MethodGet, endpoint, nil)
+			Expect(err).ToNot(HaveOccurred())
+			request.SetBasicAuth(user, password)
+
+			response, err := env.Client().Do(request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+			defer response.Body.Close()
+
+			var services models.ServiceList
+			err = json.NewDecoder(response.Body).Decode(&services)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(services).To(BeEmpty())
+		})
+	})
 })

--- a/docs/references/api/swagger.json
+++ b/docs/references/api/swagger.json
@@ -829,6 +829,36 @@
         ],
         "summary": "Return list of all controlled namespaces.",
         "operationId": "Namespaces",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Namespaces",
+            "description": "Comma-separated namespaces to filter by, e.g. \"ns1,ns2\". Matches the\nnamespace name exactly. Names the user cannot see are ignored.",
+            "name": "namespaces",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Search",
+            "description": "Case-insensitive substring match on the namespace name",
+            "name": "search",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Page",
+            "description": "Page number, 1-based. Pagination is off unless page or pageSize is set.",
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "PageSize",
+            "description": "Items per page (default 25)",
+            "name": "pageSize",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/responses/NamespacesResponse"

--- a/internal/api/v1/application/fullindex.go
+++ b/internal/api/v1/application/fullindex.go
@@ -41,7 +41,10 @@ func FullIndex(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
+	namespaces := response.GetNamespacesParam(c)
+
 	filteredApps := auth.FilterResources(user, allApps)
+	filteredApps = auth.FilterByNamespaces(filteredApps, namespaces)
 
 	if search := response.GetSearchParam(c); search != "" {
 		lower := strings.ToLower(search)

--- a/internal/api/v1/configuration/fullindex.go
+++ b/internal/api/v1/configuration/fullindex.go
@@ -40,7 +40,13 @@ func FullIndex(c *gin.Context) apierror.APIErrors {
 	if err != nil {
 		return apierror.InternalError(err)
 	}
+	namespaces := response.GetNamespacesParam(c)
+
 	filteredConfigurations := auth.FilterResources(user, allConfigurations)
+	filteredConfigurations = auth.FilterByNamespaces(
+		filteredConfigurations,
+		namespaces,
+	)
 
 	if search := response.GetSearchParam(c); search != "" {
 		lower := strings.ToLower(search)

--- a/internal/api/v1/docs/application.go
+++ b/internal/api/v1/docs/application.go
@@ -21,7 +21,21 @@ import "github.com/epinio/epinio/pkg/api/core/v1/models"
 //   200: AppsResponse
 
 // swagger:parameters AllApps
-type AllAppsParam struct{}
+type AllAppsParam struct {
+	// Comma-separated namespaces to filter by, e.g. "ns1,ns2". Names the user
+	// cannot see, or that do not exist, are ignored.
+	// in: query
+	Namespaces string `json:"namespaces"`
+	// Case-insensitive substring match on the application name
+	// in: query
+	Search string `json:"search"`
+	// Page number, 1-based. Pagination is off unless page or pageSize is set.
+	// in: query
+	Page string `json:"page"`
+	// Items per page (default 25)
+	// in: query
+	PageSize string `json:"pageSize"`
+}
 
 // response: See Apps.
 

--- a/internal/api/v1/docs/configuration.go
+++ b/internal/api/v1/docs/configuration.go
@@ -192,6 +192,20 @@ type ConfigurationReplaceResponse struct {
 //   200: ConfigurationsResponse
 
 // swagger:parameters AllConfigurations
-type ConfigurationAllConfigurationsParam struct{}
+type ConfigurationAllConfigurationsParam struct {
+	// Comma-separated namespaces to filter by, e.g. "ns1,ns2". Names the user
+	// cannot see, or that do not exist, are ignored.
+	// in: query
+	Namespaces string `json:"namespaces"`
+	// Case-insensitive substring match on the configuration name
+	// in: query
+	Search string `json:"search"`
+	// Page number, 1-based. Pagination is off unless page or pageSize is set.
+	// in: query
+	Page string `json:"page"`
+	// Items per page (default 25)
+	// in: query
+	PageSize string `json:"pageSize"`
+}
 
 // response: See Configurations.

--- a/internal/api/v1/docs/namespace.go
+++ b/internal/api/v1/docs/namespace.go
@@ -20,6 +20,23 @@ import "github.com/epinio/epinio/pkg/api/core/v1/models"
 // responses:
 //   200: NamespacesResponse
 
+// swagger:parameters Namespaces
+type NamespacesParam struct {
+	// Comma-separated namespaces to filter by, e.g. "ns1,ns2". Matches the
+	// namespace name exactly. Names the user cannot see are ignored.
+	// in: query
+	Namespaces string `json:"namespaces"`
+	// Case-insensitive substring match on the namespace name
+	// in: query
+	Search string `json:"search"`
+	// Page number, 1-based. Pagination is off unless page or pageSize is set.
+	// in: query
+	Page string `json:"page"`
+	// Items per page (default 25)
+	// in: query
+	PageSize string `json:"pageSize"`
+}
+
 // swagger:response NamespacesResponse
 type NamespacesResponse struct {
 	// in: body

--- a/internal/api/v1/docs/service.go
+++ b/internal/api/v1/docs/service.go
@@ -112,6 +112,23 @@ type CatalogMatchResponse struct {
 // responses:
 //   200: ServiceListResponse
 
+// swagger:parameters AllServices
+type AllServicesParam struct {
+	// Comma-separated namespaces to filter by, e.g. "ns1,ns2". Names the user
+	// cannot see, or that do not exist, are ignored.
+	// in: query
+	Namespaces string `json:"namespaces"`
+	// Case-insensitive substring match on the service name
+	// in: query
+	Search string `json:"search"`
+	// Page number, 1-based. Pagination is off unless page or pageSize is set.
+	// in: query
+	Page string `json:"page"`
+	// Items per page (default 25)
+	// in: query
+	PageSize string `json:"pageSize"`
+}
+
 // swagger:route POST /namespaces/{Namespace}/services service ServiceCreate
 // Create a named service of an Epinio catalog service in the `Namespace`.
 // responses:

--- a/internal/api/v1/namespace/index.go
+++ b/internal/api/v1/namespace/index.go
@@ -47,6 +47,11 @@ func Index(c *gin.Context) apierror.APIErrors {
 	}
 	namespaceList = auth.FilterResources(user, namespaceList)
 
+	// Namespace() returns a namespace's own name, so this is an exact-name
+	// filter here, unlike the substring match that ?search= applies below.
+	requestedNamespaces := response.GetNamespacesParam(c)
+	namespaceList = auth.FilterByNamespaces(namespaceList, requestedNamespaces)
+
 	if search := response.GetSearchParam(c); search != "" {
 		lower := strings.ToLower(search)
 		var filtered []namespaces.Namespace

--- a/internal/api/v1/response/response.go
+++ b/internal/api/v1/response/response.go
@@ -17,6 +17,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/epinio/epinio/internal/cli/server/requestctx"
 	"github.com/gin-gonic/gin"
@@ -70,6 +71,23 @@ func OKReturn(c *gin.Context, response interface{}) {
 // GetSearchParam returns the optional "search" query parameter for name filtering.
 func GetSearchParam(c *gin.Context) string {
 	return c.Query("search")
+}
+
+// GetNamespacesParam returns the optional "namespaces" query parameter, a
+// comma-separated list of names ("?namespaces=a,b"). Nil when absent or empty.
+func GetNamespacesParam(c *gin.Context) []string {
+	var namespaces []string
+
+	for _, name := range strings.Split(c.Query("namespaces"), ",") {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+
+		namespaces = append(namespaces, name)
+	}
+
+	return namespaces
 }
 
 // PaginatedResponse represents a generic paginated response payload.

--- a/internal/api/v1/response/response_test.go
+++ b/internal/api/v1/response/response_test.go
@@ -14,6 +14,7 @@ package response_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/epinio/epinio/internal/api/v1/response"
@@ -196,6 +197,73 @@ func TestGetPaginationParams(t *testing.T) {
 			}
 			if pageSize != tc.wantPageSize {
 				t.Errorf("pageSize: got %d want %d", pageSize, tc.wantPageSize)
+			}
+		})
+	}
+}
+
+func TestGetNamespacesParam(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	makeCtx := func(query string) *gin.Context {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		req, _ := http.NewRequest("GET", "/test?"+query, nil)
+		c.Request = req
+		return c
+	}
+
+	tests := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{name: "no namespaces param", query: "", want: nil},
+		{name: "empty namespaces param", query: "namespaces=", want: nil},
+		{name: "separators only", query: "namespaces=,,", want: nil},
+		{name: "whitespace only", query: "namespaces=%20,%20", want: nil},
+		{
+			name:  "single namespace",
+			query: "namespaces=workspace",
+			want:  []string{"workspace"},
+		},
+		{
+			name:  "comma separated",
+			query: "namespaces=alpha,beta",
+			want:  []string{"alpha", "beta"},
+		},
+		{
+			name:  "surrounding whitespace trimmed",
+			query: "namespaces=%20alpha%20,%20beta%20",
+			want:  []string{"alpha", "beta"},
+		},
+		{
+			name:  "trailing separator ignored",
+			query: "namespaces=alpha,",
+			want:  []string{"alpha"},
+		},
+		{
+			// Duplicates are harmless: the filter builds a set from these.
+			name:  "duplicates pass through",
+			query: "namespaces=alpha,alpha",
+			want:  []string{"alpha", "alpha"},
+		},
+		{
+			// One shape only. Repeated params are not part of the contract.
+			name:  "repeated param takes the first value",
+			query: "namespaces=alpha&namespaces=beta",
+			want:  []string{"alpha"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := makeCtx(tc.query)
+
+			got := response.GetNamespacesParam(c)
+
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("GetNamespacesParam: got %#v want %#v", got, tc.want)
 			}
 		})
 	}

--- a/internal/api/v1/service/fullindex.go
+++ b/internal/api/v1/service/fullindex.go
@@ -45,7 +45,10 @@ func FullIndex(c *gin.Context) apierror.APIErrors {
 		return apierror.InternalError(err)
 	}
 
+	namespaces := response.GetNamespacesParam(c)
+
 	filteredServices := auth.FilterResources(user, serviceList)
+	filteredServices = auth.FilterByNamespaces(filteredServices, namespaces)
 
 	if search := response.GetSearchParam(c); search != "" {
 		lower := strings.ToLower(search)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -337,6 +337,33 @@ func FilterResources[T NamespacedResource](user User, resources []T) []T {
 	return filteredResources
 }
 
+// FilterByNamespaces narrows resources to the named namespaces; an empty list
+// is a pass-through. It narrows an authorized set, it does not authorize.
+func FilterByNamespaces[T NamespacedResource](
+	resources []T,
+	namespaces []string,
+) []T {
+	if len(namespaces) == 0 {
+		return resources
+	}
+
+	namespacesMap := make(map[string]struct{}, len(namespaces))
+	for _, ns := range namespaces {
+		namespacesMap[ns] = struct{}{}
+	}
+
+	filteredResources := []T{}
+	for _, resource := range resources {
+		_, requested := namespacesMap[resource.Namespace()]
+
+		if requested {
+			filteredResources = append(filteredResources, resource)
+		}
+	}
+
+	return filteredResources
+}
+
 type GitconfigResource interface {
 	Gitconfig() string
 	IsGlobal() bool

--- a/internal/auth/filter_test.go
+++ b/internal/auth/filter_test.go
@@ -1,0 +1,109 @@
+// Copyright © 2021 - 2023 SUSE LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth_test
+
+import (
+	"github.com/epinio/epinio/internal/auth"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type namespacedFake struct {
+	namespace string
+	name      string
+}
+
+func (f namespacedFake) Namespace() string {
+	return f.namespace
+}
+
+var _ = Describe("FilterByNamespaces", func() {
+	var resources []namespacedFake
+
+	BeforeEach(func() {
+		resources = []namespacedFake{
+			{namespace: "alpha", name: "one"},
+			{namespace: "beta", name: "two"},
+			{namespace: "alpha", name: "three"},
+			{namespace: "gamma", name: "four"},
+		}
+	})
+
+	When("the namespaces list is empty", func() {
+		It("returns the resources untouched for a nil list", func() {
+			filtered := auth.FilterByNamespaces(resources, nil)
+
+			Expect(filtered).To(Equal(resources))
+		})
+
+		It("returns the resources untouched for an empty list", func() {
+			filtered := auth.FilterByNamespaces(resources, []string{})
+
+			Expect(filtered).To(Equal(resources))
+		})
+	})
+
+	When("one namespace is requested", func() {
+		It("keeps every resource in that namespace", func() {
+			filtered := auth.FilterByNamespaces(resources, []string{"alpha"})
+
+			Expect(filtered).To(Equal([]namespacedFake{
+				{namespace: "alpha", name: "one"},
+				{namespace: "alpha", name: "three"},
+			}))
+		})
+	})
+
+	When("several namespaces are requested", func() {
+		It("keeps the union and preserves input order", func() {
+			requested := []string{"gamma", "beta"}
+
+			filtered := auth.FilterByNamespaces(resources, requested)
+
+			Expect(filtered).To(Equal([]namespacedFake{
+				{namespace: "beta", name: "two"},
+				{namespace: "gamma", name: "four"},
+			}))
+		})
+
+		It("ignores a duplicate namespace", func() {
+			requested := []string{"alpha", "alpha"}
+
+			filtered := auth.FilterByNamespaces(resources, requested)
+
+			Expect(filtered).To(HaveLen(2))
+		})
+	})
+
+	When("a requested namespace matches nothing", func() {
+		It("drops the unknown name and honours the rest", func() {
+			requested := []string{"beta", "does-not-exist"}
+
+			filtered := auth.FilterByNamespaces(resources, requested)
+
+			Expect(filtered).To(Equal([]namespacedFake{
+				{namespace: "beta", name: "two"},
+			}))
+		})
+
+		// Empty but not nil: the non-paginated handlers return this slice
+		// straight to the client, and nil marshals to JSON null.
+		It("returns an empty non-nil slice when nothing matches", func() {
+			requested := []string{"does-not-exist"}
+
+			filtered := auth.FilterByNamespaces(resources, requested)
+
+			Expect(filtered).To(BeEmpty())
+			Expect(filtered).NotTo(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
### PR Checklist
- [x] Linting Test is passing
- [x] New Unit and Acceptance tests written for the context of the PR
- [x] Unit Tests are passing
- [x] Acceptance Tests are passing
- [x] Code is well documented
- [ ] Does the [MCP](https://github.com/epinio/mcp) server need an update?
- [ ] If applicable, a PR in the [epinio/docs](https://github.com/epinio/docs) repository has been opened

### Summary
Fixes EPINIO-732

Adds an optional `?namespaces=` filter to the three cross-namespace list endpoints, so the dashboard can scope one table to a chosen set of namespaces instead of one table per namespace.

### Occurred changes and/or fixed issues
- `GET /applications`, `GET /services`, `GET /configurations` accept `?namespaces=ns1,ns2`
- Absent or empty param keeps existing behaviour, so this is backwards compatible

### Technical notes summary
`response.GetNamespacesParam` parses the list, `auth.FilterByNamespaces` applies it to the output of `auth.FilterResources`, before search and pagination.

### Areas or cases that should be tested
- test api/v1/applications?namespaces=, api/v1/services?namespaces=, and api/v1/configurations?namespaces=
- only the named namespaces come back
- unknown name returns `[]`, HTTP 200
- a user without access to a named namespace sees nothing from it
- page reset when the selection changes

### Areas which could experience regressions
- These three endpoints only. Namespace-scoped routes and `/applications/grouped` untouched.
- Bound-apps enrichment on configurations and services is page-scoped; confirmed it still resolves under the filter.
